### PR TITLE
Migrate repository access from local git to mcp-repo service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,11 +107,14 @@ services:
         condition: service_healthy
       mcp-database:
         condition: service_healthy
+      mcp-repo:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://bronco:${POSTGRES_PASSWORD_URLENCODED}@postgres:5432/bronco
       REDIS_URL: redis://redis:6379
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       MCP_DATABASE_URL: ${MCP_DATABASE_URL:-http://mcp-database:3100}
+      MCP_REPO_URL: http://mcp-repo:3111
       REPO_WORKSPACE_PATH: /var/lib/ticket-analyzer/repos
       REPO_RETENTION_DAYS: ${REPO_RETENTION_DAYS:-14}
       ARTIFACT_STORAGE_PATH: ${ARTIFACT_STORAGE_PATH:-/mnt/qnap/artifacts}
@@ -272,6 +275,8 @@ services:
         condition: service_healthy
       mcp-platform:
         condition: service_healthy
+      mcp-repo:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://bronco:${POSTGRES_PASSWORD_URLENCODED}@postgres:5432/bronco
       REDIS_URL: redis://redis:6379
@@ -279,6 +284,7 @@ services:
       API_KEY: ${API_KEY}
       HEALTH_PORT: "3108"
       MCP_PLATFORM_URL: http://mcp-platform:3110
+      MCP_REPO_URL: http://mcp-repo:3111
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:-}
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3108/health || exit 1"]

--- a/mcp-servers/repo/src/tools/index.ts
+++ b/mcp-servers/repo/src/tools/index.ts
@@ -18,9 +18,21 @@ export function registerAllTools(
       repoId: z.string().uuid().describe('The CodeRepo ID'),
       command: z.string().describe('The shell command to execute'),
       sessionId: z.string().optional().describe('Session ID for worktree reuse (auto-generated if omitted)'),
+      clientId: z.string().uuid().optional().describe('Client ID for ownership validation'),
     },
