### PR TITLE
fix: seed migration + ticketNumber + deploy prune

### DIFF
--- a/.github/workflows/deploy-hugo.yml
+++ b/.github/workflows/deploy-hugo.yml
@@ -278,8 +278,10 @@ jobs:
               docker pull "$IMAGE_PREFIX/$svc:latest"
             done
 
-            # Clean up old images and build cache to prevent disk exhaustion
-            docker image prune -a --filter "until=24h" --force
+            # Clean up unused images and build cache to prevent disk exhaustion.
+            # Prune ALL images not used by running containers (not just >24h old)
+            # to handle multiple deploys in a single day.
+            docker image prune -a --force
             docker builder prune --force
 
             # Restart services

--- a/packages/db/prisma/migrations/20260330050000_add_azure_devops_ticket_source/migration.sql
+++ b/packages/db/prisma/migrations/20260330050000_add_azure_devops_ticket_source/migration.sql
@@ -1,0 +1,2 @@
+-- Add AZURE_DEVOPS to ticket_source enum (was in schema but never migrated)
+ALTER TYPE "ticket_source" ADD VALUE IF NOT EXISTS 'AZURE_DEVOPS';

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -131,6 +131,7 @@ async function main() {
       source: 'EMAIL',
       category: 'DATABASE_PERF',
       priority: 'HIGH',
+      ticketNumber: 1,
       followers: {
         create: { contactId: contact.id, followerType: 'REQUESTER' },
       },


### PR DESCRIPTION
## Summary

Fixes discovered while running `pnpm db:seed` on Hugo:

- **Missing migration**: `AZURE_DEVOPS` was in the Prisma schema's `TicketSource` enum but never had a migration to add it to the database. The seed's DevOps ingestion route creation failed with `invalid input value for enum ticket_source: "AZURE_DEVOPS"`.
- **Missing field**: Sample ticket in seed was missing required `ticketNumber` field.
- **Docker prune**: Removed `--filter "until=24h"` from deploy-hugo image prune. Multiple deploys in one day filled Hugo's 48GB disk to 100%, crash-looping Postgres.

## Test plan

- [ ] `pnpm db:seed` runs to completion on Hugo after deploy
- [ ] Docker disk usage stays reasonable after multiple deploys
