### PR TITLE
Move operational alerts to notification preferences

### DIFF
--- a/packages/shared-types/src/operational-alert.ts
+++ b/packages/shared-types/src/operational-alert.ts
@@ -10,7 +10,7 @@ export type OperationalAlertType =
 
 export interface OperationalAlertConfig {
   enabled: boolean;
-  recipientEmail: string;
+  recipientOperatorId: string;
   throttleMinutes: number;
   alerts: {
     failedJobs: boolean;
@@ -23,7 +23,7 @@ export interface OperationalAlertConfig {
 
 export const DEFAULT_OPERATIONAL_ALERT_CONFIG: OperationalAlertConfig = {
   enabled: false,
-  recipientEmail: '',
+  recipientOperatorId: '',
   throttleMinutes: 60,
   alerts: {
     failedJobs: true,

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -61,7 +61,7 @@ export interface UpdateCategoryConfig {
 
 export interface OperationalAlertConfig {
   enabled: boolean;
-  recipientEmail: string;
+  recipientOperatorId: string;
   throttleMinutes: number;
   alerts: {
     failedJobs: boolean;

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -72,6 +72,19 @@ export interface OperationalAlertConfig {
   };
 }
 
+export const DEFAULT_OPERATIONAL_ALERT_CONFIG: OperationalAlertConfig = {
+  enabled: false,
+  recipientOperatorId: '',
+  throttleMinutes: 60,
+  alerts: {
+    failedJobs: true,
+    probeMisses: true,
+    aiProviderDown: true,
+    devopsSyncStale: true,
+    summarizationStale: true,
+  },
+};
+
 export interface TestAlertResult {
   success: boolean;
   message?: string;

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -13,6 +13,10 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { environment } from '../../../environments/environment';
+import {
+  DEFAULT_OPERATIONAL_ALERT_CONFIG,
+  OperationalAlertConfig,
+} from '../../core/services/settings.service';
 
 interface NotificationPreference {
   id: string;
@@ -32,32 +36,6 @@ interface OperatorOption {
   slackUserId: string | null;
   isActive: boolean;
 }
-
-interface OperationalAlertConfig {
-  enabled: boolean;
-  recipientOperatorId: string;
-  throttleMinutes: number;
-  alerts: {
-    failedJobs: boolean;
-    probeMisses: boolean;
-    aiProviderDown: boolean;
-    devopsSyncStale: boolean;
-    summarizationStale: boolean;
-  };
-}
-
-const DEFAULT_ALERT_CONFIG: OperationalAlertConfig = {
-  enabled: false,
-  recipientOperatorId: '',
-  throttleMinutes: 60,
-  alerts: {
-    failedJobs: true,
-    probeMisses: true,
-    aiProviderDown: true,
-    devopsSyncStale: true,
-    summarizationStale: true,
-  },
-};
 
 const EVENT_LABELS: Record<string, string> = {
   TICKET_CREATED: 'New Ticket',
@@ -426,7 +404,7 @@ export class NotificationPreferencesComponent implements OnInit {
   preferences = signal<NotificationPreference[]>([]);
   operators = signal<OperatorOption[]>([]);
 
-  alertConfig = signal<OperationalAlertConfig>({ ...DEFAULT_ALERT_CONFIG });
+  alertConfig = signal<OperationalAlertConfig>({ ...DEFAULT_OPERATIONAL_ALERT_CONFIG });
   alertsLoading = signal(false);
   alertsError = signal(false);
   alertsSaving = signal(false);
@@ -590,8 +568,9 @@ export class NotificationPreferencesComponent implements OnInit {
         this.alertTestResult.set(result);
         this.alertsTesting.set(false);
       },
-      error: () => {
-        this.alertTestResult.set({ success: false, error: 'Request failed' });
+      error: (err) => {
+        const serverError = err?.error?.error ?? err?.error?.message ?? 'Request failed';
+        this.alertTestResult.set({ success: false, error: serverError });
         this.alertsTesting.set(false);
       },
     });

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -11,6 +11,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
 import { environment } from '../../../environments/environment';
 
 interface NotificationPreference {
@@ -31,6 +32,32 @@ interface OperatorOption {
   slackUserId: string | null;
   isActive: boolean;
 }
+
+interface OperationalAlertConfig {
+  enabled: boolean;
+  recipientOperatorId: string;
+  throttleMinutes: number;
+  alerts: {
+    failedJobs: boolean;
+    probeMisses: boolean;
+    aiProviderDown: boolean;
+    devopsSyncStale: boolean;
+    summarizationStale: boolean;
+  };
+}
+
+const DEFAULT_ALERT_CONFIG: OperationalAlertConfig = {
+  enabled: false,
+  recipientOperatorId: '',
+  throttleMinutes: 60,
+  alerts: {
+    failedJobs: true,
+    probeMisses: true,
+    aiProviderDown: true,
+    devopsSyncStale: true,
+    summarizationStale: true,
+  },
+};
 
 const EVENT_LABELS: Record<string, string> = {
   TICKET_CREATED: 'New Ticket',
@@ -74,125 +101,244 @@ const EMAIL_TARGET_OPTIONS = [
     MatIconModule,
     MatProgressSpinnerModule,
     MatSnackBarModule,
+    MatTabsModule,
   ],
   template: `
-    <h1>Notification Preferences</h1>
-    <p class="subtitle">Configure which events trigger notifications and through which channels.</p>
+    <h1>Notifications</h1>
+    <p class="subtitle">Configure event notifications and operational alerts.</p>
 
-    @if (loading()) {
-      <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-    } @else {
-      <mat-card>
-        <mat-card-content>
-          <div class="table-wrapper">
-            <table mat-table [dataSource]="preferences()" class="pref-table">
+    <mat-tab-group>
 
-              <ng-container matColumnDef="event">
-                <th mat-header-cell *matHeaderCellDef>Event</th>
-                <td mat-cell *matCellDef="let pref">
-                  <div class="event-cell">
-                    <strong>{{ eventLabel(pref.event) }}</strong>
-                    <span class="event-desc">{{ pref.description }}</span>
+      <mat-tab label="Event Notifications">
+        @if (loading()) {
+          <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
+        } @else {
+          <mat-card>
+            <mat-card-content>
+              <div class="table-wrapper">
+                <table mat-table [dataSource]="preferences()" class="pref-table">
+
+                  <ng-container matColumnDef="event">
+                    <th mat-header-cell *matHeaderCellDef>Event</th>
+                    <td mat-cell *matCellDef="let pref">
+                      <div class="event-cell">
+                        <strong>{{ eventLabel(pref.event) }}</strong>
+                        <span class="event-desc">{{ pref.description }}</span>
+                      </div>
+                    </td>
+                  </ng-container>
+
+                  <ng-container matColumnDef="emailEnabled">
+                    <th mat-header-cell *matHeaderCellDef>Email</th>
+                    <td mat-cell *matCellDef="let pref">
+                      <mat-slide-toggle [(ngModel)]="pref.emailEnabled" />
+                    </td>
+                  </ng-container>
+
+                  <ng-container matColumnDef="emailTarget">
+                    <th mat-header-cell *matHeaderCellDef>Email Target</th>
+                    <td mat-cell *matCellDef="let pref">
+                      @if (pref.emailEnabled) {
+                        <mat-form-field appearance="outline" class="compact-field">
+                          <mat-select [value]="emailTargetSelection(pref)" (selectionChange)="onEmailTargetChange(pref, $event.value)">
+                            @for (opt of emailTargetOptions; track opt.value) {
+                              <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+                            }
+                          </mat-select>
+                        </mat-form-field>
+                        @if (emailTargetSelection(pref) === 'custom') {
+                          <mat-form-field appearance="outline" class="compact-field custom-input">
+                            <input matInput [(ngModel)]="pref.emailTarget" placeholder="user@example.com">
+                          </mat-form-field>
+                        }
+                        @if (emailTargetSelection(pref) === 'specific_operator') {
+                          <mat-form-field appearance="outline" class="compact-field custom-input">
+                            <mat-select
+                              [value]="selectedOperatorValue(pref.emailTarget)"
+                              (selectionChange)="pref.emailTarget = $event.value"
+                              placeholder="Select operator">
+                              @for (op of operators(); track op.id) {
+                                <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
+                              }
+                            </mat-select>
+                          </mat-form-field>
+                        }
+                      }
+                    </td>
+                  </ng-container>
+
+                  <ng-container matColumnDef="slackEnabled">
+                    <th mat-header-cell *matHeaderCellDef>Slack</th>
+                    <td mat-cell *matCellDef="let pref">
+                      <mat-slide-toggle [(ngModel)]="pref.slackEnabled" />
+                    </td>
+                  </ng-container>
+
+                  <ng-container matColumnDef="slackTarget">
+                    <th mat-header-cell *matHeaderCellDef>Slack Target</th>
+                    <td mat-cell *matCellDef="let pref">
+                      @if (pref.slackEnabled) {
+                        <mat-form-field appearance="outline" class="compact-field">
+                          <mat-select [value]="slackTargetSelection(pref)" (selectionChange)="onSlackTargetChange(pref, $event.value)">
+                            @for (opt of slackTargetOptions; track opt.value) {
+                              <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+                            }
+                          </mat-select>
+                        </mat-form-field>
+                        @if (slackTargetSelection(pref) === 'custom') {
+                          <mat-form-field appearance="outline" class="compact-field custom-input">
+                            <input matInput [(ngModel)]="pref.slackTarget" placeholder="C0123456789">
+                          </mat-form-field>
+                        }
+                        @if (slackTargetSelection(pref) === 'specific_operator') {
+                          <mat-form-field appearance="outline" class="compact-field custom-input">
+                            <mat-select
+                              [value]="selectedOperatorValue(pref.slackTarget)"
+                              (selectionChange)="pref.slackTarget = $event.value"
+                              placeholder="Select operator">
+                              @for (op of operators(); track op.id) {
+                                <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
+                              }
+                            </mat-select>
+                          </mat-form-field>
+                        }
+                      }
+                    </td>
+                  </ng-container>
+
+                  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                </table>
+              </div>
+
+              <div class="actions">
+                <button mat-flat-button color="primary" (click)="saveAll()" [disabled]="saving()">
+                  @if (saving()) {
+                    <mat-spinner diameter="20" />
+                  } @else {
+                    <mat-icon>save</mat-icon>
+                    Save All
+                  }
+                </button>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        }
+      </mat-tab>
+
+      <mat-tab label="Operational Alerts">
+        <div class="tab-content">
+          @if (alertsLoading()) {
+            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
+          } @else if (alertsError()) {
+            <p>Failed to load alert configuration. <button mat-button (click)="loadAlertConfig()">Retry</button></p>
+          } @else {
+            <mat-card>
+              <mat-card-header>
+                <mat-card-title>Alert Notifications</mat-card-title>
+              </mat-card-header>
+              <mat-card-content>
+                <p class="subtitle">
+                  Get email notifications when background processes fail silently.
+                </p>
+
+                <div class="alert-toggle-row">
+                  <mat-slide-toggle
+                    [checked]="alertConfig().enabled"
+                    (change)="setAlertEnabled($event.checked)">
+                    Enable operational alerts
+                  </mat-slide-toggle>
+                </div>
+
+                <mat-form-field appearance="outline" class="full-width">
+                  <mat-label>Recipient Operator</mat-label>
+                  <mat-select
+                    [value]="alertConfig().recipientOperatorId"
+                    (selectionChange)="setAlertRecipientOperator($event.value)">
+                    @for (op of operators(); track op.id) {
+                      <mat-option [value]="op.id">{{ op.name }} ({{ op.email }})</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+
+                <mat-form-field appearance="outline" class="full-width">
+                  <mat-label>Throttle (minutes between repeat alerts)</mat-label>
+                  <mat-select
+                    [value]="alertConfig().throttleMinutes"
+                    (selectionChange)="setAlertThrottleMinutes($event.value)">
+                    <mat-option [value]="15">15 minutes</mat-option>
+                    <mat-option [value]="30">30 minutes</mat-option>
+                    <mat-option [value]="60">1 hour</mat-option>
+                    <mat-option [value]="120">2 hours</mat-option>
+                  </mat-select>
+                </mat-form-field>
+
+                <h3>Alert Types</h3>
+                <div class="alert-toggles">
+                  <div class="alert-toggle-row">
+                    <mat-slide-toggle
+                      [checked]="alertConfig().alerts.failedJobs"
+                      (change)="setAlertType('failedJobs', $event.checked)">
+                      Failed BullMQ jobs
+                    </mat-slide-toggle>
+                    <span class="alert-desc">Alert when background job queues have failed jobs</span>
                   </div>
-                </td>
-              </ng-container>
+                  <div class="alert-toggle-row">
+                    <mat-slide-toggle
+                      [checked]="alertConfig().alerts.probeMisses"
+                      (change)="setAlertType('probeMisses', $event.checked)">
+                      Missed probe schedules
+                    </mat-slide-toggle>
+                    <span class="alert-desc">Alert when scheduled probes miss their expected run window</span>
+                  </div>
+                  <div class="alert-toggle-row">
+                    <mat-slide-toggle
+                      [checked]="alertConfig().alerts.aiProviderDown"
+                      (change)="setAlertType('aiProviderDown', $event.checked)">
+                      AI provider outages
+                    </mat-slide-toggle>
+                    <span class="alert-desc">Alert when Ollama or cloud AI providers are unreachable or failing</span>
+                  </div>
+                  <div class="alert-toggle-row">
+                    <mat-slide-toggle
+                      [checked]="alertConfig().alerts.devopsSyncStale"
+                      (change)="setAlertType('devopsSyncStale', $event.checked)">
+                      DevOps sync staleness
+                    </mat-slide-toggle>
+                    <span class="alert-desc">Alert when Azure DevOps sync stops (PAT expired, rate limit, etc)</span>
+                  </div>
+                  <div class="alert-toggle-row">
+                    <mat-slide-toggle
+                      [checked]="alertConfig().alerts.summarizationStale"
+                      (change)="setAlertType('summarizationStale', $event.checked)">
+                      Log summarization staleness
+                    </mat-slide-toggle>
+                    <span class="alert-desc">Alert when log summarization hasn't run in over 2 hours</span>
+                  </div>
+                </div>
 
-              <ng-container matColumnDef="emailEnabled">
-                <th mat-header-cell *matHeaderCellDef>Email</th>
-                <td mat-cell *matCellDef="let pref">
-                  <mat-slide-toggle [(ngModel)]="pref.emailEnabled" />
-                </td>
-              </ng-container>
+                @if (alertTestResult()) {
+                  <div class="test-result" [class.success]="alertTestResult()!.success" [class.error]="!alertTestResult()!.success">
+                    {{ alertTestResult()!.success ? alertTestResult()!.message : alertTestResult()!.error }}
+                  </div>
+                }
+              </mat-card-content>
+              <mat-card-actions>
+                <button mat-flat-button color="primary" (click)="saveAlertConfig()" [disabled]="alertsSaving()">
+                  @if (alertsSaving()) { <mat-spinner diameter="18" /> } @else { <mat-icon>save</mat-icon> }
+                  Save
+                </button>
+                <button mat-button (click)="testAlert()" [disabled]="alertsTesting()">
+                  @if (alertsTesting()) { <mat-spinner diameter="18" /> }
+                  Test Alert
+                </button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        </div>
+      </mat-tab>
 
-              <ng-container matColumnDef="emailTarget">
-                <th mat-header-cell *matHeaderCellDef>Email Target</th>
-                <td mat-cell *matCellDef="let pref">
-                  @if (pref.emailEnabled) {
-                    <mat-form-field appearance="outline" class="compact-field">
-                      <mat-select [value]="emailTargetSelection(pref)" (selectionChange)="onEmailTargetChange(pref, $event.value)">
-                        @for (opt of emailTargetOptions; track opt.value) {
-                          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
-                        }
-                      </mat-select>
-                    </mat-form-field>
-                    @if (emailTargetSelection(pref) === 'custom') {
-                      <mat-form-field appearance="outline" class="compact-field custom-input">
-                        <input matInput [(ngModel)]="pref.emailTarget" placeholder="user@example.com">
-                      </mat-form-field>
-                    }
-                    @if (emailTargetSelection(pref) === 'specific_operator') {
-                      <mat-form-field appearance="outline" class="compact-field custom-input">
-                        <mat-select
-                          [value]="selectedOperatorValue(pref.emailTarget)"
-                          (selectionChange)="pref.emailTarget = $event.value"
-                          placeholder="Select operator">
-                          @for (op of operators(); track op.id) {
-                            <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
-                          }
-                        </mat-select>
-                      </mat-form-field>
-                    }
-                  }
-                </td>
-              </ng-container>
-
-              <ng-container matColumnDef="slackEnabled">
-                <th mat-header-cell *matHeaderCellDef>Slack</th>
-                <td mat-cell *matCellDef="let pref">
-                  <mat-slide-toggle [(ngModel)]="pref.slackEnabled" />
-                </td>
-              </ng-container>
-
-              <ng-container matColumnDef="slackTarget">
-                <th mat-header-cell *matHeaderCellDef>Slack Target</th>
-                <td mat-cell *matCellDef="let pref">
-                  @if (pref.slackEnabled) {
-                    <mat-form-field appearance="outline" class="compact-field">
-                      <mat-select [value]="slackTargetSelection(pref)" (selectionChange)="onSlackTargetChange(pref, $event.value)">
-                        @for (opt of slackTargetOptions; track opt.value) {
-                          <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
-                        }
-                      </mat-select>
-                    </mat-form-field>
-                    @if (slackTargetSelection(pref) === 'custom') {
-                      <mat-form-field appearance="outline" class="compact-field custom-input">
-                        <input matInput [(ngModel)]="pref.slackTarget" placeholder="C0123456789">
-                      </mat-form-field>
-                    }
-                    @if (slackTargetSelection(pref) === 'specific_operator') {
-                      <mat-form-field appearance="outline" class="compact-field custom-input">
-                        <mat-select
-                          [value]="selectedOperatorValue(pref.slackTarget)"
-                          (selectionChange)="pref.slackTarget = $event.value"
-                          placeholder="Select operator">
-                          @for (op of operators(); track op.id) {
-                            <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
-                          }
-                        </mat-select>
-                      </mat-form-field>
-                    }
-                  }
-                </td>
-              </ng-container>
-
-              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-            </table>
-          </div>
-
-          <div class="actions">
-            <button mat-flat-button color="primary" (click)="saveAll()" [disabled]="saving()">
-              @if (saving()) {
-                <mat-spinner diameter="20" />
-              } @else {
-                <mat-icon>save</mat-icon>
-                Save All
-              }
-            </button>
-          </div>
-        </mat-card-content>
-      </mat-card>
-    }
+    </mat-tab-group>
   `,
   styles: [`
     .subtitle {
@@ -238,6 +384,37 @@ const EMAIL_TARGET_OPTIONS = [
     .actions button mat-icon {
       margin-right: 4px;
     }
+    .tab-content {
+      padding-top: 16px;
+    }
+    .full-width {
+      width: 100%;
+      max-width: 400px;
+      display: block;
+      margin-bottom: 12px;
+    }
+    .alert-toggle-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .alert-toggles {
+      display: flex;
+      flex-direction: column;
+    }
+    .alert-desc {
+      font-size: 12px;
+      color: #888;
+    }
+    .test-result {
+      margin-top: 8px;
+      padding: 8px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+    .test-result.success { background: #e8f5e9; color: #2e7d32; }
+    .test-result.error { background: #fce4ec; color: #c62828; }
   `],
 })
 export class NotificationPreferencesComponent implements OnInit {
@@ -249,15 +426,27 @@ export class NotificationPreferencesComponent implements OnInit {
   preferences = signal<NotificationPreference[]>([]);
   operators = signal<OperatorOption[]>([]);
 
+  alertConfig = signal<OperationalAlertConfig>({ ...DEFAULT_ALERT_CONFIG });
+  alertsLoading = signal(false);
+  alertsError = signal(false);
+  alertsSaving = signal(false);
+  alertsTesting = signal(false);
+  alertTestResult = signal<{ success: boolean; message?: string; error?: string } | null>(null);
+
   displayedColumns = ['event', 'emailEnabled', 'emailTarget', 'slackEnabled', 'slackTarget'];
   slackTargetOptions = SLACK_TARGET_OPTIONS;
   emailTargetOptions = EMAIL_TARGET_OPTIONS;
 
   ngOnInit(): void {
     this.load();
+    this.loadOperators();
+    this.loadAlertConfig();
+  }
+
+  private loadOperators(): void {
     this.http.get<OperatorOption[]>(`${environment.apiUrl}/operators`).subscribe({
       next: ops => this.operators.set(ops.filter(o => o.isActive !== false)),
-      error: () => { /* non-critical, leave empty */ },
+      error: () => { /* non-critical */ },
     });
   }
 
@@ -337,6 +526,73 @@ export class NotificationPreferencesComponent implements OnInit {
       error: () => {
         this.snackBar.open('Failed to save preferences', 'Dismiss', { duration: 5000 });
         this.saving.set(false);
+      },
+    });
+  }
+
+  loadAlertConfig(): void {
+    this.alertsLoading.set(true);
+    this.alertsError.set(false);
+    this.http.get<OperationalAlertConfig>(`${environment.apiUrl}/settings/operational-alerts`).subscribe({
+      next: config => {
+        this.alertConfig.set(config);
+        this.alertsLoading.set(false);
+      },
+      error: () => {
+        this.alertsError.set(true);
+        this.alertsLoading.set(false);
+      },
+    });
+  }
+
+  setAlertEnabled(value: boolean): void {
+    this.alertConfig.update(c => ({ ...c, enabled: value }));
+  }
+
+  setAlertRecipientOperator(operatorId: string): void {
+    this.alertConfig.update(c => ({ ...c, recipientOperatorId: operatorId }));
+  }
+
+  setAlertThrottleMinutes(value: number): void {
+    this.alertConfig.update(c => ({ ...c, throttleMinutes: value }));
+  }
+
+  setAlertType(key: keyof OperationalAlertConfig['alerts'], value: boolean): void {
+    this.alertConfig.update(c => ({ ...c, alerts: { ...c.alerts, [key]: value } }));
+  }
+
+  saveAlertConfig(): void {
+    this.alertsSaving.set(true);
+    this.http.put<OperationalAlertConfig>(
+      `${environment.apiUrl}/settings/operational-alerts`,
+      this.alertConfig(),
+    ).subscribe({
+      next: saved => {
+        this.alertConfig.set(saved);
+        this.alertsSaving.set(false);
+        this.snackBar.open('Alert configuration saved', 'Dismiss', { duration: 3000 });
+      },
+      error: () => {
+        this.alertsSaving.set(false);
+        this.snackBar.open('Failed to save alert configuration', 'Dismiss', { duration: 5000 });
+      },
+    });
+  }
+
+  testAlert(): void {
+    this.alertsTesting.set(true);
+    this.alertTestResult.set(null);
+    this.http.post<{ success: boolean; message?: string; error?: string }>(
+      `${environment.apiUrl}/settings/operational-alerts/test`,
+      {},
+    ).subscribe({
+      next: result => {
+        this.alertTestResult.set(result);
+        this.alertsTesting.set(false);
+      },
+      error: () => {
+        this.alertTestResult.set({ success: false, error: 'Request failed' });
+        this.alertsTesting.set(false);
       },
     });
   }

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -26,7 +26,6 @@ import {
   SettingsService,
   TicketStatusConfig,
   TicketCategoryConfig,
-  OperationalAlertConfig,
 } from '../../core/services/settings.service';
 import { ExternalServiceDialogComponent } from './external-service-dialog.component';
 import { StatusConfigDialogComponent } from './status-config-dialog.component';
@@ -294,126 +293,6 @@ import { CategoryConfigDialogComponent } from './category-config-dialog.componen
         </div>
       </mat-tab>
 
-      <!-- Operational Alerts tab -->
-      <mat-tab label="Operational Alerts">
-        <div class="tab-content">
-          @if (alertsLoading()) {
-            <div class="empty-state">
-              <mat-icon>hourglass_empty</mat-icon>
-              <p>Loading alert configuration...</p>
-            </div>
-          } @else if (alertsError()) {
-            <div class="empty-state">
-              <mat-icon>error_outline</mat-icon>
-              <p>Failed to load alert configuration.</p>
-              <button mat-button color="primary" (click)="loadAlertConfig()">Retry</button>
-            </div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Alert Notifications</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
-                <p class="hint">
-                  Get email notifications when background processes fail silently.
-                  Requires an active EMAIL notification channel configured under Notification Channels.
-                </p>
-
-                <div class="alert-toggle-row">
-                  <mat-slide-toggle
-                    [checked]="alertConfig().enabled"
-                    (change)="setAlertEnabled($event.checked)">
-                    Enable operational alerts
-                  </mat-slide-toggle>
-                </div>
-
-                <mat-form-field class="full-width">
-                  <mat-label>Recipient Email</mat-label>
-                  <input matInput type="email"
-                    [ngModel]="alertConfig().recipientEmail"
-                    (ngModelChange)="setAlertRecipientEmail($event)"
-                    placeholder="operator@example.com">
-                </mat-form-field>
-
-                <mat-form-field class="full-width">
-                  <mat-label>Throttle (minutes between repeat alerts)</mat-label>
-                  <mat-select
-                    [ngModel]="alertConfig().throttleMinutes"
-                    (ngModelChange)="setAlertThrottleMinutes($event)">
-                    <mat-option [value]="15">15 minutes</mat-option>
-                    <mat-option [value]="30">30 minutes</mat-option>
-                    <mat-option [value]="60">1 hour</mat-option>
-                    <mat-option [value]="120">2 hours</mat-option>
-                  </mat-select>
-                </mat-form-field>
-
-                <h3>Alert Types</h3>
-
-                <div class="alert-toggles">
-                  <div class="alert-toggle-row">
-                    <mat-slide-toggle
-                      [checked]="alertConfig().alerts.failedJobs"
-                      (change)="setAlertType('failedJobs', $event.checked)">
-                      Failed BullMQ jobs
-                    </mat-slide-toggle>
-                    <span class="alert-desc">Alert when background job queues have failed jobs</span>
-                  </div>
-
-                  <div class="alert-toggle-row">
-                    <mat-slide-toggle
-                      [checked]="alertConfig().alerts.probeMisses"
-                      (change)="setAlertType('probeMisses', $event.checked)">
-                      Missed probe schedules
-                    </mat-slide-toggle>
-                    <span class="alert-desc">Alert when scheduled probes miss their expected run window</span>
-                  </div>
-
-                  <div class="alert-toggle-row">
-                    <mat-slide-toggle
-                      [checked]="alertConfig().alerts.aiProviderDown"
-                      (change)="setAlertType('aiProviderDown', $event.checked)">
-                      AI provider outages
-                    </mat-slide-toggle>
-                    <span class="alert-desc">Alert when Ollama or cloud AI providers are unreachable or failing</span>
-                  </div>
-
-                  <div class="alert-toggle-row">
-                    <mat-slide-toggle
-                      [checked]="alertConfig().alerts.devopsSyncStale"
-                      (change)="setAlertType('devopsSyncStale', $event.checked)">
-                      DevOps sync staleness
-                    </mat-slide-toggle>
-                    <span class="alert-desc">Alert when Azure DevOps sync stops (PAT expired, rate limit, etc)</span>
-                  </div>
-
-                  <div class="alert-toggle-row">
-                    <mat-slide-toggle
-                      [checked]="alertConfig().alerts.summarizationStale"
-                      (change)="setAlertType('summarizationStale', $event.checked)">
-                      Log summarization staleness
-                    </mat-slide-toggle>
-                    <span class="alert-desc">Alert when log summarization hasn't run in over 2 hours</span>
-                  </div>
-                </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveAlertConfig()" [disabled]="alertsSaving()">
-                  @if (alertsSaving()) {
-                    <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
-                  }
-                  Save
-                </button>
-                <button mat-button (click)="testAlert()" [disabled]="alertsTesting()">
-                  @if (alertsTesting()) {
-                    <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
-                  }
-                  Test Alert
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
       <!-- External Services tab -->
       <mat-tab label="External Services">
         <div class="tab-content">
@@ -750,24 +629,6 @@ export class SettingsComponent implements OnInit {
   categoriesError = signal(false);
   catColumns = ['catColor', 'catValue', 'catDisplayName', 'catDescription', 'catSortOrder', 'catActive', 'catActions'];
 
-  // Operational Alerts tab
-  alertConfig = signal<OperationalAlertConfig>({
-    enabled: false,
-    recipientEmail: '',
-    throttleMinutes: 60,
-    alerts: {
-      failedJobs: true,
-      probeMisses: true,
-      aiProviderDown: true,
-      devopsSyncStale: true,
-      summarizationStale: true,
-    },
-  });
-  alertsLoading = signal(true);
-  alertsError = signal(false);
-  alertsSaving = signal(false);
-  alertsTesting = signal(false);
-
   // Action Safety tab
   actionSafetyConfig = signal<Record<string, 'auto' | 'approval'>>({});
   actionSafetyLoading = signal(true);
@@ -794,7 +655,6 @@ export class SettingsComponent implements OnInit {
     this.loadServices();
     this.loadStatuses();
     this.loadCategories();
-    this.loadAlertConfig();
     this.loadActionSafety();
     this.loadAnalysisStrategy();
   }
@@ -988,74 +848,6 @@ export class SettingsComponent implements OnInit {
     });
     ref.afterClosed().subscribe((saved) => {
       if (saved) this.loadCategories();
-    });
-  }
-
-  // ─── Operational Alerts tab ───
-
-  loadAlertConfig(): void {
-    this.alertsLoading.set(true);
-    this.alertsError.set(false);
-    this.settingsSvc.getOperationalAlerts().subscribe({
-      next: (config) => {
-        this.alertConfig.set(config);
-        this.alertsLoading.set(false);
-      },
-      error: () => {
-        this.alertsLoading.set(false);
-        this.alertsError.set(true);
-        this.snackBar.open('Failed to load alert configuration', 'OK', { duration: 5000 });
-      },
-    });
-  }
-
-  setAlertEnabled(value: boolean): void {
-    this.alertConfig.update(c => ({ ...c, enabled: value }));
-  }
-
-  setAlertRecipientEmail(value: string): void {
-    this.alertConfig.update(c => ({ ...c, recipientEmail: value }));
-  }
-
-  setAlertThrottleMinutes(value: number): void {
-    this.alertConfig.update(c => ({ ...c, throttleMinutes: value }));
-  }
-
-  setAlertType(key: keyof OperationalAlertConfig['alerts'], value: boolean): void {
-    this.alertConfig.update(c => ({ ...c, alerts: { ...c.alerts, [key]: value } }));
-  }
-
-  saveAlertConfig(): void {
-    this.alertsSaving.set(true);
-    this.settingsSvc.updateOperationalAlerts(this.alertConfig()).subscribe({
-      next: (saved) => {
-        this.alertConfig.set(saved);
-        this.alertsSaving.set(false);
-        this.snackBar.open('Alert configuration saved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
-      },
-      error: () => {
-        this.alertsSaving.set(false);
-        this.snackBar.open('Failed to save alert configuration', 'OK', { duration: 5000 });
-      },
-    });
-  }
-
-  testAlert(): void {
-    this.alertsTesting.set(true);
-    this.settingsSvc.testOperationalAlert().subscribe({
-      next: (result) => {
-        this.alertsTesting.set(false);
-        if (result.success) {
-          this.snackBar.open(result.message ?? 'Test alert sent', 'OK', { duration: 5000, panelClass: 'success-snackbar' });
-        } else {
-          this.snackBar.open(`Test failed: ${result.error}`, 'OK', { duration: 8000 });
-        }
-      },
-      error: (err) => {
-        this.alertsTesting.set(false);
-        const msg = err?.error?.error ?? 'Failed to send test alert';
-        this.snackBar.open(msg, 'OK', { duration: 8000 });
-      },
     });
   }
 

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -30,8 +30,6 @@ const VALID_CATEGORIES: ReadonlySet<string> = new Set(Object.values(TicketCatego
 const VALID_STATUS_CLASSES: ReadonlySet<string> = new Set(['open', 'closed']);
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 const logger = createLogger('settings');
 
 const SETTINGS_KEY_OPERATIONAL_ALERTS = 'operational-alerts';
@@ -98,44 +96,18 @@ const slackConfigSchema = z
     }
   });
 
-const operationalAlertConfigSchema = z
-  .object({
-    enabled: z.boolean(),
-    recipientEmail: z.string().transform((value) => value.trim()),
-    throttleMinutes: z.number().int().min(1),
-    alerts: z.object({
-      failedJobs: z.boolean(),
-      probeMisses: z.boolean(),
-      aiProviderDown: z.boolean(),
-      devopsSyncStale: z.boolean(),
-      summarizationStale: z.boolean(),
-    }),
-  })
-  .superRefine((value, ctx) => {
-    const email = value.recipientEmail;
-
-    if (!value.enabled) {
-      // When alerts are disabled, allow an empty or missing recipientEmail.
-      return;
-    }
-
-    if (!email) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'recipientEmail is required when alerts are enabled',
-        path: ['recipientEmail'],
-      });
-      return;
-    }
-
-    if (!EMAIL_RE.test(email)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'recipientEmail must be a valid email address',
-        path: ['recipientEmail'],
-      });
-    }
-  });
+const operationalAlertConfigSchema = z.object({
+  enabled: z.boolean(),
+  recipientOperatorId: z.string(),
+  throttleMinutes: z.number().int().min(1),
+  alerts: z.object({
+    failedJobs: z.boolean(),
+    probeMisses: z.boolean(),
+    aiProviderDown: z.boolean(),
+    devopsSyncStale: z.boolean(),
+    summarizationStale: z.boolean(),
+  }),
+});
 
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
@@ -432,8 +404,16 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
       ? (settingRow.value as unknown as OperationalAlertConfig)
       : DEFAULT_OPERATIONAL_ALERT_CONFIG;
 
-    if (!alertConfig.recipientEmail) {
-      return fastify.httpErrors.badRequest('No recipient email configured in operational alert settings');
+    if (!alertConfig.recipientOperatorId) {
+      return fastify.httpErrors.badRequest('No recipient operator configured in operational alert settings');
+    }
+
+    const operator = await fastify.db.operator.findUnique({
+      where: { id: alertConfig.recipientOperatorId },
+    });
+
+    if (!operator) {
+      return fastify.httpErrors.badRequest('Configured recipient operator not found');
     }
 
     // Load SMTP config from System Settings
@@ -448,7 +428,7 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
 
     try {
       await mailer.send({
-        to: alertConfig.recipientEmail,
+        to: operator.email,
         subject: '[Bronco Alert] Test notification',
         body: [
           'This is a test alert from Bronco operational monitoring.',
@@ -456,10 +436,10 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
           'If you received this email, your alert configuration is working correctly.',
           '',
           '---',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
-      return { success: true, message: `Test alert sent to ${alertConfig.recipientEmail}` };
+      return { success: true, message: `Test alert sent to ${operator.email}` };
     } catch (err) {
       logger.error({ err }, 'Test alert email failed');
       return { success: false, error: err instanceof Error ? err.message : 'Failed to send test email' };

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -96,18 +96,37 @@ const slackConfigSchema = z
     }
   });
 
-const operationalAlertConfigSchema = z.object({
-  enabled: z.boolean(),
-  recipientOperatorId: z.string(),
-  throttleMinutes: z.number().int().min(1),
-  alerts: z.object({
-    failedJobs: z.boolean(),
-    probeMisses: z.boolean(),
-    aiProviderDown: z.boolean(),
-    devopsSyncStale: z.boolean(),
-    summarizationStale: z.boolean(),
-  }),
-});
+const operationalAlertConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+    recipientOperatorId: z.string().trim(),
+    throttleMinutes: z.number().int().min(1),
+    alerts: z.object({
+      failedJobs: z.boolean(),
+      probeMisses: z.boolean(),
+      aiProviderDown: z.boolean(),
+      devopsSyncStale: z.boolean(),
+      summarizationStale: z.boolean(),
+    }),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.enabled) return;
+    if (!value.recipientOperatorId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'recipientOperatorId is required when alerts are enabled',
+        path: ['recipientOperatorId'],
+      });
+      return;
+    }
+    if (!z.string().uuid().safeParse(value.recipientOperatorId).success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'recipientOperatorId must be a valid UUID',
+        path: ['recipientOperatorId'],
+      });
+    }
+  });
 
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;

