### PR TITLE
fix/feat: debug session fixes — MCP tools, log alerts, ticket live reload, AI log cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ systems-config.json
 
 # User-local scripts
 usr/
+.claude/worktrees/

--- a/services/control-panel/src/app/core/services/system-analysis.service.ts
+++ b/services/control-panel/src/app/core/services/system-analysis.service.ts
@@ -57,4 +57,12 @@ export class SystemAnalysisService {
   regenerate(id: string): Observable<{ message: string }> {
     return this.api.post<{ message: string }>(`/system-analyses/${id}/regenerate`, {});
   }
+
+  reopen(id: string): Observable<SystemAnalysis> {
+    return this.api.patch<SystemAnalysis>(`/system-analyses/${id}/reopen`, {});
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/system-analyses/${id}`);
+  }
 }

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -198,7 +198,7 @@ export class TicketService {
     return this.api.get<TicketAiUsageResponse>(`/tickets/${ticketId}/ai-usage`, filters as Record<string, string | number>);
   }
 
-  getUnifiedLogs(ticketId: string, filters?: { limit?: number; offset?: number; type?: string; level?: string; search?: string }): Observable<UnifiedLogsResponse> {
+  getUnifiedLogs(ticketId: string, filters?: { limit?: number; offset?: number; type?: string; level?: string; search?: string; createdAfter?: string }): Observable<UnifiedLogsResponse> {
     return this.api.get<UnifiedLogsResponse>(`/tickets/${ticketId}/unified-logs`, filters as Record<string, string | number>);
   }
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -80,7 +80,7 @@ import { AiUsageService, type AiUsageClientSummary, type AiUsageLogEntry } from 
       }
 
       <div class="slack-channel-row">
-        <mat-form-field class="slack-channel-field">
+        <mat-form-field class="slack-channel-field" floatLabel="always">
           <mat-label>Slack Channel ID</mat-label>
           <input matInput [ngModel]="c.slackChannelId ?? ''" (ngModelChange)="pendingSlackChannelId = $event" placeholder="C0AQ0ELLGCV">
           <mat-hint>Right-click channel in Slack → View channel details → scroll to bottom</mat-hint>

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -349,12 +349,8 @@ export class IntegrationDialogComponent implements OnInit {
       if (config['authHeader'] === 'bearer') {
         delete config['authHeader'];
       }
-      // Persist disabled tools
-      if (this.disabledTools.size > 0) {
-        config['disabledTools'] = [...this.disabledTools];
-      } else {
-        delete config['disabledTools'];
-      }
+      // Always send disabledTools (even as empty array) so the backend merge can clear it
+      config['disabledTools'] = [...this.disabledTools];
     }
 
     // When editing, strip blank secret fields so the backend keeps the existing encrypted value

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -1,16 +1,17 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { IntegrationService } from '../../core/services/integration.service';
 import type { ClientIntegration } from '../../core/services/integration.service';
 import { AuthService } from '../../core/services/auth.service';
+import { McpToolVisibilityDialogComponent } from './mcp-tool-visibility-dialog.component';
 
 interface DialogData {
   clientId: string;
@@ -19,7 +20,7 @@ interface DialogData {
 
 @Component({
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule, MatCheckboxModule],
+  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule, MatIconModule],
   template: `
     <h2 mat-dialog-title>{{ editing ? 'Edit' : 'Add' }} Integration</h2>
     <mat-dialog-content>
@@ -143,18 +144,13 @@ interface DialogData {
 
         @if (discoveredTools.length > 0) {
           <div class="tool-visibility-section">
-            <h4 class="tool-heading">Tool Visibility for Agentic Analysis</h4>
-            <p class="tool-hint">Uncheck tools to hide them from the AI during agentic analysis.</p>
-            @for (tool of discoveredTools; track tool.name) {
-              <mat-checkbox
-                [checked]="!disabledTools.has(tool.name)"
-                (change)="toggleTool(tool.name, $event.checked)">
-                <span class="tool-name">{{ tool.name }}</span>
-                @if (tool.description) {
-                  <span class="tool-desc"> — {{ tool.description }}</span>
-                }
-              </mat-checkbox>
-            }
+            <span class="tool-summary">
+              {{ discoveredTools.length - disabledTools.size }}/{{ discoveredTools.length }} tools enabled
+              @if (disabledTools.size > 0) { <span class="disabled-count">({{ disabledTools.size }} hidden)</span> }
+            </span>
+            <button mat-stroked-button type="button" (click)="openToolVisibility()">
+              <mat-icon>tune</mat-icon> Manage Tools
+            </button>
           </div>
         }
       }
@@ -200,12 +196,9 @@ interface DialogData {
     .full-width { width: 100%; margin-bottom: 8px; }
     .advanced-toggle { font-size: 13px; color: #666; margin-bottom: 8px; }
     .loop-warning { background: #fff3e0; border: 1px solid #ff9800; border-radius: 6px; padding: 10px 14px; margin-bottom: 12px; font-size: 13px; color: #e65100; line-height: 1.4; }
-    .tool-visibility-section { margin-top: 12px; border-top: 1px solid #e0e0e0; padding-top: 12px; }
-    .tool-heading { font-size: 14px; font-weight: 500; margin: 0 0 4px; color: #333; }
-    .tool-hint { font-size: 12px; color: #777; margin: 0 0 8px; }
-    .tool-visibility-section mat-checkbox { display: block; margin-bottom: 4px; }
-    .tool-name { font-weight: 500; font-size: 13px; }
-    .tool-desc { font-size: 12px; color: #666; }
+    .tool-visibility-section { display: flex; align-items: center; gap: 12px; margin-top: 12px; border-top: 1px solid #e0e0e0; padding-top: 12px; }
+    .tool-summary { font-size: 13px; color: #555; flex: 1; }
+    .disabled-count { color: #e65100; margin-left: 4px; }
   `],
 })
 export class IntegrationDialogComponent implements OnInit {
@@ -214,6 +207,7 @@ export class IntegrationDialogComponent implements OnInit {
   private integrationService = inject(IntegrationService);
   private authService = inject(AuthService);
   private snackBar = inject(MatSnackBar);
+  private matDialog = inject(MatDialog);
 
   editing = false;
   type = '';
@@ -297,12 +291,15 @@ export class IntegrationDialogComponent implements OnInit {
     this.disabledTools = new Set();
   }
 
-  toggleTool(name: string, enabled: boolean): void {
-    if (enabled) {
-      this.disabledTools.delete(name);
-    } else {
-      this.disabledTools.add(name);
-    }
+  openToolVisibility(): void {
+    this.matDialog.open(McpToolVisibilityDialogComponent, {
+      width: '480px',
+      data: { tools: this.discoveredTools, disabledTools: this.disabledTools },
+    }).afterClosed().subscribe((result: Set<string> | undefined) => {
+      if (result !== undefined) {
+        this.disabledTools = result;
+      }
+    });
   }
 
   checkImapLoop(): void {

--- a/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
@@ -1,0 +1,103 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+
+export interface McpToolVisibilityDialogData {
+  tools: Array<{ name: string; description: string }>;
+  disabledTools: Set<string>;
+}
+
+@Component({
+  standalone: true,
+  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatSelectModule, MatButtonModule, MatChipsModule, MatIconModule],
+  template: `
+    <h2 mat-dialog-title>Tool Visibility</h2>
+    <mat-dialog-content>
+      <p class="summary">
+        {{ data.tools.length - disabledTools.size }} of {{ data.tools.length }} tools enabled for agentic analysis.
+      </p>
+
+      @if (disabledTools.size > 0) {
+        <div class="disabled-section">
+          <p class="section-label">Hidden from AI:</p>
+          <mat-chip-set>
+            @for (name of disabledToolList(); track name) {
+              <mat-chip (removed)="enable(name)">
+                {{ name }}
+                <button matChipRemove><mat-icon>cancel</mat-icon></button>
+              </mat-chip>
+            }
+          </mat-chip-set>
+        </div>
+      } @else {
+        <p class="all-enabled">All tools are currently enabled.</p>
+      }
+
+      @if (enabledTools().length > 0) {
+        <mat-form-field class="add-field">
+          <mat-label>Disable a tool…</mat-label>
+          <mat-select [(ngModel)]="toolToDisable" (ngModelChange)="disableSelected()">
+            @for (tool of enabledTools(); track tool.name) {
+              <mat-option [value]="tool.name">
+                <span class="opt-name">{{ tool.name }}</span>
+                @if (tool.description) {
+                  <span class="opt-desc"> — {{ tool.description }}</span>
+                }
+              </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+      <button mat-raised-button color="primary" (click)="apply()">Apply</button>
+    </mat-dialog-actions>
+  `,
+  styles: [`
+    .summary { font-size: 13px; color: #555; margin: 0 0 12px; }
+    .section-label { font-size: 12px; color: #777; margin: 0 0 6px; }
+    .disabled-section { margin-bottom: 16px; }
+    .all-enabled { font-size: 13px; color: #4caf50; margin: 0 0 16px; }
+    .add-field { width: 100%; }
+    .opt-name { font-weight: 500; }
+    .opt-desc { font-size: 12px; color: #888; }
+    mat-chip { font-size: 13px; }
+  `],
+})
+export class McpToolVisibilityDialogComponent {
+  private dialogRef = inject(MatDialogRef<McpToolVisibilityDialogComponent>);
+  readonly data: McpToolVisibilityDialogData = inject(MAT_DIALOG_DATA);
+
+  disabledTools = new Set<string>(this.data.disabledTools);
+  toolToDisable = '';
+
+  disabledToolList(): string[] {
+    return [...this.disabledTools].sort();
+  }
+
+  enabledTools(): Array<{ name: string; description: string }> {
+    return this.data.tools.filter(t => !this.disabledTools.has(t.name));
+  }
+
+  enable(name: string): void {
+    this.disabledTools = new Set(this.disabledTools);
+    this.disabledTools.delete(name);
+  }
+
+  disableSelected(): void {
+    if (!this.toolToDisable) return;
+    this.disabledTools = new Set(this.disabledTools);
+    this.disabledTools.add(this.toolToDisable);
+    this.toolToDisable = '';
+  }
+
+  apply(): void {
+    this.dialogRef.close(this.disabledTools);
+  }
+}

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -232,16 +232,18 @@ const COMMON_TIMEZONES = [
         </mat-form-field>
       }
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Category</mat-label>
-        <mat-select [(ngModel)]="category">
-          <mat-option [value]="null">None</mat-option>
-          @for (cat of data.categories; track cat.value) {
-            <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
-          }
-        </mat-select>
-        <mat-hint>Category assigned to tickets created by this probe.</mat-hint>
-      </mat-form-field>
+      @if (action !== 'email_direct') {
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Category</mat-label>
+          <mat-select [(ngModel)]="category">
+            <mat-option [value]="null">None</mat-option>
+            @for (cat of data.categories; track cat.value) {
+              <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
+            }
+          </mat-select>
+          <mat-hint>Category assigned to tickets created by this probe.</mat-hint>
+        </mat-form-field>
+      }
 
       @if (isEdit) {
         <div class="retention-section">

--- a/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
@@ -129,16 +129,24 @@ const STATUS_META: Record<string, { icon: string; label: string; color: string }
               </div>
             }
 
-            @if (a.status === 'PENDING') {
-              <div class="action-bar">
+            <div class="action-bar">
+              @if (a.status === 'PENDING') {
                 <button mat-raised-button color="primary" (click)="acknowledge(a)">
                   <mat-icon>check</mat-icon> Acknowledge
                 </button>
                 <button mat-raised-button color="warn" (click)="openRejectDialog(a)">
                   <mat-icon>close</mat-icon> Reject
                 </button>
-              </div>
-            }
+              }
+              @if (a.status !== 'PENDING') {
+                <button mat-stroked-button (click)="reopen(a)" matTooltip="Reset to pending for re-review">
+                  <mat-icon>undo</mat-icon> Reopen
+                </button>
+              }
+              <button mat-icon-button color="warn" (click)="deleteAnalysis(a)" matTooltip="Delete permanently">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
           </mat-card-content>
         </mat-card>
       } @empty {
@@ -373,6 +381,33 @@ export class SystemAnalysisComponent implements OnInit {
           },
         });
       }
+    });
+  }
+
+  reopen(a: SystemAnalysis): void {
+    this.analysisService.reopen(a.id).subscribe({
+      next: () => {
+        this.snackBar.open('Analysis reopened', 'OK', { duration: 3000 });
+        this.load();
+        this.loadStats();
+      },
+      error: (err) => {
+        this.snackBar.open(err.error?.error ?? 'Failed to reopen', 'OK', { duration: 5000 });
+      },
+    });
+  }
+
+  deleteAnalysis(a: SystemAnalysis): void {
+    if (!confirm('Delete this analysis permanently?')) return;
+    this.analysisService.delete(a.id).subscribe({
+      next: () => {
+        this.snackBar.open('Analysis deleted', 'OK', { duration: 3000 });
+        this.load();
+        this.loadStats();
+      },
+      error: (err) => {
+        this.snackBar.open(err.error?.error ?? 'Failed to delete', 'OK', { duration: 5000 });
+      },
     });
   }
 

--- a/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
+++ b/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
@@ -1,0 +1,196 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { type UnifiedLogEntry } from '../../core/services/ticket.service';
+
+@Component({
+  selector: 'app-ai-log-entry',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule],
+  template: `
+    <div class="ai-log-entry unified-type-ai" [class.iteration-grouped]="iterationGrouped()">
+      <!-- Header row -->
+      <div class="log-entry-header">
+        <span class="log-seq">#{{ idx() + 1 }}</span>
+        <span class="log-time" [matTooltip]="entry().timestamp">{{ formatTime(entry().timestamp) }}</span>
+        <span class="unified-type-badge ubadge-ai">AI</span>
+        <span class="meta-chip provider-chip provider-{{ (entry().provider ?? '').toLowerCase() }}">{{ entry().provider }}</span>
+        <code class="meta-chip model-chip">{{ entry().model }}</code>
+        <span class="meta-chip task-chip">{{ entry().taskType }}</span>
+        <span class="meta-chip token-chip">{{ entry().inputTokens | number }}in / {{ entry().outputTokens | number }}out</span>
+        @if (entry().durationMs != null) {
+          <span class="meta-chip duration-chip">{{ entry().durationMs | number }}ms</span>
+        }
+        @if (entry().costUsd != null) {
+          <span class="ai-usage-cost">\${{ entry().costUsd | number:'1.4-4' }}</span>
+        }
+      </div>
+
+      <!-- Prompt -->
+      @if (promptText()) {
+        <div class="inline-text-block">
+          <span class="inline-block-label">Prompt</span>
+          <pre class="inline-text-content" [class.clamped]="!promptExpanded">{{ promptExpanded ? promptText() : firstLine(promptText()!) }}</pre>
+          @if (isMultiline(promptText()!)) {
+            <button mat-button class="inline-expand-btn" (click)="promptExpanded = !promptExpanded">
+              {{ promptExpanded ? 'less' : 'more' }}
+              <mat-icon>{{ promptExpanded ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+            </button>
+          }
+        </div>
+      }
+
+      <!-- Response -->
+      @if (responseText()) {
+        <div class="inline-text-block">
+          <span class="inline-block-label">Response</span>
+          <pre class="inline-text-content" [class.clamped]="!responseExpanded">{{ responseExpanded ? responseText() : firstLine(responseText()!) }}</pre>
+          @if (isMultiline(responseText()!)) {
+            <button mat-button class="inline-expand-btn" (click)="responseExpanded = !responseExpanded">
+              {{ responseExpanded ? 'less' : 'more' }}
+              <mat-icon>{{ responseExpanded ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+            </button>
+          }
+        </div>
+      }
+
+      <!-- More data (system prompt, prompt key, conversation metadata, archive stats) -->
+      @if (hasMoreData()) {
+        <button mat-button class="log-expand-btn" (click)="moreDataExpanded = !moreDataExpanded">
+          {{ moreDataExpanded ? 'less data' : 'more data' }}
+          <mat-icon>{{ moreDataExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+        </button>
+        @if (moreDataExpanded) {
+          <div class="ai-detail-sections">
+            @if (entry().promptKey) {
+              <div class="ai-detail-label">Prompt Key: <code>{{ entry().promptKey }}</code></div>
+            }
+            @if (systemPromptText()) {
+              <div class="ai-detail-block">
+                <button mat-button class="log-expand-btn sys-prompt-toggle" (click)="systemPromptExpanded = !systemPromptExpanded">
+                  System Prompt
+                  <mat-icon>{{ systemPromptExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+                </button>
+                @if (systemPromptExpanded) {
+                  <pre class="log-metadata">{{ systemPromptText() }}</pre>
+                }
+              </div>
+            }
+            @if (entry().conversationMetadata) {
+              <div class="ai-detail-block">
+                <div class="ai-detail-label">Conversation Metadata</div>
+                <pre class="log-metadata">{{ entry().conversationMetadata | json }}</pre>
+              </div>
+            }
+            @if (entry().archive?.messageCount != null) {
+              <div class="ai-detail-label">Messages: {{ entry().archive?.messageCount }} &middot; Context tokens: {{ entry().archive?.totalContextTokens | number }}</div>
+            }
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [`
+    .ai-log-entry {
+      border-left: 3px solid #7c4dff;
+      background: #fafafa;
+      padding: 6px 10px;
+      border-radius: 0 4px 4px 0;
+      margin-bottom: 4px;
+    }
+    .iteration-grouped { margin-left: 20px; border-left-color: #b39ddb; }
+    .log-entry-header { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+    .log-seq { font-size: 10px; color: #bbb; min-width: 28px; }
+    .log-time { font-size: 11px; color: #999; white-space: nowrap; }
+    .unified-type-badge { font-size: 10px; font-weight: 700; padding: 1px 5px; border-radius: 3px; }
+    .ubadge-ai { background: #7c4dff; color: white; }
+    .meta-chip { font-size: 11px; padding: 1px 6px; border-radius: 10px; white-space: nowrap; }
+    .provider-chip { background: #e8eaf6; color: #3949ab; }
+    .provider-anthropic { background: #fce4ec; color: #c2185b; }
+    .provider-openai { background: #e0f7fa; color: #00838f; }
+    .provider-ollama { background: #f3e5f5; color: #7b1fa2; }
+    .model-chip { background: #f5f5f5; color: #444; }
+    .task-chip { background: #e8f5e9; color: #2e7d32; }
+    .token-chip { background: #fff3e0; color: #e65100; }
+    .duration-chip { background: #fce4ec; color: #880e4f; }
+    .ai-usage-cost { font-size: 12px; font-weight: 600; color: #2e7d32; margin-left: 4px; }
+
+    /* Inline prompt/response blocks */
+    .inline-text-block { margin-top: 6px; }
+    .inline-block-label { font-size: 10px; font-weight: 700; color: #999; text-transform: uppercase; letter-spacing: 0.5px; display: block; margin-bottom: 2px; }
+    .inline-text-content {
+      font-size: 12px;
+      font-family: monospace;
+      color: #333;
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      background: #f7f7f7;
+      padding: 6px 8px;
+      border-radius: 4px;
+      border-left: 2px solid #e0e0e0;
+    }
+    .inline-expand-btn {
+      font-size: 11px;
+      min-height: 22px;
+      color: #666;
+      padding: 0 4px;
+      display: inline-flex;
+      align-items: center;
+    }
+    .inline-expand-btn mat-icon { font-size: 14px; width: 14px; height: 14px; }
+
+    /* More data section */
+    .log-expand-btn { font-size: 11px; min-height: 24px; color: #888; padding: 0 4px; }
+    .ai-detail-sections { padding: 4px 0 2px; }
+    .ai-detail-label { font-size: 11px; font-weight: 600; color: #666; margin: 4px 0 2px; }
+    .ai-detail-label code { font-weight: 400; background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
+    .ai-detail-block { margin-bottom: 8px; }
+    .sys-prompt-toggle { min-height: 24px; font-size: 11px; font-weight: 600; color: #666; padding: 0 4px; text-transform: uppercase; letter-spacing: 0.3px; }
+    .log-metadata { font-size: 12px; font-family: monospace; white-space: pre-wrap; word-break: break-word; background: #f5f5f5; padding: 8px; border-radius: 4px; margin: 4px 0; max-height: 400px; overflow-y: auto; }
+  `],
+})
+export class AiLogEntryComponent {
+  entry = input.required<UnifiedLogEntry>();
+  idx = input.required<number>();
+  iterationGrouped = input(false);
+
+  promptExpanded = false;
+  responseExpanded = false;
+  moreDataExpanded = false;
+  systemPromptExpanded = false;
+
+  promptText(): string | null {
+    return this.entry().archive?.fullPrompt ?? this.entry().promptText ?? null;
+  }
+
+  responseText(): string | null {
+    return this.entry().archive?.fullResponse ?? this.entry().responseText ?? null;
+  }
+
+  systemPromptText(): string | null {
+    return this.entry().archive?.systemPrompt ?? this.entry().systemPrompt ?? null;
+  }
+
+  hasMoreData(): boolean {
+    const e = this.entry();
+    return !!(e.promptKey || this.systemPromptText() || e.conversationMetadata || e.archive?.messageCount != null);
+  }
+
+  firstLine(text: string): string {
+    return text.split('\n').find(l => l.trim().length > 0) ?? '';
+  }
+
+  isMultiline(text: string): boolean {
+    const lines = text.split('\n').filter(l => l.trim().length > 0);
+    return lines.length > 1;
+  }
+
+  formatTime(dateStr: string): string {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
+      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit' });
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1088,6 +1088,8 @@ export class TicketDetailComponent implements OnInit {
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
   private readonly TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'PENDING']);
+  private knownEventIds = new Set<string>();
+  private lastUnifiedLogAt: string | null = null;
 
   ticket = signal<(Ticket & { client?: { name: string }; system?: { name: string } | null }) | null>(null);
   events = signal<TicketEvent[]>([]);
@@ -1240,7 +1242,17 @@ export class TicketDetailComponent implements OnInit {
   load(): void {
     this.ticketService.getTicket(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => {
       this.ticket.set(t);
-      this.events.set(t.events ?? []);
+      const incoming = t.events ?? [];
+      if (this.knownEventIds.size === 0) {
+        this.events.set(incoming);
+        for (const e of incoming) this.knownEventIds.add(e.id);
+      } else {
+        const newEvents = incoming.filter(e => !this.knownEventIds.has(e.id));
+        if (newEvents.length > 0) {
+          this.events.update(current => [...current, ...newEvents]);
+          for (const e of newEvents) this.knownEventIds.add(e.id);
+        }
+      }
       this.managePoll(t.analysisStatus);
     });
   }
@@ -1248,7 +1260,12 @@ export class TicketDetailComponent implements OnInit {
   private managePoll(analysisStatus: string | null | undefined): void {
     if (analysisStatus === 'IN_PROGRESS') {
       if (!this.pollHandle) {
-        this.pollHandle = setInterval(() => this.load(), this.POLL_INTERVAL_MS);
+        this.pollHandle = setInterval(() => {
+          this.load();
+          this.pollUnifiedLogs();
+          this.loadTicketCost();
+          this.loadCostSummary();
+        }, this.POLL_INTERVAL_MS);
       }
     } else {
       this.stopPolling();
@@ -1309,8 +1326,36 @@ export class TicketDetailComponent implements OnInit {
           this.unifiedLogs.set(res.entries);
           this.unifiedLogsTotal.set(res.total);
           this.unifiedLogsLoading.set(false);
+          if (res.entries.length > 0) {
+            this.lastUnifiedLogAt = res.entries[res.entries.length - 1].timestamp;
+          }
         },
         error: () => this.unifiedLogsLoading.set(false),
+      });
+  }
+
+  private pollUnifiedLogs(): void {
+    if (!this.lastUnifiedLogAt) return;
+    const filters: Record<string, string | number> = { limit: 200, createdAfter: this.lastUnifiedLogAt };
+    const type = this.unifiedTypeFilter();
+    const level = this.logsLevelFilter();
+    const search = this.logsSearchFilter();
+    if (type) filters['type'] = type;
+    if (level) filters['level'] = level;
+    if (search) filters['search'] = search;
+
+    this.ticketService
+      .getUnifiedLogs(this.id(), filters as never)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          if (res.entries.length > 0) {
+            this.unifiedLogs.update(current => [...current, ...res.entries]);
+            this.unifiedLogsTotal.update(t => t + res.entries.length);
+            this.lastUnifiedLogAt = res.entries[res.entries.length - 1].timestamp;
+          }
+        },
+        error: () => {},
       });
   }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -20,6 +20,7 @@ import { TicketService, Ticket, TicketEvent, type TicketAppLog, type TicketAiUsa
 import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service';
 import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service';
 import { AiHelpDialogComponent, type AiHelpDialogData } from '../../shared/components/ai-help-dialog.component';
+import { AiLogEntryComponent } from './ai-log-entry.component';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
 
@@ -32,7 +33,7 @@ interface FlowNode {
 
 @Component({
   standalone: true,
-  imports: [CommonModule, RouterLink, DatePipe, JsonPipe, FormsModule, MatCardModule, MatButtonModule, MatIconModule, MatChipsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatProgressBarModule, MatTooltipModule, MatTabsModule, MarkdownPipe, RelativeTimePipe],
+  imports: [CommonModule, RouterLink, DatePipe, JsonPipe, FormsModule, MatCardModule, MatButtonModule, MatIconModule, MatChipsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatProgressBarModule, MatTooltipModule, MatTabsModule, MarkdownPipe, RelativeTimePipe, AiLogEntryComponent],
   template: `
     @if (ticket(); as t) {
       <div class="page-header">
@@ -239,103 +240,33 @@ interface FlowNode {
                     <span class="log-seq">#{{ idx + 1 }}</span>
                     <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
                   </div>
+                } @else if (entry.type === 'ai') {
+                  <app-ai-log-entry [entry]="entry" [idx]="idx" [iterationGrouped]="isWithinIteration(entry)" />
                 } @else {
                 <div class="log-entry" [ngClass]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
                   <div class="log-entry-header">
                     <span class="log-seq">#{{ idx + 1 }}</span>
                     <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
                     <span class="unified-type-badge" [ngClass]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
-
-                    <!-- AI entry display -->
-                    @if (entry.type === 'ai') {
-                      <span class="meta-chip provider-chip provider-{{ (entry.provider ?? '').toLowerCase() }}">{{ entry.provider }}</span>
-                      <code class="meta-chip model-chip">{{ entry.model }}</code>
-                      <span class="meta-chip task-chip">{{ entry.taskType }}</span>
-                      <span class="meta-chip token-chip">{{ entry.inputTokens | number }}in / {{ entry.outputTokens | number }}out</span>
-                      @if (entry.durationMs != null) {
-                        <span class="meta-chip duration-chip">{{ entry.durationMs | number }}ms</span>
-                      }
-                      @if (entry.costUsd != null) {
-                        <span class="ai-usage-cost">\${{ entry.costUsd | number:'1.4-4' }}</span>
-                      }
-                      @if (!expandedLogs[entry.id] && promptFirstLine(entry)) {
-                        <span class="prompt-preview">{{ promptFirstLine(entry) }}</span>
-                      }
+                    @if (entry.level) {
+                      <span class="log-level-badge log-badge-{{ entry.level.toLowerCase() }}">{{ entry.level }}</span>
                     }
-
-                    <!-- Log/Tool/Step/Error entry display -->
-                    @if (entry.type !== 'ai') {
-                      @if (entry.level) {
-                        <span class="log-level-badge log-badge-{{ entry.level.toLowerCase() }}">{{ entry.level }}</span>
-                      }
-                      @if (entry.service) {
-                        <span class="log-service">{{ entry.service }}</span>
-                      }
-                      <span class="log-message">{{ entry.message }}</span>
+                    @if (entry.service) {
+                      <span class="log-service">{{ entry.service }}</span>
                     }
+                    <span class="log-message">{{ entry.message }}</span>
                   </div>
-
-                  <!-- Expandable AI detail -->
-                  @if (entry.type === 'ai') {
+                  @if (entry.context && hasKeys(entry.context)) {
                     <button mat-button class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
-                      {{ expandedLogs[entry.id] ? 'Hide details' : 'Show details' }}
+                      {{ expandedLogs[entry.id] ? 'Hide metadata' : 'Show metadata' }}
                       <mat-icon>{{ expandedLogs[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
                     </button>
                     @if (expandedLogs[entry.id]) {
-                      <div class="ai-detail-sections">
-                        @if (entry.promptKey) {
-                          <div class="ai-detail-label">Prompt Key: <code>{{ entry.promptKey }}</code></div>
-                        }
-                        @if (entry.archive?.fullPrompt || entry.promptText) {
-                          <div class="ai-detail-block">
-                            <div class="ai-detail-label">Prompt</div>
-                            <pre class="log-metadata">{{ entry.archive?.fullPrompt ?? entry.promptText }}</pre>
-                          </div>
-                        }
-                        @if (entry.archive?.systemPrompt || entry.systemPrompt) {
-                          <div class="ai-detail-block">
-                            <button mat-button class="log-expand-btn sys-prompt-toggle" (click)="expandedSystemPrompts[entry.id] = !expandedSystemPrompts[entry.id]">
-                              System Prompt
-                              <mat-icon>{{ expandedSystemPrompts[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                            </button>
-                            @if (expandedSystemPrompts[entry.id]) {
-                              <pre class="log-metadata">{{ entry.archive?.systemPrompt ?? entry.systemPrompt }}</pre>
-                            }
-                          </div>
-                        }
-                        @if (entry.archive?.fullResponse || entry.responseText) {
-                          <div class="ai-detail-block">
-                            <div class="ai-detail-label">Response</div>
-                            <pre class="log-metadata">{{ entry.archive?.fullResponse ?? entry.responseText }}</pre>
-                          </div>
-                        }
-                        @if (entry.conversationMetadata) {
-                          <div class="ai-detail-block">
-                            <div class="ai-detail-label">Conversation Metadata</div>
-                            <pre class="log-metadata">{{ entry.conversationMetadata | json }}</pre>
-                          </div>
-                        }
-                        @if (entry.archive?.messageCount != null) {
-                          <div class="ai-detail-label">Messages: {{ entry.archive?.messageCount }} &middot; Context tokens: {{ entry.archive?.totalContextTokens | number }}</div>
-                        }
-                      </div>
+                      <pre class="log-metadata">{{ entry.context | json }}</pre>
                     }
                   }
-
-                  <!-- Expandable metadata for log entries -->
-                  @if (entry.type !== 'ai') {
-                    @if (entry.context && hasKeys(entry.context)) {
-                      <button mat-button class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
-                        {{ expandedLogs[entry.id] ? 'Hide metadata' : 'Show metadata' }}
-                        <mat-icon>{{ expandedLogs[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                      </button>
-                      @if (expandedLogs[entry.id]) {
-                        <pre class="log-metadata">{{ entry.context | json }}</pre>
-                      }
-                    }
-                    @if (entry.error) {
-                      <div class="log-error-detail">{{ entry.error }}</div>
-                    }
+                  @if (entry.error) {
+                    <div class="log-error-detail">{{ entry.error }}</div>
                   }
                 </div>
                 }
@@ -1055,10 +986,7 @@ interface FlowNode {
     /* AI detail sections in unified logs */
     .ai-detail-sections { padding: 8px 0 4px; }
     .ai-detail-label { font-size: 11px; font-weight: 600; color: #666; margin: 4px 0 2px; }
-    .ai-detail-label code { font-weight: 400; background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
     .ai-detail-block { margin-bottom: 8px; }
-    .prompt-preview { display: block; font-size: 11px; color: #888; font-family: monospace; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 600px; }
-    .sys-prompt-toggle { min-height: 24px; font-size: 11px; font-weight: 600; color: #666; padding: 0 4px; text-transform: uppercase; letter-spacing: 0.3px; }
 
     /* Logs cost summary */
     .logs-cost-summary { background: #f8faf8; border: 1px solid #e0e8e0; border-radius: 8px; padding: 12px 16px; margin-bottom: 12px; }
@@ -1123,7 +1051,6 @@ export class TicketDetailComponent implements OnInit {
   logsLevelFilter = signal('');
   logsSearchFilter = signal('');
   expandedLogs: Record<string, boolean> = {};
-  expandedSystemPrompts: Record<string, boolean> = {};
   costSummary = signal<TicketCostSummary | null>(null);
 
   // Legacy — still used by loadTicketAiUsage for the existing AI Cost card
@@ -1411,12 +1338,6 @@ export class TicketDetailComponent implements OnInit {
 
   hasKeys(obj: Record<string, unknown>): boolean {
     return Object.keys(obj).length > 0;
-  }
-
-  promptFirstLine(entry: UnifiedLogEntry): string {
-    const text = entry.archive?.fullPrompt ?? entry.promptText ?? '';
-    const line = text.split('\n').find(l => l.trim().length > 0) ?? '';
-    return line.length > 120 ? line.slice(0, 120) + '…' : line;
   }
 
   generateLogSummary(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1025,8 +1025,8 @@ export class TicketDetailComponent implements OnInit {
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
-  private readonly TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'PENDING']);
   private knownEventIds = new Set<string>();
+  private knownUnifiedLogIds = new Set<string>();
   private lastUnifiedLogAt: string | null = null;
 
   ticket = signal<(Ticket & { client?: { name: string }; system?: { name: string } | null }) | null>(null);
@@ -1264,6 +1264,8 @@ export class TicketDetailComponent implements OnInit {
           this.unifiedLogs.set(res.entries);
           this.unifiedLogsTotal.set(res.total);
           this.unifiedLogsLoading.set(false);
+          this.knownUnifiedLogIds.clear();
+          for (const e of res.entries) this.knownUnifiedLogIds.add(e.id);
           if (res.entries.length > 0) {
             this.lastUnifiedLogAt = res.entries[res.entries.length - 1].timestamp;
           }
@@ -1273,8 +1275,10 @@ export class TicketDetailComponent implements OnInit {
   }
 
   private pollUnifiedLogs(): void {
-    if (!this.lastUnifiedLogAt) return;
-    const filters: Record<string, string | number> = { limit: 200, createdAfter: this.lastUnifiedLogAt };
+    const filters: Record<string, string | number> = { limit: 200 };
+    if (this.lastUnifiedLogAt) {
+      filters['createdAfter'] = this.lastUnifiedLogAt;
+    }
     const type = this.unifiedTypeFilter();
     const level = this.logsLevelFilter();
     const search = this.logsSearchFilter();
@@ -1287,10 +1291,12 @@ export class TicketDetailComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
-          if (res.entries.length > 0) {
-            this.unifiedLogs.update(current => [...current, ...res.entries]);
-            this.unifiedLogsTotal.update(t => t + res.entries.length);
-            this.lastUnifiedLogAt = res.entries[res.entries.length - 1].timestamp;
+          const newEntries = res.entries.filter(e => !this.knownUnifiedLogIds.has(e.id));
+          if (newEntries.length > 0) {
+            this.unifiedLogs.update(current => [...current, ...newEntries]);
+            this.unifiedLogsTotal.update(t => t + newEntries.length);
+            this.lastUnifiedLogAt = newEntries[newEntries.length - 1].timestamp;
+            for (const e of newEntries) this.knownUnifiedLogIds.add(e.id);
           }
         },
         error: () => {},

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1085,6 +1085,10 @@ export class TicketDetailComponent implements OnInit {
   private snackBar = inject(MatSnackBar);
   private dialog = inject(MatDialog);
 
+  private pollHandle: ReturnType<typeof setInterval> | null = null;
+  private readonly POLL_INTERVAL_MS = 4_000;
+  private readonly TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'PENDING']);
+
   ticket = signal<(Ticket & { client?: { name: string }; system?: { name: string } | null }) | null>(null);
   events = signal<TicketEvent[]>([]);
   logSummaries = signal<LogSummary[]>([]);
@@ -1230,13 +1234,32 @@ export class TicketDetailComponent implements OnInit {
     this.loadUnifiedLogs();
     this.loadCostSummary();
     this.loadTicketAiUsage();
+    this.destroyRef.onDestroy(() => this.stopPolling());
   }
 
   load(): void {
     this.ticketService.getTicket(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => {
       this.ticket.set(t);
       this.events.set(t.events ?? []);
+      this.managePoll(t.analysisStatus);
     });
+  }
+
+  private managePoll(analysisStatus: string | null | undefined): void {
+    if (analysisStatus === 'IN_PROGRESS') {
+      if (!this.pollHandle) {
+        this.pollHandle = setInterval(() => this.load(), this.POLL_INTERVAL_MS);
+      }
+    } else {
+      this.stopPolling();
+    }
+  }
+
+  private stopPolling(): void {
+    if (this.pollHandle) {
+      clearInterval(this.pollHandle);
+      this.pollHandle = null;
+    }
   }
 
   loadTicketCost(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -258,6 +258,9 @@ interface FlowNode {
                       @if (entry.costUsd != null) {
                         <span class="ai-usage-cost">\${{ entry.costUsd | number:'1.4-4' }}</span>
                       }
+                      @if (!expandedLogs[entry.id] && promptFirstLine(entry)) {
+                        <span class="prompt-preview">{{ promptFirstLine(entry) }}</span>
+                      }
                     }
 
                     <!-- Log/Tool/Step/Error entry display -->
@@ -291,8 +294,13 @@ interface FlowNode {
                         }
                         @if (entry.archive?.systemPrompt || entry.systemPrompt) {
                           <div class="ai-detail-block">
-                            <div class="ai-detail-label">System Prompt</div>
-                            <pre class="log-metadata">{{ entry.archive?.systemPrompt ?? entry.systemPrompt }}</pre>
+                            <button mat-button class="log-expand-btn sys-prompt-toggle" (click)="expandedSystemPrompts[entry.id] = !expandedSystemPrompts[entry.id]">
+                              System Prompt
+                              <mat-icon>{{ expandedSystemPrompts[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
+                            </button>
+                            @if (expandedSystemPrompts[entry.id]) {
+                              <pre class="log-metadata">{{ entry.archive?.systemPrompt ?? entry.systemPrompt }}</pre>
+                            }
                           </div>
                         }
                         @if (entry.archive?.fullResponse || entry.responseText) {
@@ -1049,6 +1057,8 @@ interface FlowNode {
     .ai-detail-label { font-size: 11px; font-weight: 600; color: #666; margin: 4px 0 2px; }
     .ai-detail-label code { font-weight: 400; background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
     .ai-detail-block { margin-bottom: 8px; }
+    .prompt-preview { display: block; font-size: 11px; color: #888; font-family: monospace; margin-top: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 600px; }
+    .sys-prompt-toggle { min-height: 24px; font-size: 11px; font-weight: 600; color: #666; padding: 0 4px; text-transform: uppercase; letter-spacing: 0.3px; }
 
     /* Logs cost summary */
     .logs-cost-summary { background: #f8faf8; border: 1px solid #e0e8e0; border-radius: 8px; padding: 12px 16px; margin-bottom: 12px; }
@@ -1113,6 +1123,7 @@ export class TicketDetailComponent implements OnInit {
   logsLevelFilter = signal('');
   logsSearchFilter = signal('');
   expandedLogs: Record<string, boolean> = {};
+  expandedSystemPrompts: Record<string, boolean> = {};
   costSummary = signal<TicketCostSummary | null>(null);
 
   // Legacy — still used by loadTicketAiUsage for the existing AI Cost card
@@ -1400,6 +1411,12 @@ export class TicketDetailComponent implements OnInit {
 
   hasKeys(obj: Record<string, unknown>): boolean {
     return Object.keys(obj).length > 0;
+  }
+
+  promptFirstLine(entry: UnifiedLogEntry): string {
+    const text = entry.archive?.fullPrompt ?? entry.promptText ?? '';
+    const line = text.split('\n').find(l => l.trim().length > 0) ?? '';
+    return line.length > 120 ? line.slice(0, 120) + '…' : line;
   }
 
   generateLogSummary(): void {

--- a/services/copilot-api/src/routes/system-analyses.ts
+++ b/services/copilot-api/src/routes/system-analyses.ts
@@ -177,4 +177,39 @@ export async function systemAnalysisRoutes(
       return { message: 'Analysis regeneration queued' };
     },
   );
+
+  // PATCH /api/system-analyses/:id/reopen — reset to PENDING so it can be re-reviewed
+  fastify.patch<{ Params: { id: string } }>(
+    '/api/system-analyses/:id/reopen',
+    async (request) => {
+      const existing = await fastify.db.systemAnalysis.findUnique({
+        where: { id: request.params.id },
+        select: { status: true },
+      });
+      if (!existing) return fastify.httpErrors.notFound('Analysis not found');
+      if (existing.status === 'PENDING') {
+        return fastify.httpErrors.badRequest('Analysis is already pending');
+      }
+
+      return fastify.db.systemAnalysis.update({
+        where: { id: request.params.id },
+        data: { status: 'PENDING', rejectionReason: null },
+      });
+    },
+  );
+
+  // DELETE /api/system-analyses/:id — permanently delete an analysis
+  fastify.delete<{ Params: { id: string } }>(
+    '/api/system-analyses/:id',
+    async (request, reply) => {
+      const existing = await fastify.db.systemAnalysis.findUnique({
+        where: { id: request.params.id },
+        select: { id: true },
+      });
+      if (!existing) return fastify.httpErrors.notFound('Analysis not found');
+
+      await fastify.db.systemAnalysis.delete({ where: { id: request.params.id } });
+      reply.code(204);
+    },
+  );
 }

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -541,9 +541,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
 
   fastify.get<{
     Params: { id: string };
-    Querystring: { limit?: string; offset?: string; type?: string; level?: string; search?: string; includeArchive?: string };
+    Querystring: { limit?: string; offset?: string; type?: string; level?: string; search?: string; includeArchive?: string; createdAfter?: string };
   }>('/api/tickets/:id/unified-logs', async (request) => {
-    const { limit: rawLimit = '100', offset: rawOffset = '0', type, level, search, includeArchive } = request.query;
+    const { limit: rawLimit = '100', offset: rawOffset = '0', type, level, search, includeArchive, createdAfter } = request.query;
 
     const take = Math.trunc(Number(rawLimit));
     const skip = Math.trunc(Number(rawOffset));
@@ -562,13 +562,20 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     const wantLogs = !type || type === 'log' || type === 'tool' || type === 'step' || type === 'error';
     const wantAi = !type || type === 'ai';
 
+    const afterDate = createdAfter ? new Date(createdAfter) : null;
+    if (afterDate && isNaN(afterDate.getTime())) {
+      return fastify.httpErrors.badRequest('createdAfter must be a valid ISO timestamp');
+    }
+
     // Build app_logs where clause
     const logWhere: Record<string, unknown> = { entityId: ticketId, entityType: 'ticket' };
     if (level) logWhere.level = level;
     if (search) logWhere.message = { contains: search, mode: 'insensitive' };
+    if (afterDate) logWhere.createdAt = { gt: afterDate };
 
     // Build ai_usage_logs where clause
     const aiWhere: Record<string, unknown> = { entityId: ticketId, entityType: 'ticket' };
+    if (afterDate) aiWhere.createdAt = { gt: afterDate };
     if (search) {
       aiWhere.OR = [
         { taskType: { contains: search, mode: 'insensitive' } },

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -571,11 +571,11 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     const logWhere: Record<string, unknown> = { entityId: ticketId, entityType: 'ticket' };
     if (level) logWhere.level = level;
     if (search) logWhere.message = { contains: search, mode: 'insensitive' };
-    if (afterDate) logWhere.createdAt = { gt: afterDate };
+    if (afterDate) logWhere.createdAt = { gte: afterDate };
 
     // Build ai_usage_logs where clause
     const aiWhere: Record<string, unknown> = { entityId: ticketId, entityType: 'ticket' };
-    if (afterDate) aiWhere.createdAt = { gt: afterDate };
+    if (afterDate) aiWhere.createdAt = { gte: afterDate };
     if (search) {
       aiWhere.OR = [
         { taskType: { contains: search, mode: 'insensitive' } },

--- a/services/scheduler-worker/src/log-summarizer.ts
+++ b/services/scheduler-worker/src/log-summarizer.ts
@@ -479,6 +479,13 @@ export async function runSummarizationPass(
     'Log summarization pass complete',
   );
 
+  // Write heartbeat so the staleness alert knows the pass ran, even when nothing was summarized
+  await db.appSetting.upsert({
+    where: { key: 'log-summarizer:last-run-at' },
+    create: { key: 'log-summarizer:last-run-at', value: new Date().toISOString() as unknown as object },
+    update: { value: new Date().toISOString() as unknown as object },
+  });
+
   return {
     ticketSummaries,
     orphanSummaries: orphanResult.created,

--- a/services/scheduler-worker/src/log-summarizer.ts
+++ b/services/scheduler-worker/src/log-summarizer.ts
@@ -480,10 +480,11 @@ export async function runSummarizationPass(
   );
 
   // Write heartbeat so the staleness alert knows the pass ran, even when nothing was summarized
+  const heartbeatTimestamp = new Date().toISOString();
   await db.appSetting.upsert({
     where: { key: 'log-summarizer:last-run-at' },
-    create: { key: 'log-summarizer:last-run-at', value: new Date().toISOString() as unknown as object },
-    update: { value: new Date().toISOString() as unknown as object },
+    create: { key: 'log-summarizer:last-run-at', value: heartbeatTimestamp },
+    update: { value: heartbeatTimestamp },
   });
 
   return {

--- a/services/scheduler-worker/src/operational-alerts.ts
+++ b/services/scheduler-worker/src/operational-alerts.ts
@@ -314,36 +314,29 @@ async function checkDevopsSyncStaleness(db: PrismaClient): Promise<AlertMessage[
 async function checkSummarizationStaleness(db: PrismaClient): Promise<AlertMessage[]> {
   const alerts: AlertMessage[] = [];
   try {
-    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    // Use the heartbeat written by runSummarizationPass after every pass — this updates even
+    // when there is nothing to summarize, preventing false positives on idle systems.
+    const heartbeatRow = await db.appSetting.findUnique({
+      where: { key: 'log-summarizer:last-run-at' },
+    });
 
-    const [latestSummary, unsummarizedCount] = await Promise.all([
-      db.logSummary.findFirst({
-        orderBy: { createdAt: 'desc' },
-        select: { createdAt: true },
-      }),
-      db.appLog.count({
-        where: {
-          createdAt: { gte: twoHoursAgo },
-        },
-      }),
-    ]);
+    if (!heartbeatRow) return alerts; // Summarizer hasn't run yet — system is new
 
-    if (!latestSummary) return alerts; // No summaries yet — system is new
+    const lastRunAt = new Date(heartbeatRow.value as string);
+    const sinceLast = Date.now() - lastRunAt.getTime();
+    const staleThresholdMs = 90 * 60 * 1000; // 90 min — runs every 30 min, so 3 missed passes = alert
 
-    const sinceLast = Date.now() - latestSummary.createdAt.getTime();
-    const staleThresholdMs = 2 * 60 * 60 * 1000; // 2 hours
-
-    if (sinceLast > staleThresholdMs && unsummarizedCount > 0) {
-      const hoursAgo = Math.round(sinceLast / (60 * 60 * 1000));
+    if (sinceLast > staleThresholdMs) {
+      const minutesAgo = Math.round(sinceLast / (60 * 1000));
       alerts.push({
         key: 'summarization-stale',
-        subject: `[Bronco Alert] Log summarization stale (${hoursAgo}h since last summary)`,
+        subject: `[Bronco Alert] Log summarizer not running (${minutesAgo}m since last pass)`,
         body: [
-          `No log summary has been created in ${hoursAgo} hours, and there are ${unsummarizedCount} recent log entries.`,
+          `The log summarizer has not completed a pass in ${minutesAgo} minutes.`,
           '',
-          `Last summary: ${latestSummary.createdAt.toISOString()}`,
+          `Last run: ${lastRunAt.toISOString()}`,
           '',
-          'The log summarizer cron may be hanging on slow Ollama calls.',
+          'The log summarizer cron may be hanging on slow Ollama calls, or the scheduler-worker may have stopped.',
           '',
           'Action required: Check scheduler-worker logs and Ollama availability.',
           '',

--- a/services/scheduler-worker/src/operational-alerts.ts
+++ b/services/scheduler-worker/src/operational-alerts.ts
@@ -322,7 +322,10 @@ async function checkSummarizationStaleness(db: PrismaClient): Promise<AlertMessa
 
     if (!heartbeatRow) return alerts; // Summarizer hasn't run yet — system is new
 
-    const lastRunAt = new Date(heartbeatRow.value as string);
+    const raw = heartbeatRow.value;
+    if (typeof raw !== 'string') return alerts; // Unexpected value type — skip
+    const lastRunAt = new Date(raw);
+    if (isNaN(lastRunAt.getTime())) return alerts; // Invalid date — skip
     const sinceLast = Date.now() - lastRunAt.getTime();
     const staleThresholdMs = 90 * 60 * 1000; // 90 min — runs every 30 min, so 3 missed passes = alert
 


### PR DESCRIPTION
## Summary

A batch of UI and backend fixes from a live debug session:

- **MCP integration**: Always send `disabledTools` array on save (fixes bug where empty array didn't clear previously-disabled tools); move tool visibility list to a dedicated chip-based dialog
- **Client detail**: Float Slack Channel ID label so pre-filled value isn't obscured
- **Stale log alert**: Track summarizer heartbeat in `AppSetting` instead of last summary `createdAt` — prevents false positives when summarizer runs but finds nothing new
- **System analysis**: Add reopen and delete actions to API and control panel UI
- **Probe dialog**: Hide Category field when action is Email Direct
- **Ticket page live reload**: Poll every 4s while analysis is `IN_PROGRESS`; incremental fetch for events (ID-set diff), unified logs (`createdAfter` cursor), and cost refresh on each tick
- **AI log cards**: Extract `AiLogEntryComponent`; show prompt and response inline with first-line preview and expand/collapse toggle; system prompt collapsible under "more data"

## Test plan

- [ ] Edit an MCP integration, clear all disabled tools, save — confirm tools stay cleared on reopen
- [ ] Manage tools via the chip dialog — add/remove, confirm persists
- [ ] Open a client with a Slack Channel ID set — label should float above the value
- [ ] Trigger a log summarization run that finds nothing — confirm no stale-log alert fires within 90 min
- [ ] Acknowledge/reject a system analysis, then reopen it; delete one permanently
- [ ] Create a probe with Email Direct action — confirm Category field is hidden
- [ ] Open a ticket being analyzed — confirm page updates live; check events, logs, and cost all refresh incrementally
- [ ] Open a ticket with AI logs — confirm prompt/response first line visible, expand/collapse works, system prompt is under "more data" and collapsed by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
