### PR TITLE
Add MCP tool artifact storage to disk with database tracking

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1966,7 +1966,7 @@ async function saveMcpToolArtifact(
     const mimeType = isJson ? 'application/json' : 'text/plain';
     const ext = isJson ? 'json' : 'txt';
     const safeToolName = sanitizeFilenameSegment(toolName || 'unknown');
-    const filename = `mcp-${safeToolName}-${Date.now()}.${ext}`;
+    const filename = `mcp-${safeToolName}-${Date.now()}-${randomUUID()}.${ext}`;
     const resolvedStorage = resolve(storagePath);
     const ticketDir = resolve(resolvedStorage, 'tickets', ticketId);
     const rel = relative(resolvedStorage, ticketDir);
@@ -2113,7 +2113,13 @@ async function executeOrchestratedSubTask(
             ...(result.isError ? { is_error: true } : {}),
           });
           if (deps.artifactStoragePath && !result.isError) {
-            await saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath);
+            void saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath).catch(error => {
+              logger.warn({
+                err: error,
+                ticketId,
+                toolName: toolUse.name,
+              }, 'Failed to persist MCP tool artifact');
+            });
           }
           if (result.isError) hasToolError = true;
         }
@@ -3244,7 +3250,13 @@ async function executeRoutePipeline(
               ...(result.isError ? { is_error: true } : {}),
             });
             if (deps.artifactStoragePath && !result.isError) {
-              await saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath);
+              void saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath).catch(error => {
+                logger.warn({
+                  err: error,
+                  ticketId,
+                  toolName: toolUse.name,
+                }, 'Failed to persist MCP tool artifact');
+              });
             }
             appLog.info(
               `Agentic tool call: ${toolUse.name} (${elapsed}ms)`,

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { readdir, rm, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
 import { Prisma } from '@bronco/db';
@@ -322,6 +322,8 @@ export interface AnalyzerDeps {
   mcpAuthToken?: string;
   /** Optional BullMQ queue for self-analysis triggers (post-pipeline analysis). */
   selfAnalysisQueue?: import('bullmq').Queue;
+  /** Optional path for storing full MCP tool result artifacts on disk. */
+  artifactStoragePath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -1941,6 +1943,57 @@ function resolveTaskTools(
   return { resolved, fuzzy, unmatched };
 }
 
+/**
+ * Sanitize a string to be safe for use as a filename component.
+ * Only allows alphanumerics, dots, hyphens, and underscores; replaces all
+ * other characters (including path separators) with underscores and trims
+ * to 64 characters to prevent path traversal or excessively long filenames.
+ */
+function sanitizeFilenameSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64);
+}
+
+async function saveMcpToolArtifact(
+  db: PrismaClient,
+  ticketId: string,
+  toolName: string,
+  rawResult: string,
+  storagePath: string,
+): Promise<void> {
+  try {
+    let isJson = false;
+    try { JSON.parse(rawResult); isJson = true; } catch { /* not JSON */ }
+    const mimeType = isJson ? 'application/json' : 'text/plain';
+    const ext = isJson ? 'json' : 'txt';
+    const safeToolName = sanitizeFilenameSegment(toolName || 'unknown');
+    const filename = `mcp-${safeToolName}-${Date.now()}.${ext}`;
+    const resolvedStorage = resolve(storagePath);
+    const ticketDir = resolve(resolvedStorage, 'tickets', ticketId);
+    const rel = relative(resolvedStorage, ticketDir);
+    if (rel.startsWith('..') || rel === '') {
+      logger.warn({ ticketId, ticketDir, resolvedStorage }, 'MCP artifact path escaped storage root — skipping');
+      return;
+    }
+    const fullPath = join(ticketDir, filename);
+    await mkdir(ticketDir, { recursive: true });
+    await writeFile(fullPath, rawResult, 'utf-8');
+    const relativePath = `tickets/${ticketId}/${filename}`;
+    await db.artifact.create({
+      data: {
+        ticketId,
+        filename,
+        mimeType,
+        sizeBytes: Buffer.byteLength(rawResult, 'utf-8'),
+        storagePath: relativePath,
+        description: `Raw MCP tool output from agentic analysis (${toolName})`,
+      },
+    });
+    logger.info({ ticketId, filename }, 'MCP tool artifact saved');
+  } catch (err) {
+    logger.warn({ err, ticketId }, 'Failed to save MCP tool artifact — continuing');
+  }
+}
+
 // Signals indicating a sub-task result may be irrelevant (checked in first 500 chars)
 const IRRELEVANT_SIGNALS = [
   'not relevant', 'unable to', 'cannot access', 'i cannot', "i don't have",
@@ -2059,6 +2112,9 @@ async function executeOrchestratedSubTask(
             content: result.result,
             ...(result.isError ? { is_error: true } : {}),
           });
+          if (deps.artifactStoragePath && !result.isError) {
+            await saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath);
+          }
           if (result.isError) hasToolError = true;
         }
 
@@ -3187,6 +3243,9 @@ async function executeRoutePipeline(
               content: result.result,
               ...(result.isError ? { is_error: true } : {}),
             });
+            if (deps.artifactStoragePath && !result.isError) {
+              await saveMcpToolArtifact(deps.db, ticketId, toolUse.name, result.result, deps.artifactStoragePath);
+            }
             appLog.info(
               `Agentic tool call: ${toolUse.name} (${elapsed}ms)`,
               {

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -69,6 +69,7 @@ async function main(): Promise<void> {
     apiKey: config.API_KEY,
     mcpAuthToken: config.MCP_AUTH_TOKEN,
     selfAnalysisQueue,
+    artifactStoragePath: config.ARTIFACT_STORAGE_PATH,
   });
   const analysisWorker = createWorker<AnalysisJob>(
     'ticket-analysis',


### PR DESCRIPTION
## Summary
This PR adds functionality to persist MCP (Model Context Protocol) tool execution results to disk and track them in the database as artifacts. This enables audit trails and historical analysis of tool outputs during ticket analysis.

## Key Changes
- **New `saveMcpToolArtifact()` function**: Saves raw MCP tool results to disk with automatic MIME type detection (JSON vs plain text) and creates corresponding database records in the `artifact` table
- **Filename sanitization**: Implements `sanitizeFilenameSegment()` to safely convert tool names to filesystem-safe filenames while preventing path traversal attacks
- **Path validation**: Validates that artifact storage paths cannot escape the configured storage root using relative path analysis
- **Integration points**: Calls artifact saving in two locations:
  - `executeOrchestratedSubTask()`: For sub-task MCP tool executions
  - `executeRoutePipeline()`: For route pipeline MCP tool executions
- **Configuration**: Adds optional `artifactStoragePath` to `AnalyzerDeps` interface and wires it through from environment config
- **Error handling**: Gracefully handles artifact save failures with warning logs, allowing analysis to continue

## Implementation Details
- Artifacts are stored in a `tickets/{ticketId}/` directory structure under the configured storage path
- File naming follows pattern: `mcp-{sanitized-tool-name}-{timestamp}.{ext}`
- Database records include filename, MIME type, size in bytes, relative storage path, and descriptive metadata
- Only successful tool executions are saved (errors are skipped)
- All path operations use `resolve()` and `relative()` to prevent directory traversal vulnerabilities

https://claude.ai/code/session_01LZp8JHdff1qiLTcZNPzyQC