### PR TITLE
fix/feat: timestamps, conversation nesting, recommendation cleanup, model catalog

### DIFF
--- a/packages/ai-provider/src/router.ts
+++ b/packages/ai-provider/src/router.ts
@@ -214,6 +214,9 @@ export class AIRouter {
       messageCount: 1,
       totalContextTokens: inputTokens,
       messages: [{ role: 'user', tokenCount: inputTokens }],
+      ...(request.context?.orchestrationId ? { orchestrationId: request.context.orchestrationId as string } : {}),
+      ...(request.context?.orchestrationIteration != null ? { orchestrationIteration: request.context.orchestrationIteration as number } : {}),
+      ...(request.context?.isSubTask ? { isSubTask: true } : {}),
     };
 
     // Persist usage to database (fire-and-forget)
@@ -369,6 +372,9 @@ export class AIRouter {
       messageCount: convMessages.length || 1,
       totalContextTokens: inputTokens,
       messages: convMessages.length > 0 ? convMessages : [{ role: 'user', tokenCount: inputTokens }],
+      ...(request.context?.orchestrationId ? { orchestrationId: request.context.orchestrationId as string } : {}),
+      ...(request.context?.orchestrationIteration != null ? { orchestrationIteration: request.context.orchestrationIteration as number } : {}),
+      ...(request.context?.isSubTask ? { isSubTask: true } : {}),
     };
 
     if (this.usageWriter) {

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -36,6 +36,9 @@ export interface ConversationMetadata {
   messageCount: number;
   totalContextTokens: number;
   messages: Array<{ role: string; tokenCount?: number; toolName?: string }>;
+  orchestrationId?: string;
+  orchestrationIteration?: number;
+  isSubTask?: boolean;
 }
 
 /** Data written to the prompt archive table alongside a usage log entry. */

--- a/packages/shared-utils/src/mailer.ts
+++ b/packages/shared-utils/src/mailer.ts
@@ -27,15 +27,25 @@ export interface ReplyOptions {
 export class Mailer {
   private transport: Transporter;
   private from: string | { name: string; address: string };
+  private configLoader?: () => Promise<SmtpConfig | null>;
+  private configCacheUntil = 0;
+  private static readonly CONFIG_TTL_MS = 60_000;
 
-  constructor(config: SmtpConfig) {
+  constructor(config: SmtpConfig, configLoader?: () => Promise<SmtpConfig | null>) {
+    this.configLoader = configLoader;
+    this.applyConfig(config);
+    this.transport = this.buildTransport(config);
+  }
+
+  private applyConfig(config: SmtpConfig): void {
     this.from = config.fromName
       ? { name: config.fromName, address: config.from }
       : config.from;
+  }
 
+  private buildTransport(config: SmtpConfig): Transporter {
     const secure = config.secure ?? config.port === 465;
-
-    this.transport = createTransport({
+    return createTransport({
       host: config.host,
       port: config.port,
       secure,
@@ -47,11 +57,27 @@ export class Mailer {
     });
   }
 
+  private async reloadIfStale(): Promise<void> {
+    if (!this.configLoader || Date.now() < this.configCacheUntil) return;
+    try {
+      const fresh = await this.configLoader();
+      if (fresh) {
+        this.applyConfig(fresh);
+        this.transport = this.buildTransport(fresh);
+        logger.debug('SMTP config reloaded from DB');
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Failed to reload SMTP config — using cached');
+    }
+    this.configCacheUntil = Date.now() + Mailer.CONFIG_TTL_MS;
+  }
+
   /**
    * Send a reply email with proper threading headers so the recipient's
    * mail client groups it with the original conversation.
    */
   async sendReply(opts: ReplyOptions): Promise<string | undefined> {
+    await this.reloadIfStale();
     const headers: Record<string, string> = {};
     if (opts.inReplyTo) {
       headers['In-Reply-To'] = opts.inReplyTo;
@@ -78,6 +104,7 @@ export class Mailer {
 
   /** Send a plain outbound email (not a reply — no Re: prefix or threading headers). */
   async send(opts: { to: string; subject: string; body: string }): Promise<string | undefined> {
+    await this.reloadIfStale();
     const info = await this.transport.sendMail({
       from: this.from,
       to: opts.to,

--- a/packages/shared-utils/src/mailer.ts
+++ b/packages/shared-utils/src/mailer.ts
@@ -26,7 +26,7 @@ export interface ReplyOptions {
 
 export class Mailer {
   private transport: Transporter;
-  private from: string | { name: string; address: string };
+  private from!: string | { name: string; address: string };
   private configLoader?: () => Promise<SmtpConfig | null>;
   private configCacheUntil = 0;
   private static readonly CONFIG_TTL_MS = 60_000;

--- a/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
+++ b/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
@@ -333,6 +333,6 @@ export class ActivityFeedComponent implements OnInit, OnDestroy {
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit' });
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit' });
   }
 }

--- a/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
@@ -982,7 +982,7 @@ export class AiUsageComponent implements OnInit {
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit', second: '2-digit' });
   }
 
   private getDateSince(preset: string): string | null {

--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -419,7 +419,7 @@ export class EmailLogComponent implements OnInit, OnDestroy {
 
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
-    return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: true });
   }
 
   formatClassification(c: string): string {

--- a/services/control-panel/src/app/features/logs/log-viewer.component.ts
+++ b/services/control-panel/src/app/features/logs/log-viewer.component.ts
@@ -362,8 +362,8 @@ export class LogViewerComponent implements OnInit, OnDestroy {
 
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit', second: '2-digit' });
   }
 
   formatJson(obj: unknown): string {

--- a/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
+++ b/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
@@ -295,7 +295,7 @@ export class SlackConversationsComponent implements OnInit, OnDestroy {
 
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
-    return d.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
   }
 
   private buildFilters(): Record<string, string | number> {

--- a/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
@@ -436,6 +436,6 @@ export class SystemAnalysisComponent implements OnInit {
   formatDate(dateStr: string): string {
     const d = new Date(dateStr);
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) + ' ' +
-      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit' });
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit' });
   }
 }

--- a/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
+++ b/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
@@ -191,6 +191,6 @@ export class AiLogEntryComponent {
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit' });
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit' });
   }
 }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -418,6 +418,18 @@ interface FlowNode {
                               }
                             </div>
                           }
+                          @if (entry.archive?.fullPrompt || entry.promptText) {
+                            <div class="conv-final-response conv-prompt-block">
+                              <span class="conv-final-label">Prompt</span>
+                              <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[entry.id]">{{ convPromptText(entry) }}</pre>
+                              @if (isMultilineConvPrompt(entry)) {
+                                <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
+                                  {{ convPromptExpanded[entry.id] ? 'less' : 'more' }}
+                                  <mat-icon>{{ convPromptExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+                                </button>
+                              }
+                            </div>
+                          }
                           @if (entry.archive?.fullResponse || entry.responseText) {
                             <div class="conv-final-response">
                               <span class="conv-final-label">Response</span>
@@ -452,6 +464,18 @@ interface FlowNode {
                               @if (turn.toolName) { <span class="conv-tool-call">🔧 {{ turn.toolName }}</span> }
                               @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
                             </div>
+                          }
+                        </div>
+                      }
+                      @if (entry.archive?.fullPrompt || entry.promptText) {
+                        <div class="conv-final-response conv-prompt-block">
+                          <span class="conv-final-label">Prompt</span>
+                          <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[entry.id]">{{ convPromptText(entry) }}</pre>
+                          @if (isMultilineConvPrompt(entry)) {
+                            <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
+                              {{ convPromptExpanded[entry.id] ? 'less' : 'more' }}
+                              <mat-icon>{{ convPromptExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+                            </button>
                           }
                         </div>
                       }
@@ -1237,6 +1261,7 @@ interface FlowNode {
     .conv-final-label { font-size: 10px; font-weight: 700; color: #999; text-transform: uppercase; letter-spacing: 0.5px; display: block; margin-bottom: 2px; }
     .conv-final-response { margin-top: 6px; }
     .conv-response-text { font-size: 12px; font-family: monospace; color: #333; margin: 0; white-space: pre-wrap; word-break: break-word; background: #f7f7f7; padding: 6px 8px; border-radius: 4px; border-left: 2px solid #7c4dff; }
+    .conv-prompt-block .conv-response-text { border-left-color: #ff9800; background: #fffdf5; }
     .conv-response-text.clamped { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
     .conv-empty { padding: 24px; text-align: center; color: #888; }
     .inline-expand-btn { font-size: 11px; color: #666; padding: 0; min-width: auto; margin-top: 2px; }
@@ -1290,6 +1315,7 @@ export class TicketDetailComponent implements OnInit {
   convStepGroups = signal<StepGroup[]>([]);
   convUngrouped = signal<UnifiedLogEntry[]>([]);
   convExpanded: Record<string, boolean> = {};
+  convPromptExpanded: Record<string, boolean> = {};
 
   // Legacy — still used by loadTicketAiUsage for the existing AI Cost card
   ticketLogs = signal<TicketAppLog[]>([]);
@@ -1670,8 +1696,17 @@ export class TicketDetailComponent implements OnInit {
     return meta?.messages ?? [];
   }
 
+  convPromptText(entry: UnifiedLogEntry): string {
+    return entry.archive?.fullPrompt ?? entry.promptText ?? '';
+  }
+
   convResponseText(entry: UnifiedLogEntry): string {
     return entry.archive?.fullResponse ?? entry.responseText ?? '';
+  }
+
+  isMultilineConvPrompt(entry: UnifiedLogEntry): boolean {
+    const text = this.convPromptText(entry);
+    return text.split('\n').filter(l => l.trim().length > 0).length > 2;
   }
 
   isMultilineConv(entry: UnifiedLogEntry): boolean {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1997,7 +1997,7 @@ export class TicketDetailComponent implements OnInit {
   formatTime(dateStr: string): string {
     const d = new Date(dateStr);
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
-      d.toLocaleTimeString(undefined, { hour12: false, hour: '2-digit', minute: '2-digit' });
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit' });
   }
 
   formatDuration(ms: number): string {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -399,7 +399,7 @@ interface FlowNode {
                       {{ group.stepName }}
                     </div>
                     @for (entry of group.entries; track entry.id) {
-                      @if (entry.type === 'ai') {
+                      @if (entry.type === 'ai' && !isSubTask(entry)) {
                         <div class="conv-ai-block">
                           <div class="conv-ai-header">
                             <span class="conv-task-type">{{ entry.taskType }}</span>
@@ -441,6 +441,44 @@ interface FlowNode {
                                 </button>
                               }
                             </div>
+                          }
+                          <!-- Nested sub-tasks -->
+                          @if (getOrchestrationId(entry)) {
+                            @for (sub of getSubTasks(group.entries, getOrchestrationId(entry)!); track sub.id) {
+                              <div class="conv-subtask">
+                                <div class="conv-ai-header">
+                                  <mat-icon class="subtask-icon">subdirectory_arrow_right</mat-icon>
+                                  <span class="conv-task-type">{{ sub.taskType }}</span>
+                                  <span class="conv-model">{{ sub.model }}</span>
+                                  <span class="conv-tokens">{{ sub.inputTokens | number }}in / {{ sub.outputTokens | number }}out</span>
+                                  @if (sub.costUsd != null) { <span class="conv-cost">\${{ sub.costUsd | number:'1.4-4' }}</span> }
+                                </div>
+                                @if (sub.archive?.fullPrompt || sub.promptText) {
+                                  <div class="conv-final-response conv-prompt-block">
+                                    <span class="conv-final-label">Prompt</span>
+                                    <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[sub.id]">{{ convPromptText(sub) }}</pre>
+                                    @if (isMultilineConvPrompt(sub)) {
+                                      <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[sub.id] = !convPromptExpanded[sub.id]">
+                                        {{ convPromptExpanded[sub.id] ? 'less' : 'more' }}
+                                        <mat-icon>{{ convPromptExpanded[sub.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+                                      </button>
+                                    }
+                                  </div>
+                                }
+                                @if (sub.archive?.fullResponse || sub.responseText) {
+                                  <div class="conv-final-response">
+                                    <span class="conv-final-label">Response</span>
+                                    <pre class="conv-response-text" [class.clamped]="!convExpanded[sub.id]">{{ convResponseText(sub) }}</pre>
+                                    @if (isMultilineConv(sub)) {
+                                      <button mat-button class="inline-expand-btn" (click)="convExpanded[sub.id] = !convExpanded[sub.id]">
+                                        {{ convExpanded[sub.id] ? 'less' : 'more' }}
+                                        <mat-icon>{{ convExpanded[sub.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
+                                      </button>
+                                    }
+                                  </div>
+                                }
+                              </div>
+                            }
                           }
                         </div>
                       }
@@ -1249,6 +1287,8 @@ interface FlowNode {
     .conv-step-label { display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: #888; margin-bottom: 8px; border-bottom: 1px solid #eee; padding-bottom: 4px; }
     .conv-step-icon { font-size: 14px; width: 14px; height: 14px; color: #aaa; }
     .conv-ai-block { border-left: 3px solid #7c4dff; background: #fafafa; border-radius: 0 6px 6px 0; padding: 8px 12px; margin-bottom: 10px; }
+    .conv-subtask { margin-left: 20px; border-left: 2px solid #b39ddb; background: #f5f3ff; border-radius: 0 6px 6px 0; padding: 6px 10px; margin-top: 6px; }
+    .subtask-icon { font-size: 16px; width: 16px; height: 16px; color: #9575cd; }
     .conv-ai-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 6px; }
     .conv-task-type { font-size: 12px; font-weight: 700; background: #e8f5e9; color: #2e7d32; padding: 1px 7px; border-radius: 10px; }
     .conv-model { font-size: 11px; color: #888; font-family: monospace; }
@@ -1692,6 +1732,20 @@ export class TicketDetailComponent implements OnInit {
     if (event.tab.textLabel === 'Conversation') {
       this.loadConversationEntries();
     }
+  }
+
+  isSubTask(entry: UnifiedLogEntry): boolean {
+    return !!(entry.conversationMetadata as Record<string, unknown> | null)?.['isSubTask'];
+  }
+
+  getOrchestrationId(entry: UnifiedLogEntry): string | null {
+    return ((entry.conversationMetadata as Record<string, unknown> | null)?.['orchestrationId'] as string) ?? null;
+  }
+
+  getSubTasks(entries: UnifiedLogEntry[], orchestrationId: string): UnifiedLogEntry[] {
+    return entries.filter(e =>
+      e.type === 'ai' && this.isSubTask(e) && this.getOrchestrationId(e) === orchestrationId
+    );
   }
 
   convMessages(entry: UnifiedLogEntry): Array<{ role: string; tokenCount?: number; toolName?: string }> {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -443,8 +443,8 @@ interface FlowNode {
                             </div>
                           }
                           <!-- Nested sub-tasks -->
-                          @if (getOrchestrationId(entry)) {
-                            @for (sub of getSubTasks(group.entries, getOrchestrationId(entry)!); track sub.id) {
+                          @if (getOrchestrationId(entry); as orchestrationId) {
+                            @for (sub of getSubTasks(group.entries, orchestrationId); track sub.id) {
                               <div class="conv-subtask">
                                 <div class="conv-ai-header">
                                   <mat-icon class="subtask-icon">subdirectory_arrow_right</mat-icon>

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -824,21 +824,30 @@ interface FlowNode {
                   <!-- AI Recommendation action cards -->
                   <div class="recommendation-actions">
                     @for (act of getEventActions(event); track $index) {
-                      <div class="rec-action-row">
-                        <mat-icon class="rec-icon">{{ recActionIcon(act.action) }}</mat-icon>
-                        <div class="rec-action-detail">
+                      <div class="rec-action-row" [class.rec-resolved]="getActionOutcome(act) !== 'pending_approval'">
+                        <div class="rec-action-header" (click)="getActionOutcome(act) !== 'pending_approval' ? expandedEvents[event.id + '-act-' + $index] = !expandedEvents[event.id + '-act-' + $index] : null">
+                          <mat-icon class="rec-icon">{{ recActionIcon(act.action) }}</mat-icon>
                           <span class="rec-action-type">{{ formatRecActionType(act.action) }}</span>
-                          @if (act.value) {
-                            <span class="rec-action-value">{{ act.value }}</span>
+                          <span class="rec-status-badge" [class]="'rec-badge-' + getActionOutcome(act)">
+                            {{ getActionOutcomeLabel(act) }}
+                          </span>
+                          @if (getActionOutcome(act) !== 'pending_approval') {
+                            <mat-icon class="rec-expand-icon">{{ expandedEvents[event.id + '-act-' + $index] ? 'expand_less' : 'expand_more' }}</mat-icon>
                           }
-                          <span class="rec-action-reason">{{ act.reason }}</span>
                         </div>
-                        <span class="rec-status-badge" [class]="'rec-badge-' + getActionOutcome(act)">
-                          {{ getActionOutcomeLabel(act) }}
-                        </span>
+                        @if (getActionOutcome(act) === 'pending_approval' || expandedEvents[event.id + '-act-' + $index]) {
+                          <div class="rec-action-detail">
+                            @if (act.value) {
+                              <span class="rec-action-value">{{ act.value }}</span>
+                            }
+                            <span class="rec-action-reason">{{ act.reason }}</span>
+                          </div>
+                        }
                         @if (getActionOutcome(act) === 'pending_approval') {
-                          <button mat-stroked-button color="primary" class="rec-approve-btn" (click)="approvePendingAction(act.pendingActionId)">Approve</button>
-                          <button mat-stroked-button class="rec-dismiss-btn" (click)="dismissPendingAction(act.pendingActionId)">Dismiss</button>
+                          <div class="rec-action-buttons">
+                            <button mat-stroked-button color="primary" class="rec-approve-btn" (click)="approvePendingAction(act.pendingActionId)">Approve</button>
+                            <button mat-stroked-button class="rec-dismiss-btn" (click)="dismissPendingAction(act.pendingActionId)">Dismiss</button>
+                          </div>
                         }
                       </div>
                     }
@@ -1102,13 +1111,17 @@ interface FlowNode {
     .probe-data-code { background: #263238; color: #eeffff; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 12px; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
     /* AI Recommendation action list */
     .recommendation-actions { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
-    .rec-action-row { display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: #fafafa; border-radius: 6px; border: 1px solid #eee; }
+    .rec-action-row { display: flex; flex-direction: column; gap: 4px; padding: 6px 10px; background: #fafafa; border-radius: 6px; border: 1px solid #eee; }
+    .rec-action-header { display: flex; align-items: center; gap: 8px; }
+    .rec-resolved .rec-action-header { cursor: pointer; }
+    .rec-expand-icon { font-size: 16px; width: 16px; height: 16px; color: #999; }
     .rec-icon { font-size: 18px; width: 18px; height: 18px; color: #666; flex-shrink: 0; }
-    .rec-action-detail { flex: 1; display: flex; flex-wrap: wrap; gap: 4px; align-items: baseline; }
+    .rec-action-detail { display: flex; flex-wrap: wrap; gap: 4px; align-items: baseline; padding-left: 26px; }
+    .rec-action-buttons { display: flex; gap: 6px; padding-left: 26px; }
     .rec-action-type { font-weight: 600; font-size: 13px; }
     .rec-action-value { font-family: monospace; font-size: 12px; background: #e8eaf6; padding: 1px 6px; border-radius: 3px; color: #283593; }
     .rec-action-reason { font-size: 12px; color: #666; }
-    .rec-status-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; }
+    .rec-status-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; margin-left: auto; }
     .rec-badge-auto_executed { background: #e8f5e9; color: #2e7d32; }
     .rec-badge-pending_approval { background: #fff3e0; color: #e65100; }
     .rec-badge-skipped { background: #f5f5f5; color: #999; }
@@ -1319,8 +1332,6 @@ export class TicketDetailComponent implements OnInit {
 
   filteredEvents = computed(() => {
     let evts = this.events();
-    // Hide COMMENT events auto-created by AI recommendation execution — they duplicate the action cards
-    evts = evts.filter(e => !(e.eventType === 'COMMENT' && this.isAiTriggered(e)));
     if (this.timelineFilter()) {
       evts = evts.filter(e => e.eventType === this.timelineFilter());
     }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -796,17 +796,6 @@ interface FlowNode {
                     </div>
                   }
                 }
-                @if (recommendationActions(event); as actions) {
-                  <div class="recommendation-actions">
-                    @for (action of actions; track $index) {
-                      <div class="recommendation-row" [class.action-applied]="action.applied">
-                        <mat-icon class="action-status-icon">{{ action.applied ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
-                        <span class="action-label">{{ action.action }}</span>
-                        @if (action.detail) { <span class="action-detail">{{ action.detail }}</span> }
-                      </div>
-                    }
-                  </div>
-                }
               }
               @if (event.content) {
                 @if (event.eventType === 'SYSTEM_NOTE' && isJsonContent(event.content)) {
@@ -821,7 +810,18 @@ interface FlowNode {
                     }
                   </div>
                 } @else if (event.eventType === 'AI_RECOMMENDATION' && hasActionsMeta(event)) {
-                  <!-- AI Recommendation with actions — human-readable list -->
+                  <!-- AI Recommendation summary above action cards -->
+                  @if (event.content && event.content.length > 0) {
+                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && event.content.length > 300">
+                      <div [innerHTML]="event.content | markdown"></div>
+                    </div>
+                    @if (event.content.length > 300) {
+                      <button mat-button class="show-more-btn" (click)="expandedEvents[event.id + '-raw'] = !expandedEvents[event.id + '-raw']">
+                        {{ expandedEvents[event.id + '-raw'] ? 'Hide details' : 'Show details' }}
+                      </button>
+                    }
+                  }
+                  <!-- AI Recommendation action cards -->
                   <div class="recommendation-actions">
                     @for (act of getEventActions(event); track $index) {
                       <div class="rec-action-row">
@@ -843,16 +843,6 @@ interface FlowNode {
                       </div>
                     }
                   </div>
-                  @if (event.content && event.content.length > 0) {
-                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && event.content.length > 300">
-                      <div [innerHTML]="event.content | markdown"></div>
-                    </div>
-                    @if (event.content.length > 300) {
-                      <button mat-button class="show-more-btn" (click)="expandedEvents[event.id + '-raw'] = !expandedEvents[event.id + '-raw']">
-                        {{ expandedEvents[event.id + '-raw'] ? 'Hide details' : 'Show details' }}
-                      </button>
-                    }
-                  }
                 } @else if (isMarkdownEvent(event.eventType)) {
                   <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
                     <div [innerHTML]="event.content | markdown"></div>
@@ -1329,6 +1319,8 @@ export class TicketDetailComponent implements OnInit {
 
   filteredEvents = computed(() => {
     let evts = this.events();
+    // Hide COMMENT events auto-created by AI recommendation execution — they duplicate the action cards
+    evts = evts.filter(e => !(e.eventType === 'COMMENT' && this.isAiTriggered(e)));
     if (this.timelineFilter()) {
       evts = evts.filter(e => e.eventType === this.timelineFilter());
     }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1849,7 +1849,7 @@ export class TicketDetailComponent implements OnInit {
   }
 
   isMarkdownEvent(eventType: string): boolean {
-    return eventType === 'AI_ANALYSIS' || eventType === 'AI_RECOMMENDATION';
+    return eventType === 'AI_ANALYSIS' || eventType === 'AI_RECOMMENDATION' || eventType === 'COMMENT';
   }
 
   formatEventType(type: string): string {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -810,12 +810,12 @@ interface FlowNode {
                     }
                   </div>
                 } @else if (event.eventType === 'AI_RECOMMENDATION' && hasActionsMeta(event)) {
-                  <!-- AI Recommendation summary above action cards -->
-                  @if (event.content && event.content.length > 0) {
-                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && event.content.length > 300">
-                      <div [innerHTML]="event.content | markdown"></div>
+                  <!-- AI Recommendation summary above action cards (action bullets stripped) -->
+                  @if (recSummaryContent(event); as summary) {
+                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && summary.length > 300">
+                      <div [innerHTML]="summary | markdown"></div>
                     </div>
-                    @if (event.content.length > 300) {
+                    @if (summary.length > 300) {
                       <button mat-button class="show-more-btn" (click)="expandedEvents[event.id + '-raw'] = !expandedEvents[event.id + '-raw']">
                         {{ expandedEvents[event.id + '-raw'] ? 'Hide details' : 'Show details' }}
                       </button>
@@ -1850,6 +1850,17 @@ export class TicketDetailComponent implements OnInit {
 
   isMarkdownEvent(eventType: string): boolean {
     return eventType === 'AI_ANALYSIS' || eventType === 'AI_RECOMMENDATION' || eventType === 'COMMENT';
+  }
+
+  recSummaryContent(event: TicketEvent): string {
+    if (!event.content) return '';
+    const actionPrefixes = /^[-•]\s*(Auto-executed|Pending approval|Skipped):/i;
+    const headerPrefixes = /^\*\*(Auto-executed|Pending approval|Skipped):\*\*$/i;
+    return event.content
+      .split('\n')
+      .filter(line => !actionPrefixes.test(line.trim()) && !headerPrefixes.test(line.trim()))
+      .join('\n')
+      .trim();
   }
 
   formatEventType(type: string): string {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1350,6 +1350,7 @@ export class TicketDetailComponent implements OnInit {
   logsSearchFilter = signal('');
   expandedLogs: Record<string, boolean> = {};
   costSummary = signal<TicketCostSummary | null>(null);
+  pendingActionMap = signal<Record<string, string>>({});
   stepGroups = signal<StepGroup[]>([]);
   ungroupedEntries = signal<UnifiedLogEntry[]>([]);
   conversationEntries = signal<UnifiedLogEntry[]>([]);
@@ -1481,7 +1482,18 @@ export class TicketDetailComponent implements OnInit {
     this.loadUnifiedLogs();
     this.loadCostSummary();
     this.loadTicketAiUsage();
+    this.loadPendingActions();
     this.destroyRef.onDestroy(() => this.stopPolling());
+  }
+
+  loadPendingActions(): void {
+    this.ticketService.getPendingActions(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (actions) => {
+        const map: Record<string, string> = {};
+        for (const a of actions) map[a.id] = a.status;
+        this.pendingActionMap.set(map);
+      },
+    });
   }
 
   load(): void {
@@ -1973,7 +1985,14 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  getActionOutcome(act: { outcome?: string; applied?: boolean }): string {
+  getActionOutcome(act: { outcome?: string; applied?: boolean; pendingActionId?: string }): string {
+    // Check live pending action status first (reflects approve/dismiss without reload)
+    if (act.pendingActionId) {
+      const liveStatus = this.pendingActionMap()[act.pendingActionId];
+      if (liveStatus === 'approved') return 'approved';
+      if (liveStatus === 'dismissed') return 'dismissed';
+      if (liveStatus === 'pending') return 'pending_approval';
+    }
     if (act.outcome) return act.outcome;
     if (act.applied === true) return 'auto_executed';
     return 'skipped';
@@ -2028,6 +2047,7 @@ export class TicketDetailComponent implements OnInit {
     this.ticketService.approvePendingAction(ticketId, actionId).subscribe({
       next: () => {
         this.snackBar.open('Action approved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.loadPendingActions();
         this.load();
       },
       error: () => this.snackBar.open('Failed to approve action', 'OK', { duration: 5000 }),
@@ -2041,6 +2061,7 @@ export class TicketDetailComponent implements OnInit {
     this.ticketService.dismissPendingAction(ticketId, actionId).subscribe({
       next: () => {
         this.snackBar.open('Action dismissed', 'OK', { duration: 3000 });
+        this.loadPendingActions();
         this.load();
       },
       error: () => this.snackBar.open('Failed to dismiss action', 'OK', { duration: 5000 }),

--- a/services/control-panel/src/app/shared/pipes/local-date.pipe.ts
+++ b/services/control-panel/src/app/shared/pipes/local-date.pipe.ts
@@ -9,7 +9,7 @@ export class LocalDatePipe implements PipeTransform {
     if (includeTime) {
       return d.toLocaleString(undefined, {
         month: 'short', day: 'numeric', year: 'numeric',
-        hour: '2-digit', minute: '2-digit', hour12: false,
+        hour: 'numeric', minute: '2-digit', hour12: true,
       });
     }
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });

--- a/services/copilot-api/src/services/model-catalog-refresher.ts
+++ b/services/copilot-api/src/services/model-catalog-refresher.ts
@@ -178,20 +178,23 @@ export async function refreshModelCatalog(db: PrismaClient, appLog?: AppLogger):
     throw new Error('Model catalog refresh failed: no models fetched from any source');
   }
 
-  // 3. Upsert
+  // 3. Update existing model costs only — do not create new records
   let updated = 0;
   let skipped = 0;
-  let newModels = 0;
+  const newModels = 0;
   for (const m of models) {
     if (!m.provider || !m.model || !Number.isFinite(m.inputCostPer1m) || !Number.isFinite(m.outputCostPer1m)) continue;
     if (customKeys.has(`${m.provider}:${m.model}`)) {
       skipped++;
       continue;
     }
-    const isNew = !existingKeys.has(`${m.provider}:${m.model}`);
-    await db.aiModelCost.upsert({
+    if (!existingKeys.has(`${m.provider}:${m.model}`)) {
+      skipped++;
+      continue;
+    }
+    await db.aiModelCost.update({
       where: { provider_model: { provider: m.provider, model: m.model } },
-      update: {
+      data: {
         displayName: m.displayName ?? null,
         description: m.description ?? undefined,
         inputCostPer1m: m.inputCostPer1m,
@@ -201,20 +204,8 @@ export async function refreshModelCatalog(db: PrismaClient, appLog?: AppLogger):
         modality: m.modality ?? undefined,
         isActive: true,
       },
-      create: {
-        provider: m.provider,
-        model: m.model,
-        displayName: m.displayName ?? null,
-        description: m.description ?? null,
-        inputCostPer1m: m.inputCostPer1m,
-        outputCostPer1m: m.outputCostPer1m,
-        contextLength: m.contextLength ?? null,
-        maxCompletionTokens: m.maxCompletionTokens ?? null,
-        modality: m.modality ?? null,
-      },
     });
     updated++;
-    if (isNew) newModels++;
   }
 
   const durationMs = Date.now() - start;

--- a/services/probe-worker/src/index.ts
+++ b/services/probe-worker/src/index.ts
@@ -22,8 +22,9 @@ async function main(): Promise<void> {
   // --- SMTP mailer (DB config takes priority, env vars as fallback) ---
   let mailer: Mailer | null = null;
   const dbSmtp = await loadSmtpFromDb(db, config.ENCRYPTION_KEY);
+  const smtpLoader = () => loadSmtpFromDb(db, config.ENCRYPTION_KEY);
   if (dbSmtp) {
-    mailer = new Mailer(dbSmtp);
+    mailer = new Mailer(dbSmtp, smtpLoader);
   } else if (config.SMTP_HOST && config.SMTP_USER && config.SMTP_FROM && config.SMTP_PASSWORD) {
     logger.warn('No SMTP config in DB — falling back to env vars');
     mailer = new Mailer({

--- a/services/scheduler-worker/src/model-catalog-refresher.ts
+++ b/services/scheduler-worker/src/model-catalog-refresher.ts
@@ -178,20 +178,23 @@ export async function refreshModelCatalog(db: PrismaClient, appLog?: AppLogger):
     throw new Error('Model catalog refresh failed: no models fetched from any source');
   }
 
-  // 3. Upsert
+  // 3. Update existing model costs only — do not create new records
   let updated = 0;
   let skipped = 0;
-  let newModels = 0;
+  const newModels = 0;
   for (const m of models) {
     if (!m.provider || !m.model || !Number.isFinite(m.inputCostPer1m) || !Number.isFinite(m.outputCostPer1m)) continue;
     if (customKeys.has(`${m.provider}:${m.model}`)) {
       skipped++;
       continue;
     }
-    const isNew = !existingKeys.has(`${m.provider}:${m.model}`);
-    await db.aiModelCost.upsert({
+    if (!existingKeys.has(`${m.provider}:${m.model}`)) {
+      skipped++;
+      continue;
+    }
+    await db.aiModelCost.update({
       where: { provider_model: { provider: m.provider, model: m.model } },
-      update: {
+      data: {
         displayName: m.displayName ?? null,
         description: m.description ?? undefined,
         inputCostPer1m: m.inputCostPer1m,
@@ -201,20 +204,8 @@ export async function refreshModelCatalog(db: PrismaClient, appLog?: AppLogger):
         modality: m.modality ?? undefined,
         isActive: true,
       },
-      create: {
-        provider: m.provider,
-        model: m.model,
-        displayName: m.displayName ?? null,
-        description: m.description ?? null,
-        inputCostPer1m: m.inputCostPer1m,
-        outputCostPer1m: m.outputCostPer1m,
-        contextLength: m.contextLength ?? null,
-        maxCompletionTokens: m.maxCompletionTokens ?? null,
-        modality: m.modality ?? null,
-      },
     });
     updated++;
-    if (isNew) newModels++;
   }
 
   const durationMs = Date.now() - start;

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1838,13 +1838,30 @@ async function resolveOrchestratedModelMap(db: PrismaClient): Promise<Record<str
   const models = await db.aiProviderModel.findMany({
     where: { isActive: true, provider: { provider: 'CLAUDE' } },
     select: { model: true },
+    orderBy: [{ model: 'asc' }],
   });
-  const map: Record<string, string> = {};
+  const matches: Record<'haiku' | 'sonnet' | 'opus', string[]> = {
+    haiku: [],
+    sonnet: [],
+    opus: [],
+  };
   for (const { model } of models) {
     const lower = model.toLowerCase();
-    if (lower.includes('haiku') && !map.haiku) map.haiku = model;
-    else if (lower.includes('sonnet') && !map.sonnet) map.sonnet = model;
-    else if (lower.includes('opus') && !map.opus) map.opus = model;
+    if (lower.includes('haiku')) matches.haiku.push(model);
+    else if (lower.includes('sonnet')) matches.sonnet.push(model);
+    else if (lower.includes('opus')) matches.opus.push(model);
+  }
+  const map: Record<string, string> = {};
+  for (const shortName of ['haiku', 'sonnet', 'opus'] as const) {
+    const candidates = matches[shortName];
+    if (candidates.length === 0) continue;
+    if (candidates.length > 1) {
+      logger.warn(
+        { shortName, candidates },
+        'Multiple active Claude models matched orchestrated short name; using first from deterministic ordering',
+      );
+    }
+    map[shortName] = candidates[0];
   }
   return map;
 }

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1959,6 +1959,7 @@ async function executeOrchestratedSubTask(
   agenticTools: AIToolDefinition[],
   mcpIntegrations: Map<string, McpIntegrationInfo>,
   repoIdByPrefix: Map<string, string>,
+  orchestration?: { id: string; iteration: number },
 ): Promise<SubTaskResult> {
   const { ai } = deps;
   const model = ORCHESTRATED_MODEL_MAP[task.model] ?? ORCHESTRATED_MODEL_MAP.sonnet;
@@ -2021,9 +2022,10 @@ async function executeOrchestratedSubTask(
     let hasToolError = false;
 
     if (tools.length > 0) {
+      const orchCtx = orchestration ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true } : {};
       const response = await ai.generateWithTools({
         taskType: TaskType.DEEP_ANALYSIS,
-        context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory },
+        context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
         messages: [{ role: 'user', content: task.prompt }],
         tools,
         systemPrompt: subTaskSystemPrompt,
@@ -2064,7 +2066,7 @@ async function executeOrchestratedSubTask(
 
         const summaryResponse = await ai.generateWithTools({
           taskType: TaskType.DEEP_ANALYSIS,
-          context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory },
+          context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
           messages: [
             { role: 'user', content: task.prompt },
             { role: 'assistant', content: response.contentBlocks },
@@ -2110,9 +2112,10 @@ async function executeOrchestratedSubTask(
     }
 
     // No tools — pure analysis
+    const orchCtx = orchestration ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true } : {};
     const response = await ai.generate({
       taskType: TaskType.DEEP_ANALYSIS,
-      context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory },
+      context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
       prompt: task.prompt,
       providerOverride: 'CLAUDE',
       modelOverride: model,
@@ -2883,7 +2886,8 @@ async function executeRoutePipeline(
 
           for (let i = 0; i < orchMaxIterations; i++) {
             orchIterationsRun = i + 1;
-            appLog.info(`Orchestrated analysis iteration ${i + 1}/${orchMaxIterations}`, { ticketId, iteration: i + 1 }, ticketId, 'ticket');
+            const orchestrationId = randomUUID();
+            appLog.info(`Orchestrated analysis iteration ${i + 1}/${orchMaxIterations}`, { ticketId, iteration: i + 1, orchestrationId }, ticketId, 'ticket');
 
             // Extract only the current run content (after the run header) for the strategist
             const currentRunStart = knowledgeDoc.lastIndexOf(currentRunHeader);
@@ -2903,7 +2907,7 @@ async function executeRoutePipeline(
 
             const strategistResponse = await ai.generate({
               taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
-              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext },
+              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1 },
               prompt: strategistPrompt,
               systemPrompt: ORCHESTRATED_SYSTEM_PROMPT,
               providerOverride: 'CLAUDE',
@@ -2937,7 +2941,7 @@ async function executeRoutePipeline(
             const taskBatches = chunkArray(plan.tasks, maxParallelTasks);
             for (const batch of taskBatches) {
               const results = await Promise.allSettled(
-                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix)),
+                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1 })),
               );
 
               for (let j = 0; j < results.length; j++) {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1832,11 +1832,22 @@ interface SubTaskResult {
   toolCalls: Array<{ tool: string; system?: string; input: Record<string, unknown>; output: string; durationMs: number }>;
 }
 
-const ORCHESTRATED_MODEL_MAP: Record<string, string> = {
-  haiku: 'claude-haiku-4-5-20251001',
-  sonnet: 'claude-sonnet-4-6',
-  opus: 'claude-opus-4-6',
-};
+/** Resolve the orchestrated model map from active Claude provider models.
+ *  Maps short names (haiku/sonnet/opus) to the actual model IDs configured in the DB. */
+async function resolveOrchestratedModelMap(db: PrismaClient): Promise<Record<string, string>> {
+  const models = await db.aiProviderModel.findMany({
+    where: { isActive: true, provider: { provider: 'CLAUDE' } },
+    select: { model: true },
+  });
+  const map: Record<string, string> = {};
+  for (const { model } of models) {
+    const lower = model.toLowerCase();
+    if (lower.includes('haiku') && !map.haiku) map.haiku = model;
+    else if (lower.includes('sonnet') && !map.sonnet) map.sonnet = model;
+    else if (lower.includes('opus') && !map.opus) map.opus = model;
+  }
+  return map;
+}
 
 // ---------------------------------------------------------------------------
 // Tool resolution: exact → base-name → substring → fuzzy
@@ -1960,9 +1971,11 @@ async function executeOrchestratedSubTask(
   mcpIntegrations: Map<string, McpIntegrationInfo>,
   repoIdByPrefix: Map<string, string>,
   orchestration?: { id: string; iteration: number },
+  modelMap?: Record<string, string>,
 ): Promise<SubTaskResult> {
   const { ai } = deps;
-  const model = ORCHESTRATED_MODEL_MAP[task.model] ?? ORCHESTRATED_MODEL_MAP.sonnet;
+  const map = modelMap ?? {};
+  const model = map[task.model] ?? map.sonnet ?? 'claude-sonnet-4-6';
 
   const toolCalls: SubTaskResult['toolCalls'] = [];
   let inputTokens = 0;
@@ -2840,6 +2853,7 @@ async function executeRoutePipeline(
               maxParallelTasks = Math.min(10, Math.max(1, Math.trunc(coerced)));
             }
           }
+          const orchModelMap = await resolveOrchestratedModelMap(db);
           const orchMaxIterations = maxIterations;
           const existingDoc = ticket.knowledgeDoc ?? '';
           const runTimestamp = new Date().toISOString().slice(0, 16).replace('T', ' ');
@@ -2941,7 +2955,7 @@ async function executeRoutePipeline(
             const taskBatches = chunkArray(plan.tasks, maxParallelTasks);
             for (const batch of taskBatches) {
               const results = await Promise.allSettled(
-                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1 })),
+                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1 }, orchModelMap)),
               );
 
               for (let j = 0; j < results.length; j++) {

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -27,8 +27,9 @@ async function main(): Promise<void> {
   // --- SMTP mailer (DB config takes priority, env vars as fallback) ---
   let mailer: Mailer | null = null;
   const dbSmtp = await loadSmtpFromDb(db, config.ENCRYPTION_KEY);
+  const smtpLoader = () => loadSmtpFromDb(db, config.ENCRYPTION_KEY);
   if (dbSmtp) {
-    mailer = new Mailer(dbSmtp);
+    mailer = new Mailer(dbSmtp, smtpLoader);
   } else if (config.SMTP_HOST && config.SMTP_USER && config.SMTP_FROM && config.SMTP_PASSWORD) {
     logger.warn('No SMTP config in DB — falling back to env vars');
     mailer = new Mailer({


### PR DESCRIPTION
## Summary

- **Timestamps**: Switch all time displays across the control panel from 24-hour to AM/PM format using browser locale (8 components + LocalDatePipe)
- **Conversation tab**: Show prompt text alongside responses; nest orchestrated sub-tasks under their strategist card via new `orchestrationId` metadata
- **AI Recommendation timeline**: Move summary above action cards, strip redundant action bullet lines, collapse resolved action bodies (click to expand), render COMMENT event content
- **Model catalog refresh**: Update-only mode — no longer creates new model cost records on refresh. Dot-to-dash normalization for Claude IDs was already in place
- **Orchestrated model map**: Resolve haiku/sonnet/opus model IDs dynamically from active AI provider models instead of hardcoded map

## Test plan

- [ ] Verify timestamps show AM/PM across: app logs, ticket detail, activity feed, AI usage, system analysis, email logs, slack conversations
- [ ] Open a ticket's Conversation tab — confirm prompts shown alongside responses with expand/collapse
- [ ] Trigger an orchestrated analysis — verify sub-task AI logs show `orchestrationId` in conversationMetadata and nest under strategist in Conversation tab
- [ ] Check AI Recommendation event in timeline — summary above cards, resolved actions collapsed, comment events visible
- [ ] Run model catalog refresh — confirm no new model cost records created, existing costs updated
- [ ] Verify orchestrated analysis uses active provider models (haiku now resolves from DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
