### PR TITLE
Add support for sending notifications to specific operators

### DIFF
--- a/packages/shared-utils/src/notify-operators.ts
+++ b/packages/shared-utils/src/notify-operators.ts
@@ -245,7 +245,7 @@ async function dispatchWithPreference(
       } else if (slackTarget.startsWith('operator:')) {
         const id = slackTarget.slice('operator:'.length);
         const op = operators.find(o => o.id === id);
-        if (op?.slackUserId) {
+        if (op?.slackUserId && op.notifySlack) {
           if (opts.slack.sendDMWithTs) {
             const result = await opts.slack.sendDMWithTs(op.slackUserId, slackText, blocks);
             slackMessages.push({ ...result, operatorId: op.id });
@@ -260,7 +260,7 @@ async function dispatchWithPreference(
           } else {
             await opts.slack.sendMessage(opts.defaultSlackChannelId, slackText, blocks);
           }
-          logger.info({ event: opts.event }, 'Specific operator has no slackUserId — sent to default channel');
+          logger.info({ event: opts.event }, 'Specific operator not eligible for Slack DM — sent to default channel');
         }
       } else {
         // Treat as a channel ID

--- a/packages/shared-utils/src/notify-operators.ts
+++ b/packages/shared-utils/src/notify-operators.ts
@@ -242,6 +242,26 @@ async function dispatchWithPreference(
             }
           }
         }
+      } else if (slackTarget.startsWith('operator:')) {
+        const id = slackTarget.slice('operator:'.length);
+        const op = operators.find(o => o.id === id);
+        if (op?.slackUserId) {
+          if (opts.slack.sendDMWithTs) {
+            const result = await opts.slack.sendDMWithTs(op.slackUserId, slackText, blocks);
+            slackMessages.push({ ...result, operatorId: op.id });
+          } else {
+            await opts.slack.sendDM(op.slackUserId, slackText, blocks);
+          }
+          logger.info({ slackUserId: op.slackUserId, event: opts.event }, 'Event-driven Slack DM sent to specific operator');
+        } else if (opts.defaultSlackChannelId) {
+          if (opts.slack.sendMessageWithTs) {
+            const result = await opts.slack.sendMessageWithTs(opts.defaultSlackChannelId, slackText, blocks);
+            slackMessages.push({ ...result });
+          } else {
+            await opts.slack.sendMessage(opts.defaultSlackChannelId, slackText, blocks);
+          }
+          logger.info({ event: opts.event }, 'Specific operator has no slackUserId — sent to default channel');
+        }
       } else {
         // Treat as a channel ID
         if (opts.slack.sendMessageWithTs) {
@@ -278,6 +298,12 @@ function resolveEmailRecipients(
 
   if (emailTarget === 'all_operators') {
     return operators.filter(o => o.notifyEmail).map(o => o.email);
+  }
+
+  if (emailTarget.startsWith('operator:')) {
+    const id = emailTarget.slice('operator:'.length);
+    const op = operators.find(o => o.id === id && o.notifyEmail);
+    return op ? [op.email] : [];
   }
 
   // Specific email address

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -285,15 +285,21 @@ export class NotificationPreferencesComponent implements OnInit {
     } else if (value === 'custom') {
       pref.slackTarget = '';
     } else if (value === 'specific_operator') {
-      pref.slackTarget = '';
+      // Use 'operator:' prefix as placeholder so slackTargetSelection() keeps returning
+      // 'specific_operator' until the user picks an operator from the dropdown.
+      pref.slackTarget = 'operator:';
     } else {
       pref.slackTarget = value;
     }
   }
 
   onEmailTargetChange(pref: NotificationPreference, value: string): void {
-    if (value === 'custom' || value === 'specific_operator') {
+    if (value === 'custom') {
       pref.emailTarget = '';
+    } else if (value === 'specific_operator') {
+      // Use 'operator:' prefix as placeholder so emailTargetSelection() keeps returning
+      // 'specific_operator' until the user picks an operator from the dropdown.
+      pref.emailTarget = 'operator:';
     } else {
       pref.emailTarget = value;
     }
@@ -324,8 +330,8 @@ export class NotificationPreferencesComponent implements OnInit {
       event: p.event,
       emailEnabled: p.emailEnabled,
       slackEnabled: p.slackEnabled,
-      slackTarget: p.slackTarget || null,
-      emailTarget: p.emailTarget || null,
+      slackTarget: (p.slackTarget && p.slackTarget !== 'operator:') ? p.slackTarget : null,
+      emailTarget: (p.emailTarget && p.emailTarget !== 'operator:') ? p.emailTarget : null,
       isActive: p.isActive,
     }));
 

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -24,6 +24,14 @@ interface NotificationPreference {
   isActive: boolean;
 }
 
+interface OperatorOption {
+  id: string;
+  name: string;
+  email: string;
+  slackUserId: string | null;
+  isActive: boolean;
+}
+
 const EVENT_LABELS: Record<string, string> = {
   TICKET_CREATED: 'New Ticket',
   ANALYSIS_COMPLETE: 'Analysis Complete',
@@ -38,15 +46,17 @@ const EVENT_LABELS: Record<string, string> = {
 };
 
 const SLACK_TARGET_OPTIONS = [
-  { value: null, label: 'Default Channel' },
+  { value: 'default', label: 'Default Channel' },
   { value: 'assigned_operator', label: 'Assigned Operator (DM)' },
   { value: 'all_operators', label: 'All Operators (DM each)' },
+  { value: 'specific_operator', label: 'Specific Operator' },
   { value: 'custom', label: 'Custom Channel ID' },
 ];
 
 const EMAIL_TARGET_OPTIONS = [
   { value: 'all_operators', label: 'All Operators' },
   { value: 'assigned_operator', label: 'Assigned Operator' },
+  { value: 'specific_operator', label: 'Specific Operator' },
   { value: 'custom', label: 'Custom Email' },
 ];
 
@@ -110,6 +120,18 @@ const EMAIL_TARGET_OPTIONS = [
                         <input matInput [(ngModel)]="pref.emailTarget" placeholder="user@example.com">
                       </mat-form-field>
                     }
+                    @if (emailTargetSelection(pref) === 'specific_operator') {
+                      <mat-form-field appearance="outline" class="compact-field custom-input">
+                        <mat-select
+                          [value]="selectedOperatorValue(pref.emailTarget)"
+                          (selectionChange)="pref.emailTarget = $event.value"
+                          placeholder="Select operator">
+                          @for (op of operators(); track op.id) {
+                            <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
+                          }
+                        </mat-select>
+                      </mat-form-field>
+                    }
                   }
                 </td>
               </ng-container>
@@ -135,6 +157,18 @@ const EMAIL_TARGET_OPTIONS = [
                     @if (slackTargetSelection(pref) === 'custom') {
                       <mat-form-field appearance="outline" class="compact-field custom-input">
                         <input matInput [(ngModel)]="pref.slackTarget" placeholder="C0123456789">
+                      </mat-form-field>
+                    }
+                    @if (slackTargetSelection(pref) === 'specific_operator') {
+                      <mat-form-field appearance="outline" class="compact-field custom-input">
+                        <mat-select
+                          [value]="selectedOperatorValue(pref.slackTarget)"
+                          (selectionChange)="pref.slackTarget = $event.value"
+                          placeholder="Select operator">
+                          @for (op of operators(); track op.id) {
+                            <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
+                          }
+                        </mat-select>
                       </mat-form-field>
                     }
                   }
@@ -213,6 +247,7 @@ export class NotificationPreferencesComponent implements OnInit {
   loading = signal(true);
   saving = signal(false);
   preferences = signal<NotificationPreference[]>([]);
+  operators = signal<OperatorOption[]>([]);
 
   displayedColumns = ['event', 'emailEnabled', 'emailTarget', 'slackEnabled', 'slackTarget'];
   slackTargetOptions = SLACK_TARGET_OPTIONS;
@@ -220,26 +255,36 @@ export class NotificationPreferencesComponent implements OnInit {
 
   ngOnInit(): void {
     this.load();
+    this.http.get<OperatorOption[]>(`${environment.apiUrl}/operators`).subscribe({
+      next: ops => this.operators.set(ops.filter(o => o.isActive !== false)),
+      error: () => { /* non-critical, leave empty */ },
+    });
   }
 
   eventLabel(event: string): string {
     return EVENT_LABELS[event] ?? event;
   }
 
-  slackTargetSelection(pref: NotificationPreference): string | null {
-    if (!pref.slackTarget) return null;
+  slackTargetSelection(pref: NotificationPreference): string {
+    if (pref.slackTarget === null || pref.slackTarget === undefined) return 'default';
     if (pref.slackTarget === 'assigned_operator' || pref.slackTarget === 'all_operators') return pref.slackTarget;
+    if (pref.slackTarget.startsWith('operator:')) return 'specific_operator';
     return 'custom';
   }
 
   emailTargetSelection(pref: NotificationPreference): string {
-    if (!pref.emailTarget || pref.emailTarget === 'all_operators') return 'all_operators';
+    if (pref.emailTarget === null || pref.emailTarget === undefined || pref.emailTarget === 'all_operators') return 'all_operators';
     if (pref.emailTarget === 'assigned_operator') return 'assigned_operator';
+    if (pref.emailTarget.startsWith('operator:')) return 'specific_operator';
     return 'custom';
   }
 
-  onSlackTargetChange(pref: NotificationPreference, value: string | null): void {
-    if (value === 'custom') {
+  onSlackTargetChange(pref: NotificationPreference, value: string): void {
+    if (value === 'default') {
+      pref.slackTarget = null;
+    } else if (value === 'custom') {
+      pref.slackTarget = '';
+    } else if (value === 'specific_operator') {
       pref.slackTarget = '';
     } else {
       pref.slackTarget = value;
@@ -247,11 +292,16 @@ export class NotificationPreferencesComponent implements OnInit {
   }
 
   onEmailTargetChange(pref: NotificationPreference, value: string): void {
-    if (value === 'custom') {
+    if (value === 'custom' || value === 'specific_operator') {
       pref.emailTarget = '';
     } else {
       pref.emailTarget = value;
     }
+  }
+
+  selectedOperatorValue(target: string | null): string {
+    if (target?.startsWith('operator:')) return target;
+    return '';
   }
 
   private load(): void {


### PR DESCRIPTION
## Summary
This PR adds the ability to send notifications (email and Slack) to specific operators by their ID, rather than only to all operators or assigned operators. Users can now select individual operators from a dropdown menu in the notification preferences UI.

## Key Changes

- **New `OperatorOption` interface**: Defines the structure for operator data with id, name, email, slackUserId, and isActive fields
- **UI enhancements**:
  - Added "Specific Operator" option to both email and Slack target dropdowns
  - Added operator selection dropdowns that appear when "Specific Operator" is selected
  - Operators are fetched from the API and filtered to show only active ones
- **Target value encoding**: Specific operator selections are stored with an `operator:` prefix (e.g., `operator:123`) to distinguish them from other target types
- **Component logic updates**:
  - `slackTargetSelection()` and `emailTargetSelection()` now detect and handle operator-specific targets
  - `onSlackTargetChange()` and `onEmailTargetChange()` initialize empty strings for operator selection mode
  - New `selectedOperatorValue()` helper method extracts operator IDs from encoded target values
- **Notification dispatch logic**:
  - `dispatchWithPreference()` now handles `operator:` prefixed Slack targets by looking up the operator's slackUserId and sending a DM
  - Falls back to default channel if operator has no slackUserId
  - `resolveEmailRecipients()` now handles `operator:` prefixed email targets by returning the specific operator's email
- **Default value change**: Slack "Default Channel" option value changed from `null` to `'default'` for consistency

## Implementation Details
- Operator data is loaded asynchronously on component init; failures are silently ignored as non-critical
- The `operator:` prefix convention allows the system to distinguish between operator-specific targets and custom channel/email inputs
- Slack notifications to specific operators use DM functionality when available, with fallback to default channel
- Email notifications to specific operators only include that operator's email if they have email notifications enabled

https://claude.ai/code/session_01Qqa7gZ7YN2xf86awpAwYkD