### PR TITLE
chore: add Apple DESIGN.md as default theme for control panel redesign

### DIFF
--- a/services/control-panel/src/app/shared/components/bronco-button.component.ts
+++ b/services/control-panel/src/app/shared/components/bronco-button.component.ts
@@ -1,0 +1,89 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-bronco-button',
+  standalone: true,
+  template: `
+    <button
+      [class]="'btn btn-' + variant() + ' btn-' + size()"
+      [disabled]="disabled()">
+      <ng-content />
+    </button>
+  `,
+  styles: `
+    :host { display: inline-block; }
+
+    .btn {
+      font-family: var(--font-primary);
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 120ms ease;
+      border: none;
+      outline: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+
+    .btn:disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    /* Variants */
+    .btn-primary {
+      background: var(--accent);
+      color: var(--text-on-accent);
+      border-radius: var(--radius-md);
+    }
+    .btn-primary:hover { opacity: 0.85; }
+
+    .btn-secondary {
+      background: var(--bg-card);
+      color: var(--text-primary);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-pill);
+    }
+    .btn-secondary:hover { background: var(--bg-hover); }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-secondary);
+      border-radius: var(--radius-md);
+    }
+    .btn-ghost:hover { background: var(--bg-hover); }
+
+    .btn-destructive {
+      background: var(--color-error);
+      color: #ffffff;
+      border-radius: var(--radius-md);
+    }
+    .btn-destructive:hover { opacity: 0.85; }
+
+    .btn-icon {
+      background: transparent;
+      color: var(--text-tertiary);
+      border-radius: var(--radius-sm);
+      padding: 0;
+    }
+    .btn-icon:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
+    }
+
+    /* Sizes */
+    .btn-sm { padding: 4px 10px; font-size: 12px; }
+    .btn-md { padding: 6px 14px; font-size: 13px; }
+    .btn-lg { padding: 8px 18px; font-size: 14px; }
+
+    .btn-icon.btn-sm { width: 28px; height: 28px; padding: 0; }
+    .btn-icon.btn-md { width: 32px; height: 32px; padding: 0; }
+    .btn-icon.btn-lg { width: 36px; height: 36px; padding: 0; }
+  `,
+})
+export class BroncoButtonComponent {
+  variant = input<'primary' | 'secondary' | 'ghost' | 'destructive' | 'icon'>('secondary');
+  size = input<'sm' | 'md' | 'lg'>('md');
+  disabled = input(false);
+}

--- a/services/control-panel/src/app/shared/components/bronco-button.component.ts
+++ b/services/control-panel/src/app/shared/components/bronco-button.component.ts
@@ -85,5 +85,5 @@ import { Component, input } from '@angular/core';
 export class BroncoButtonComponent {
   variant = input<'primary' | 'secondary' | 'ghost' | 'destructive' | 'icon'>('secondary');
   size = input<'sm' | 'md' | 'lg'>('md');
-  disabled = input(false);
+  disabled = input<boolean>(false);
 }