--- a/services/copilot-api/src/services/operational-alerts.ts
+++ b/services/copilot-api/src/services/operational-alerts.ts
@@ -104,7 +104,7 @@ async function checkFailedJobs(redisUrl: string): Promise<AlertMessage[]> {
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -159,7 +159,7 @@ async function checkProbeMisses(db: PrismaClient): Promise<AlertMessage[]> {
             '',
             '---',
             'This is an automated alert from Bronco operational monitoring.',
-            'To configure alerts: Control Panel → Settings → Operational Alerts.',
+            'To configure alerts: Control Panel → Notifications → Operational Alerts.',
           ].join('\n'),
         });
       }
@@ -202,7 +202,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
                 '',
                 '---',
                 'This is an automated alert from Bronco operational monitoring.',
-                'To configure alerts: Control Panel → Settings → Operational Alerts.',
+                'To configure alerts: Control Panel → Notifications → Operational Alerts.',
               ].join('\n'),
             });
           }
@@ -217,7 +217,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
               '',
               '---',
               'This is an automated alert from Bronco operational monitoring.',
-              'To configure alerts: Control Panel → Settings → Operational Alerts.',
+              'To configure alerts: Control Panel → Notifications → Operational Alerts.',
             ].join('\n'),
           });
         }
@@ -243,7 +243,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
                 '',
                 '---',
                 'This is an automated alert from Bronco operational monitoring.',
