### PR TITLE
fix: operational alerts use System Settings SMTP + fix Test Alert endpoint (fixes #49)

### DIFF
--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { TicketStatus, TicketCategory, DEFAULT_OPERATIONAL_ALERT_CONFIG } from '@bronco/shared-types';
 import type { OperationalAlertConfig } from '@bronco/shared-types';
-import { Mailer, createLogger, decrypt, encrypt, looksEncrypted } from '@bronco/shared-utils';
+import { Mailer, createLogger, decrypt, encrypt, loadSmtpFromDb, looksEncrypted } from '@bronco/shared-utils';
 import { reconnectSlack } from '../services/slack-connection.js';
 import { z } from 'zod';
 
@@ -432,29 +432,15 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
       return fastify.httpErrors.badRequest('No recipient email configured in operational alert settings');
     }
 
-    // Find the first active EMAIL notification channel
-    const channel = await fastify.db.notificationChannel.findFirst({
-      where: { type: 'EMAIL', isActive: true },
-    });
-
-    if (!channel) {
+    // Load SMTP config from System Settings
+    const smtpConfig = await loadSmtpFromDb(fastify.db, opts.encryptionKey);
+    if (!smtpConfig) {
       return fastify.httpErrors.badRequest(
-        'No active EMAIL notification channel configured. Add one in Settings → Notification Channels.',
+        'SMTP not configured. Configure it in System Settings → SMTP.',
       );
     }
 
-    const cfg = channel.config as Record<string, unknown>;
-    const password = typeof cfg.password === 'string' && looksEncrypted(cfg.password)
-      ? decrypt(cfg.password, opts.encryptionKey)
-      : (cfg.password as string);
-
-    const mailer = new Mailer({
-      host: cfg.host as string,
-      port: cfg.port as number,
-      user: cfg.user as string,
-      password,
-      from: cfg.from as string,
-    });
+    const mailer = new Mailer(smtpConfig);
 
     try {
       await mailer.send({

--- a/services/copilot-api/src/services/operational-alerts.ts
+++ b/services/copilot-api/src/services/operational-alerts.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from '@bronco/db';
 import { DEFAULT_OPERATIONAL_ALERT_CONFIG } from '@bronco/shared-types';
 import type { OperationalAlertConfig } from '@bronco/shared-types';
-import { Mailer, createLogger, decrypt, looksEncrypted } from '@bronco/shared-utils';
+import { Mailer, createLogger, loadSmtpFromDb } from '@bronco/shared-utils';
 import cronParser from 'cron-parser';
 import { sendRedisCommand } from './redis.js';
 
@@ -367,28 +367,13 @@ interface OperationalAlertOpts {
   encryptionKey: string;
 }
 
-async function createMailerFromChannel(
+async function createMailerFromSmtpSettings(
   db: PrismaClient,
   encryptionKey: string,
 ): Promise<Mailer | null> {
-  const channel = await db.notificationChannel.findFirst({
-    where: { type: 'EMAIL', isActive: true },
-  });
-
-  if (!channel) return null;
-
-  const cfg = channel.config as Record<string, unknown>;
-  const password = typeof cfg.password === 'string' && looksEncrypted(cfg.password)
-    ? decrypt(cfg.password, encryptionKey)
-    : (cfg.password as string);
-
-  return new Mailer({
-    host: cfg.host as string,
-    port: cfg.port as number,
-    user: cfg.user as string,
-    password,
-    from: cfg.from as string,
-  });
+  const smtpConfig = await loadSmtpFromDb(db, encryptionKey);
+  if (!smtpConfig) return null;
+  return new Mailer(smtpConfig);
 }
 
 async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
@@ -443,10 +428,10 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
 
   if (alertsToSend.length === 0) return;
 
-  // Create mailer from notification channel
-  const mailer = await createMailerFromChannel(db, encryptionKey);
+  // Create mailer from System Settings SMTP config
+  const mailer = await createMailerFromSmtpSettings(db, encryptionKey);
   if (!mailer) {
-    logger.warn('No active EMAIL notification channel — cannot send operational alerts');
+    logger.warn('SMTP not configured in System Settings — cannot send operational alerts');
     return;
   }
 


### PR DESCRIPTION
Both the operational alert sender and the Test Alert endpoint were
looking for a NotificationChannel of type EMAIL, which doesn't exist.
Now they use loadSmtpFromDb() to read SMTP config directly from System
Settings (AppSetting table), matching the pattern used by other services.

https://claude.ai/code/session_01Sr9xgMjisKEiBW5VKDAdM8