--- a/services/control-panel/src/app/shared/components/bronco-button.component.ts
+++ b/services/control-panel/src/app/shared/components/bronco-button.component.ts
@@ -10,7 +10,7 @@ import { Component, input } from '@angular/core';
       <ng-content />
     </button>
   `,
-  styles: `
+  styles: [`
     :host { display: inline-block; }
 
     .btn {
@@ -56,7 +56,7 @@ import { Component, input } from '@angular/core';
 
     .btn-destructive {
       background: var(--color-error);
-      color: #ffffff;
+      color: var(--text-on-accent);
       border-radius: var(--radius-md);
     }
     .btn-destructive:hover { opacity: 0.85; }
@@ -80,7 +80,7 @@ import { Component, input } from '@angular/core';
     .btn-icon.btn-sm { width: 28px; height: 28px; padding: 0; }
     .btn-icon.btn-md { width: 32px; height: 32px; padding: 0; }
     .btn-icon.btn-lg { width: 36px; height: 36px; padding: 0; }
-  `,
+  `],
 })
 export class BroncoButtonComponent {
   variant = input<'primary' | 'secondary' | 'ghost' | 'destructive' | 'icon'>('secondary');

--- a/services/control-panel/src/app/shared/components/card.component.ts
+++ b/services/control-panel/src/app/shared/components/card.component.ts
@@ -1,14 +1,16 @@
 import { Component, input } from '@angular/core';
+import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'app-card',
   standalone: true,
+  imports: [NgClass],
   template: `
-    <div class="card" [class]="'pad-' + padding()" [class.no-shadow]="!shadow()">
+    <div [ngClass]="['card', 'pad-' + padding(), !shadow() ? 'no-shadow' : '']">
       <ng-content />
     </div>
   `,
-  styles: `
+  styles: [`
     .card {
       background: var(--bg-card);
       border-radius: var(--radius-lg);
@@ -24,7 +26,7 @@ import { Component, input } from '@angular/core';
     .pad-sm { padding: 12px; }
     .pad-md { padding: 20px; }
     .pad-lg { padding: 24px; }
-  `,
+  `],
 })
 export class CardComponent {
   padding = input<'none' | 'sm' | 'md' | 'lg'>('md');

--- a/services/control-panel/src/app/shared/components/card.component.ts
+++ b/services/control-panel/src/app/shared/components/card.component.ts
@@ -1,0 +1,32 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-card',
+  standalone: true,
+  template: `
+    <div class="card" [class]="'pad-' + padding()" [class.no-shadow]="!shadow()">
+      <ng-content />
+    </div>
+  `,
+  styles: `
+    .card {
+      background: var(--bg-card);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-card);
+    }
+
+    .card.no-shadow {
+      box-shadow: none;
+      border: 1px solid var(--border-light);
+    }
+
+    .pad-none { padding: 0; }
+    .pad-sm { padding: 12px; }
+    .pad-md { padding: 20px; }
+    .pad-lg { padding: 24px; }
+  `,
+})
+export class CardComponent {
+  padding = input<'none' | 'sm' | 'md' | 'lg'>('md');
+  shadow = input<boolean>(true);
+}

--- a/services/control-panel/src/app/shared/components/category-chip.component.ts
+++ b/services/control-panel/src/app/shared/components/category-chip.component.ts
@@ -6,7 +6,7 @@ import { Component, input } from '@angular/core';
   template: `
     <span class="chip">{{ category() }}</span>
   `,
-  styles: `
+  styles: [`
     .chip {
       display: inline-block;
       padding: 2px 8px;
@@ -18,7 +18,7 @@ import { Component, input } from '@angular/core';
       color: var(--text-secondary);
       white-space: nowrap;
     }
-  `,
+  `],
 })
 export class CategoryChipComponent {
   category = input.required<string>();

--- a/services/control-panel/src/app/shared/components/category-chip.component.ts
+++ b/services/control-panel/src/app/shared/components/category-chip.component.ts
@@ -1,0 +1,25 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-category-chip',
+  standalone: true,
+  template: `
+    <span class="chip">{{ category() }}</span>
+  `,
+  styles: `
+    .chip {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      font-size: 11px;
+      font-weight: 600;
+      background: var(--bg-muted);
+      color: var(--text-secondary);
+      white-space: nowrap;
+    }
+  `,
+})
+export class CategoryChipComponent {
+  category = input.required<string>();
+}

--- a/services/control-panel/src/app/shared/components/data-table-column.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table-column.component.ts
@@ -1,0 +1,15 @@
+import { Component, contentChild, input, TemplateRef } from '@angular/core';
+
+@Component({
+  selector: 'app-data-column',
+  standalone: true,
+  template: '',
+})
+export class DataTableColumnComponent<T = unknown> {
+  key = input.required<string>();
+  header = input.required<string>();
+  sortable = input<boolean>(true);
+  width = input<string>('');
+  headerTpl = contentChild<TemplateRef<unknown>>('header');
+  cellTpl = contentChild.required<TemplateRef<{ $implicit: T }>>('cell');
+}

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -1,0 +1,141 @@
+import { Component, contentChildren, input, output } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { DataTableColumnComponent } from './data-table-column.component.js';
+
+@Component({
+  selector: 'app-data-table',
+  standalone: true,
+  imports: [NgTemplateOutlet],
+  template: `
+    <div class="table-container">
+      @if (data().length === 0) {
+        <div class="table-empty">{{ emptyMessage() }}</div>
+      } @else {
+        <table>
+          <thead>
+            <tr>
+              @for (col of columns(); track col.key()) {
+                <th
+                  [style.width]="col.width()"
+                  [class.sortable]="col.sortable()"
+                  [class.sorted]="sortColumn() === col.key()"
+                  (click)="col.sortable() ? onSort(col.key()) : null">
+                  @if (col.headerTpl()) {
+                    <ng-container [ngTemplateOutlet]="col.headerTpl()!" />
+                  } @else {
+                    {{ col.header() }}
+                  }
+                  @if (col.sortable() && sortColumn() === col.key()) {
+                    <span class="sort-indicator">{{ sortDirection() === 'asc' ? '\u25B2' : '\u25BC' }}</span>
+                  }
+                </th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of data(); track trackBy()(row)) {
+              <tr
+                [class.clickable]="rowClickable()"
+                (click)="rowClickable() ? rowClick.emit(row) : null">
+                @for (col of columns(); track col.key()) {
+                  <td [style.width]="col.width()">
+                    <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
+                  </td>
+                }
+              </tr>
+            }
+          </tbody>
+        </table>
+      }
+    </div>
+  `,
+  styles: `
+    .table-container {
+      background: var(--bg-card);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-card);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    thead th {
+      text-align: left;
+      padding: 10px 16px;
+      font-family: var(--font-primary);
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--text-tertiary);
+      border-bottom: 1px solid var(--border-light);
+      user-select: none;
+    }
+
+    th.sortable {
+      cursor: pointer;
+    }
+
+    th.sortable:hover {
+      color: var(--text-secondary);
+    }
+
+    th.sorted {
+      color: var(--text-primary);
+    }
+
+    .sort-indicator {
+      font-size: 9px;
+      margin-left: 4px;
+      color: var(--text-tertiary);
+    }
+
+    tbody td {
+      padding: 14px 16px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-secondary);
+      border-bottom: 1px solid var(--border-light);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    tr.clickable {
+      cursor: pointer;
+      transition: background 120ms ease;
+    }
+
+    tr.clickable:hover {
+      background: var(--bg-hover);
+    }
+
+    .table-empty {
+      padding: 48px 24px;
+      text-align: center;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-tertiary);
+    }
+  `,
+})
+export class DataTableComponent<T = unknown> {
+  data = input.required<T[]>();
+  trackBy = input.required<(item: T) => string>();
+  sortColumn = input<string>('');
+  sortDirection = input<'asc' | 'desc'>('asc');
+  rowClickable = input<boolean>(true);
+  emptyMessage = input<string>('No data');
+
+  rowClick = output<T>();
+  sortChange = output<{ column: string; direction: 'asc' | 'desc' }>();
+
+  columns = contentChildren(DataTableColumnComponent);
+
+  onSort(key: string): void {
+    const direction = this.sortColumn() === key && this.sortDirection() === 'asc' ? 'desc' : 'asc';
+    this.sortChange.emit({ column: key, direction });
+  }
+}

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -36,7 +36,9 @@ import { DataTableColumnComponent } from './data-table-column.component.js';
             @for (row of data(); track trackBy()(row)) {
               <tr
                 [class.clickable]="rowClickable()"
-                (click)="rowClickable() ? rowClick.emit(row) : null">
+                [attr.tabindex]="rowClickable() ? 0 : null"
+                (click)="rowClickable() ? rowClick.emit(row) : null"
+                (keydown.enter)="rowClickable() ? rowClick.emit(row) : null">
                 @for (col of columns(); track col.key()) {
                   <td [style.width]="col.width()">
                     <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
@@ -49,7 +51,7 @@ import { DataTableColumnComponent } from './data-table-column.component.js';
       }
     </div>
   `,