-                'To configure alerts: Control Panel → Settings → Operational Alerts.',
+                'To configure alerts: Control Panel → Notifications → Operational Alerts.',
               ].join('\n'),
             });
           }
@@ -258,7 +258,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
               '',
               '---',
               'This is an automated alert from Bronco operational monitoring.',
-              'To configure alerts: Control Panel → Settings → Operational Alerts.',
+              'To configure alerts: Control Panel → Notifications → Operational Alerts.',
             ].join('\n'),
           });
         }
@@ -301,7 +301,7 @@ async function checkDevopsSyncStaleness(db: PrismaClient): Promise<AlertMessage[
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -349,7 +349,7 @@ async function checkSummarizationStaleness(db: PrismaClient): Promise<AlertMessa
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -388,21 +388,17 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     ? (settingRow.value as unknown as OperationalAlertConfig)
     : DEFAULT_OPERATIONAL_ALERT_CONFIG;
 
-  if (!config.enabled || !config.recipientOperatorId) {
-    logger.debug('Operational alerts disabled or no recipient operator — skipping');
+  if (!config.enabled) {
+    logger.debug('Operational alerts disabled — skipping');
+    return;
+  }
+  if (!config.recipientOperatorId) {
+    logger.warn('Operational alerts enabled but no recipient operator configured — skipping');
     return;
   }
 
   // Restore throttle state from DB so restarts don't reset the throttle window
   await loadThrottleState(db);
-
-  const operator = await db.operator.findUnique({
-    where: { id: config.recipientOperatorId },
-  });
-  if (!operator) {
-    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
-    return;
-  }
 
   // Gather alerts from all enabled checks in parallel
   const checkPromises: Promise<AlertMessage[]>[] = [];
@@ -435,6 +431,14 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
   );
 
   if (alertsToSend.length === 0) return;
+
+  const operator = await db.operator.findUnique({
+    where: { id: config.recipientOperatorId },
+  });
+  if (!operator) {
+    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
+    return;
+  }
 
   // Create mailer from System Settings SMTP config
   const mailer = await createMailerFromSmtpSettings(db, encryptionKey);

--- a/services/copilot-api/src/services/operational-alerts.ts
+++ b/services/copilot-api/src/services/operational-alerts.ts
@@ -388,13 +388,21 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     ? (settingRow.value as unknown as OperationalAlertConfig)
     : DEFAULT_OPERATIONAL_ALERT_CONFIG;
 
-  if (!config.enabled || !config.recipientEmail) {
-    logger.debug('Operational alerts disabled or no recipient — skipping');
+  if (!config.enabled || !config.recipientOperatorId) {
+    logger.debug('Operational alerts disabled or no recipient operator — skipping');
     return;
   }
 
   // Restore throttle state from DB so restarts don't reset the throttle window
   await loadThrottleState(db);
+
+  const operator = await db.operator.findUnique({
+    where: { id: config.recipientOperatorId },
+  });
+  if (!operator) {
+    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
+    return;
+  }
 
   // Gather alerts from all enabled checks in parallel
   const checkPromises: Promise<AlertMessage[]>[] = [];
@@ -439,12 +447,12 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     for (const alert of alertsToSend) {
       try {
         await mailer.send({
-          to: config.recipientEmail,
+          to: operator.email,
           subject: alert.subject,
           body: alert.body,
         });
         markAlertSent(alert.key);
-        logger.info({ alertKey: alert.key, to: config.recipientEmail }, 'Operational alert sent');
+        logger.info({ alertKey: alert.key, to: operator.email }, 'Operational alert sent');
       } catch (err) {
         logger.error({ err, alertKey: alert.key }, 'Failed to send operational alert email');
       }

--- a/services/scheduler-worker/src/operational-alerts.ts
+++ b/services/scheduler-worker/src/operational-alerts.ts
@@ -104,7 +104,7 @@ async function checkFailedJobs(redisUrl: string): Promise<AlertMessage[]> {
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -159,7 +159,7 @@ async function checkProbeMisses(db: PrismaClient): Promise<AlertMessage[]> {
             '',
             '---',
             'This is an automated alert from Bronco operational monitoring.',
-            'To configure alerts: Control Panel → Settings → Operational Alerts.',
+            'To configure alerts: Control Panel → Notifications → Operational Alerts.',
           ].join('\n'),
         });
       }
@@ -202,7 +202,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
                 '',
                 '---',
                 'This is an automated alert from Bronco operational monitoring.',
-                'To configure alerts: Control Panel → Settings → Operational Alerts.',
+                'To configure alerts: Control Panel → Notifications → Operational Alerts.',
               ].join('\n'),
             });
           }
