### PR TITLE
fix: make pnpm db:seed work on Hugo without manual env sourcing

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^25.3.0",
+    "dotenv": "^16.4.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"
   }

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,6 +1,11 @@
+import { config as loadEnv } from 'dotenv';
+import { resolve } from 'node:path';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import { seedPromptKeywords } from './seed-prompts.js';
+
+// Load .env from monorepo root (needed when running outside Docker, e.g. on Hugo via pnpm db:seed)
+loadEnv({ path: resolve(import.meta.dirname, '../../../.env') });
 
 const prisma = new PrismaClient();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
       tsx:
         specifier: ^4.0.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

- Add dotenv to db package and load `.env` from monorepo root in `seed.ts`
- Previously required `source .env && pnpm db:seed` which failed because Docker Compose `.env` format isn't valid shell syntax
- Now `pnpm db:seed` just works on Hugo without manual env sourcing