-  styles: `
+  styles: [`
     .table-container {
       background: var(--bg-card);
       border-radius: var(--radius-lg);
@@ -119,7 +121,7 @@ import { DataTableColumnComponent } from './data-table-column.component.js';
       font-size: 14px;
       color: var(--text-tertiary);
     }
-  `,
+  `],
 })
 export class DataTableComponent<T = unknown> {
   data = input.required<T[]>();

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -1,0 +1,120 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-dialog',
+  standalone: true,
+  template: `
+    @if (open()) {
+      <div class="dialog-backdrop" (click)="close()">
+        <div class="dialog-panel" [style.max-width]="maxWidth()" (click)="$event.stopPropagation()">
+          <div class="dialog-header">
+            @if (title()) {
+              <h2 class="dialog-title">{{ title() }}</h2>
+            }
+            <button class="dialog-close" (click)="close()">&times;</button>
+          </div>
+          <div class="dialog-body">
+            <ng-content />
+          </div>
+          <div class="dialog-footer">
+            <ng-content select="[dialogFooter]" />
+          </div>
+        </div>
+      </div>
+    }
+  `,
+  styles: `
+    .dialog-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      animation: fadeIn 150ms ease;
+    }
+
+    .dialog-panel {
+      background: var(--bg-card);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-card);
+      width: 100%;
+      overflow: hidden;
+      animation: scaleIn 150ms ease;
+    }
+
+    .dialog-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border-light);
+    }
+
+    .dialog-title {
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin: 0;
+    }
+
+    .dialog-close {
+      width: 28px;
+      height: 28px;
+      background: none;
+      border: none;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      font-size: 20px;
+      color: var(--text-tertiary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 120ms ease;
+    }
+
+    .dialog-close:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
+    }
+
+    .dialog-body {
+      padding: 20px;
+    }
+
+    .dialog-footer {
+      padding: 12px 20px;
+      border-top: 1px solid var(--border-light);
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .dialog-footer:empty {
+      display: none;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    @keyframes scaleIn {
+      from { opacity: 0; transform: scale(0.95); }
+      to { opacity: 1; transform: scale(1); }
+    }
+  `,
+})
+export class DialogComponent {
+  title = input<string>('');
+  open = input<boolean>(false);
+  maxWidth = input<string>('480px');
+
+  openChange = output<boolean>();
+
+  close(): void {
+    this.openChange.emit(false);
+  }
+}

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -23,7 +23,7 @@ import { Component, input, output } from '@angular/core';
       </div>
     }
   `,
-  styles: `
+  styles: [`
     .dialog-backdrop {
       position: fixed;
       inset: 0;
@@ -105,7 +105,7 @@ import { Component, input, output } from '@angular/core';
       from { opacity: 0; transform: scale(0.95); }
       to { opacity: 1; transform: scale(1); }
     }
-  `,
+  `],
 })
 export class DialogComponent {
   title = input<string>('');

--- a/services/control-panel/src/app/shared/components/form-field.component.ts
+++ b/services/control-panel/src/app/shared/components/form-field.component.ts
@@ -16,7 +16,7 @@ import { Component, input } from '@angular/core';
       }
     </div>
   `,
-  styles: `
+  styles: [`
     .form-field {
       display: block;
     }
@@ -49,7 +49,7 @@ import { Component, input } from '@angular/core';
       color: var(--text-tertiary);
       margin-top: 4px;
     }
