### PR TITLE
Detail panel quick-look for client and probe entities

### DIFF
--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1,8 +1,10 @@
 import { Component, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { DatePipe } from '@angular/common';
+import { DatePipe, SlicePipe } from '@angular/common';
 import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
 import { TicketService, Ticket } from '../core/services/ticket.service';
+import { ClientService, Client } from '../core/services/client.service';
+import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service';
 import {
   StatusBadgeComponent,
   PriorityPillComponent,
@@ -28,6 +30,7 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
   standalone: true,
   imports: [
     DatePipe,
+    SlicePipe,
     StatusBadgeComponent,
     PriorityPillComponent,
     CategoryChipComponent,
@@ -37,17 +40,18 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
   template: `
     <aside class="detail-panel">
       <div class="panel-header">
-        @if (ticket(); as t) {
-          <div class="panel-title">
-            <span class="entity-type">Ticket</span>
+        <div class="panel-title">
+          <span class="entity-type">{{ detailPanel.entityType() }}</span>
+          @if (ticket(); as t) {
             <span class="entity-subject">{{ t.subject }}</span>
-          </div>
-        } @else {
-          <div class="panel-title">
-            <span class="entity-type">{{ detailPanel.entityType() }}</span>
+          } @else if (client(); as c) {
+            <span class="entity-subject">{{ c.name }}</span>
+          } @else if (probe(); as p) {
+            <span class="entity-subject">{{ p.name }}</span>
+          } @else {
             <span class="entity-id">{{ detailPanel.entityId() }}</span>
-          </div>
-        }
+          }
+        </div>
         <div class="panel-actions">
           <button class="panel-btn" (click)="expandToFullPage()" title="Open full page" aria-label="Open full page">
             <span class="expand-icon">&#x2197;</span>
@@ -60,6 +64,8 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
 
       @if (loading()) {
         <div class="panel-loading">Loading...</div>
+
+      <!-- TICKET -->
       } @else if (ticket(); as t) {
         <div class="panel-meta">
           <app-status-badge [status]="mapStatus(t.status)" />
@@ -113,6 +119,144 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
             <p class="placeholder-text">Events view coming soon</p>
           </app-tab>
         </app-tab-group>
+
+      <!-- CLIENT -->
+      } @else if (client(); as c) {
+        <div class="panel-meta">
+          @if (c.isActive) {
+            <span class="meta-badge meta-success">Active</span>
+          } @else {
+            <span class="meta-badge meta-muted">Inactive</span>
+          }
+          <span class="meta-badge meta-accent">{{ c.shortCode }}</span>
+        </div>
+
+        <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
+          <app-tab label="Details">
+            <div class="detail-fields">
+              <div class="field-row">
+                <span class="field-label">Short Code</span>
+                <span class="field-value client-code">{{ c.shortCode }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Systems</span>
+                <span class="field-value">{{ c._count?.systems ?? 0 }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Tickets</span>
+                <span class="field-value">{{ c._count?.tickets ?? 0 }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">AI Mode</span>
+                <span class="field-value">{{ c.aiMode ?? 'Default' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Auto Route</span>
+                <span class="field-value">{{ c.autoRouteTickets ? 'Yes' : 'No' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Created</span>
+                <span class="field-value">{{ c.createdAt | date:'medium' }}</span>
+              </div>
+            </div>
+            @if (c.notes) {
+              <div class="detail-section">
+                <span class="section-label">Notes</span>
+                <p class="summary-text">{{ c.notes }}</p>
+              </div>
+            }
+          </app-tab>
+          <app-tab label="Systems">
+            @if (c.systems?.length) {
+              @for (sys of c.systems; track sys.id) {
+                <div class="list-item">
+                  <span class="list-item-name">{{ sys.name }}</span>
+                </div>
+              }
+            } @else {
+              <p class="placeholder-text">No systems</p>
+            }
+          </app-tab>
+        </app-tab-group>
+
+      <!-- PROBE -->
+      } @else if (probe(); as p) {
+        <div class="panel-meta">
+          @if (p.isActive) {
+            <span class="meta-badge meta-success">Active</span>
+          } @else {
+            <span class="meta-badge meta-muted">Inactive</span>
+          }
+          <span class="meta-badge meta-accent">{{ p.action }}</span>
+        </div>
+
+        <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
+          <app-tab label="Details">
+            <div class="detail-fields">
+              <div class="field-row">
+                <span class="field-label">Tool</span>
+                <span class="field-value" style="font-family: ui-monospace, monospace; font-size: 12px;">{{ p.toolName }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Client</span>
+                <span class="field-value">
+                  @if (p.client; as pc) {
+                    @if (pc.shortCode) {
+                      <span class="client-code">{{ pc.shortCode }}</span>
+                    }
+                    {{ pc.name }}
+                  } @else {
+                    —
+                  }
+                </span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Schedule</span>
+                <span class="field-value">{{ p.cronExpression }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Category</span>
+                <span class="field-value">{{ p.category ?? 'Any' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Retention</span>
+                <span class="field-value">{{ p.retentionDays }}d / {{ p.retentionMaxRuns }} runs</span>
+              </div>
+            </div>
+            @if (p.description) {
+              <div class="detail-section">
+                <span class="section-label">Description</span>
+                <p class="summary-text">{{ p.description }}</p>
+              </div>
+            }
+          </app-tab>
+          <app-tab label="Last Run">
+            @if (p.lastRunAt) {
+              <div class="detail-fields">
+                <div class="field-row">
+                  <span class="field-label">Status</span>
+                  <span class="field-value">
+                    <span class="run-status" [class]="'run-' + p.lastRunStatus">{{ p.lastRunStatus }}</span>
+                  </span>
+                </div>
+                <div class="field-row">
+                  <span class="field-label">Time</span>
+                  <span class="field-value">{{ p.lastRunAt | date:'medium' }}</span>
+                </div>
+              </div>
+              @if (p.lastRunResult) {
+                <div class="detail-section">
+                  <span class="section-label">Result</span>
+                  <pre class="result-block">{{ p.lastRunResult | slice:0:500 }}</pre>
+                </div>
+              }
+            } @else {
+              <p class="placeholder-text">No runs yet</p>
+            }
+          </app-tab>
+        </app-tab-group>
+
+      <!-- FALLBACK for system, analysis, job -->
       } @else {
         <div class="panel-body">
           <p class="placeholder-text">
@@ -281,14 +425,94 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
       line-height: 1.6;
       margin: 0;
     }
+
+    .meta-badge {
+      font-size: 12px;
+      font-weight: 500;
+      padding: 2px 10px;
+      border-radius: var(--radius-pill);
+    }
+
+    .meta-success {
+      background: rgba(52,199,89,0.08);
+      color: var(--color-success);
+    }
+
+    .meta-muted {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .meta-accent {
+      background: var(--bg-active);
+      color: var(--accent);
+      font-family: ui-monospace, monospace;
+    }
+
+    .list-item {
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-light);
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .list-item:last-child {
+      border-bottom: none;
+    }
+
+    .list-item-name {
+      font-weight: 500;
+      color: var(--text-primary);
+    }
+
+    .run-status {
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+    }
+
+    .run-success {
+      background: rgba(52,199,89,0.08);
+      color: var(--color-success);
+    }
+
+    .run-error {
+      background: rgba(255,59,48,0.08);
+      color: var(--color-error);
+    }
+
+    .run-skipped {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .result-block {
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      background: var(--bg-muted);
+      border-radius: var(--radius-md);
+      padding: 12px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 200px;
+      overflow-y: auto;
+      color: var(--text-secondary);
+      margin: 0;
+    }
   `],
 })
 export class DetailPanelComponent {
   readonly detailPanel = inject(DetailPanelService);
   private readonly router = inject(Router);
   private readonly ticketService = inject(TicketService);
+  private readonly clientService = inject(ClientService);
+  private readonly probeService = inject(ScheduledProbeService);
 
   ticket = signal<Ticket | null>(null);
+  client = signal<Client | null>(null);
+  probe = signal<ScheduledProbe | null>(null);
   selectedTab = signal(0);
   loading = signal(false);
 
@@ -296,10 +520,36 @@ export class DetailPanelComponent {
     effect(() => {
       const type = this.detailPanel.entityType();
       const id = this.detailPanel.entityId();
-      if (type === 'ticket' && id) {
-        this.loadTicket(id);
-      } else {
-        this.ticket.set(null);
+      // Reset all
+      this.ticket.set(null);
+      this.client.set(null);
+      this.probe.set(null);
+      this.selectedTab.set(0);
+
+      if (!type || !id) return;
+      this.loading.set(true);
+
+      switch (type) {
+        case 'ticket':
+          this.ticketService.getTicket(id).subscribe({
+            next: (t) => { this.ticket.set(t); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        case 'client':
+          this.clientService.getClient(id).subscribe({
+            next: (c) => { this.client.set(c); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        case 'probe':
+          this.probeService.getProbe(id).subscribe({
+            next: (p) => { this.probe.set(p); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        default:
+          this.loading.set(false);
       }
     });
   }
@@ -330,11 +580,4 @@ export class DetailPanelComponent {
     return map[status] ?? 'open';
   }
 
-  private loadTicket(id: string): void {
-    this.loading.set(true);
-    this.ticketService.getTicket(id).subscribe({
-      next: (t) => { this.ticket.set(t); this.loading.set(false); },
-      error: () => { this.ticket.set(null); this.loading.set(false); },
-    });
-  }
 }

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1,4 +1,5 @@
 import { Component, effect, inject, signal } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { Router } from '@angular/router';
 import { DatePipe, SlicePipe } from '@angular/common';
 import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
@@ -64,6 +65,9 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
 
       @if (loading()) {
         <div class="panel-loading">Loading...</div>
+
+      } @else if (error()) {
+        <div class="panel-loading">Failed to load {{ detailPanel.entityType() }} details.</div>
 
       <!-- TICKET -->
       } @else if (ticket(); as t) {
@@ -236,7 +240,7 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
                 <div class="field-row">
                   <span class="field-label">Status</span>
                   <span class="field-value">
-                    <span class="run-status" [class]="'run-' + p.lastRunStatus">{{ p.lastRunStatus }}</span>
+                    <span [class]="'run-status' + (p.lastRunStatus ? ' run-' + p.lastRunStatus : '')">{{ p.lastRunStatus ?? '—' }}</span>
                   </span>
                 </div>
                 <div class="field-row">
@@ -515,42 +519,46 @@ export class DetailPanelComponent {
   probe = signal<ScheduledProbe | null>(null);
   selectedTab = signal(0);
   loading = signal(false);
+  error = signal(false);
 
   constructor() {
-    effect(() => {
+    effect((onCleanup) => {
       const type = this.detailPanel.entityType();
       const id = this.detailPanel.entityId();
       // Reset all
       this.ticket.set(null);
       this.client.set(null);
       this.probe.set(null);
+      this.error.set(false);
       this.selectedTab.set(0);
 
       if (!type || !id) return;
       this.loading.set(true);
 
+      let sub: Subscription | undefined;
       switch (type) {
         case 'ticket':
-          this.ticketService.getTicket(id).subscribe({
+          sub = this.ticketService.getTicket(id).subscribe({
             next: (t) => { this.ticket.set(t); this.loading.set(false); },
-            error: () => { this.loading.set(false); },
+            error: () => { this.error.set(true); this.loading.set(false); },
           });
           break;
         case 'client':
-          this.clientService.getClient(id).subscribe({
+          sub = this.clientService.getClient(id).subscribe({
             next: (c) => { this.client.set(c); this.loading.set(false); },
-            error: () => { this.loading.set(false); },
+            error: () => { this.error.set(true); this.loading.set(false); },
           });
           break;
         case 'probe':
-          this.probeService.getProbe(id).subscribe({
+          sub = this.probeService.getProbe(id).subscribe({
             next: (p) => { this.probe.set(p); this.loading.set(false); },
-            error: () => { this.loading.set(false); },
+            error: () => { this.error.set(true); this.loading.set(false); },
           });
           break;
         default:
           this.loading.set(false);
       }
+      onCleanup(() => sub?.unsubscribe());
     });
   }
 


### PR DESCRIPTION
## Summary
- Add quick-look content to the detail panel for **client** and **probe** entity types (previously only tickets had real content)
- Client panel shows active/inactive badge, short code, system/ticket counts, AI mode, auto-route setting, notes, and a systems list tab
- Probe panel shows active/inactive badge, action type, tool name, client, schedule, retention, description, and a last-run tab with status and truncated result
- Unified header displays entity name for all loaded types; fallback placeholder remains for system/analysis/job

## Test plan
- [ ] Click a client row in the clients list — detail panel should show client details and systems tab
- [ ] Click a probe row in scheduled probes — detail panel should show probe details and last run tab
- [ ] Click a ticket row — existing ticket quick-look should be unchanged
- [ ] Verify expand button navigates to the correct full page for each entity type
- [ ] Verify close button works for all entity types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