-    async ({ repoId, command, sessionId }) => {
+    async ({ repoId, command, sessionId, clientId }) => {
       const sid = sessionId ?? randomUUID();
+
+      // Ownership validation: if clientId is provided, verify the repo belongs to that client
+      if (clientId) {
+        const repo = await db.codeRepo.findUnique({ where: { id: repoId }, select: { clientId: true } });
+        if (!repo || repo.clientId !== clientId) {
+          return {
+            content: [{ type: 'text' as const, text: 'Access denied: repository does not belong to the specified client.' }],
+            isError: true,
+          };
+        }
+      }
 
       // Validate before creating worktree
       const validation = validateCommand(command);

--- a/packages/db/prisma/migrations/20260403010000_add_code_repo_description/migration.sql
+++ b/packages/db/prisma/migrations/20260403010000_add_code_repo_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "code_repos" ADD COLUMN "description" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -514,6 +514,7 @@ model CodeRepo {
   repoUrl       String   @map("repo_url")
   defaultBranch String   @default("master") @map("default_branch")
   branchPrefix  String   @default("claude") @map("branch_prefix")
+  description   String?  @map("description")
   isActive      Boolean  @default(true) @map("is_active")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")

--- a/services/control-panel/src/app/core/services/repo.service.ts
+++ b/services/control-panel/src/app/core/services/repo.service.ts
@@ -9,6 +9,7 @@ export interface CodeRepo {
   repoUrl: string;
   defaultBranch: string;
   branchPrefix: string;
+  description?: string;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -21,6 +21,11 @@ import { RepoService, type CodeRepo } from '../../core/services/repo.service';
         <mat-label>Repository URL</mat-label>
         <input matInput [(ngModel)]="form.repoUrl" required placeholder="https://github.com/org/repo.git">
       </mat-form-field>
+      <mat-form-field class="full-width">
+        <mat-label>Description (helps AI understand repo contents)</mat-label>
+        <textarea matInput [(ngModel)]="form.description" rows="2"
+          placeholder="SQL Server stored procedures, table schemas, and ETL jobs for..."></textarea>
+      </mat-form-field>
       <div class="row">
         <mat-form-field class="flex">
           <mat-label>Default Branch</mat-label>
@@ -55,6 +60,7 @@ export class RepoDialogComponent {
   form = {
     name: this.data.repo?.name ?? '',
     repoUrl: this.data.repo?.repoUrl ?? '',
+    description: this.data.repo?.description ?? '',
     defaultBranch: this.data.repo?.defaultBranch ?? 'master',
     branchPrefix: this.data.repo?.branchPrefix ?? 'claude',
   };
@@ -63,6 +69,7 @@ export class RepoDialogComponent {
     const payload = {
       name: this.form.name,
       repoUrl: this.form.repoUrl,
+      description: this.form.description || undefined,
       defaultBranch: this.form.defaultBranch,
       branchPrefix: this.form.branchPrefix,
     };

--- a/services/slack-worker/src/config.ts
+++ b/services/slack-worker/src/config.ts
@@ -7,7 +7,7 @@ const configSchema = z.object({
   ENCRYPTION_KEY: z.string().min(64),
   HEALTH_PORT: z.coerce.number().default(3108),
   MCP_PLATFORM_URL: z.string().default('http://mcp-platform:3110'),
-  MCP_REPO_URL: z.string().default('http://mcp-repo:3111'),
+  MCP_REPO_URL: z.string().url().default('http://mcp-repo:3111'),
   API_KEY: z.string().optional().transform(v => v || undefined),
   MCP_AUTH_TOKEN: z.string().optional().transform(v => v || undefined),
 });

--- a/services/slack-worker/src/config.ts
+++ b/services/slack-worker/src/config.ts
@@ -7,6 +7,7 @@ const configSchema = z.object({
   ENCRYPTION_KEY: z.string().min(64),
   HEALTH_PORT: z.coerce.number().default(3108),
   MCP_PLATFORM_URL: z.string().default('http://mcp-platform:3110'),
+  MCP_REPO_URL: z.string().default('http://mcp-repo:3111'),
   API_KEY: z.string().optional().transform(v => v || undefined),
   MCP_AUTH_TOKEN: z.string().optional().transform(v => v || undefined),
 });

--- a/services/slack-worker/src/hugo-conversation.ts
+++ b/services/slack-worker/src/hugo-conversation.ts
@@ -198,6 +198,8 @@ async function executeToolLoop(
             if (repoId) {
               toolInput = { ...toolInput, repoId, ...(client ? { clientId: client.id } : {}) };
             }
+          } else if (actualToolName === 'list_repos' && client) {
+            toolInput = { ...toolInput, clientId: client.id };
           }
           logger.info({ tool: toolUse.name, actualTool: actualToolName, iteration: i + 1 }, 'Executing mcp-repo tool');
           result = await callMcpToolViaSdk(
@@ -447,6 +449,7 @@ export async function handleHugoConversation(
             properties: {
               clientId: { type: 'string', description: 'Client ID to filter by' },
             },
+            required: ['clientId'],
           },
         });
         repoToolPrefixes.add('repo');

--- a/services/slack-worker/src/hugo-conversation.ts
+++ b/services/slack-worker/src/hugo-conversation.ts
@@ -164,6 +164,8 @@ async function executeToolLoop(
   client: { id: string; name: string; shortCode: string } | null,
   operator: { id: string; name: string },
   usage: UsageAccumulator,
+  repoIdByPrefix: Map<string, string> = new Map(),
+  repoToolPrefixes: Set<string> = new Set(),
 ): Promise<{ text: string; timestampedMessages: TimestampedMessage[] }> {
   let response = initialResponse;
   const current: TimestampedMessage[] = [...timestampedMessages];
@@ -182,15 +184,41 @@ async function executeToolLoop(
       let result: string;
       let isError = false;
       try {
-        logger.info({ tool: toolUse.name, iteration: i + 1 }, 'Executing MCP Platform tool');
-        result = await callMcpToolViaSdk(
-          deps.config.MCP_PLATFORM_URL,
-          '/mcp',
-          toolUse.name,
-          toolUse.input,
-          deps.config.MCP_AUTH_TOKEN || deps.config.API_KEY,
-          deps.config.MCP_AUTH_TOKEN ? undefined : 'x-api-key',
-        );
+        // Route repo tools to mcp-repo, everything else to mcp-platform
+        const sepIdx = toolUse.name.indexOf('__');
+        const toolPrefix = sepIdx !== -1 ? toolUse.name.slice(0, sepIdx) : '';
+        const isRepoTool = repoToolPrefixes.has(toolPrefix);
+
+        if (isRepoTool) {
+          const actualToolName = toolUse.name.slice(sepIdx + 2);
+          let toolInput = toolUse.input;
+          // For repo_exec, inject the baked-in repoId and clientId
+          if (actualToolName === 'repo_exec') {
+            const repoId = repoIdByPrefix.get(toolPrefix);
+            if (repoId) {
+              toolInput = { ...toolInput, repoId, ...(client ? { clientId: client.id } : {}) };
+            }
+          }
+          logger.info({ tool: toolUse.name, actualTool: actualToolName, iteration: i + 1 }, 'Executing mcp-repo tool');
+          result = await callMcpToolViaSdk(
+            deps.config.MCP_REPO_URL,
+            '/mcp',
+            actualToolName,
+            toolInput,
+            deps.config.MCP_AUTH_TOKEN || deps.config.API_KEY,
+            deps.config.MCP_AUTH_TOKEN ? undefined : 'x-api-key',
+          );
+        } else {
+          logger.info({ tool: toolUse.name, iteration: i + 1 }, 'Executing MCP Platform tool');
+          result = await callMcpToolViaSdk(
+            deps.config.MCP_PLATFORM_URL,
+            '/mcp',
+            toolUse.name,
+            toolUse.input,
+            deps.config.MCP_AUTH_TOKEN || deps.config.API_KEY,
+            deps.config.MCP_AUTH_TOKEN ? undefined : 'x-api-key',
+          );
+        }
       } catch (err) {
         result = err instanceof Error ? err.message : String(err);
         isError = true;
@@ -391,6 +419,8 @@ export async function handleHugoConversation(
 
   // 5. Get MCP Platform tools
   let tools: AIToolDefinition[];
+  const repoIdByPrefix = new Map<string, string>();
+  const repoToolPrefixes = new Set<string>();
   try {
     tools = await getPlatformTools(config.MCP_PLATFORM_URL, { apiKey: config.API_KEY, authToken: config.MCP_AUTH_TOKEN });
   } catch (err) {
@@ -401,6 +431,62 @@ export async function handleHugoConversation(
       'I couldn\'t connect to the platform tools service. Please check that `mcp-platform` is running and try again.',
     );
     return;
+  }
+
+  // 5b. Discover mcp-repo tools for the client's code repositories
+  if (client) {
+    try {
+      const clientRepos = await db.codeRepo.findMany({ where: { clientId: client.id, isActive: true } });
+      if (clientRepos.length > 0) {
+        // Register shared list_repos and repo_cleanup tools
+        tools.push({
+          name: 'repo__list_repos',
+          description: 'List available code repositories registered for this client.',
+          input_schema: {
+            type: 'object',
+            properties: {
+              clientId: { type: 'string', description: 'Client ID to filter by' },
+            },
+          },
+        });
+        repoToolPrefixes.add('repo');
+
+        tools.push({
+          name: 'repo__repo_cleanup',
+          description: 'Release a session\'s repository worktrees to free disk space.',
+          input_schema: {
+            type: 'object',
+            properties: {
+              sessionId: { type: 'string', description: 'The session ID to clean up' },
+            },
+            required: ['sessionId'],
+          },
+        });
+
+        // Register per-repo repo_exec tools with repoId baked in
+        for (const repo of clientRepos) {
+          const prefix = `repo-${repo.name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()}-${repo.id.slice(0, 8)}`;
+          repoIdByPrefix.set(prefix, repo.id);
+          repoToolPrefixes.add(prefix);
+
+          tools.push({
+            name: `${prefix}__repo_exec`,
+            description: `[${repo.name}] ${repo.description || 'Code repository'}. Execute a read-only shell command in a sandboxed worktree. Allowed: grep, find, cat, head, tail, ls, tree, diff, stat. Pipes to grep/sed/awk/sort allowed.`,
+            input_schema: {
+              type: 'object',
+              properties: {
+                command: { type: 'string', description: 'The shell command to execute' },
+                sessionId: { type: 'string', description: 'Session ID for worktree reuse (auto-generated if omitted)' },
+              },
+              required: ['command'],
+            },
+          });
+        }
+        logger.info({ clientId: client.id, repoCount: clientRepos.length }, 'Registered mcp-repo tools for client');
+      }
+    } catch (err) {
+      logger.warn({ err, clientId: client.id }, 'Failed to discover mcp-repo tools, continuing without repo access');
+    }
   }
 
   // 6. Load thread context if this is a reply in an existing thread
@@ -469,6 +555,8 @@ export async function handleHugoConversation(
       client,
       operator,
       usage,
+      repoIdByPrefix,
+      repoToolPrefixes,
     );
     finalText = result.text;
     finalTimestampedMessages = result.timestampedMessages;

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,9 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { execFile } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises';
-import { join, resolve, basename } from 'node:path';
-import { promisify } from 'node:util';
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
 import { Prisma } from '@bronco/db';
@@ -17,7 +14,6 @@ import type { Mailer, ReplyOptions } from '@bronco/shared-utils';
 import { executeRecommendations } from './recommendation-executor.js';
 import type { ParsedAction } from './recommendation-executor.js';
 
-const execFileAsync = promisify(execFile);
 const logger = createLogger('ticket-analyzer');
 export const appLog = new AppLogger('ticket-analyzer');
 
@@ -33,11 +29,6 @@ function sanitizeName(raw: string, maxLen = 120): string {
 
 /** Max events to include in ticket summary prompts to bound prompt size. */
 const SUMMARY_EVENT_LIMIT = 50;
-
-const DEFAULT_REPO_BASE_DIR = '/tmp/bronco-repos';
-
-/** Timeout (ms) for git clone/fetch operations to prevent indefinite blocking. */
-const GIT_CLONE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Canonical list of AI action types — used in both the LLM prompt and runtime validation. */
 const KNOWN_ACTIONS = [
@@ -283,33 +274,6 @@ async function sendReplyWithRetry(
   throw lastError ?? new Error('All email send attempts failed');
 }
 
-// ---------------------------------------------------------------------------
-// In-process mutex for bare-clone fetch/clone operations
-// ---------------------------------------------------------------------------
-
-const repoLocks = new Map<string, Promise<void>>();
-
-function acquireRepoLock(repoName: string): { wait: Promise<void>; release: () => void } {
-  const prev = repoLocks.get(repoName) ?? Promise.resolve();
-  let release!: () => void;
-  const next = new Promise<void>((res) => {
-    release = res;
-  });
-  const chain = prev.then(() => next);
-  repoLocks.set(repoName, chain);
-  chain.finally(() => {
-    if (repoLocks.get(repoName) === chain) {
-      repoLocks.delete(repoName);
-    }
-  });
-  return { wait: prev, release };
-}
-
-interface WorktreeResult {
-  worktreePath: string;
-  cleanup: () => Promise<void>;
-}
-
 // Re-export AnalysisJob from shared-types for backward compatibility with existing imports.
 export type { AnalysisJob } from '@bronco/shared-types';
 
@@ -338,6 +302,8 @@ export interface AnalyzerDeps {
   repoWorkspacePath: string;
   /** AES-256-GCM encryption key for decrypting integration secrets (API keys, etc.). */
   encryptionKey: string;
+  /** MCP repo server URL for code repository access via mcp-repo. */
+  mcpRepoUrl: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -759,139 +725,6 @@ async function sendReceiptConfirmation(
 // ---------------------------------------------------------------------------
 
 /**
- * Clone or pull a git repository to a local directory.
- */
-function validateGitArgument(value: string, kind: 'branch' | 'url'): string {
-  if (value.startsWith('-')) {
-    throw new Error(`Invalid git ${kind}: must not start with '-'`);
-  }
-  if (kind === 'url') {
-    // Only allow https:// and git@ (SSH) URLs
-    if (!/^(https:\/\/|git@)/.test(value)) {
-      throw new Error('Invalid git url: only https:// and git@ (SSH) URLs are allowed');
-    }
-  }
-  if (kind === 'branch') {
-    // git branch names: alphanumeric, slashes, dashes, dots, underscores
-    if (!/^[a-zA-Z0-9._\/-]+$/.test(value)) {
-      throw new Error('Invalid git branch: contains disallowed characters');
-    }
-    // Disallow path traversal sequences in branch names
-    if (value.includes('..')) {
-      throw new Error('Invalid git branch: must not contain ".."');
-    }
-  }
-  return value;
-}
-
-/** Sanitize a search term for use with git grep to prevent argument injection. */
-function sanitizeSearchTerm(term: string): string {
-  // Strip control characters and limit length
-  return term.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
-}
-
-async function ensureRepo(
-  url: string,
-  branch: string,
-  name: string,
-  clientId: string,
-  jobId: string,
-  baseDir: string = DEFAULT_REPO_BASE_DIR,
-): Promise<WorktreeResult> {
-  const safeUrl = validateGitArgument(url, 'url');
-  const safeBranch = validateGitArgument(branch, 'branch');
-
-  // Sanitize repo name to prevent path traversal — use only the basename
-  // and strip any characters that aren't alphanumeric, dash, dot, or underscore.
-  const safeName = basename(name).replace(/[^a-zA-Z0-9._-]/g, '_');
-  if (!safeName) {
-    throw new Error('Invalid repository name');
-  }
-  const safeJobId = basename(jobId).replace(/[^a-zA-Z0-9._-]/g, '_');
-
-  // Sanitize clientId the same way as repo name to prevent path traversal
-  const safeClientId = basename(clientId).replace(/[^a-zA-Z0-9._-]/g, '_');
-
-  // Include clientId in path/lock key to avoid cross-client repo collisions
-  const repoKey = `${safeClientId}_${safeName}`;
-
-  const bareDir = join(baseDir, 'bare');
-  const worktreeDir = join(baseDir, 'worktrees');
-
-  await mkdir(bareDir, { recursive: true });
-  await mkdir(worktreeDir, { recursive: true });
-
-  const barePath = join(bareDir, `${repoKey}.git`);
-
-  // Lock the bare clone so concurrent jobs for the same repo don't race
-  const lock = acquireRepoLock(repoKey);
-  await lock.wait;
-  try {
-    if (existsSync(join(barePath, 'HEAD'))) {
-      // Fetch latest into the bare clone (shallow — full history not needed for analysis)
-      await execFileAsync('git', ['-C', barePath, 'fetch', '--depth', '1', 'origin', safeBranch], { timeout: GIT_CLONE_TIMEOUT_MS });
-      await execFileAsync('git', ['-C', barePath, 'worktree', 'prune']);
-      // Verify the remote branch exists after fetch
-      try {
-        await execFileAsync('git', ['-C', barePath, 'rev-parse', '--verify', `origin/${safeBranch}`]);
-      } catch {
-        throw new Error(`Remote branch 'origin/${safeBranch}' not found in ${safeName}`);
-      }
-      logger.info({ repo: safeName, branch: safeBranch }, 'Bare repo fetched');
-    } else {
-      // If the directory exists without a valid bare repo, remove it first
-      if (existsSync(barePath)) {
-        logger.warn({ repo: safeName }, 'Removing corrupted bare repo directory');
-        await rm(barePath, { recursive: true, force: true });
-      }
-      await execFileAsync('git', [
-        'clone', '--bare', '--single-branch', '--branch', safeBranch,
-        '--depth', '1',
-        safeUrl, barePath,
-      ], { timeout: GIT_CLONE_TIMEOUT_MS });
-      logger.info({ repo: safeName, branch: safeBranch }, 'Bare repo cloned');
-    }
-  } finally {
-    lock.release();
-  }
-
-  // Create a per-job worktree (no lock needed — path is unique)
-  const worktreePath = join(worktreeDir, `${repoKey}-${safeJobId}`);
-
-  // Clean up any stale worktree registration and directory before adding
-  try {
-    await execFileAsync('git', ['-C', barePath, 'worktree', 'remove', '--force', worktreePath]);
-  } catch {
-    // Worktree may not be registered — just clean up the directory
-    if (existsSync(worktreePath)) {
-      await rm(worktreePath, { recursive: true, force: true });
-    }
-  }
-  try {
-    await execFileAsync('git', ['-C', barePath, 'worktree', 'prune']);
-  } catch { /* best effort */ }
-
-  await execFileAsync('git', [
-    '-C', barePath, 'worktree', 'add', '--detach', worktreePath, `origin/${safeBranch}`,
-  ]);
-  logger.info({ repo: safeName, worktree: worktreePath }, 'Worktree created');
-
-  const cleanup = async () => {
-    try {
-      await execFileAsync('git', ['-C', barePath, 'worktree', 'remove', '--force', worktreePath]);
-      logger.debug({ repo: safeName, worktree: worktreePath }, 'Worktree removed');
-    } catch {
-      // Fallback: just delete the directory and let prune clean up metadata
-      try {
-        await rm(worktreePath, { recursive: true, force: true });
-      } catch { /* best effort */ }
-    }
-  };
-
-  return { worktreePath, cleanup };
-}
-
-/**
  * Remove bare repo clones and orphaned worktrees that haven't been
  * accessed within `retentionDays`. Runs best-effort — errors are logged
  * but never propagated.
@@ -943,43 +776,6 @@ export async function cleanupStaleRepos(
     logger.warn({ err, worktreeDir }, 'Failed to list worktree directory for cleanup');
   }
 }
-
-/**
- * Read a set of files from a repo directory, returning their contents
- * truncated to a reasonable size for AI context. Uses a total byte budget
- * instead of an arbitrary file-count cap so that all mentioned files have
- * a chance to be included.
- */
-async function readRepoFiles(
-  repoPath: string,
-  filePaths: string[],
-  maxPerFile = 3000,
-  maxTotalBytes = 60_000,
-): Promise<string> {
-  const absRepoPath = resolve(repoPath);
-  const parts: string[] = [];
-  let totalBytes = 0;
-  for (const fp of filePaths) {
-    if (totalBytes >= maxTotalBytes) break;
-    try {
-      const full = resolve(absRepoPath, fp);
-      // Ensure the resolved path stays within the repo directory
-      if (!full.startsWith(absRepoPath + '/')) {
-        logger.warn({ filePath: fp }, 'Skipping file outside repo boundary');
-        continue;
-      }
-      const content = await readFile(full, 'utf-8');
-      const truncated = content.slice(0, maxPerFile);
-      const formatted = `--- ${fp} ---\n${truncated}\n`;
-      parts.push(formatted);
-      totalBytes += formatted.length;
-    } catch {
-      // File not found or unreadable — skip
-    }
-  }
-  return parts.join('\n');
-}
-
 
 /** Map MCP tool names (snake_case) to REST bridge paths (kebab-case, prefix stripped). */
 const MCP_TOOL_TO_REST_PATH: Record<string, string> = {
@@ -1089,15 +885,10 @@ async function deepAnalysis(
   const failedRepos: Array<{ name: string; error: string }> = [];
 
   try {
-  for (const repo of ticket.client.repositories) {
+  const clientCodeRepos = await db.codeRepo.findMany({ where: { clientId: ticket.clientId, isActive: true } });
+  const initialSessionId = `initial-${ticketId}`;
+  for (const repo of clientCodeRepos) {
     try {
-      const { worktreePath, cleanup } = await ensureRepo(
-        repo.url, repo.branch, repo.name, ticket.clientId, `${ticketId}-${bullmqJobId}`,
-        deps.repoWorkspacePath,
-      );
-      cleanups.push(cleanup);
-
-      // Use git grep to find relevant files based on keywords/errors
       const searchTerms = [
         ...(facts.keywords ?? []),
         ...(facts.filesMentioned ?? []),
@@ -1107,31 +898,47 @@ async function deepAnalysis(
       const relevantFiles = new Set<string>();
 
       for (const rawTerm of searchTerms) {
-        const term = sanitizeSearchTerm(rawTerm);
-        if (!term) continue;
+        if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
+        const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
         try {
-          const { stdout } = await execFileAsync(
-            'git',
-            ['-C', worktreePath, 'grep', '-l', '--max-count=3', '-i', '--', term],
-            { timeout: 10_000 },
+          const grepResult = await callMcpToolViaSdk(
+            deps.mcpRepoUrl, '/mcp', 'repo_exec',
+            { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
           );
-          for (const line of stdout.trim().split('\n').filter(Boolean)) {
-            relevantFiles.add(line);
+          for (const line of grepResult.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+              relevantFiles.add(trimmed);
+            }
           }
         } catch {
           // grep found nothing — that's fine
         }
       }
 
-      // Also check explicitly mentioned files
       for (const f of facts.filesMentioned ?? []) {
         relevantFiles.add(f);
       }
 
       if (relevantFiles.size > 0) {
-        const content = await readRepoFiles(worktreePath, [...relevantFiles]);
-        if (content) {
-          codeContext.push(`## Repository: ${repo.name}\n\n${content}`);
+        const fileParts: string[] = [];
+        let totalBytes = 0;
+        for (const fp of relevantFiles) {
+          if (totalBytes >= 60_000) break;
+          try {
+            const catResult = await callMcpToolViaSdk(
+              deps.mcpRepoUrl, '/mcp', 'repo_exec',
+              { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `cat ${fp}` },
+            );
+            const content = catResult.split('\n').filter(l => !l.startsWith('[session:')).join('\n');
+            const truncated = content.slice(0, 3000);
+            const formatted = `--- ${fp} ---\n${truncated}\n`;
+            fileParts.push(formatted);
+            totalBytes += formatted.length;
+          } catch { /* file not found or unreadable */ }
+        }
+        if (fileParts.length > 0) {
+          codeContext.push(`## Repository: ${repo.name}\n\n${fileParts.join('\n')}`);
         }
       }
     } catch (err) {
@@ -1140,6 +947,8 @@ async function deepAnalysis(
       appLog.warn(`Repo context unavailable for ${repo.name}: ${errMsg}`, { ticketId, repo: repo.name, err }, ticketId, 'ticket');
     }
   }
+  // Clean up session worktrees
+  try { await callMcpToolViaSdk(deps.mcpRepoUrl, '/mcp', 'repo_cleanup', { sessionId: initialSessionId }); } catch { /* best effort */ }
 
   // --- Gather context from MCP (database) ---
   let dbContext = '';
@@ -1703,20 +1512,24 @@ interface McpIntegrationInfo {
 
 /**
  * Build Claude tool definitions from a client's active MCP_DATABASE integrations
- * and code repositories. MCP tool names are prefixed with the integration label
- * to disambiguate across servers (e.g. `prod-db__get_blocking_tree`).
+ * and code repositories (via mcp-repo). MCP tool names are prefixed with the
+ * integration label to disambiguate across servers (e.g. `prod-db__get_blocking_tree`).
  */
 async function buildAgenticTools(
   db: PrismaClient,
   clientId: string,
   encryptionKey: string,
-  repos: Array<{ name: string; url: string; branch: string }>,
+  mcpRepoUrl: string,
+  apiKey?: string,
+  mcpAuthToken?: string,
 ): Promise<{
   tools: AIToolDefinition[];
   mcpIntegrations: Map<string, McpIntegrationInfo>;
+  repoIdByPrefix: Map<string, string>;
 }> {
   const tools: AIToolDefinition[] = [];
   const mcpIntegrations = new Map<string, McpIntegrationInfo>();
+  const repoIdByPrefix = new Map<string, string>();
 
   // Collect MCP_DATABASE integrations
   const integrations = await db.clientIntegration.findMany({
@@ -1730,10 +1543,10 @@ async function buildAgenticTools(
     if (!url) continue;
 
     // Decrypt API key if present
-    let apiKey: string | undefined;
+    let integApiKey: string | undefined;
     if (typeof cfg['apiKey'] === 'string' && cfg['apiKey']) {
       try {
-        apiKey = looksEncrypted(cfg['apiKey'])
+        integApiKey = looksEncrypted(cfg['apiKey'])
           ? decrypt(cfg['apiKey'], encryptionKey)
           : cfg['apiKey'];
       } catch (err) {
@@ -1747,7 +1560,7 @@ async function buildAgenticTools(
     const prefix = `${labelSlug}-${integ.id.slice(0, 8)}`;
 
     const mcpPath = typeof cfg['mcpPath'] === 'string' ? cfg['mcpPath'] : undefined;
-    mcpIntegrations.set(prefix, { label: integ.label, url, mcpPath, apiKey, authHeader });
+    mcpIntegrations.set(prefix, { label: integ.label, url, mcpPath, apiKey: integApiKey, authHeader });
 
     // Read tool metadata — includes inputSchema from discovery
     const disabledTools = new Set(
@@ -1768,36 +1581,64 @@ async function buildAgenticTools(
     }
   }
 
-  // Add repo tools if repos exist
+  // Discover mcp-repo tools for client repositories
+  const repos = await db.codeRepo.findMany({ where: { clientId, isActive: true } });
   if (repos.length > 0) {
-    const repoNames = repos.map((r) => r.name);
+    // Resolve auth for mcp-repo — prefer MCP_AUTH_TOKEN, fall back to API_KEY
+    const repoAuth = mcpAuthToken || apiKey;
+    const repoAuthHeader = mcpAuthToken ? 'bearer' : 'x-api-key';
+
+    // Register shared mcp-repo integration for list_repos and repo_cleanup
+    mcpIntegrations.set('repo', { label: 'mcp-repo', url: mcpRepoUrl, mcpPath: '/mcp', apiKey: repoAuth, authHeader: repoAuthHeader });
+
     tools.push({
-      name: 'search_repo',
-      description: `Search code repositories using git grep. Available repos: ${repoNames.join(', ')}`,
+      name: 'repo__list_repos',
+      description: 'List available code repositories registered for this client.',
       input_schema: {
         type: 'object',
         properties: {
-          repo: { type: 'string', description: 'Repository name', enum: repoNames },
-          query: { type: 'string', description: 'Search pattern (git grep pattern)' },
+          clientId: { type: 'string', description: 'Client ID to filter by' },
         },
-        required: ['repo', 'query'],
       },
     });
+
     tools.push({
-      name: 'read_file',
-      description: `Read a file from a code repository. Available repos: ${repoNames.join(', ')}`,
+      name: 'repo__repo_cleanup',
+      description: 'Release a session\'s repository worktrees to free disk space.',
       input_schema: {
         type: 'object',
         properties: {
-          repo: { type: 'string', description: 'Repository name', enum: repoNames },
-          path: { type: 'string', description: 'File path relative to repo root' },
+          sessionId: { type: 'string', description: 'The session ID to clean up' },
         },
-        required: ['repo', 'path'],
+        required: ['sessionId'],
       },
     });
+
+    // Register per-repo repo_exec tools with repoId baked in
+    for (const repo of repos) {
+      const prefix = `repo-${repo.name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()}-${repo.id.slice(0, 8)}`;
+      repoIdByPrefix.set(prefix, repo.id);
+
+      // Register this prefix to point at mcp-repo
+      mcpIntegrations.set(prefix, { label: `repo:${repo.name}`, url: mcpRepoUrl, mcpPath: '/mcp', apiKey: repoAuth, authHeader: repoAuthHeader });
+
+      // Build a modified input schema for repo_exec with repoId removed
+      tools.push({
+        name: `${prefix}__repo_exec`,
+        description: `[${repo.name}] ${repo.description || 'Code repository'}. Execute a read-only shell command in a sandboxed worktree. Allowed: grep, find, cat, head, tail, ls, tree, diff, stat. Pipes to grep/sed/awk/sort allowed.`,
+        input_schema: {
+          type: 'object',
+          properties: {
+            command: { type: 'string', description: 'The shell command to execute' },
+            sessionId: { type: 'string', description: 'Session ID for worktree reuse (auto-generated if omitted)' },
+          },
+          required: ['command'],
+        },
+      });
+    }
   }
 
-  return { tools, mcpIntegrations };
+  return { tools, mcpIntegrations, repoIdByPrefix };
 }
 
 /**
@@ -1807,45 +1648,12 @@ async function buildAgenticTools(
 async function executeAgenticToolCall(
   toolCall: AIToolUseBlock,
   mcpIntegrations: Map<string, McpIntegrationInfo>,
-  worktrees: Map<string, string>,
+  repoIdByPrefix: Map<string, string>,
+  clientId?: string,
 ): Promise<{ toolUseId: string; result: string; isError: boolean }> {
   const { id: toolUseId, name, input } = toolCall;
 
   try {
-    // Check for repo tools first
-    if (name === 'search_repo') {
-      const repoName = input['repo'] as string;
-      const query = input['query'] as string;
-      const worktreePath = worktrees.get(repoName);
-      if (!worktreePath) {
-        return { toolUseId, result: `Repository "${repoName}" not available`, isError: true };
-      }
-      const sanitized = sanitizeSearchTerm(query);
-      if (!sanitized) {
-        return { toolUseId, result: 'Invalid search query', isError: true };
-      }
-      try {
-        const { stdout } = await execFileAsync(
-          'git', ['-C', worktreePath, 'grep', '-n', '--max-count=20', '-i', '--', sanitized],
-          { timeout: 15_000, maxBuffer: 256 * 1024 },
-        );
-        return { toolUseId, result: stdout.trim() || 'No matches found', isError: false };
-      } catch {
-        return { toolUseId, result: 'No matches found', isError: false };
-      }
-    }
-
-    if (name === 'read_file') {
-      const repoName = input['repo'] as string;
-      const filePath = input['path'] as string;
-      const worktreePath = worktrees.get(repoName);
-      if (!worktreePath) {
-        return { toolUseId, result: `Repository "${repoName}" not available`, isError: true };
-      }
-      const content = await readRepoFiles(worktreePath, [filePath], 5000, 30_000);
-      return { toolUseId, result: content || 'File not found or empty', isError: false };
-    }
-
     // MCP tool — parse prefix
     const sepIndex = name.indexOf('__');
     if (sepIndex === -1) {
@@ -1858,11 +1666,20 @@ async function executeAgenticToolCall(
       return { toolUseId, result: `No MCP integration found for prefix "${prefix}"`, isError: true };
     }
 
+    // For repo_exec, inject the baked-in repoId and clientId for defense-in-depth
+    let toolInput = input;
+    if (actualToolName === 'repo_exec') {
+      const repoId = repoIdByPrefix.get(prefix);
+      if (repoId) {
+        toolInput = { ...input, repoId, ...(clientId ? { clientId } : {}) };
+      }
+    }
+
     const result = await callMcpToolViaSdk(
       integration.url,
       integration.mcpPath,
       actualToolName,
-      input,
+      toolInput,
       integration.apiKey,
       integration.authHeader,
     );
@@ -2111,7 +1928,7 @@ async function executeOrchestratedSubTask(
   task: { prompt: string; tools: string[]; model: string },
   agenticTools: AIToolDefinition[],
   mcpIntegrations: Map<string, McpIntegrationInfo>,
-  worktrees: Map<string, string>,
+  repoIdByPrefix: Map<string, string>,
 ): Promise<SubTaskResult> {
   const { ai } = deps;
   const model = ORCHESTRATED_MODEL_MAP[task.model] ?? ORCHESTRATED_MODEL_MAP.sonnet;
@@ -2196,7 +2013,7 @@ async function executeOrchestratedSubTask(
 
         for (const toolUse of toolUseBlocks) {
           const start = Date.now();
-          const result = await executeAgenticToolCall(toolUse, mcpIntegrations, worktrees);
+          const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId);
           const elapsed = Date.now() - start;
           passToolCalls.push({
             tool: toolUse.name,
@@ -2722,21 +2539,16 @@ async function executeRoutePipeline(
       }
 
       case RouteStepType.GATHER_REPO_CONTEXT: {
-        // Reload ticket to get repos
-        ticket = await db.ticket.findUnique({
-          where: { id: ticketId },
-          include: { client: { include: { repositories: { where: { isActive: true } } } }, system: true },
-        });
-        if (!ticket || !ticket.client) break;
+        // Query client repos via CodeRepo model
+        const clientRepos = await db.codeRepo.findMany({ where: { clientId: ticket?.clientId, isActive: true } });
+        if (!ticket || clientRepos.length === 0) break;
 
-        for (const repo of ticket.client.repositories) {
+        const gatherSessionId = `gather-${ticketId}`;
+        const mcpRepoUrl = deps.mcpRepoUrl;
+        const repoAuth = undefined; // mcp-repo uses same auth as env — handled by callMcpToolViaSdk
+
+        for (const repo of clientRepos) {
           try {
-            const { worktreePath, cleanup } = await ensureRepo(
-              repo.url, repo.branch, repo.name, ticket.clientId, `${ticketId}-${bullmqJobId}`,
-              deps.repoWorkspacePath,
-            );
-            cleanups.push(cleanup);
-
             const searchTerms = [
               ...(facts.keywords ?? []),
               ...(facts.filesMentioned ?? []),
@@ -2745,25 +2557,48 @@ async function executeRoutePipeline(
 
             const relevantFiles = new Set<string>();
             for (const rawTerm of searchTerms) {
-              const term = sanitizeSearchTerm(rawTerm);
-              if (!term) continue;
+              if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
+              const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
               try {
-                const { stdout } = await execFileAsync(
-                  'git', ['-C', worktreePath, 'grep', '-l', '--max-count=3', '-i', '--', term],
-                  { timeout: 10_000 },
+                const grepResult = await callMcpToolViaSdk(
+                  mcpRepoUrl, '/mcp', 'repo_exec',
+                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
+                  repoAuth,
                 );
-                for (const line of stdout.trim().split('\n').filter(Boolean)) {
-                  relevantFiles.add(line);
+                // Parse file paths from stdout (skip the [session:...] line)
+                for (const line of grepResult.split('\n')) {
+                  const trimmed = line.trim();
+                  if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+                    relevantFiles.add(trimmed);
+                  }
                 }
               } catch { /* grep found nothing */ }
             }
             for (const f of facts.filesMentioned ?? []) {
               relevantFiles.add(f);
             }
+
             if (relevantFiles.size > 0) {
-              const content = await readRepoFiles(worktreePath, [...relevantFiles]);
-              if (content) {
-                codeContext.push(`## Repository: ${repo.name}\n\n${content}`);
+              const fileParts: string[] = [];
+              let totalBytes = 0;
+              for (const fp of relevantFiles) {
+                if (totalBytes >= 60_000) break;
+                try {
+                  const catResult = await callMcpToolViaSdk(
+                    mcpRepoUrl, '/mcp', 'repo_exec',
+                    { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `cat ${fp}` },
+                    repoAuth,
+                  );
+                  // Strip the [session:...] prefix line
+                  const content = catResult.split('\n').filter(l => !l.startsWith('[session:')).join('\n');
+                  const truncated = content.slice(0, 3000);
+                  const formatted = `--- ${fp} ---\n${truncated}\n`;
+                  fileParts.push(formatted);
+                  totalBytes += formatted.length;
+                } catch { /* file not found or unreadable */ }
+              }
+              if (fileParts.length > 0) {
+                codeContext.push(`## Repository: ${repo.name}\n\n${fileParts.join('\n')}`);
               }
             }
           } catch (err) {
@@ -2771,12 +2606,17 @@ async function executeRoutePipeline(
             appLog.warn(`Repo context unavailable for ${repo.name}: ${errMsg}`, { ticketId, repo: repo.name, err }, ticketId, 'ticket');
           }
         }
+
+        // Clean up the gather session worktrees
+        try {
+          await callMcpToolViaSdk(mcpRepoUrl, '/mcp', 'repo_cleanup', { sessionId: gatherSessionId });
+        } catch { /* best effort */ }
+
         {
           const stepDuration = Date.now() - stepStart;
-          const repoCount = ticket?.client?.repositories.length ?? 0;
           appLog.info(
-            `Repo context gathered: ${repoCount} repos checked, ${codeContext.length} with results (${(stepDuration / 1000).toFixed(1)}s)`,
-            { ticketId, reposChecked: repoCount, reposWithResults: codeContext.length, durationMs: stepDuration },
+            `Repo context gathered: ${clientRepos.length} repos checked, ${codeContext.length} with results (${(stepDuration / 1000).toFixed(1)}s)`,
+            { ticketId, reposChecked: clientRepos.length, reposWithResults: codeContext.length, durationMs: stepDuration },
             ticketId, 'ticket',
           );
         }
@@ -2910,34 +2750,14 @@ async function executeRoutePipeline(
           break;
         }
 
-        const repos = ticket.client.repositories.map((r) => ({
-          name: r.name, url: r.url, branch: r.branch,
-        }));
-
-        // Build tool definitions from MCP integrations and repos
-        const { tools: agenticTools, mcpIntegrations } = await buildAgenticTools(
-          db, ticket.clientId, deps.encryptionKey, repos,
+        // Build tool definitions from MCP integrations and mcp-repo
+        const { tools: agenticTools, mcpIntegrations, repoIdByPrefix } = await buildAgenticTools(
+          db, ticket.clientId, deps.encryptionKey, deps.mcpRepoUrl,
         );
 
         if (agenticTools.length === 0) {
           appLog.info('No tools available for agentic analysis, skipping', { ticketId }, ticketId, 'ticket');
           break;
-        }
-
-        // Set up worktrees for repo tools
-        const worktrees = new Map<string, string>();
-        for (const repo of repos) {
-          try {
-            const { worktreePath, cleanup } = await ensureRepo(
-              repo.url, repo.branch, repo.name, ticket.clientId,
-              `${ticketId}-agentic-${bullmqJobId}`, deps.repoWorkspacePath,
-            );
-            worktrees.set(repo.name, worktreePath);
-            cleanups.push(cleanup);
-          } catch (err) {
-            const errMsg = redactUrls(err instanceof Error ? err.message : String(err));
-            appLog.warn(`Repo unavailable for agentic analysis: ${repo.name}: ${errMsg}`, { ticketId, repo: repo.name }, ticketId, 'ticket');
-          }
         }
 
         // ── Strategy check: orchestrated vs full_context ──
@@ -3054,7 +2874,7 @@ async function executeRoutePipeline(
             const taskBatches = chunkArray(plan.tasks, maxParallelTasks);
             for (const batch of taskBatches) {
               const results = await Promise.allSettled(
-                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, task, agenticTools, mcpIntegrations, worktrees)),
+                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, task, agenticTools, mcpIntegrations, repoIdByPrefix)),
               );
 
               for (let j = 0; j < results.length; j++) {
@@ -3068,7 +2888,7 @@ async function executeRoutePipeline(
                 } else {
                   // Retry once on failure
                   try {
-                    const retryResult = await executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, task, agenticTools, mcpIntegrations, worktrees);
+                    const retryResult = await executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, task, agenticTools, mcpIntegrations, repoIdByPrefix);
                     knowledgeDoc += `\n\n#### ${task.prompt} (retry)\n${retryResult.content}`;
                     orchTotalInputTokens += retryResult.inputTokens;
                     orchTotalOutputTokens += retryResult.outputTokens;
@@ -3288,7 +3108,7 @@ async function executeRoutePipeline(
 
           for (const toolUse of toolUseBlocks) {
             const start = Date.now();
-            const result = await executeAgenticToolCall(toolUse, mcpIntegrations, worktrees);
+            const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId);
             const elapsed = Date.now() - start;
             toolCallLog.push({
               tool: toolUse.name,
@@ -3615,49 +3435,36 @@ async function executeRoutePipeline(
           }
         }
 
-        // Gather fresh repo context
+        // Gather fresh repo context via mcp-repo
         if (queryCfg.repoSearches?.length) {
-          ticket = await db.ticket.findUnique({
-            where: { id: ticketId },
-            include: { client: { include: { repositories: { where: { isActive: true } } } }, system: true },
-          });
-          if (ticket?.client) {
+          const customRepos = await db.codeRepo.findMany({ where: { clientId, isActive: true } });
+          if (customRepos.length > 0) {
             const freshRepoParts: string[] = [];
-            // Cache worktree paths by repo id to avoid repeated ensureRepo calls
-            // when the same repo appears across multiple searches.
-            const repoWorktreeCache = new Map<string, string>();
+            const customSessionId = `custom-${ticketId}-${bullmqJobId}`;
             for (const rs of queryCfg.repoSearches) {
-              const repos = rs.repoName
-                ? ticket.client.repositories.filter((r) => r.name === rs.repoName)
-                : ticket.client.repositories;
+              const targetRepos = rs.repoName
+                ? customRepos.filter((r) => r.name === rs.repoName)
+                : customRepos;
 
-              for (const repo of repos) {
+              for (const repo of targetRepos) {
                 try {
-                  let worktreePath = repoWorktreeCache.get(repo.id);
-                  if (!worktreePath) {
-                    const { worktreePath: wtp, cleanup } = await ensureRepo(
-                      repo.url, repo.branch, repo.name, ticket.clientId,
-                      `${ticketId}-custom-${bullmqJobId}`, deps.repoWorkspacePath,
-                    );
-                    worktreePath = wtp;
-                    repoWorktreeCache.set(repo.id, worktreePath);
-                    cleanups.push(cleanup);
-                  }
-
                   const relevantFiles = new Set<string>();
 
                   // Search by terms (skip non-string entries from untyped JSON config)
                   for (const rawTerm of rs.searchTerms ?? []) {
                     if (typeof rawTerm !== 'string') continue;
-                    const term = sanitizeSearchTerm(rawTerm);
-                    if (!term) continue;
+                    const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+                    if (!sanitized) continue;
                     try {
-                      const { stdout } = await execFileAsync(
-                        'git', ['-C', worktreePath, 'grep', '-l', '--max-count=3', '-i', '--', term],
-                        { timeout: 10_000 },
+                      const grepResult = await callMcpToolViaSdk(
+                        deps.mcpRepoUrl, '/mcp', 'repo_exec',
+                        { repoId: repo.id, sessionId: customSessionId, clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
                       );
-                      for (const line of stdout.trim().split('\n').filter(Boolean)) {
-                        relevantFiles.add(line);
+                      for (const line of grepResult.split('\n')) {
+                        const trimmed = line.trim();
+                        if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+                          relevantFiles.add(trimmed);
+                        }
                       }
                     } catch { /* grep found nothing */ }
                   }
@@ -3675,9 +3482,24 @@ async function executeRoutePipeline(
                   }
 
                   if (relevantFiles.size > 0) {
-                    const content = await readRepoFiles(worktreePath, [...relevantFiles]);
-                    if (content) {
-                      freshRepoParts.push(`### Repository: ${repo.name}`, '', content, '');
+                    const fileParts: string[] = [];
+                    let totalBytes = 0;
+                    for (const fp of relevantFiles) {
+                      if (totalBytes >= 60_000) break;
+                      try {
+                        const catResult = await callMcpToolViaSdk(
+                          deps.mcpRepoUrl, '/mcp', 'repo_exec',
+                          { repoId: repo.id, sessionId: customSessionId, clientId, command: `cat ${fp}` },
+                        );
+                        const content = catResult.split('\n').filter(l => !l.startsWith('[session:')).join('\n');
+                        const truncated = content.slice(0, 3000);
+                        const formatted = `--- ${fp} ---\n${truncated}\n`;
+                        fileParts.push(formatted);
+                        totalBytes += formatted.length;
+                      } catch { /* file not found or unreadable */ }
+                    }
+                    if (fileParts.length > 0) {
+                      freshRepoParts.push(`### Repository: ${repo.name}`, '', fileParts.join('\n'), '');
                     }
                   }
                 } catch (err) {
@@ -3686,6 +3508,8 @@ async function executeRoutePipeline(
                 }
               }
             }
+            // Clean up session worktrees
+            try { await callMcpToolViaSdk(deps.mcpRepoUrl, '/mcp', 'repo_cleanup', { sessionId: customSessionId }); } catch { /* best effort */ }
             if (freshRepoParts.length > 0) {
               promptParts.push('## Fresh Repository Context', '', ...freshRepoParts);
             }

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -27,6 +27,18 @@ function sanitizeName(raw: string, maxLen = 120): string {
   return raw.replace(/[\x00-\x1f\x7f-\x9f]/g, '').trim().slice(0, maxLen);
 }
 
+/**
+ * Sanitize a file path for safe use in shell commands within repo worktrees.
+ * Rejects absolute paths, paths with `..` segments, and strips leading `./`.
+ * Returns null for invalid paths, the sanitized path for valid ones.
+ */
+function sanitizeFilePath(fp: string): string | null {
+  if (!fp || fp.startsWith('/')) return null;
+  const normalized = fp.replace(/\\/g, '/');
+  if (normalized.split('/').some(seg => seg === '..')) return null;
+  return normalized.replace(/^\.\//, '');
+}
+
 /** Max events to include in ticket summary prompts to bound prompt size. */
 const SUMMARY_EVENT_LIMIT = 50;
 
@@ -903,11 +915,12 @@ async function deepAnalysis(
         try {
           const grepResult = await callMcpToolViaSdk(
             deps.mcpRepoUrl, '/mcp', 'repo_exec',
-            { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
+            { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" .` },
           );
+          const exts = ['.sql', '.cs', '.ts'];
           for (const line of grepResult.split('\n')) {
             const trimmed = line.trim();
-            if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+            if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]') && exts.some(e => trimmed.endsWith(e))) {
               relevantFiles.add(trimmed);
             }
           }
@@ -923,12 +936,14 @@ async function deepAnalysis(
       if (relevantFiles.size > 0) {
         const fileParts: string[] = [];
         let totalBytes = 0;
-        for (const fp of relevantFiles) {
+        for (const rawFp of relevantFiles) {
           if (totalBytes >= 60_000) break;
+          const fp = sanitizeFilePath(rawFp);
+          if (!fp) continue;
           try {
             const catResult = await callMcpToolViaSdk(
               deps.mcpRepoUrl, '/mcp', 'repo_exec',
-              { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `cat ${fp}` },
+              { repoId: repo.id, sessionId: initialSessionId, clientId: ticket.clientId, command: `cat '${fp.replace(/'/g, "'\\''")}'` },
             );
             const content = catResult.split('\n').filter(l => !l.startsWith('[session:')).join('\n');
             const truncated = content.slice(0, 3000);
@@ -1599,6 +1614,7 @@ async function buildAgenticTools(
         properties: {
           clientId: { type: 'string', description: 'Client ID to filter by' },
         },
+        required: ['clientId'],
       },
     });
 
@@ -1667,12 +1683,15 @@ async function executeAgenticToolCall(
     }
 
     // For repo_exec, inject the baked-in repoId and clientId for defense-in-depth
+    // For list_repos, inject clientId to prevent cross-client repo enumeration
     let toolInput = input;
     if (actualToolName === 'repo_exec') {
       const repoId = repoIdByPrefix.get(prefix);
       if (repoId) {
         toolInput = { ...input, repoId, ...(clientId ? { clientId } : {}) };
       }
+    } else if (actualToolName === 'list_repos' && clientId) {
+      toolInput = { ...input, clientId };
     }
 
     const result = await callMcpToolViaSdk(
@@ -2539,9 +2558,10 @@ async function executeRoutePipeline(
       }
 
       case RouteStepType.GATHER_REPO_CONTEXT: {
+        if (!ticket) break;
         // Query client repos via CodeRepo model
-        const clientRepos = await db.codeRepo.findMany({ where: { clientId: ticket?.clientId, isActive: true } });
-        if (!ticket || clientRepos.length === 0) break;
+        const clientRepos = await db.codeRepo.findMany({ where: { clientId: ticket.clientId, isActive: true } });
+        if (clientRepos.length === 0) break;
 
         const gatherSessionId = `gather-${ticketId}`;
         const mcpRepoUrl = deps.mcpRepoUrl;
@@ -2562,13 +2582,14 @@ async function executeRoutePipeline(
               try {
                 const grepResult = await callMcpToolViaSdk(
                   mcpRepoUrl, '/mcp', 'repo_exec',
-                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
+                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" .` },
                   repoAuth,
                 );
                 // Parse file paths from stdout (skip the [session:...] line)
+                const exts = ['.sql', '.cs', '.ts'];
                 for (const line of grepResult.split('\n')) {
                   const trimmed = line.trim();
-                  if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+                  if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]') && exts.some(e => trimmed.endsWith(e))) {
                     relevantFiles.add(trimmed);
                   }
                 }
@@ -2581,12 +2602,14 @@ async function executeRoutePipeline(
             if (relevantFiles.size > 0) {
               const fileParts: string[] = [];
               let totalBytes = 0;
-              for (const fp of relevantFiles) {
+              for (const rawFp of relevantFiles) {
                 if (totalBytes >= 60_000) break;
+                const fp = sanitizeFilePath(rawFp);
+                if (!fp) continue;
                 try {
                   const catResult = await callMcpToolViaSdk(
                     mcpRepoUrl, '/mcp', 'repo_exec',
-                    { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `cat ${fp}` },
+                    { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `cat '${fp.replace(/'/g, "'\\''")}'` },
                     repoAuth,
                   );
                   // Strip the [session:...] prefix line
@@ -3458,11 +3481,12 @@ async function executeRoutePipeline(
                     try {
                       const grepResult = await callMcpToolViaSdk(
                         deps.mcpRepoUrl, '/mcp', 'repo_exec',
-                        { repoId: repo.id, sessionId: customSessionId, clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" . --include="*.sql" --include="*.cs" --include="*.ts"` },
+                        { repoId: repo.id, sessionId: customSessionId, clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" .` },
                       );
+                      const exts = ['.sql', '.cs', '.ts'];
                       for (const line of grepResult.split('\n')) {
                         const trimmed = line.trim();
-                        if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]')) {
+                        if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]') && exts.some(e => trimmed.endsWith(e))) {
                           relevantFiles.add(trimmed);
                         }
                       }
@@ -3484,12 +3508,14 @@ async function executeRoutePipeline(
                   if (relevantFiles.size > 0) {
                     const fileParts: string[] = [];
                     let totalBytes = 0;
-                    for (const fp of relevantFiles) {
+                    for (const rawFp of relevantFiles) {
                       if (totalBytes >= 60_000) break;
+                      const fp = sanitizeFilePath(rawFp);
+                      if (!fp) continue;
                       try {
                         const catResult = await callMcpToolViaSdk(
                           deps.mcpRepoUrl, '/mcp', 'repo_exec',
-                          { repoId: repo.id, sessionId: customSessionId, clientId, command: `cat ${fp}` },
+                          { repoId: repo.id, sessionId: customSessionId, clientId, command: `cat '${fp.replace(/'/g, "'\\''")}'` },
                         );
                         const content = catResult.split('\n').filter(l => !l.startsWith('[session:')).join('\n');
                         const truncated = content.slice(0, 3000);

--- a/services/ticket-analyzer/src/config.ts
+++ b/services/ticket-analyzer/src/config.ts
@@ -14,6 +14,8 @@ const configSchema = z.object({
   EMAIL_SENDER_NAME: z.string().optional().default('Support Team'),
   // MCP database server (defaults to internal mcp-database service for DB issue analysis)
   MCP_DATABASE_URL: z.string().url().optional().default('http://mcp-database:3100'),
+  // MCP repo server (defaults to internal mcp-repo service for code repository access)
+  MCP_REPO_URL: z.string().default('http://mcp-repo:3111'),
   // Artifact storage is opt-in — only activated when explicitly set
   ARTIFACT_STORAGE_PATH: z.string().optional(),
   REPO_WORKSPACE_PATH: z.string().default('/tmp/bronco-repos'),

--- a/services/ticket-analyzer/src/config.ts
+++ b/services/ticket-analyzer/src/config.ts
@@ -15,7 +15,7 @@ const configSchema = z.object({
   // MCP database server (defaults to internal mcp-database service for DB issue analysis)
   MCP_DATABASE_URL: z.string().url().optional().default('http://mcp-database:3100'),
   // MCP repo server (defaults to internal mcp-repo service for code repository access)
-  MCP_REPO_URL: z.string().default('http://mcp-repo:3111'),
+  MCP_REPO_URL: z.string().url().default('http://mcp-repo:3111'),
   // Artifact storage is opt-in — only activated when explicitly set
   ARTIFACT_STORAGE_PATH: z.string().optional(),
   REPO_WORKSPACE_PATH: z.string().default('/tmp/bronco-repos'),

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -62,6 +62,7 @@ async function main(): Promise<void> {
     senderSignature,
     repoWorkspacePath: config.REPO_WORKSPACE_PATH,
     encryptionKey: config.ENCRYPTION_KEY,
+    mcpRepoUrl: config.MCP_REPO_URL,
   });
   const analysisWorker = createWorker<AnalysisJob>(
     'ticket-analysis',


### PR DESCRIPTION
## Summary
This PR migrates code repository access from local git operations to a centralized mcp-repo MCP server. Instead of cloning/fetching repositories locally and managing worktrees in-process, the system now delegates all repository operations to the mcp-repo service via MCP tool calls.

## Key Changes

- **Removed local git operations**: Deleted `ensureRepo()`, `validateGitArgument()`, `sanitizeSearchTerm()`, and `readRepoFiles()` functions that handled local repository cloning, fetching, and file reading
- **Removed in-process mutex**: Deleted the `repoLocks` map and `acquireRepoLock()` function that synchronized concurrent git operations
- **Removed git/fs imports**: Cleaned up unused imports (`execFile`, `existsSync`, `mkdir`, `readFile`, `basename`, `promisify`)
- **Added mcp-repo integration**: 
  - New `mcpRepoUrl` dependency in `AnalyzerDeps`
  - Repository operations now use `callMcpToolViaSdk()` to invoke `repo_exec` commands on mcp-repo
  - Added `repo__list_repos` and `repo__repo_cleanup` tools for repository management
  - Per-repository tools (`repo_exec`) are dynamically registered with baked-in `repoId` for security
- **Updated tool execution**: Modified `executeAgenticToolCall()` to inject `repoId` and `clientId` into repo_exec tool calls for defense-in-depth validation
- **Refactored repository context gathering**: 
  - `GATHER_REPO_CONTEXT` route step now queries `CodeRepo` model and uses mcp-repo for grep/cat operations
  - Inline file reading logic replaces the deleted `readRepoFiles()` function
  - Session-based worktree management via `repo_cleanup` tool
- **Updated database schema**: Added optional `description` field to `CodeRepo` model to help AI understand repository contents
- **Updated configuration**: Added `MCP_REPO_URL` config variable to both ticket-analyzer and slack-worker services
- **Updated Slack worker**: Integrated mcp-repo tool discovery and routing in `handleHugoConversation()` with proper tool prefix tracking

## Implementation Details

- Repository grep/cat operations now use mcp-repo's `repo_exec` tool with sanitized commands
- Session IDs are used to group related repository operations for efficient worktree reuse and cleanup
- The `repoIdByPrefix` map tracks which tool prefixes correspond to which repository IDs, enabling secure tool invocation
- File content is still truncated to 3000 bytes per file and 60KB total per repository to bound AI context
- Control characters are stripped from search terms inline (replacing the deleted `sanitizeSearchTerm()` function)
- Ownership validation is performed server-side in mcp-repo when `clientId` is provided

https://claude.ai/code/session_0112M8QfUpKikvUTQkhXH2SK