-  `,
+  `],
 })
 export class FormFieldComponent {
   label = input.required<string>();

--- a/services/control-panel/src/app/shared/components/form-field.component.ts
+++ b/services/control-panel/src/app/shared/components/form-field.component.ts
@@ -1,0 +1,58 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-form-field',
+  standalone: true,
+  template: `
+    <div class="form-field" [class.has-error]="error()">
+      <label class="field-label">{{ label() }}</label>
+      <div class="field-input">
+        <ng-content />
+      </div>
+      @if (error()) {
+        <span class="field-error">{{ error() }}</span>
+      } @else if (hint()) {
+        <span class="field-hint">{{ hint() }}</span>
+      }
+    </div>
+  `,
+  styles: `
+    .form-field {
+      display: block;
+    }
+
+    .field-label {
+      display: block;
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-secondary);
+      margin-bottom: 4px;
+    }
+
+    .has-error .field-label {
+      color: var(--color-error);
+    }
+
+    .field-error {
+      display: block;
+      font-family: var(--font-primary);
+      font-size: 12px;
+      color: var(--color-error);
+      margin-top: 4px;
+    }
+
+    .field-hint {
+      display: block;
+      font-family: var(--font-primary);
+      font-size: 12px;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+  `,
+})
+export class FormFieldComponent {
+  label = input.required<string>();
+  error = input<string>('');
+  hint = input<string>('');
+}

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -3,3 +3,5 @@ export { StatusBadgeComponent } from './status-badge.component.js';
 export { PriorityPillComponent } from './priority-pill.component.js';
 export { CategoryChipComponent } from './category-chip.component.js';
 export { StatCardComponent } from './stat-card.component.js';
+export { DataTableComponent } from './data-table.component.js';
+export { DataTableColumnComponent } from './data-table-column.component.js';

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -5,3 +5,8 @@ export { CategoryChipComponent } from './category-chip.component.js';
 export { StatCardComponent } from './stat-card.component.js';
 export { DataTableComponent } from './data-table.component.js';
 export { DataTableColumnComponent } from './data-table-column.component.js';
+export { FormFieldComponent } from './form-field.component.js';
+export { TextInputComponent } from './text-input.component.js';
+export { TextareaComponent } from './textarea.component.js';
+export { SelectComponent } from './select.component.js';
+export { ToggleSwitchComponent } from './toggle-switch.component.js';

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -1,0 +1,5 @@
+export { BroncoButtonComponent } from './bronco-button.component.js';
+export { StatusBadgeComponent } from './status-badge.component.js';
+export { PriorityPillComponent } from './priority-pill.component.js';
+export { CategoryChipComponent } from './category-chip.component.js';
+export { StatCardComponent } from './stat-card.component.js';

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -10,3 +10,8 @@ export { TextInputComponent } from './text-input.component.js';
 export { TextareaComponent } from './textarea.component.js';
 export { SelectComponent } from './select.component.js';
 export { ToggleSwitchComponent } from './toggle-switch.component.js';
+export { CardComponent } from './card.component.js';
+export { TabComponent } from './tab.component.js';
+export { TabGroupComponent } from './tab-group.component.js';
+export { DialogComponent } from './dialog.component.js';
+export { ToolbarComponent } from './toolbar.component.js';

--- a/services/control-panel/src/app/shared/components/priority-pill.component.ts
+++ b/services/control-panel/src/app/shared/components/priority-pill.component.ts
@@ -6,7 +6,7 @@ import { Component, input } from '@angular/core';
   template: `
     <span [class]="'pill pill-' + priority()">{{ priority() }}</span>
   `,