@@ -217,7 +217,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
               '',
               '---',
               'This is an automated alert from Bronco operational monitoring.',
-              'To configure alerts: Control Panel → Settings → Operational Alerts.',
+              'To configure alerts: Control Panel → Notifications → Operational Alerts.',
             ].join('\n'),
           });
         }
@@ -243,7 +243,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
                 '',
                 '---',
                 'This is an automated alert from Bronco operational monitoring.',
-                'To configure alerts: Control Panel → Settings → Operational Alerts.',
+                'To configure alerts: Control Panel → Notifications → Operational Alerts.',
               ].join('\n'),
             });
           }
@@ -258,7 +258,7 @@ async function checkAiProviderHealth(db: PrismaClient): Promise<AlertMessage[]> 
               '',
               '---',
               'This is an automated alert from Bronco operational monitoring.',
-              'To configure alerts: Control Panel → Settings → Operational Alerts.',
+              'To configure alerts: Control Panel → Notifications → Operational Alerts.',
             ].join('\n'),
           });
         }
@@ -301,7 +301,7 @@ async function checkDevopsSyncStaleness(db: PrismaClient): Promise<AlertMessage[
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -349,7 +349,7 @@ async function checkSummarizationStaleness(db: PrismaClient): Promise<AlertMessa
           '',
           '---',
           'This is an automated alert from Bronco operational monitoring.',
-          'To configure alerts: Control Panel → Settings → Operational Alerts.',
+          'To configure alerts: Control Panel → Notifications → Operational Alerts.',
         ].join('\n'),
       });
     }
