### PR TITLE
feat: add hardcoded fallback routes for ingestion and analysis

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1597,7 +1597,7 @@ interface ResolvedRoute {
  * 2. Global route matching the ticket category
  * 3. AI-based selection using route summaries
  * 4. Default route (isDefault=true)
- * 5. null (fall back to hardcoded pipeline)
+ * 5. null (fall back to a synthetic default route matching the architecture flowchart)
  */
 async function resolveTicketRoute(
   deps: AnalyzerDeps,

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1034,7 +1034,7 @@ export function createIngestionProcessor(deps: IngestionDeps) {
       const isEmail = source === TicketSource.EMAIL;
       const defaultSteps = [
         ...(isEmail ? [{ id: 'default-resolve-thread', stepOrder: 1, name: 'Resolve Thread', stepType: RouteStepType.RESOLVE_THREAD, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true }] : []),
-        { id: 'default-summarize', stepOrder: isEmail ? 2 : 1, name: 'Summarize', stepType: isEmail ? RouteStepType.SUMMARIZE_EMAIL : RouteStepType.SUMMARIZE_EMAIL, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
+        { id: 'default-summarize', stepOrder: isEmail ? 2 : 1, name: 'Summarize', stepType: RouteStepType.SUMMARIZE_EMAIL, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 'default-categorize', stepOrder: isEmail ? 3 : 2, name: 'Categorize', stepType: RouteStepType.CATEGORIZE, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 'default-triage', stepOrder: isEmail ? 4 : 3, name: 'Triage Priority', stepType: RouteStepType.TRIAGE_PRIORITY, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 'default-title', stepOrder: isEmail ? 5 : 4, name: 'Generate Title', stepType: RouteStepType.GENERATE_TITLE, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
@@ -1042,7 +1042,7 @@ export function createIngestionProcessor(deps: IngestionDeps) {
         ...(isEmail ? [{ id: 'default-receipt', stepOrder: 7, name: 'Draft Receipt', stepType: RouteStepType.DRAFT_RECEIPT, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true }] : []),
       ];
       route = {
-        id: 'default-ingestion-fallback',
+        id: null,
         name: `Default ${isEmail ? 'Email' : source} Ingestion (fallback)`,
         description: 'Built-in default ingestion pipeline — configure a route in the control panel to customize.',
         routeType: 'INGESTION',


### PR DESCRIPTION
## Summary

When no DB-configured route matches, the system now falls back to synthetic routes matching the architecture flowchart instead of dropping payloads (ingestion) or using the legacy hardcoded flow (analysis).

**Ingestion fallback** — previously payloads were silently dropped when no route matched. Now builds a synthetic pipeline:
- EMAIL: RESOLVE_THREAD → SUMMARIZE_EMAIL → CATEGORIZE → TRIAGE → GENERATE_TITLE → CREATE_TICKET → DRAFT_RECEIPT
- Other sources: SUMMARIZE_EMAIL → CATEGORIZE → TRIAGE → GENERATE_TITLE → CREATE_TICKET

**Analysis fallback** — previously fell back to a legacy Phase 1/Phase 2 flow that lacked the new features. Now uses the full flowchart pipeline:
- LOAD_CLIENT_CONTEXT → EXTRACT_FACTS → GATHER_REPO_CONTEXT → GATHER_DB_CONTEXT → AGENTIC_ANALYSIS (with sufficiency evaluation + contact user) → DRAFT_FINDINGS_EMAIL → SUGGEST_NEXT_STEPS → UPDATE_TICKET_SUMMARY

The legacy hardcoded analysis code (sendReceiptConfirmation + deepAnalysis) is removed — replaced by the route step handlers which have all the new capabilities.

## Test plan
- [ ] Send an email with no ingestion routes configured → ticket should be created via fallback
- [ ] Ticket with no analysis route configured → should get full agentic analysis with sufficiency evaluation