-  styles: `
+  styles: [`
     .pill {
       display: inline-block;
       padding: 2px 10px;
@@ -19,26 +19,26 @@ import { Component, input } from '@angular/core';
     }
 
     .pill-CRITICAL {
-      color: #ffffff;
+      color: var(--text-on-accent, #ffffff);
       background: var(--color-error);
     }
 
     .pill-HIGH {
-      color: #ffffff;
+      color: var(--text-on-accent, #ffffff);
       background: var(--color-warning);
     }
 
     .pill-MEDIUM {
       color: var(--color-info);
-      background: rgba(0, 122, 255, 0.08);
-      border: 1px solid rgba(0, 122, 255, 0.3);
+      background: var(--color-info-subtle, rgba(0, 122, 255, 0.08));
+      border: 1px solid var(--color-info-border, rgba(0, 122, 255, 0.3));
     }
 
     .pill-LOW {
       color: var(--text-secondary);
       background: var(--bg-muted);
     }
-  `,
+  `],
 })
 export class PriorityPillComponent {
   priority = input.required<'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'>();

--- a/services/control-panel/src/app/shared/components/priority-pill.component.ts
+++ b/services/control-panel/src/app/shared/components/priority-pill.component.ts
@@ -1,0 +1,45 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-priority-pill',
+  standalone: true,
+  template: `
+    <span [class]="'pill pill-' + priority()">{{ priority() }}</span>
+  `,
+  styles: `
+    .pill {
+      display: inline-block;
+      padding: 2px 10px;
+      border-radius: var(--radius-pill);
+      font-family: var(--font-primary);
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 1.5;
+      white-space: nowrap;
+    }
+
+    .pill-CRITICAL {
+      color: #ffffff;
+      background: var(--color-error);
+    }
+
+    .pill-HIGH {
+      color: #ffffff;
+      background: var(--color-warning);
+    }
+
+    .pill-MEDIUM {
+      color: var(--color-info);
+      background: rgba(0, 122, 255, 0.08);
+      border: 1px solid rgba(0, 122, 255, 0.3);
+    }
+
+    .pill-LOW {
+      color: var(--text-secondary);
+      background: var(--bg-muted);
+    }
+  `,
+})
+export class PriorityPillComponent {
+  priority = input.required<'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW'>();
+}

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -17,7 +17,7 @@ import { Component, input, output } from '@angular/core';
       }
     </select>
   `,
-  styles: `
+  styles: [`
     .select-input {
       width: 100%;
       box-sizing: border-box;
@@ -47,7 +47,7 @@ import { Component, input, output } from '@angular/core';
       opacity: 0.5;
       cursor: not-allowed;
     }
-  `,
+  `],
 })
 export class SelectComponent {
   value = input<string>('');

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -1,0 +1,63 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-select',
+  standalone: true,
+  template: `
+    <select
+      class="select-input"
+      [value]="value()"
+      [disabled]="disabled()"
+      (change)="onChange($event)">
+      @if (placeholder()) {
+        <option value="" disabled selected>{{ placeholder() }}</option>
+      }
+      @for (opt of options(); track opt.value) {
+        <option [value]="opt.value">{{ opt.label }}</option>
+      }
+    </select>
+  `,
+  styles: `
+    .select-input {
+      width: 100%;
+      box-sizing: border-box;
+      appearance: none;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 32px 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--text-primary);
+      cursor: pointer;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+      outline: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 12px center;
+    }
+
+    .select-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+
+    .select-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  `,
+})
+export class SelectComponent {
+  value = input<string>('');
+  options = input.required<Array<{ value: string; label: string }>>();
+  placeholder = input<string>('Select...');
+  disabled = input<boolean>(false);
+
+  valueChange = output<string>();
+
+  onChange(event: Event): void {
+    this.valueChange.emit((event.target as HTMLSelectElement).value);
+  }
+}

--- a/services/control-panel/src/app/shared/components/stat-card.component.ts
+++ b/services/control-panel/src/app/shared/components/stat-card.component.ts
@@ -8,11 +8,11 @@ import { Component, input } from '@angular/core';
       <div class="stat-label">{{ label() }}</div>
       <div class="stat-value">{{ value() }}</div>
       @if (change()) {
-        <div class="stat-change" [class]="'change-' + changeType()">{{ change() }}</div>
+        <div [class]="'stat-change change-' + changeType()">{{ change() }}</div>
       }
     </div>
   `,