@@ -388,21 +388,17 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     ? (settingRow.value as unknown as OperationalAlertConfig)
     : DEFAULT_OPERATIONAL_ALERT_CONFIG;
 
-  if (!config.enabled || !config.recipientOperatorId) {
-    logger.debug('Operational alerts disabled or no recipient operator — skipping');
+  if (!config.enabled) {
+    logger.debug('Operational alerts disabled — skipping');
+    return;
+  }
+  if (!config.recipientOperatorId) {
+    logger.warn('Operational alerts enabled but no recipient operator configured — skipping');
     return;
   }
 
   // Restore throttle state from DB so restarts don't reset the throttle window
   await loadThrottleState(db);
-
-  const operator = await db.operator.findUnique({
-    where: { id: config.recipientOperatorId },
-  });
-  if (!operator) {
-    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
-    return;
-  }
 
   // Gather alerts from all enabled checks in parallel
   const checkPromises: Promise<AlertMessage[]>[] = [];
@@ -435,6 +431,14 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
   );
 
   if (alertsToSend.length === 0) return;
+
+  const operator = await db.operator.findUnique({
+    where: { id: config.recipientOperatorId },
+  });
+  if (!operator) {
+    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
+    return;
+  }
 
   // Create mailer from System Settings SMTP config
   const mailer = await createMailerFromSmtpSettings(db, encryptionKey);

