### PR TITLE
fix: bump Angular component style budget to 12kB

### DIFF
--- a/services/control-panel/angular.json
+++ b/services/control-panel/angular.json
@@ -49,8 +49,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "10kB"
+                  "maximumWarning": "6kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
Fixes deploy failure — ticket-detail component exceeded 10kB CSS budget by 245 bytes after adding Logs tab and timeline features.