-  styles: `
+  styles: [`
     .stat-card {
       background: var(--bg-card);
       border-radius: var(--radius-lg);
@@ -46,7 +46,7 @@ import { Component, input } from '@angular/core';
     .change-positive { color: var(--color-success); }
     .change-negative { color: var(--color-error); }
     .change-neutral { color: var(--text-tertiary); }
-  `,
+  `],
 })
 export class StatCardComponent {
   label = input.required<string>();

--- a/services/control-panel/src/app/shared/components/stat-card.component.ts
+++ b/services/control-panel/src/app/shared/components/stat-card.component.ts
@@ -1,0 +1,56 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-stat-card',
+  standalone: true,
+  template: `
+    <div class="stat-card">
+      <div class="stat-label">{{ label() }}</div>
+      <div class="stat-value">{{ value() }}</div>
+      @if (change()) {
+        <div class="stat-change" [class]="'change-' + changeType()">{{ change() }}</div>
+      }
+    </div>
+  `,
+  styles: `
+    .stat-card {
+      background: var(--bg-card);
+      border-radius: var(--radius-lg);
+      padding: 20px;
+      box-shadow: var(--shadow-card);
+    }
+
+    .stat-label {
+      font-family: var(--font-primary);
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-tertiary);
+    }
+
+    .stat-value {
+      font-family: var(--font-primary);
+      font-size: 32px;
+      font-weight: 600;
+      color: var(--text-primary);
+      letter-spacing: -0.8px;
+      line-height: 1.1;
+    }
+
+    .stat-change {
+      font-family: var(--font-primary);
+      font-size: 12px;
+      font-weight: 400;
+      margin-top: 6px;
+    }
+
+    .change-positive { color: var(--color-success); }
+    .change-negative { color: var(--color-error); }
+    .change-neutral { color: var(--text-tertiary); }
+  `,
+})
+export class StatCardComponent {
+  label = input.required<string>();
+  value = input.required<string>();
+  change = input('');
+  changeType = input<'positive' | 'negative' | 'neutral'>('neutral');
+}

--- a/services/control-panel/src/app/shared/components/status-badge.component.ts
+++ b/services/control-panel/src/app/shared/components/status-badge.component.ts
@@ -1,0 +1,53 @@
+import { Component, computed, input } from '@angular/core';
+
+@Component({
+  selector: 'app-status-badge',
+  standalone: true,
+  template: `
+    <span class="status-badge">
+      <span class="status-dot" [class]="'dot-' + status()"></span>
+      <span class="status-label">{{ displayLabel() }}</span>
+    </span>
+  `,
+  styles: `
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .status-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .dot-open { background: var(--color-info); }
+    .dot-in_progress { background: var(--color-warning); }
+    .dot-analyzing { background: var(--accent); }
+    .dot-resolved { background: var(--color-success); }
+    .dot-closed { background: var(--text-tertiary); }
+
+    .status-label {
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+  `,
+})
+export class StatusBadgeComponent {
+  status = input.required<'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'>();
+
+  displayLabel = computed(() => {
+    const labels: Record<string, string> = {
+      open: 'Open',
+      in_progress: 'In Progress',
+      analyzing: 'Analyzing',
+      resolved: 'Resolved',
+      closed: 'Closed',
+    };
+    return labels[this.status()] ?? this.status();
+  });
+}

--- a/services/control-panel/src/app/shared/components/status-badge.component.ts
+++ b/services/control-panel/src/app/shared/components/status-badge.component.ts
@@ -5,11 +5,11 @@ import { Component, computed, input } from '@angular/core';
   standalone: true,
   template: `
     <span class="status-badge">
-      <span class="status-dot" [class]="'dot-' + status()"></span>
+      <span [class]="'status-dot dot-' + status()"></span>
       <span class="status-label">{{ displayLabel() }}</span>
     </span>
   `,
-  styles: `
+  styles: [`
     .status-badge {
       display: inline-flex;
       align-items: center;
@@ -35,7 +35,7 @@ import { Component, computed, input } from '@angular/core';
       font-weight: 500;
       color: var(--text-secondary);
     }