--- a/services/scheduler-worker/src/operational-alerts.ts
+++ b/services/scheduler-worker/src/operational-alerts.ts
@@ -388,13 +388,21 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     ? (settingRow.value as unknown as OperationalAlertConfig)
     : DEFAULT_OPERATIONAL_ALERT_CONFIG;
 
-  if (!config.enabled || !config.recipientEmail) {
-    logger.debug('Operational alerts disabled or no recipient — skipping');
+  if (!config.enabled || !config.recipientOperatorId) {
+    logger.debug('Operational alerts disabled or no recipient operator — skipping');
     return;
   }
 
   // Restore throttle state from DB so restarts don't reset the throttle window
   await loadThrottleState(db);
+
+  const operator = await db.operator.findUnique({
+    where: { id: config.recipientOperatorId },
+  });
+  if (!operator) {
+    logger.warn({ recipientOperatorId: config.recipientOperatorId }, 'Recipient operator not found — skipping alerts');
+    return;
+  }
 
   // Gather alerts from all enabled checks in parallel
   const checkPromises: Promise<AlertMessage[]>[] = [];
@@ -439,12 +447,12 @@ async function runAlertCheck(opts: OperationalAlertOpts): Promise<void> {
     for (const alert of alertsToSend) {
       try {
         await mailer.send({
-          to: config.recipientEmail,
+          to: operator.email,
           subject: alert.subject,
           body: alert.body,
         });
         markAlertSent(alert.key);
-        logger.info({ alertKey: alert.key, to: config.recipientEmail }, 'Operational alert sent');
+        logger.info({ alertKey: alert.key, to: operator.email }, 'Operational alert sent');
       } catch (err) {
         logger.error({ err, alertKey: alert.key }, 'Failed to send operational alert email');
       }


### PR DESCRIPTION
## Summary
Refactored operational alerts configuration from the Settings component to the Notification Preferences component, providing a more intuitive user experience by consolidating all notification-related settings in one place.

## Key Changes

- **UI Reorganization**: Added a tabbed interface to Notification Preferences with two tabs:
  - "Event Notifications" (existing functionality)
  - "Operational Alerts" (moved from Settings)

- **Recipient Selection**: Changed operational alert recipient from a free-form email field to operator selection:
  - Updated `OperationalAlertConfig` interface to use `recipientOperatorId` instead of `recipientEmail`
  - Alerts now send to the selected operator's email address
  - Requires operator lookup before sending test alerts and during alert checks

- **Component Migration**:
  - Removed "Operational Alerts" tab and all related methods from `SettingsComponent`
  - Moved alert configuration logic to `NotificationPreferencesComponent`
  - Added `MatTabsModule` import for tabbed interface

- **Backend Updates**:
  - Updated validation schema to accept `recipientOperatorId` instead of `recipientEmail`
  - Modified alert sending logic in both `copilot-api` and `scheduler-worker` to fetch operator details before sending emails
  - Updated test alert endpoint to reference new location in help text

- **Type Updates**: Updated `OperationalAlertConfig` interface across shared types and service definitions

## Implementation Details

- Operator selection uses existing operators list already loaded in Notification Preferences
- Alert configuration persists to the same backend endpoint (`/settings/operational-alerts`)
- Test alert functionality preserved with updated recipient lookup
- Error handling includes validation for missing or invalid operator IDs
- UI maintains consistent styling and behavior with existing notification preferences

https://claude.ai/code/session_01Qz2oCdKayvVkvHZr8se1zB