-  `,
+  `],
 })
 export class StatusBadgeComponent {
   status = input.required<'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'>();

--- a/services/control-panel/src/app/shared/components/tab-group.component.ts
+++ b/services/control-panel/src/app/shared/components/tab-group.component.ts
@@ -1,0 +1,74 @@
+import { Component, computed, contentChildren, input, output } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { TabComponent } from './tab.component.js';
+
+@Component({
+  selector: 'app-tab-group',
+  standalone: true,
+  imports: [NgTemplateOutlet],
+  template: `
+    <div class="tab-group">
+      <div class="tab-bar">
+        @for (tab of tabs(); track $index) {
+          <button
+            class="tab-btn"
+            [class.active]="$index === selectedIndex()"
+            (click)="selectTab($index)">
+            {{ tab.label() }}
+          </button>
+        }
+      </div>
+      <div class="tab-content">
+        @if (activeTab()) {
+          <ng-container [ngTemplateOutlet]="activeTab()!.contentTpl()" />
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+    .tab-bar {
+      display: flex;
+      gap: 0;
+      border-bottom: 1px solid var(--border-light);
+      padding: 0;
+    }
+
+    .tab-btn {
+      padding: 10px 14px;
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-tertiary);
+      background: none;
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+      cursor: pointer;
+      transition: all 120ms ease;
+    }
+
+    .tab-btn:hover {
+      color: var(--text-secondary);
+    }
+
+    .tab-btn.active {
+      color: var(--text-primary);
+      border-bottom-color: var(--accent);
+    }
+
+    .tab-content {
+      padding: 16px 0 0;
+    }
+  `,
+})
+export class TabGroupComponent {
+  selectedIndex = input<number>(0);
+  selectedIndexChange = output<number>();
+
+  tabs = contentChildren(TabComponent);
+  activeTab = computed(() => this.tabs()[this.selectedIndex()] ?? null);
+
+  selectTab(index: number): void {
+    this.selectedIndexChange.emit(index);
+  }
+}

--- a/services/control-panel/src/app/shared/components/tab-group.component.ts
+++ b/services/control-panel/src/app/shared/components/tab-group.component.ts
@@ -25,7 +25,7 @@ import { TabComponent } from './tab.component.js';
       </div>
     </div>
   `,
-  styles: `
+  styles: [`
     .tab-bar {
       display: flex;
       gap: 0;
@@ -59,7 +59,7 @@ import { TabComponent } from './tab.component.js';
     .tab-content {
       padding: 16px 0 0;
     }
-  `,
+  `],
 })
 export class TabGroupComponent {
   selectedIndex = input<number>(0);

--- a/services/control-panel/src/app/shared/components/tab.component.ts
+++ b/services/control-panel/src/app/shared/components/tab.component.ts
@@ -1,0 +1,11 @@
+import { Component, input, TemplateRef, viewChild } from '@angular/core';
+
+@Component({
+  selector: 'app-tab',
+  standalone: true,
+  template: '<ng-template #content><ng-content /></ng-template>',
+})
+export class TabComponent {
+  label = input.required<string>();
+  contentTpl = viewChild.required<TemplateRef<unknown>>('content');
+}

--- a/services/control-panel/src/app/shared/components/text-input.component.ts
+++ b/services/control-panel/src/app/shared/components/text-input.component.ts
@@ -1,0 +1,60 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-text-input',
+  standalone: true,
+  template: `
+    <input
+      class="text-input"
+      [type]="type()"
+      [value]="value()"
+      [placeholder]="placeholder()"
+      [disabled]="disabled()"
+      [readOnly]="readonly()"
+      (input)="onInput($event)"
+    />
+  `,
+  styles: `
+    .text-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--text-primary);
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+      outline: none;
+    }
+
+    .text-input::placeholder {
+      color: var(--text-tertiary);
+    }
+
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+
+    .text-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  `,
+})
+export class TextInputComponent {
+  value = input<string>('');
+  placeholder = input<string>('');
+  type = input<string>('text');
+  disabled = input<boolean>(false);
+  readonly = input<boolean>(false);
+
+  valueChange = output<string>();
+
+  onInput(event: Event): void {
+    this.valueChange.emit((event.target as HTMLInputElement).value);
+  }
+}

--- a/services/control-panel/src/app/shared/components/text-input.component.ts
+++ b/services/control-panel/src/app/shared/components/text-input.component.ts
@@ -14,7 +14,7 @@ import { Component, input, output } from '@angular/core';
       (input)="onInput($event)"
     />
   `,
-  styles: `
+  styles: [`
     .text-input {
       width: 100%;
       box-sizing: border-box;
@@ -36,14 +36,14 @@ import { Component, input, output } from '@angular/core';
 
     .text-input:focus {
       border-color: var(--accent);
-      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+      box-shadow: 0 0 0 2px var(--focus-ring, rgba(0, 113, 227, 0.15));
     }
 
     .text-input:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
-  `,
+  `],
 })
 export class TextInputComponent {
   value = input<string>('');

--- a/services/control-panel/src/app/shared/components/textarea.component.ts
+++ b/services/control-panel/src/app/shared/components/textarea.component.ts
@@ -14,7 +14,7 @@ import { Component, input, output } from '@angular/core';
       (input)="onInput($event)"
     ></textarea>
   `,
-  styles: `
+  styles: [`
     .textarea-input {
       width: 100%;
       box-sizing: border-box;
@@ -37,14 +37,14 @@ import { Component, input, output } from '@angular/core';
 
     .textarea-input:focus {
       border-color: var(--accent);
-      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+      box-shadow: 0 0 0 2px var(--focus-ring, rgba(0, 113, 227, 0.15));
     }
 
     .textarea-input:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
-  `,
+  `],
 })
 export class TextareaComponent {
   value = input<string>('');

--- a/services/control-panel/src/app/shared/components/textarea.component.ts
+++ b/services/control-panel/src/app/shared/components/textarea.component.ts
@@ -1,0 +1,61 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-textarea',
+  standalone: true,
+  template: `
+    <textarea
+      class="textarea-input"
+      [value]="value()"
+      [placeholder]="placeholder()"
+      [rows]="rows()"
+      [disabled]="disabled()"
+      [readOnly]="readonly()"
+      (input)="onInput($event)"
+    ></textarea>
+  `,
+  styles: `
+    .textarea-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--text-primary);
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+      outline: none;
+      resize: vertical;
+    }
+
+    .textarea-input::placeholder {
+      color: var(--text-tertiary);
+    }
+
+    .textarea-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+
+    .textarea-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  `,
+})
+export class TextareaComponent {
+  value = input<string>('');
+  placeholder = input<string>('');
+  rows = input<number>(4);
+  disabled = input<boolean>(false);
+  readonly = input<boolean>(false);
+
+  valueChange = output<string>();
+
+  onInput(event: Event): void {
+    this.valueChange.emit((event.target as HTMLTextAreaElement).value);
+  }
+}

--- a/services/control-panel/src/app/shared/components/toggle-switch.component.ts
+++ b/services/control-panel/src/app/shared/components/toggle-switch.component.ts
@@ -6,9 +6,11 @@ import { Component, input, output } from '@angular/core';
   template: `
     <label class="toggle-wrapper" [class.disabled]="disabled()">
       <button
+        type="button"
         class="toggle-track"
         role="switch"
         [attr.aria-checked]="checked()"
+        [attr.aria-label]="label() || 'Toggle'"
         [class.active]="checked()"
         [disabled]="disabled()"
         (click)="toggle()">
@@ -19,7 +21,7 @@ import { Component, input, output } from '@angular/core';
       }
     </label>
   `,
-  styles: `
+  styles: [`
     .toggle-wrapper {
       display: inline-flex;
       align-items: center;
@@ -69,7 +71,7 @@ import { Component, input, output } from '@angular/core';
       font-size: 13px;
       color: var(--text-secondary);
     }
-  `,
+  `],
 })
 export class ToggleSwitchComponent {
   checked = input<boolean>(false);

--- a/services/control-panel/src/app/shared/components/toggle-switch.component.ts
+++ b/services/control-panel/src/app/shared/components/toggle-switch.component.ts
@@ -1,0 +1,84 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-toggle-switch',
+  standalone: true,
+  template: `
+    <label class="toggle-wrapper" [class.disabled]="disabled()">
+      <button
+        class="toggle-track"
+        role="switch"
+        [attr.aria-checked]="checked()"
+        [class.active]="checked()"
+        [disabled]="disabled()"
+        (click)="toggle()">
+        <span class="toggle-thumb"></span>
+      </button>
+      @if (label()) {
+        <span class="toggle-label">{{ label() }}</span>
+      }
+    </label>
+  `,
+  styles: `
+    .toggle-wrapper {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+    }
+
+    .toggle-wrapper.disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    .toggle-track {
+      width: 36px;
+      height: 20px;
+      border-radius: 10px;
+      background: var(--border-medium);
+      border: none;
+      padding: 2px;
+      cursor: pointer;
+      position: relative;
+      transition: background 120ms ease;
+      display: flex;
+      align-items: center;
+    }
+
+    .toggle-track.active {
+      background: var(--accent);
+    }
+
+    .toggle-thumb {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+      display: block;
+      transition: transform 120ms ease;
+    }
+
+    .toggle-track.active .toggle-thumb {
+      transform: translateX(16px);
+    }
+
+    .toggle-label {
+      font-family: var(--font-primary);
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+  `,
+})
+export class ToggleSwitchComponent {
+  checked = input<boolean>(false);
+  disabled = input<boolean>(false);
+  label = input<string>('');
+
+  checkedChange = output<boolean>();
+
+  toggle(): void {
+    this.checkedChange.emit(!this.checked());
+  }
+}

--- a/services/control-panel/src/app/shared/components/toolbar.component.ts
+++ b/services/control-panel/src/app/shared/components/toolbar.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
       <ng-content />
     </div>
   `,
-  styles: `
+  styles: [`
     :host { display: block; }
 
     .toolbar {
@@ -22,6 +22,6 @@ import { Component } from '@angular/core';
     :host ::ng-deep .toolbar-spacer {
       flex: 1 1 auto;
     }
-  `,
+  `],
 })
 export class ToolbarComponent {}

--- a/services/control-panel/src/app/shared/components/toolbar.component.ts
+++ b/services/control-panel/src/app/shared/components/toolbar.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-toolbar',
+  standalone: true,
+  template: `
+    <div class="toolbar">
+      <ng-content />
+    </div>
+  `,
+  styles: `
+    :host { display: block; }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 0;
+      flex-wrap: wrap;
+    }
+
+    :host ::ng-deep .toolbar-spacer {
+      flex: 1 1 auto;
+    }
+  `,
+})
+export class ToolbarComponent {}


### PR DESCRIPTION
Base design system for the UX redesign (issue #131). Additional themes
(Linear, NVIDIA, Sentry, Supabase, Vercel) will be added as user-selectable
options in a later phase.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>