### PR TITLE
Restyle settings pages and users with custom design system (#131)

### DIFF
--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -1,22 +1,23 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
-import { MatCardModule } from '@angular/material/card';
-import { MatTableModule } from '@angular/material/table';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTabsModule } from '@angular/material/tabs';
 import { environment } from '../../../environments/environment';
 import {
   DEFAULT_OPERATIONAL_ALERT_CONFIG,
   OperationalAlertConfig,
 } from '../../core/services/settings.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+  SelectComponent,
+  ToggleSwitchComponent,
+  TabComponent,
+  TabGroupComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+} from '../../shared/components/index.js';
 
 interface NotificationPreference {
   id: string;
@@ -69,227 +70,190 @@ const EMAIL_TARGET_OPTIONS = [
   standalone: true,
   imports: [
     FormsModule,
-    MatCardModule,
-    MatTableModule,
-    MatSlideToggleModule,
-    MatSelectModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatIconModule,
-    MatProgressSpinnerModule,
     MatSnackBarModule,
-    MatTabsModule,
+    BroncoButtonComponent,
+    CardComponent,
+    FormFieldComponent,
+    SelectComponent,
+    ToggleSwitchComponent,
+    TabComponent,
+    TabGroupComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
   ],
   template: `
-    <h1>Notifications</h1>
-    <p class="subtitle">Configure event notifications and operational alerts.</p>
+    <div class="page-wrapper">
+      <h1 class="page-title">Notifications</h1>
+      <p class="subtitle">Configure event notifications and operational alerts.</p>
 
-    <mat-tab-group>
+      <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
 
-      <mat-tab label="Event Notifications">
-        @if (loading()) {
-          <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-        } @else {
-          <mat-card>
-            <mat-card-content>
+        <app-tab label="Event Notifications">
+          @if (loading()) {
+            <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+          } @else {
+            <app-card>
               <div class="table-wrapper">
-                <table mat-table [dataSource]="preferences()" class="pref-table">
-
-                  <ng-container matColumnDef="event">
-                    <th mat-header-cell *matHeaderCellDef>Event</th>
-                    <td mat-cell *matCellDef="let pref">
+                <app-data-table [data]="preferences()" [trackBy]="trackPref" [rowClickable]="false">
+                  <app-data-column key="event" header="Event" [sortable]="false">
+                    <ng-template #cell let-pref>
                       <div class="event-cell">
                         <strong>{{ eventLabel(pref.event) }}</strong>
                         <span class="event-desc">{{ pref.description }}</span>
                       </div>
-                    </td>
-                  </ng-container>
+                    </ng-template>
+                  </app-data-column>
 
-                  <ng-container matColumnDef="emailEnabled">
-                    <th mat-header-cell *matHeaderCellDef>Email</th>
-                    <td mat-cell *matCellDef="let pref">
-                      <mat-slide-toggle [(ngModel)]="pref.emailEnabled" />
-                    </td>
-                  </ng-container>
+                  <app-data-column key="emailEnabled" header="Email" [sortable]="false" width="80px">
+                    <ng-template #cell let-pref>
+                      <app-toggle-switch
+                        [checked]="pref.emailEnabled"
+                        (checkedChange)="pref.emailEnabled = $event" />
+                    </ng-template>
+                  </app-data-column>
 
-                  <ng-container matColumnDef="emailTarget">
-                    <th mat-header-cell *matHeaderCellDef>Email Target</th>
-                    <td mat-cell *matCellDef="let pref">
+                  <app-data-column key="emailTarget" header="Email Target" [sortable]="false">
+                    <ng-template #cell let-pref>
                       @if (pref.emailEnabled) {
-                        <mat-form-field appearance="outline" class="compact-field">
-                          <mat-select [value]="emailTargetSelection(pref)" (selectionChange)="onEmailTargetChange(pref, $event.value)">
-                            @for (opt of emailTargetOptions; track opt.value) {
-                              <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
-                            }
-                          </mat-select>
-                        </mat-form-field>
-                        @if (emailTargetSelection(pref) === 'custom') {
-                          <mat-form-field appearance="outline" class="compact-field custom-input">
-                            <input matInput [(ngModel)]="pref.emailTarget" placeholder="user@example.com">
-                          </mat-form-field>
-                        }
-                        @if (emailTargetSelection(pref) === 'specific_operator') {
-                          <mat-form-field appearance="outline" class="compact-field custom-input">
-                            <mat-select
+                        <div class="target-controls">
+                          <app-select
+                            [value]="emailTargetSelection(pref)"
+                            [options]="emailTargetOptions"
+                            [placeholder]="''"
+                            (valueChange)="onEmailTargetChange(pref, $event)" />
+                          @if (emailTargetSelection(pref) === 'custom') {
+                            <input class="text-input compact-input" [(ngModel)]="pref.emailTarget" placeholder="user@example.com">
+                          }
+                          @if (emailTargetSelection(pref) === 'specific_operator') {
+                            <app-select
                               [value]="selectedOperatorValue(pref.emailTarget)"
-                              (selectionChange)="pref.emailTarget = $event.value"
-                              placeholder="Select operator">
-                              @for (op of operators(); track op.id) {
-                                <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
-                              }
-                            </mat-select>
-                          </mat-form-field>
-                        }
+                              [options]="operatorOptions()"
+                              placeholder="Select operator"
+                              (valueChange)="pref.emailTarget = $event" />
+                          }
+                        </div>
                       }
-                    </td>
-                  </ng-container>
+                    </ng-template>
+                  </app-data-column>
 
-                  <ng-container matColumnDef="slackEnabled">
-                    <th mat-header-cell *matHeaderCellDef>Slack</th>
-                    <td mat-cell *matCellDef="let pref">
-                      <mat-slide-toggle [(ngModel)]="pref.slackEnabled" />
-                    </td>
-                  </ng-container>
+                  <app-data-column key="slackEnabled" header="Slack" [sortable]="false" width="80px">
+                    <ng-template #cell let-pref>
+                      <app-toggle-switch
+                        [checked]="pref.slackEnabled"
+                        (checkedChange)="pref.slackEnabled = $event" />
+                    </ng-template>
+                  </app-data-column>
 
-                  <ng-container matColumnDef="slackTarget">
-                    <th mat-header-cell *matHeaderCellDef>Slack Target</th>
-                    <td mat-cell *matCellDef="let pref">
+                  <app-data-column key="slackTarget" header="Slack Target" [sortable]="false">
+                    <ng-template #cell let-pref>
                       @if (pref.slackEnabled) {
-                        <mat-form-field appearance="outline" class="compact-field">
-                          <mat-select [value]="slackTargetSelection(pref)" (selectionChange)="onSlackTargetChange(pref, $event.value)">
-                            @for (opt of slackTargetOptions; track opt.value) {
-                              <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
-                            }
-                          </mat-select>
-                        </mat-form-field>
-                        @if (slackTargetSelection(pref) === 'custom') {
-                          <mat-form-field appearance="outline" class="compact-field custom-input">
-                            <input matInput [(ngModel)]="pref.slackTarget" placeholder="C0123456789">
-                          </mat-form-field>
-                        }
-                        @if (slackTargetSelection(pref) === 'specific_operator') {
-                          <mat-form-field appearance="outline" class="compact-field custom-input">
-                            <mat-select
+                        <div class="target-controls">
+                          <app-select
+                            [value]="slackTargetSelection(pref)"
+                            [options]="slackTargetOptions"
+                            [placeholder]="''"
+                            (valueChange)="onSlackTargetChange(pref, $event)" />
+                          @if (slackTargetSelection(pref) === 'custom') {
+                            <input class="text-input compact-input" [(ngModel)]="pref.slackTarget" placeholder="C0123456789">
+                          }
+                          @if (slackTargetSelection(pref) === 'specific_operator') {
+                            <app-select
                               [value]="selectedOperatorValue(pref.slackTarget)"
-                              (selectionChange)="pref.slackTarget = $event.value"
-                              placeholder="Select operator">
-                              @for (op of operators(); track op.id) {
-                                <mat-option [value]="'operator:' + op.id">{{ op.name }}</mat-option>
-                              }
-                            </mat-select>
-                          </mat-form-field>
-                        }
+                              [options]="operatorOptions()"
+                              placeholder="Select operator"
+                              (valueChange)="pref.slackTarget = $event" />
+                          }
+                        </div>
                       }
-                    </td>
-                  </ng-container>
-
-                  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-                </table>
+                    </ng-template>
+                  </app-data-column>
+                </app-data-table>
               </div>
 
-              <div class="actions">
-                <button mat-flat-button color="primary" (click)="saveAll()" [disabled]="saving()">
-                  @if (saving()) {
-                    <mat-spinner diameter="20" />
-                  } @else {
-                    <span><mat-icon>save</mat-icon> Save All</span>
-                  }
-                </button>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveAll()" [disabled]="saving()">
+                  @if (saving()) { <span class="loading-text">Saving...</span> } @else { <span>Save All</span> }
+                </app-bronco-button>
               </div>
-            </mat-card-content>
-          </mat-card>
-        }
-      </mat-tab>
+            </app-card>
+          }
+        </app-tab>
 
-      <mat-tab label="Operational Alerts">
-        <div class="tab-content">
-          @if (alertsLoading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else if (alertsError()) {
-            <p>Failed to load alert configuration. <button mat-button (click)="loadAlertConfig()">Retry</button></p>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Alert Notifications</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+        <app-tab label="Operational Alerts">
+          <div class="tab-content">
+            @if (alertsLoading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else if (alertsError()) {
+              <p>Failed to load alert configuration.
+                <app-bronco-button variant="ghost" (click)="loadAlertConfig()">Retry</app-bronco-button>
+              </p>
+            } @else {
+              <app-card>
+                <h2 class="section-title">Alert Notifications</h2>
                 <p class="subtitle">
                   Get email notifications when background processes fail silently.
                 </p>
 
                 <div class="alert-toggle-row">
-                  <mat-slide-toggle
+                  <app-toggle-switch
+                    label="Enable operational alerts"
                     [checked]="alertConfig().enabled"
-                    (change)="setAlertEnabled($event.checked)">
-                    Enable operational alerts
-                  </mat-slide-toggle>
+                    (checkedChange)="setAlertEnabled($event)" />
                 </div>
 
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>Recipient Operator</mat-label>
-                  <mat-select
-                    [value]="alertConfig().recipientOperatorId"
-                    (selectionChange)="setAlertRecipientOperator($event.value)">
-                    @for (op of operators(); track op.id) {
-                      <mat-option [value]="op.id">{{ op.name }} ({{ op.email }})</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
+                <div class="form-grid">
+                  <app-form-field label="Recipient Operator">
+                    <app-select
+                      [value]="alertConfig().recipientOperatorId ?? ''"
+                      [options]="operatorEmailOptions()"
+                      placeholder="Select operator"
+                      (valueChange)="setAlertRecipientOperator($event)" />
+                  </app-form-field>
 
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>Throttle (minutes between repeat alerts)</mat-label>
-                  <mat-select
-                    [value]="alertConfig().throttleMinutes"
-                    (selectionChange)="setAlertThrottleMinutes($event.value)">
-                    <mat-option [value]="15">15 minutes</mat-option>
-                    <mat-option [value]="30">30 minutes</mat-option>
-                    <mat-option [value]="60">1 hour</mat-option>
-                    <mat-option [value]="120">2 hours</mat-option>
-                  </mat-select>
-                </mat-form-field>
+                  <app-form-field label="Throttle (minutes between repeat alerts)">
+                    <app-select
+                      [value]="'' + alertConfig().throttleMinutes"
+                      [options]="throttleOptions"
+                      [placeholder]="''"
+                      (valueChange)="setAlertThrottleMinutes(+$event)" />
+                  </app-form-field>
+                </div>
 
-                <h3>Alert Types</h3>
+                <h3 class="subsection-title">Alert Types</h3>
                 <div class="alert-toggles">
                   <div class="alert-toggle-row">
-                    <mat-slide-toggle
+                    <app-toggle-switch
+                      label="Failed BullMQ jobs"
                       [checked]="alertConfig().alerts.failedJobs"
-                      (change)="setAlertType('failedJobs', $event.checked)">
-                      Failed BullMQ jobs
-                    </mat-slide-toggle>
+                      (checkedChange)="setAlertType('failedJobs', $event)" />
                     <span class="alert-desc">Alert when background job queues have failed jobs</span>
                   </div>
                   <div class="alert-toggle-row">
-                    <mat-slide-toggle
+                    <app-toggle-switch
+                      label="Missed probe schedules"
                       [checked]="alertConfig().alerts.probeMisses"
-                      (change)="setAlertType('probeMisses', $event.checked)">
-                      Missed probe schedules
-                    </mat-slide-toggle>
+                      (checkedChange)="setAlertType('probeMisses', $event)" />
                     <span class="alert-desc">Alert when scheduled probes miss their expected run window</span>
                   </div>
                   <div class="alert-toggle-row">
-                    <mat-slide-toggle
+                    <app-toggle-switch
+                      label="AI provider outages"
                       [checked]="alertConfig().alerts.aiProviderDown"
-                      (change)="setAlertType('aiProviderDown', $event.checked)">
-                      AI provider outages
-                    </mat-slide-toggle>
+                      (checkedChange)="setAlertType('aiProviderDown', $event)" />
                     <span class="alert-desc">Alert when Ollama or cloud AI providers are unreachable or failing</span>
                   </div>
                   <div class="alert-toggle-row">
-                    <mat-slide-toggle
+                    <app-toggle-switch
+                      label="DevOps sync staleness"
                       [checked]="alertConfig().alerts.devopsSyncStale"
-                      (change)="setAlertType('devopsSyncStale', $event.checked)">
-                      DevOps sync staleness
-                    </mat-slide-toggle>
+                      (checkedChange)="setAlertType('devopsSyncStale', $event)" />
                     <span class="alert-desc">Alert when Azure DevOps sync stops (PAT expired, rate limit, etc)</span>
                   </div>
                   <div class="alert-toggle-row">
-                    <mat-slide-toggle
+                    <app-toggle-switch
+                      label="Log summarization staleness"
                       [checked]="alertConfig().alerts.summarizationStale"
-                      (change)="setAlertType('summarizationStale', $event.checked)">
-                      Log summarization staleness
-                    </mat-slide-toggle>
+                      (checkedChange)="setAlertType('summarizationStale', $event)" />
                     <span class="alert-desc">Alert when log summarization hasn't run in over 2 hours</span>
                   </div>
                 </div>
@@ -299,81 +263,126 @@ const EMAIL_TARGET_OPTIONS = [
                     {{ alertTestResult()!.success ? alertTestResult()!.message : alertTestResult()!.error }}
                   </div>
                 }
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-flat-button color="primary" (click)="saveAlertConfig()" [disabled]="alertsSaving()">
-                  @if (alertsSaving()) { <mat-spinner diameter="18" /> } @else { <mat-icon>save</mat-icon> }
-                  Save
-                </button>
-                <button mat-button (click)="testAlert()" [disabled]="alertsTesting()">
-                  @if (alertsTesting()) { <mat-spinner diameter="18" /> }
-                  Test Alert
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
 
-    </mat-tab-group>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveAlertConfig()" [disabled]="alertsSaving()">
+                    @if (alertsSaving()) { <span class="loading-text">Saving...</span> } @else { Save }
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testAlert()" [disabled]="alertsTesting()">
+                    @if (alertsTesting()) { <span class="loading-text">Testing...</span> } @else { Test Alert }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
+
+      </app-tab-group>
+    </div>
   `,
   styles: [`
-    .subtitle {
-      color: #666;
-      margin-bottom: 16px;
+    .page-wrapper { max-width: 1200px; }
+    .page-title {
+      margin: 0 0 8px;
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--text-primary);
     }
-    .spinner-wrapper {
+    .subtitle {
+      color: var(--text-tertiary);
+      margin: 0 0 16px;
+      font-size: 14px;
+    }
+
+    .loading-wrapper {
       display: flex;
       justify-content: center;
       padding: 40px;
     }
-    .table-wrapper {
-      overflow-x: auto;
+    .loading-text {
+      color: var(--text-tertiary);
+      font-size: 13px;
     }
-    .pref-table {
-      width: 100%;
+
+    .section-title {
+      margin: 0 0 8px;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
     }
+    .subsection-title {
+      margin: 24px 0 8px;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .table-wrapper { overflow-x: auto; }
+
     .event-cell {
       display: flex;
       flex-direction: column;
-      padding: 8px 0;
+      padding: 4px 0;
     }
     .event-desc {
       font-size: 12px;
-      color: #888;
+      color: var(--text-tertiary);
       margin-top: 2px;
     }
-    .compact-field {
-      font-size: 13px;
-      max-width: 200px;
-    }
-    .custom-input {
-      margin-left: 8px;
-      max-width: 180px;
-    }
-    .actions {
-      display: flex;
-      justify-content: flex-end;
-      margin-top: 16px;
-      padding-top: 16px;
-      border-top: 1px solid #e0e0e0;
-    }
-    .actions button mat-icon {
-      margin-right: 4px;
-    }
-    .tab-content {
-      padding-top: 16px;
-    }
-    .full-width {
-      width: 100%;
-      max-width: 400px;
-      display: block;
-      margin-bottom: 12px;
-    }
-    .alert-toggle-row {
+
+    .target-controls {
       display: flex;
       align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .target-controls app-select {
+      max-width: 200px;
+    }
+    .compact-input {
+      max-width: 180px;
+    }
+
+    .text-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
+    }
+
+    .tab-content { padding-top: 8px; }
+
+    .form-grid {
+      display: flex;
+      flex-direction: column;
       gap: 12px;
+      max-width: 400px;
+      margin-bottom: 12px;
+    }
+
+    .alert-toggle-row {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
       margin-bottom: 12px;
     }
     .alert-toggles {
@@ -382,22 +391,24 @@ const EMAIL_TARGET_OPTIONS = [
     }
     .alert-desc {
       font-size: 12px;
-      color: #888;
+      color: var(--text-tertiary);
+      padding-left: 44px;
     }
     .test-result {
       margin-top: 8px;
-      padding: 8px;
-      border-radius: 4px;
+      padding: 8px 12px;
+      border-radius: var(--radius-md);
       font-size: 13px;
     }
-    .test-result.success { background: #e8f5e9; color: #2e7d32; }
-    .test-result.error { background: #fce4ec; color: #c62828; }
+    .test-result.success { background: rgba(52, 199, 89, 0.1); color: var(--color-success); }
+    .test-result.error { background: rgba(255, 59, 48, 0.1); color: var(--color-error); }
   `],
 })
 export class NotificationPreferencesComponent implements OnInit {
   private http = inject(HttpClient);
   private snackBar = inject(MatSnackBar);
 
+  selectedTab = signal(0);
   loading = signal(true);
   saving = signal(false);
   preferences = signal<NotificationPreference[]>([]);
@@ -410,9 +421,20 @@ export class NotificationPreferencesComponent implements OnInit {
   alertsTesting = signal(false);
   alertTestResult = signal<{ success: boolean; message?: string; error?: string } | null>(null);
 
-  displayedColumns = ['event', 'emailEnabled', 'emailTarget', 'slackEnabled', 'slackTarget'];
   slackTargetOptions = SLACK_TARGET_OPTIONS;
   emailTargetOptions = EMAIL_TARGET_OPTIONS;
+
+  throttleOptions = [
+    { value: '15', label: '15 minutes' },
+    { value: '30', label: '30 minutes' },
+    { value: '60', label: '1 hour' },
+    { value: '120', label: '2 hours' },
+  ];
+
+  trackPref = (pref: NotificationPreference) => pref.id;
+
+  operatorOptions = signal<Array<{ value: string; label: string }>>([]);
+  operatorEmailOptions = signal<Array<{ value: string; label: string }>>([]);
 
   ngOnInit(): void {
     this.load();
@@ -422,7 +444,12 @@ export class NotificationPreferencesComponent implements OnInit {
 
   private loadOperators(): void {
     this.http.get<OperatorOption[]>(`${environment.apiUrl}/operators`).subscribe({
-      next: ops => this.operators.set(ops.filter(o => o.isActive !== false)),
+      next: ops => {
+        const active = ops.filter(o => o.isActive !== false);
+        this.operators.set(active);
+        this.operatorOptions.set(active.map(o => ({ value: 'operator:' + o.id, label: o.name })));
+        this.operatorEmailOptions.set(active.map(o => ({ value: o.id, label: `${o.name} (${o.email})` })));
+      },
       error: () => { /* non-critical */ },
     });
   }
@@ -451,8 +478,6 @@ export class NotificationPreferencesComponent implements OnInit {
     } else if (value === 'custom') {
       pref.slackTarget = '';
     } else if (value === 'specific_operator') {
-      // Use 'operator:' prefix as placeholder so slackTargetSelection() keeps returning
-      // 'specific_operator' until the user picks an operator from the dropdown.
       pref.slackTarget = 'operator:';
     } else {
       pref.slackTarget = value;
@@ -463,8 +488,6 @@ export class NotificationPreferencesComponent implements OnInit {
     if (value === 'custom') {
       pref.emailTarget = '';
     } else if (value === 'specific_operator') {
-      // Use 'operator:' prefix as placeholder so emailTargetSelection() keeps returning
-      // 'specific_operator' until the user picks an operator from the dropdown.
       pref.emailTarget = 'operator:';
     } else {
       pref.emailTarget = value;

--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -1,98 +1,171 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthService } from '../../core/services/auth.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
-  imports: [FormsModule, MatCardModule, MatIconModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [FormsModule, BroncoButtonComponent, CardComponent, FormFieldComponent],
   template: `
-    <h1>Profile</h1>
+    <div class="page-wrapper">
+      <h1 class="page-title">Profile</h1>
 
-    @if (authService.currentUser(); as user) {
-      <mat-card>
-        <mat-card-header>
-          <mat-icon mat-card-avatar style="font-size: 40px; width: 40px; height: 40px;">account_circle</mat-icon>
-          <mat-card-title>{{ user.name }}</mat-card-title>
-          <mat-card-subtitle>{{ user.role }}</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
+      @if (authService.currentUser(); as user) {
+        <app-card>
+          <div class="profile-header">
+            <div class="avatar">{{ user.name.charAt(0).toUpperCase() }}</div>
+            <div>
+              <div class="profile-name">{{ user.name }}</div>
+              <div class="profile-role">{{ user.role }}</div>
+            </div>
+          </div>
           <div class="field">
             <span class="label">User ID</span>
             <span class="mono">{{ user.id }}</span>
           </div>
-        </mat-card-content>
-      </mat-card>
+        </app-card>
 
-      <mat-card class="section-card">
-        <mat-card-header>
-          <mat-card-title>Edit Profile</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-          <mat-form-field class="full-width">
-            <mat-label>Name</mat-label>
-            <input matInput [(ngModel)]="profileName" />
-          </mat-form-field>
-          <mat-form-field class="full-width">
-            <mat-label>Email</mat-label>
-            <input matInput type="email" [(ngModel)]="profileEmail" />
-          </mat-form-field>
-        </mat-card-content>
-        <mat-card-actions>
-          <button mat-raised-button color="primary" (click)="saveProfile()" [disabled]="profileSaving">
-            Save Changes
-          </button>
-        </mat-card-actions>
-      </mat-card>
+        <app-card>
+          <h2 class="section-title">Edit Profile</h2>
+          <div class="form-grid">
+            <app-form-field label="Name">
+              <input class="text-input" [(ngModel)]="profileName" />
+            </app-form-field>
+            <app-form-field label="Email">
+              <input class="text-input" type="email" [(ngModel)]="profileEmail" />
+            </app-form-field>
+          </div>
+          <div class="card-actions">
+            <app-bronco-button variant="primary" (click)="saveProfile()" [disabled]="profileSaving">
+              Save Changes
+            </app-bronco-button>
+          </div>
+        </app-card>
 
-      <mat-card class="section-card">
-        <mat-card-header>
-          <mat-card-title>Change Password</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-          <mat-form-field class="full-width">
-            <mat-label>Current Password</mat-label>
-            <input matInput type="password" [(ngModel)]="currentPassword" />
-          </mat-form-field>
-          <mat-form-field class="full-width">
-            <mat-label>New Password</mat-label>
-            <input matInput type="password" [(ngModel)]="newPassword" />
-          </mat-form-field>
-          <mat-form-field class="full-width">
-            <mat-label>Confirm New Password</mat-label>
-            <input matInput type="password" [(ngModel)]="confirmPassword" />
-          </mat-form-field>
-        </mat-card-content>
-        <mat-card-actions>
-          <button mat-raised-button color="warn" (click)="changePassword()" [disabled]="passwordSaving">
-            Change Password
-          </button>
-        </mat-card-actions>
-      </mat-card>
-    }
+        <app-card>
+          <h2 class="section-title">Change Password</h2>
+          <div class="form-grid">
+            <app-form-field label="Current Password">
+              <input class="text-input" type="password" [(ngModel)]="currentPassword" />
+            </app-form-field>
+            <app-form-field label="New Password">
+              <input class="text-input" type="password" [(ngModel)]="newPassword" />
+            </app-form-field>
+            <app-form-field label="Confirm New Password">
+              <input class="text-input" type="password" [(ngModel)]="confirmPassword" />
+            </app-form-field>
+          </div>
+          <div class="card-actions">
+            <app-bronco-button variant="destructive" (click)="changePassword()" [disabled]="passwordSaving">
+              Change Password
+            </app-bronco-button>
+          </div>
+        </app-card>
+      }
+    </div>
   `,
   styles: [`
-    h1 { margin: 0 0 24px; }
-    .section-card { margin-top: 24px; }
-    .full-width { width: 100%; }
+    .page-wrapper { max-width: 1200px; }
+    .page-title {
+      margin: 0 0 24px;
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    app-card { display: block; margin-bottom: 16px; }
+
+    .profile-header {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+    .avatar {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--text-on-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      font-weight: 600;
+    }
+    .profile-name {
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .profile-role {
+      font-size: 13px;
+      color: var(--text-tertiary);
+    }
+
     .field {
       display: flex;
       flex-direction: column;
-      margin-top: 16px;
+      margin-top: 8px;
     }
     .label {
       font-size: 12px;
-      color: #666;
+      color: var(--text-tertiary);
       margin-bottom: 4px;
     }
     .mono {
       font-family: monospace;
       font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .section-title {
+      margin: 0 0 16px;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .form-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: 600px;
+    }
+
+    .text-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+    .text-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
     }
   `],
 })

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -1,27 +1,14 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatTableModule } from '@angular/material/table';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatDividerModule } from '@angular/material/divider';
-import { MatTabsModule } from '@angular/material/tabs';
 import {
   ExternalServiceService,
   ExternalService,
 } from '../../core/services/external-service.service';
 import { UserService, ControlPanelUser } from '../../core/services/user.service';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatSelectModule } from '@angular/material/select';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import {
   SettingsService,
   TicketStatusConfig,
@@ -31,422 +18,314 @@ import {
 import { ExternalServiceDialogComponent } from './external-service-dialog.component';
 import { StatusConfigDialogComponent } from './status-config-dialog.component';
 import { CategoryConfigDialogComponent } from './category-config-dialog.component';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+  SelectComponent,
+  ToggleSwitchComponent,
+  TabComponent,
+  TabGroupComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
   imports: [
     FormsModule,
-    MatCardModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatIconModule,
     MatDialogModule,
-    MatTableModule,
-    MatChipsModule,
-    MatTooltipModule,
     MatMenuModule,
-    MatDividerModule,
-    MatTabsModule,
-    MatSlideToggleModule,
-    MatSelectModule,
-    MatProgressSpinnerModule,
+    BroncoButtonComponent,
+    CardComponent,
+    FormFieldComponent,
+    SelectComponent,
+    ToggleSwitchComponent,
+    TabComponent,
+    TabGroupComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
   ],
   template: `
-    <h1>Settings</h1>
+    <div class="page-wrapper">
+      <h1 class="page-title">Settings</h1>
 
-    <mat-tab-group [selectedIndex]="selectedTab()" (selectedTabChange)="onTabChange($event.index)">
-      <!-- General tab -->
-      <mat-tab label="General">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>API Configuration</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
+      <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="onTabChange($event)">
+        <!-- General tab -->
+        <app-tab label="General">
+          <div class="tab-content">
+            <app-card>
+              <h2 class="section-title">API Configuration</h2>
               <p class="hint">The API key is stored in session storage (cleared when tab closes) and sent with every request.</p>
-              <mat-form-field class="full-width">
-                <mat-label>API Key</mat-label>
-                <input matInput [type]="showKey() ? 'text' : 'password'" [(ngModel)]="apiKey">
-                <button mat-icon-button matSuffix (click)="showKey.set(!showKey())">
-                  <mat-icon>{{ showKey() ? 'visibility_off' : 'visibility' }}</mat-icon>
-                </button>
-              </mat-form-field>
-            </mat-card-content>
-            <mat-card-actions>
-              <button mat-raised-button color="primary" (click)="saveKey()">
-                <mat-icon>save</mat-icon> Save API Key
-              </button>
-              <button mat-button color="warn" (click)="clearKey()">Clear</button>
-            </mat-card-actions>
-          </mat-card>
+              <div class="form-grid">
+                <app-form-field label="API Key">
+                  <div class="input-with-toggle">
+                    <input class="text-input" [type]="showKey() ? 'text' : 'password'" [(ngModel)]="apiKey">
+                    <button class="toggle-vis" (click)="showKey.set(!showKey())" title="Toggle visibility">
+                      {{ showKey() ? 'Hide' : 'Show' }}
+                    </button>
+                  </div>
+                </app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveKey()">
+                  Save API Key
+                </app-bronco-button>
+                <app-bronco-button variant="destructive" size="sm" (click)="clearKey()">Clear</app-bronco-button>
+              </div>
+            </app-card>
 
-          <mat-card class="section-card">
-            <mat-card-header>
-              <mat-card-title>Super Admin</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
+            <app-card>
+              <h2 class="section-title">Super Admin</h2>
               <p class="hint">Designate a control panel user as the super admin. This user will have elevated privileges for system-wide operations.</p>
-              <mat-form-field class="full-width">
-                <mat-label>Super Admin User</mat-label>
-                <mat-select [(ngModel)]="superAdminUserId" [disabled]="usersLoading()">
-                  <mat-option [value]="null">— None —</mat-option>
-                  @for (u of adminUsers(); track u.id) {
-                    <mat-option [value]="u.id">{{ u.name }} ({{ u.email }}) — {{ u.role }}</mat-option>
-                  }
-                </mat-select>
-              </mat-form-field>
-            </mat-card-content>
-            <mat-card-actions>
-              <button mat-raised-button color="primary" (click)="saveSuperAdmin()" [disabled]="superAdminSaving()">
-                @if (superAdminSaving()) {
-                  <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
-                }
-                Save
-              </button>
-            </mat-card-actions>
-          </mat-card>
-        </div>
-      </mat-tab>
+              <div class="form-grid">
+                <app-form-field label="Super Admin User">
+                  <app-select
+                    [value]="superAdminUserId ?? ''"
+                    [options]="superAdminOptions()"
+                    [disabled]="usersLoading()"
+                    placeholder="-- None --"
+                    (valueChange)="superAdminUserId = $event || null" />
+                </app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveSuperAdmin()" [disabled]="superAdminSaving()">
+                  @if (superAdminSaving()) { Saving... } @else { Save }
+                </app-bronco-button>
+              </div>
+            </app-card>
+          </div>
+        </app-tab>
 
-      <!-- Ticket Statuses tab -->
-      <mat-tab label="Ticket Statuses">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>Ticket Statuses</mat-card-title>
-              <div class="header-spacer"></div>
-              <button mat-raised-button color="primary" (click)="createStatus()">
-                <mat-icon>add</mat-icon> Create Status
-              </button>
-            </mat-card-header>
-            <mat-card-content>
-              <p class="hint">
-                Configure how ticket statuses appear and behave. Each status belongs to either the
-                <strong>open</strong> class (active tickets) or the <strong>closed</strong> class (terminal tickets).
-              </p>
+        <!-- Ticket Statuses tab -->
+        <app-tab label="Ticket Statuses">
+          <div class="tab-content">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">Ticket Statuses</h2>
+                <p class="hint">
+                  Configure how ticket statuses appear and behave. Each status belongs to either the
+                  <strong>open</strong> class (active tickets) or the <strong>closed</strong> class (terminal tickets).
+                </p>
+              </div>
+              <app-bronco-button variant="primary" (click)="createStatus()">Create Status</app-bronco-button>
+            </div>
 
-              @if (statusesLoading()) {
-                <div class="empty-state">
-                  <mat-icon>hourglass_empty</mat-icon>
-                  <p>Loading status configurations...</p>
-                </div>
-              } @else if (statusesError()) {
-                <div class="empty-state">
-                  <mat-icon>error_outline</mat-icon>
-                  <p>Failed to load status configurations.</p>
-                  <button mat-button color="primary" (click)="loadStatuses()">Retry</button>
-                </div>
-              } @else {
-                <table mat-table [dataSource]="statuses()" class="full-table">
-                  <ng-container matColumnDef="color">
-                    <th mat-header-cell *matHeaderCellDef>Color</th>
-                    <td mat-cell *matCellDef="let s">
-                      <div class="color-swatch" [style.background]="s.color"></div>
-                    </td>
-                  </ng-container>
+            @if (statusesLoading()) {
+              <div class="empty-state"><span class="loading-text">Loading status configurations...</span></div>
+            } @else if (statusesError()) {
+              <div class="empty-state">
+                <p>Failed to load status configurations.</p>
+                <app-bronco-button variant="ghost" (click)="loadStatuses()">Retry</app-bronco-button>
+              </div>
+            } @else {
+              <app-data-table [data]="statuses()" [trackBy]="trackStatus" [rowClickable]="false">
+                <app-data-column key="color" header="Color" [sortable]="false" width="60px">
+                  <ng-template #cell let-s>
+                    <div class="color-swatch" [style.background]="s.color"></div>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="value" header="Value" [sortable]="false">
+                  <ng-template #cell let-s><code>{{ s.value }}</code></ng-template>
+                </app-data-column>
+                <app-data-column key="displayName" header="Display Name" [sortable]="false">
+                  <ng-template #cell let-s>{{ s.displayName }}</ng-template>
+                </app-data-column>
+                <app-data-column key="description" header="Description" [sortable]="false">
+                  <ng-template #cell let-s><span class="desc-text">{{ s.description ?? '—' }}</span></ng-template>
+                </app-data-column>
+                <app-data-column key="statusClass" header="Class" [sortable]="false" width="100px">
+                  <ng-template #cell let-s>
+                    <span class="class-chip" [class.class-open]="s.statusClass === 'open'" [class.class-closed]="s.statusClass === 'closed'">
+                      {{ s.statusClass }}
+                    </span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="sortOrder" header="Order" [sortable]="false" width="70px">
+                  <ng-template #cell let-s>{{ s.sortOrder }}</ng-template>
+                </app-data-column>
+                <app-data-column key="active" header="Active" [sortable]="false" width="70px">
+                  <ng-template #cell let-s>
+                    <span [class.status-yes]="s.isActive" [class.status-no]="!s.isActive">
+                      {{ s.isActive ? 'Yes' : 'No' }}
+                    </span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="actions" header="" [sortable]="false" width="60px">
+                  <ng-template #cell let-s>
+                    <app-bronco-button variant="icon" size="sm" title="Edit" (click)="editStatus(s)">
+                      Edit
+                    </app-bronco-button>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
+            }
+          </div>
+        </app-tab>
 
-                  <ng-container matColumnDef="value">
-                    <th mat-header-cell *matHeaderCellDef>Value</th>
-                    <td mat-cell *matCellDef="let s">
-                      <code>{{ s.value }}</code>
-                    </td>
-                  </ng-container>
+        <!-- Ticket Categories tab -->
+        <app-tab label="Ticket Categories">
+          <div class="tab-content">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">Ticket Categories</h2>
+                <p class="hint">
+                  Configure ticket categories used for classifying and organizing tickets.
+                  Categories help route tickets to the right workflow.
+                </p>
+              </div>
+              <app-bronco-button variant="primary" (click)="createCategory()">Create Category</app-bronco-button>
+            </div>
 
-                  <ng-container matColumnDef="displayName">
-                    <th mat-header-cell *matHeaderCellDef>Display Name</th>
-                    <td mat-cell *matCellDef="let s">{{ s.displayName }}</td>
-                  </ng-container>
+            @if (categoriesLoading()) {
+              <div class="empty-state"><span class="loading-text">Loading category configurations...</span></div>
+            } @else if (categoriesError()) {
+              <div class="empty-state">
+                <p>Failed to load category configurations.</p>
+                <app-bronco-button variant="ghost" (click)="loadCategories()">Retry</app-bronco-button>
+              </div>
+            } @else {
+              <app-data-table [data]="categories()" [trackBy]="trackCategory" [rowClickable]="false">
+                <app-data-column key="color" header="Color" [sortable]="false" width="60px">
+                  <ng-template #cell let-c>
+                    <div class="color-swatch" [style.background]="c.color"></div>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="value" header="Value" [sortable]="false">
+                  <ng-template #cell let-c><code>{{ c.value }}</code></ng-template>
+                </app-data-column>
+                <app-data-column key="displayName" header="Display Name" [sortable]="false">
+                  <ng-template #cell let-c>{{ c.displayName }}</ng-template>
+                </app-data-column>
+                <app-data-column key="description" header="Description" [sortable]="false">
+                  <ng-template #cell let-c><span class="desc-text">{{ c.description ?? '—' }}</span></ng-template>
+                </app-data-column>
+                <app-data-column key="sortOrder" header="Order" [sortable]="false" width="70px">
+                  <ng-template #cell let-c>{{ c.sortOrder }}</ng-template>
+                </app-data-column>
+                <app-data-column key="active" header="Active" [sortable]="false" width="70px">
+                  <ng-template #cell let-c>
+                    <span [class.status-yes]="c.isActive" [class.status-no]="!c.isActive">
+                      {{ c.isActive ? 'Yes' : 'No' }}
+                    </span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="actions" header="" [sortable]="false" width="60px">
+                  <ng-template #cell let-c>
+                    <app-bronco-button variant="icon" size="sm" title="Edit" (click)="editCategory(c)">
+                      Edit
+                    </app-bronco-button>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
+            }
+          </div>
+        </app-tab>
 
-                  <ng-container matColumnDef="description">
-                    <th mat-header-cell *matHeaderCellDef>Description</th>
-                    <td mat-cell *matCellDef="let s">
-                      <span class="desc-text">{{ s.description ?? '—' }}</span>
-                    </td>
-                  </ng-container>
+        <!-- External Services tab -->
+        <app-tab label="External Services">
+          <div class="tab-content">
+            <div class="section-header">
+              <div>
+                <h2 class="section-title">External Services</h2>
+                <p class="hint">
+                  Configure external services to monitor on the System Status page.
+                  Services like Ollama, reverse proxies, or other health endpoints can be tracked here.
+                </p>
+              </div>
+              <app-bronco-button variant="primary" (click)="addService()">Add Service</app-bronco-button>
+            </div>
 
-                  <ng-container matColumnDef="statusClass">
-                    <th mat-header-cell *matHeaderCellDef>Class</th>
-                    <td mat-cell *matCellDef="let s">
-                      <span class="class-chip" [class.class-open]="s.statusClass === 'open'" [class.class-closed]="s.statusClass === 'closed'">
-                        {{ s.statusClass }}
-                      </span>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="sortOrder">
-                    <th mat-header-cell *matHeaderCellDef>Order</th>
-                    <td mat-cell *matCellDef="let s">{{ s.sortOrder }}</td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="active">
-                    <th mat-header-cell *matHeaderCellDef>Active</th>
-                    <td mat-cell *matCellDef="let s">
-                      <mat-icon [class.monitored-yes]="s.isActive" [class.monitored-no]="!s.isActive">
-                        {{ s.isActive ? 'check_circle' : 'cancel' }}
-                      </mat-icon>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="statusActions">
-                    <th mat-header-cell *matHeaderCellDef></th>
-                    <td mat-cell *matCellDef="let s">
-                      <button mat-icon-button matTooltip="Edit" (click)="editStatus(s)">
-                        <mat-icon>edit</mat-icon>
+            @if (services().length === 0) {
+              <div class="empty-state">
+                <p>No external services configured.</p>
+                <p class="hint">Add services like Ollama or other endpoints to monitor them on the System Status page.</p>
+              </div>
+            } @else {
+              <app-data-table [data]="services()" [trackBy]="trackService" [rowClickable]="false">
+                <app-data-column key="name" header="Name" [sortable]="false">
+                  <ng-template #cell let-svc>{{ svc.name }}</ng-template>
+                </app-data-column>
+                <app-data-column key="endpoint" header="Endpoint" [sortable]="false">
+                  <ng-template #cell let-svc>
+                    <span class="endpoint-text" [title]="svc.endpoint">{{ truncate(svc.endpoint, 40) }}</span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="checkType" header="Check Type" [sortable]="false" width="120px">
+                  <ng-template #cell let-svc>
+                    <span class="check-type-chip">{{ svc.checkType }}</span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="monitored" header="Monitored" [sortable]="false" width="100px">
+                  <ng-template #cell let-svc>
+                    <span [class.status-yes]="svc.isMonitored" [class.status-no]="!svc.isMonitored">
+                      {{ svc.isMonitored ? 'Yes' : 'No' }}
+                    </span>
+                  </ng-template>
+                </app-data-column>
+                <app-data-column key="actions" header="" [sortable]="false" width="60px">
+                  <ng-template #cell let-svc>
+                    <app-bronco-button variant="icon" size="sm" [matMenuTriggerFor]="svcMenu" title="Actions">
+                      ...
+                    </app-bronco-button>
+                    <mat-menu #svcMenu="matMenu">
+                      <button mat-menu-item (click)="editService(svc)">Edit</button>
+                      <button mat-menu-item (click)="toggleMonitored(svc)">
+                        {{ svc.isMonitored ? 'Disable Monitoring' : 'Enable Monitoring' }}
                       </button>
-                    </td>
-                  </ng-container>
+                      <button mat-menu-item (click)="deleteService(svc)" class="delete-action">Delete</button>
+                    </mat-menu>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
+            }
+          </div>
+        </app-tab>
 
-                  <tr mat-header-row *matHeaderRowDef="statusColumns"></tr>
-                  <tr mat-row *matRowDef="let row; columns: statusColumns;"></tr>
-                </table>
-              }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-
-      <!-- Ticket Categories tab -->
-      <mat-tab label="Ticket Categories">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>Ticket Categories</mat-card-title>
-              <div class="header-spacer"></div>
-              <button mat-raised-button color="primary" (click)="createCategory()">
-                <mat-icon>add</mat-icon> Create Category
-              </button>
-            </mat-card-header>
-            <mat-card-content>
-              <p class="hint">
-                Configure ticket categories used for classifying and organizing tickets.
-                Categories help route tickets to the right workflow.
-              </p>
-
-              @if (categoriesLoading()) {
-                <div class="empty-state">
-                  <mat-icon>hourglass_empty</mat-icon>
-                  <p>Loading category configurations...</p>
-                </div>
-              } @else if (categoriesError()) {
-                <div class="empty-state">
-                  <mat-icon>error_outline</mat-icon>
-                  <p>Failed to load category configurations.</p>
-                  <button mat-button color="primary" (click)="loadCategories()">Retry</button>
-                </div>
-              } @else {
-                <table mat-table [dataSource]="categories()" class="full-table">
-                  <ng-container matColumnDef="catColor">
-                    <th mat-header-cell *matHeaderCellDef>Color</th>
-                    <td mat-cell *matCellDef="let c">
-                      <div class="color-swatch" [style.background]="c.color"></div>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catValue">
-                    <th mat-header-cell *matHeaderCellDef>Value</th>
-                    <td mat-cell *matCellDef="let c">
-                      <code>{{ c.value }}</code>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catDisplayName">
-                    <th mat-header-cell *matHeaderCellDef>Display Name</th>
-                    <td mat-cell *matCellDef="let c">{{ c.displayName }}</td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catDescription">
-                    <th mat-header-cell *matHeaderCellDef>Description</th>
-                    <td mat-cell *matCellDef="let c">
-                      <span class="desc-text">{{ c.description ?? '—' }}</span>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catSortOrder">
-                    <th mat-header-cell *matHeaderCellDef>Order</th>
-                    <td mat-cell *matCellDef="let c">{{ c.sortOrder }}</td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catActive">
-                    <th mat-header-cell *matHeaderCellDef>Active</th>
-                    <td mat-cell *matCellDef="let c">
-                      <mat-icon [class.monitored-yes]="c.isActive" [class.monitored-no]="!c.isActive">
-                        {{ c.isActive ? 'check_circle' : 'cancel' }}
-                      </mat-icon>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="catActions">
-                    <th mat-header-cell *matHeaderCellDef></th>
-                    <td mat-cell *matCellDef="let c">
-                      <button mat-icon-button matTooltip="Edit" (click)="editCategory(c)">
-                        <mat-icon>edit</mat-icon>
-                      </button>
-                    </td>
-                  </ng-container>
-
-                  <tr mat-header-row *matHeaderRowDef="catColumns"></tr>
-                  <tr mat-row *matRowDef="let row; columns: catColumns;"></tr>
-                </table>
-              }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-
-      <!-- External Services tab -->
-      <mat-tab label="External Services">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>External Services</mat-card-title>
-              <div class="header-spacer"></div>
-              <button mat-raised-button color="primary" (click)="addService()">
-                <mat-icon>add</mat-icon> Add Service
-              </button>
-            </mat-card-header>
-            <mat-card-content>
-              <p class="hint">
-                Configure external services to monitor on the System Status page.
-                Services like Ollama, reverse proxies, or other health endpoints can be tracked here.
-              </p>
-
-              @if (services().length === 0) {
-                <div class="empty-state">
-                  <mat-icon>cloud_off</mat-icon>
-                  <p>No external services configured.</p>
-                  <p class="hint">Add services like Ollama or other endpoints to monitor them on the System Status page.</p>
-                </div>
-              } @else {
-                <table mat-table [dataSource]="services()" class="full-table">
-                  <ng-container matColumnDef="name">
-                    <th mat-header-cell *matHeaderCellDef>Name</th>
-                    <td mat-cell *matCellDef="let svc">{{ svc.name }}</td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="endpoint">
-                    <th mat-header-cell *matHeaderCellDef>Endpoint</th>
-                    <td mat-cell *matCellDef="let svc">
-                      <span class="endpoint-text" [matTooltip]="svc.endpoint">{{ truncate(svc.endpoint, 40) }}</span>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="checkType">
-                    <th mat-header-cell *matHeaderCellDef>Check Type</th>
-                    <td mat-cell *matCellDef="let svc">
-                      <span class="check-type-chip">{{ svc.checkType }}</span>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="monitored">
-                    <th mat-header-cell *matHeaderCellDef>Monitored</th>
-                    <td mat-cell *matCellDef="let svc">
-                      <mat-icon
-                        [class.monitored-yes]="svc.isMonitored"
-                        [class.monitored-no]="!svc.isMonitored"
-                      >
-                        {{ svc.isMonitored ? 'check_circle' : 'cancel' }}
-                      </mat-icon>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="svcActions">
-                    <th mat-header-cell *matHeaderCellDef></th>
-                    <td mat-cell *matCellDef="let svc">
-                      <button mat-icon-button [matMenuTriggerFor]="svcMenu" matTooltip="Actions">
-                        <mat-icon>more_vert</mat-icon>
-                      </button>
-                      <mat-menu #svcMenu="matMenu">
-                        <button mat-menu-item (click)="editService(svc)">
-                          <mat-icon>edit</mat-icon> Edit
-                        </button>
-                        <button mat-menu-item (click)="toggleMonitored(svc)">
-                          <mat-icon>{{ svc.isMonitored ? 'visibility_off' : 'visibility' }}</mat-icon>
-                          {{ svc.isMonitored ? 'Disable Monitoring' : 'Enable Monitoring' }}
-                        </button>
-                        <mat-divider></mat-divider>
-                        <button mat-menu-item (click)="deleteService(svc)" class="delete-action">
-                          <mat-icon>delete</mat-icon> Delete
-                        </button>
-                      </mat-menu>
-                    </td>
-                  </ng-container>
-
-                  <tr mat-header-row *matHeaderRowDef="svcColumns"></tr>
-                  <tr mat-row *matRowDef="let row; columns: svcColumns;"></tr>
-                </table>
-              }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-      <!-- Action Safety tab -->
-      <mat-tab label="Action Safety">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>AI Action Safety</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
+        <!-- Action Safety tab -->
+        <app-tab label="Action Safety">
+          <div class="tab-content">
+            <app-card>
+              <h2 class="section-title">AI Action Safety</h2>
               <p class="hint">
                 Configure which AI-recommended actions are auto-executed and which require operator approval.
                 Unknown action types always default to requiring approval.
               </p>
 
               @if (actionSafetyLoading()) {
-                <mat-spinner diameter="24"></mat-spinner>
+                <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
               } @else {
-                <table mat-table [dataSource]="actionSafetyRows()" class="full-table action-safety-table">
-                  <ng-container matColumnDef="actionType">
-                    <th mat-header-cell *matHeaderCellDef>Action Type</th>
-                    <td mat-cell *matCellDef="let row">
+                <app-data-table [data]="actionSafetyRows()" [trackBy]="trackActionSafety" [rowClickable]="false">
+                  <app-data-column key="actionType" header="Action Type" [sortable]="false">
+                    <ng-template #cell let-row>
                       <span class="action-type-label">{{ formatActionType(row.actionType) }}</span>
-                    </td>
-                  </ng-container>
-
-                  <ng-container matColumnDef="level">
-                    <th mat-header-cell *matHeaderCellDef>Safety Level</th>
-                    <td mat-cell *matCellDef="let row">
-                      <mat-slide-toggle
+                    </ng-template>
+                  </app-data-column>
+                  <app-data-column key="level" header="Safety Level" [sortable]="false">
+                    <ng-template #cell let-row>
+                      <app-toggle-switch
                         [checked]="row.level === 'auto'"
-                        (change)="toggleActionSafety(row.actionType, $event.checked ? 'auto' : 'approval')"
-                        color="primary"
-                      >
-                        {{ row.level === 'auto' ? 'Auto-execute' : 'Require Approval' }}
-                      </mat-slide-toggle>
-                    </td>
-                  </ng-container>
+                        [label]="row.level === 'auto' ? 'Auto-execute' : 'Require Approval'"
+                        (checkedChange)="toggleActionSafety(row.actionType, $event ? 'auto' : 'approval')" />
+                    </ng-template>
+                  </app-data-column>
+                </app-data-table>
 
-                  <tr mat-header-row *matHeaderRowDef="actionSafetyColumns"></tr>
-                  <tr mat-row *matRowDef="let row; columns: actionSafetyColumns;"></tr>
-                </table>
-
-                <mat-card-actions align="end">
-                  <button
-                    mat-raised-button
-                    color="primary"
-                    (click)="saveActionSafety()"
-                    [disabled]="actionSafetySaving()"
-                  >
-                    @if (actionSafetySaving()) {
-                      <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
-                    }
-                    Save
-                  </button>
-                </mat-card-actions>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveActionSafety()" [disabled]="actionSafetySaving()">
+                    @if (actionSafetySaving()) { Saving... } @else { Save }
+                  </app-bronco-button>
+                </div>
               }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-      <!-- Analysis Strategy tab -->
-      <mat-tab label="Analysis Strategy">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>Analysis Strategy</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
+            </app-card>
+          </div>
+        </app-tab>
+
+        <!-- Analysis Strategy tab -->
+        <app-tab label="Analysis Strategy">
+          <div class="tab-content">
+            <app-card>
+              <h2 class="section-title">Analysis Strategy</h2>
               <p class="hint">
                 Configure how the AI investigates tickets during agentic analysis.
                 <strong>Full Context</strong> sends the entire conversation history on each iteration (higher quality, higher cost).
@@ -454,214 +333,259 @@ import { CategoryConfigDialogComponent } from './category-config-dialog.componen
               </p>
 
               @if (analysisStrategyLoading()) {
-                <mat-spinner diameter="24"></mat-spinner>
+                <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
               } @else {
-                <mat-form-field class="full-width">
-                  <mat-label>Strategy</mat-label>
-                  <mat-select [value]="analysisStrategy()" (selectionChange)="analysisStrategy.set($event.value)">
-                    <mat-option value="full_context">Full Context (brute force)</mat-option>
-                    <mat-option value="orchestrated">Orchestrated (parallel tasks)</mat-option>
-                  </mat-select>
-                </mat-form-field>
+                <div class="form-grid">
+                  <app-form-field label="Strategy">
+                    <app-select
+                      [value]="analysisStrategy()"
+                      [options]="strategyOptions"
+                      [placeholder]="''"
+                      (valueChange)="analysisStrategy.set($event)" />
+                  </app-form-field>
 
-                @if (analysisStrategy() === 'orchestrated') {
-                  <mat-form-field class="full-width">
-                    <mat-label>Max Parallel Tasks</mat-label>
-                    <input matInput type="number" [value]="analysisMaxParallel()" (input)="setAnalysisMaxParallel(+$any($event.target).value)" min="1" max="10">
-                    <mat-hint>Number of sub-tasks to run concurrently (1-10)</mat-hint>
-                  </mat-form-field>
-                }
+                  @if (analysisStrategy() === 'orchestrated') {
+                    <app-form-field label="Max Parallel Tasks" hint="Number of sub-tasks to run concurrently (1-10)">
+                      <input class="text-input" type="number" [value]="analysisMaxParallel()" (input)="setAnalysisMaxParallel(+$any($event.target).value)" min="1" max="10">
+                    </app-form-field>
+                  }
+                </div>
 
-                <mat-card-actions align="end">
-                  <button
-                    mat-raised-button
-                    color="primary"
-                    (click)="saveAnalysisStrategy()"
-                    [disabled]="analysisStrategySaving()"
-                  >
-                    @if (analysisStrategySaving()) {
-                      <mat-spinner diameter="18" class="inline-spinner"></mat-spinner>
-                    }
-                    Save
-                  </button>
-                </mat-card-actions>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveAnalysisStrategy()" [disabled]="analysisStrategySaving()">
+                    @if (analysisStrategySaving()) { Saving... } @else { Save }
+                  </app-bronco-button>
+                </div>
               }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-      <!-- Self Analysis tab -->
-      <mat-tab label="Self Analysis">
-        <div class="tab-content">
-          <mat-card>
-            <mat-card-header>
-              <mat-card-title>Self Analysis</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
+            </app-card>
+          </div>
+        </app-tab>
+
+        <!-- Self Analysis tab -->
+        <app-tab label="Self Analysis">
+          <div class="tab-content">
+            <app-card>
+              <h2 class="section-title">Self Analysis</h2>
               <p class="hint">
                 Configure triggers for Bronco to analyze its own operations and suggest improvements.
                 Results appear on the System Analysis page.
               </p>
 
               @if (selfAnalysisLoading()) {
-                <mat-spinner diameter="24"></mat-spinner>
+                <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
               } @else {
                 <div class="self-analysis-toggles">
-                  <mat-slide-toggle
-                    color="primary"
-                    [checked]="selfAnalysisPostAnalysis()"
-                    (change)="updateSelfAnalysis({ postAnalysisTrigger: $event.checked })"
-                  >
-                    Post-analysis trigger
-                  </mat-slide-toggle>
-                  <p class="alert-desc">After each ticket analysis pipeline completes, review the run for token usage, model selection, and route efficiency.</p>
+                  <div class="analysis-toggle-row">
+                    <app-toggle-switch
+                      label="Post-analysis trigger"
+                      [checked]="selfAnalysisPostAnalysis()"
+                      (checkedChange)="updateSelfAnalysis({ postAnalysisTrigger: $event })" />
+                    <p class="alert-desc">After each ticket analysis pipeline completes, review the run for token usage, model selection, and route efficiency.</p>
+                  </div>
 
-                  <mat-slide-toggle
-                    color="primary"
-                    [checked]="selfAnalysisTicketClose()"
-                    (change)="updateSelfAnalysis({ ticketCloseTrigger: $event.checked })"
-                  >
-                    Ticket close trigger
-                  </mat-slide-toggle>
-                  <p class="alert-desc">When a ticket is closed, analyze its lifecycle for process improvements and knowledge gaps.</p>
+                  <div class="analysis-toggle-row">
+                    <app-toggle-switch
+                      label="Ticket close trigger"
+                      [checked]="selfAnalysisTicketClose()"
+                      (checkedChange)="updateSelfAnalysis({ ticketCloseTrigger: $event })" />
+                    <p class="alert-desc">When a ticket is closed, analyze its lifecycle for process improvements and knowledge gaps.</p>
+                  </div>
 
-                  <mat-slide-toggle
-                    color="primary"
-                    [checked]="selfAnalysisScheduled()"
-                    (change)="updateSelfAnalysis({ scheduledEnabled: $event.checked })"
-                  >
-                    Scheduled analysis
-                  </mat-slide-toggle>
-                  <p class="alert-desc">Run a periodic health analysis of the entire platform (ticket patterns, AI usage, error logs).</p>
+                  <div class="analysis-toggle-row">
+                    <app-toggle-switch
+                      label="Scheduled analysis"
+                      [checked]="selfAnalysisScheduled()"
+                      (checkedChange)="updateSelfAnalysis({ scheduledEnabled: $event })" />
+                    <p class="alert-desc">Run a periodic health analysis of the entire platform (ticket patterns, AI usage, error logs).</p>
+                  </div>
                 </div>
 
                 @if (selfAnalysisScheduled()) {
-                  <mat-form-field class="full-width" style="margin-top: 16px;">
-                    <mat-label>Cron Expression</mat-label>
-                    <input matInput [value]="selfAnalysisCron()" (blur)="updateSelfAnalysis({ scheduledCron: $any($event.target).value })">
-                    <mat-hint>Standard cron (e.g., "0 9 * * 1" = Monday 9am UTC)</mat-hint>
-                  </mat-form-field>
+                  <div class="form-grid" style="margin-top: 16px;">
+                    <app-form-field label="Cron Expression" hint="Standard cron (e.g., &quot;0 9 * * 1&quot; = Monday 9am UTC)">
+                      <input class="text-input" [value]="selfAnalysisCron()" (blur)="updateSelfAnalysis({ scheduledCron: $any($event.target).value })">
+                    </app-form-field>
 
-                  <mat-form-field class="full-width">
-                    <mat-label>Repository URL</mat-label>
-                    <input matInput [value]="selfAnalysisRepoUrl()" (blur)="updateSelfAnalysis({ repoUrl: $any($event.target).value })">
-                    <mat-hint>Git repo URL for code-aware analysis via mcp-repo</mat-hint>
-                  </mat-form-field>
+                    <app-form-field label="Repository URL" hint="Git repo URL for code-aware analysis via mcp-repo">
+                      <input class="text-input" [value]="selfAnalysisRepoUrl()" (blur)="updateSelfAnalysis({ repoUrl: $any($event.target).value })">
+                    </app-form-field>
+                  </div>
                 }
               }
-            </mat-card-content>
-          </mat-card>
-        </div>
-      </mat-tab>
-    </mat-tab-group>
+            </app-card>
+          </div>
+        </app-tab>
+      </app-tab-group>
+    </div>
   `,
   styles: [`
-    h1 { margin: 0 0 24px; }
-    .full-width { width: 100%; }
-    .hint { color: #666; margin-bottom: 16px; font-size: 14px; }
-    .section-card { margin-top: 24px; }
-    .section-card mat-card-header {
+    .page-wrapper { max-width: 1200px; }
+    .page-title {
+      margin: 0 0 24px;
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .tab-content { padding-top: 8px; }
+
+    .section-header {
       display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    .section-title {
+      margin: 0 0 8px;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .hint {
+      color: var(--text-tertiary);
+      margin-bottom: 16px;
+      font-size: 14px;
+    }
+
+    .form-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: 600px;
+    }
+
+    .input-with-toggle {
+      display: flex;
+      gap: 8px;
       align-items: center;
     }
-    .header-spacer { flex: 1; }
-    .tab-content { padding-top: 24px; }
-    .full-table { width: 100%; }
-    .endpoint-text { font-family: monospace; font-size: 13px; color: #555; }
+    .input-with-toggle .text-input { flex: 1; }
+    .toggle-vis {
+      background: none;
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 6px 12px;
+      font-family: var(--font-primary);
+      font-size: 12px;
+      color: var(--text-tertiary);
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .toggle-vis:hover { color: var(--text-primary); }
+
+    .text-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+    .text-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
+    }
+
+    app-card { display: block; margin-bottom: 16px; }
+
+    .loading-wrapper {
+      display: flex;
+      justify-content: center;
+      padding: 32px;
+    }
+    .loading-text { color: var(--text-tertiary); font-size: 13px; }
+
+    .empty-state {
+      text-align: center;
+      padding: 32px 16px;
+      color: var(--text-tertiary);
+    }
+    .empty-state p { margin: 8px 0; }
+
+    .endpoint-text { font-family: monospace; font-size: 13px; color: var(--text-tertiary); }
     .check-type-chip {
       font-size: 11px;
       font-weight: 600;
       padding: 2px 8px;
-      border-radius: 4px;
-      background: #e3f2fd;
-      color: #1565c0;
+      border-radius: var(--radius-sm);
+      background: var(--color-info-subtle);
+      color: var(--color-info);
       font-family: monospace;
     }
-    .monitored-yes { color: #4caf50; font-size: 20px; }
-    .monitored-no { color: #9e9e9e; font-size: 20px; }
-    .empty-state {
-      text-align: center;
-      padding: 32px 16px;
-      color: #888;
-    }
-    .empty-state mat-icon {
-      font-size: 48px;
-      width: 48px;
-      height: 48px;
-      color: #ccc;
-    }
-    .empty-state p { margin: 8px 0; }
-    .delete-action { color: #c62828; }
-    code {
-      font-size: 12px;
-      padding: 2px 6px;
-      background: #f5f5f5;
-      border-radius: 3px;
-      font-family: monospace;
-    }
+
     .color-swatch {
       width: 24px;
       height: 24px;
       border-radius: 4px;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border-light);
     }
-    .desc-text {
-      font-size: 13px;
-      color: #666;
+    .desc-text { font-size: 13px; color: var(--text-tertiary); }
+    code {
+      font-size: 12px;
+      padding: 2px 6px;
+      background: var(--bg-muted);
+      border-radius: 3px;
+      font-family: monospace;
     }
+
     .class-chip {
       font-size: 11px;
       font-weight: 600;
       padding: 2px 10px;
-      border-radius: 12px;
+      border-radius: var(--radius-pill);
       text-transform: uppercase;
     }
-    .class-open {
-      background: #e3f2fd;
-      color: #1565c0;
-    }
-    .class-closed {
-      background: #fce4ec;
-      color: #c62828;
-    }
-    .alert-toggle-row {
-      display: flex;
-      flex-direction: column;
-      margin-bottom: 16px;
-    }
-    .alert-toggles {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      margin-top: 8px;
-    }
-    .alert-desc {
-      font-size: 12px;
-      color: #888;
-      margin-top: 4px;
-      padding-left: 48px;
-    }
-    h3 {
-      margin: 24px 0 8px;
-      font-size: 16px;
-      font-weight: 500;
-    }
-    .inline-spinner {
-      display: inline-block;
-      margin-right: 8px;
-      vertical-align: middle;
-    }
+    .class-open { background: var(--color-info-subtle); color: var(--color-info); }
+    .class-closed { background: rgba(255, 59, 48, 0.1); color: var(--color-error); }
+
+    .status-yes { color: var(--color-success); font-size: 13px; font-weight: 500; }
+    .status-no { color: var(--text-tertiary); font-size: 13px; }
+
+    .delete-action { color: var(--color-error); }
+
     .action-type-label {
       font-family: monospace;
       font-size: 13px;
       font-weight: 500;
     }
-    .action-safety-table { margin-bottom: 16px; }
+
     .self-analysis-toggles {
       display: flex;
       flex-direction: column;
       gap: 4px;
     }
+    .analysis-toggle-row {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 12px;
+    }
+    .alert-desc {
+      font-size: 12px;
+      color: var(--text-tertiary);
+      margin: 4px 0 0;
+      padding-left: 44px;
+    }
+
+    .strategyOptions { max-width: 400px; }
   `],
 })
 export class SettingsComponent implements OnInit {
@@ -681,35 +605,36 @@ export class SettingsComponent implements OnInit {
   superAdminUserId: string | null = null;
   superAdminLoading = signal(true);
   superAdminSaving = signal(false);
+  superAdminOptions = signal<Array<{ value: string; label: string }>>([]);
 
   // External Services tab
   services = signal<ExternalService[]>([]);
-  svcColumns = ['name', 'endpoint', 'checkType', 'monitored', 'svcActions'];
 
   // Statuses tab
   statuses = signal<TicketStatusConfig[]>([]);
   statusesLoading = signal(true);
   statusesError = signal(false);
-  statusColumns = ['color', 'value', 'displayName', 'description', 'statusClass', 'sortOrder', 'active', 'statusActions'];
 
   // Categories tab
   categories = signal<TicketCategoryConfig[]>([]);
   categoriesLoading = signal(true);
   categoriesError = signal(false);
-  catColumns = ['catColor', 'catValue', 'catDisplayName', 'catDescription', 'catSortOrder', 'catActive', 'catActions'];
 
   // Action Safety tab
   actionSafetyConfig = signal<Record<string, 'auto' | 'approval'>>({});
   actionSafetyLoading = signal(true);
   actionSafetySaving = signal(false);
-  actionSafetyColumns = ['actionType', 'level'];
   actionSafetyRows = signal<Array<{ actionType: string; level: 'auto' | 'approval' }>>([]);
 
   // Analysis Strategy tab
-  analysisStrategy = signal<'full_context' | 'orchestrated'>('full_context');
+  analysisStrategy = signal<string>('full_context');
   analysisMaxParallel = signal(3);
   analysisStrategyLoading = signal(true);
   analysisStrategySaving = signal(false);
+  strategyOptions = [
+    { value: 'full_context', label: 'Full Context (brute force)' },
+    { value: 'orchestrated', label: 'Orchestrated (parallel tasks)' },
+  ];
 
   // Self Analysis tab
   selfAnalysisLoading = signal(true);
@@ -720,6 +645,11 @@ export class SettingsComponent implements OnInit {
   selfAnalysisRepoUrl = signal('https://github.com/siir/bronco');
 
   selectedTab = signal(0);
+
+  trackStatus = (s: TicketStatusConfig) => s.value;
+  trackCategory = (c: TicketCategoryConfig) => c.value;
+  trackService = (svc: ExternalService) => svc.id;
+  trackActionSafety = (row: { actionType: string }) => row.actionType;
 
   ngOnInit(): void {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
@@ -759,12 +689,16 @@ export class SettingsComponent implements OnInit {
     this.usersLoading.set(true);
     this.userSvc.getUsers().subscribe({
       next: (users) => {
-        this.adminUsers.set(users.filter(u => u.isActive && (u.role === 'ADMIN' || u.role === 'OPERATOR')));
+        const filtered = users.filter(u => u.isActive && (u.role === 'ADMIN' || u.role === 'OPERATOR'));
+        this.adminUsers.set(filtered);
+        this.superAdminOptions.set(filtered.map(u => ({
+          value: u.id,
+          label: `${u.name} (${u.email}) — ${u.role}`,
+        })));
         this.usersLoading.set(false);
       },
       error: (err) => {
         this.usersLoading.set(false);
-        // 403 is expected for OPERATOR users — silently leave dropdown empty
         if (err?.status !== 403) {
           this.snackBar.open('Failed to load users', 'OK', { duration: 5000 });
         }
@@ -1019,7 +953,7 @@ export class SettingsComponent implements OnInit {
   saveAnalysisStrategy(): void {
     this.analysisStrategySaving.set(true);
     const config = {
-      strategy: this.analysisStrategy(),
+      strategy: this.analysisStrategy() as 'full_context' | 'orchestrated',
       maxParallelTasks: Math.min(10, Math.max(1, this.analysisMaxParallel())),
     };
     this.settingsSvc.saveAnalysisStrategy(config).subscribe({
@@ -1057,7 +991,6 @@ export class SettingsComponent implements OnInit {
   }
 
   updateSelfAnalysis(partial: Partial<SelfAnalysisConfig>): void {
-    // Optimistically update local state
     if (partial.postAnalysisTrigger !== undefined) this.selfAnalysisPostAnalysis.set(partial.postAnalysisTrigger);
     if (partial.ticketCloseTrigger !== undefined) this.selfAnalysisTicketClose.set(partial.ticketCloseTrigger);
     if (partial.scheduledEnabled !== undefined) this.selfAnalysisScheduled.set(partial.scheduledEnabled);
@@ -1075,7 +1008,7 @@ export class SettingsComponent implements OnInit {
       },
       error: () => {
         this.snackBar.open('Failed to save self-analysis config', 'OK', { duration: 5000 });
-        this.loadSelfAnalysis(); // Revert on failure
+        this.loadSelfAnalysis();
       },
     });
   }

--- a/services/control-panel/src/app/features/system-settings/system-settings.component.ts
+++ b/services/control-panel/src/app/features/system-settings/system-settings.component.ts
@@ -1,16 +1,8 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTabsModule } from '@angular/material/tabs';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import {
   SettingsService,
   SmtpSystemConfig,
@@ -20,343 +12,324 @@ import {
   SlackSystemConfig,
   PromptRetentionConfig,
 } from '../../core/services/settings.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+  ToggleSwitchComponent,
+  TabComponent,
+  TabGroupComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
   imports: [
     FormsModule,
-    MatCardModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatIconModule,
-    MatTabsModule,
-    MatProgressSpinnerModule,
     MatSnackBarModule,
-    MatSlideToggleModule,
+    BroncoButtonComponent,
+    CardComponent,
+    FormFieldComponent,
+    ToggleSwitchComponent,
+    TabComponent,
+    TabGroupComponent,
   ],
   template: `
-    <h1>System Settings</h1>
+    <div class="page-wrapper">
+      <h1 class="page-title">System Settings</h1>
 
-    <mat-tab-group [selectedIndex]="selectedTab()" (selectedTabChange)="onTabChange($event.index)">
+      <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="onTabChange($event)">
 
-      <!-- SMTP Tab -->
-      <mat-tab label="SMTP">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>SMTP Configuration</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+        <!-- SMTP Tab -->
+        <app-tab label="SMTP">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">SMTP Configuration</h2>
                 <p class="hint">Configure the SMTP server used for sending emails. Password is encrypted at rest.</p>
                 <div class="form-grid">
-                  <mat-form-field class="full-width">
-                    <mat-label>Host</mat-label>
-                    <input matInput [(ngModel)]="smtp.host" placeholder="smtp.example.com">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Port</mat-label>
-                    <input matInput type="number" [(ngModel)]="smtp.port" placeholder="587">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>User</mat-label>
-                    <input matInput [(ngModel)]="smtp.user" placeholder="user@example.com">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Password</mat-label>
-                    <input matInput type="password" [(ngModel)]="smtp.password">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>From Address</mat-label>
-                    <input matInput [(ngModel)]="smtp.from" placeholder="noreply@example.com">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>From Name (optional)</mat-label>
-                    <input matInput [(ngModel)]="smtp.fromName" placeholder="Bronco">
-                  </mat-form-field>
+                  <app-form-field label="Host">
+                    <input class="text-input" [(ngModel)]="smtp.host" placeholder="smtp.example.com">
+                  </app-form-field>
+                  <app-form-field label="Port">
+                    <input class="text-input" type="number" [(ngModel)]="smtp.port" placeholder="587">
+                  </app-form-field>
+                  <app-form-field label="User">
+                    <input class="text-input" [(ngModel)]="smtp.user" placeholder="user@example.com">
+                  </app-form-field>
+                  <app-form-field label="Password">
+                    <input class="text-input" type="password" [(ngModel)]="smtp.password">
+                  </app-form-field>
+                  <app-form-field label="From Address">
+                    <input class="text-input" [(ngModel)]="smtp.from" placeholder="noreply@example.com">
+                  </app-form-field>
+                  <app-form-field label="From Name (optional)">
+                    <input class="text-input" [(ngModel)]="smtp.fromName" placeholder="Bronco">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveSmtp()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-                <button mat-stroked-button (click)="testSmtp()" [disabled]="testing()">
-                  @if (testing()) {
-                    <mat-spinner diameter="18" />
-                  } @else {
-                    <mat-icon>send</mat-icon>
-                  }
-                  Test Connection
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveSmtp()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testSmtp()" [disabled]="testing()">
+                    @if (testing()) { Testing... } @else { Test Connection }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
 
-      <!-- Azure DevOps Tab -->
-      <mat-tab label="Azure DevOps">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Azure DevOps Configuration</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+        <!-- Azure DevOps Tab -->
+        <app-tab label="Azure DevOps">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">Azure DevOps Configuration</h2>
                 <p class="hint">Configure the Azure DevOps integration for work item sync. PAT is encrypted at rest.</p>
                 <div class="form-grid">
-                  <mat-form-field class="full-width">
-                    <mat-label>Organization URL</mat-label>
-                    <input matInput [(ngModel)]="devops.orgUrl" placeholder="https://dev.azure.com/myorg">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Project</mat-label>
-                    <input matInput [(ngModel)]="devops.project" placeholder="MyProject">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Personal Access Token</mat-label>
-                    <input matInput type="password" [(ngModel)]="devops.pat">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Assigned User</mat-label>
-                    <input matInput [(ngModel)]="devops.assignedUser" placeholder="user@example.com">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Client Short Code (optional)</mat-label>
-                    <input matInput [(ngModel)]="devops.clientShortCode">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Poll Interval (seconds)</mat-label>
-                    <input matInput type="number" [(ngModel)]="devops.pollIntervalSeconds" placeholder="120">
-                  </mat-form-field>
+                  <app-form-field label="Organization URL">
+                    <input class="text-input" [(ngModel)]="devops.orgUrl" placeholder="https://dev.azure.com/myorg">
+                  </app-form-field>
+                  <app-form-field label="Project">
+                    <input class="text-input" [(ngModel)]="devops.project" placeholder="MyProject">
+                  </app-form-field>
+                  <app-form-field label="Personal Access Token">
+                    <input class="text-input" type="password" [(ngModel)]="devops.pat">
+                  </app-form-field>
+                  <app-form-field label="Assigned User">
+                    <input class="text-input" [(ngModel)]="devops.assignedUser" placeholder="user@example.com">
+                  </app-form-field>
+                  <app-form-field label="Client Short Code (optional)">
+                    <input class="text-input" [(ngModel)]="devops.clientShortCode">
+                  </app-form-field>
+                  <app-form-field label="Poll Interval (seconds)">
+                    <input class="text-input" type="number" [(ngModel)]="devops.pollIntervalSeconds" placeholder="120">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveDevOps()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-                <button mat-stroked-button (click)="testDevOps()" [disabled]="testing()">
-                  @if (testing()) {
-                    <mat-spinner diameter="18" />
-                  } @else {
-                    <mat-icon>send</mat-icon>
-                  }
-                  Test Connection
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveDevOps()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testDevOps()" [disabled]="testing()">
+                    @if (testing()) { Testing... } @else { Test Connection }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
 
-      <!-- GitHub Tab -->
-      <mat-tab label="GitHub">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>GitHub Configuration</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+        <!-- GitHub Tab -->
+        <app-tab label="GitHub">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">GitHub Configuration</h2>
                 <p class="hint">Configure the GitHub token used for repository access and release notes. Token is encrypted at rest.</p>
                 <div class="form-grid">
-                  <mat-form-field class="full-width">
-                    <mat-label>Token</mat-label>
-                    <input matInput type="password" [(ngModel)]="github.token">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Repository</mat-label>
-                    <input matInput [(ngModel)]="github.repo" placeholder="owner/repo">
-                  </mat-form-field>
+                  <app-form-field label="Token">
+                    <input class="text-input" type="password" [(ngModel)]="github.token">
+                  </app-form-field>
+                  <app-form-field label="Repository">
+                    <input class="text-input" [(ngModel)]="github.repo" placeholder="owner/repo">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveGithub()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-                <button mat-stroked-button (click)="testGithub()" [disabled]="testing()">
-                  @if (testing()) {
-                    <mat-spinner diameter="18" />
-                  } @else {
-                    <mat-icon>send</mat-icon>
-                  }
-                  Test Connection
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveGithub()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testGithub()" [disabled]="testing()">
+                    @if (testing()) { Testing... } @else { Test Connection }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
 
-      <!-- IMAP Tab -->
-      <mat-tab label="IMAP">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>IMAP Configuration</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+        <!-- IMAP Tab -->
+        <app-tab label="IMAP">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">IMAP Configuration</h2>
                 <p class="hint">Configure the IMAP server used for polling inbound emails. Password is encrypted at rest.</p>
                 <div class="form-grid">
-                  <mat-form-field class="full-width">
-                    <mat-label>Host</mat-label>
-                    <input matInput [(ngModel)]="imap.host" placeholder="imap.example.com">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Port</mat-label>
-                    <input matInput type="number" [(ngModel)]="imap.port" placeholder="993">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>User</mat-label>
-                    <input matInput [(ngModel)]="imap.user" placeholder="user@example.com">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Password</mat-label>
-                    <input matInput type="password" [(ngModel)]="imap.password">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Poll Interval (seconds)</mat-label>
-                    <input matInput type="number" [(ngModel)]="imap.pollIntervalSeconds" placeholder="60">
-                  </mat-form-field>
+                  <app-form-field label="Host">
+                    <input class="text-input" [(ngModel)]="imap.host" placeholder="imap.example.com">
+                  </app-form-field>
+                  <app-form-field label="Port">
+                    <input class="text-input" type="number" [(ngModel)]="imap.port" placeholder="993">
+                  </app-form-field>
+                  <app-form-field label="User">
+                    <input class="text-input" [(ngModel)]="imap.user" placeholder="user@example.com">
+                  </app-form-field>
+                  <app-form-field label="Password">
+                    <input class="text-input" type="password" [(ngModel)]="imap.password">
+                  </app-form-field>
+                  <app-form-field label="Poll Interval (seconds)">
+                    <input class="text-input" type="number" [(ngModel)]="imap.pollIntervalSeconds" placeholder="60">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveImap()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-                <button mat-stroked-button (click)="testImap()" [disabled]="testing()">
-                  @if (testing()) {
-                    <mat-spinner diameter="18" />
-                  } @else {
-                    <mat-icon>send</mat-icon>
-                  }
-                  Test Connection
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
-      <!-- Slack Tab -->
-      <mat-tab label="Slack">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Slack Configuration</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveImap()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testImap()" [disabled]="testing()">
+                    @if (testing()) { Testing... } @else { Test Connection }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
+
+        <!-- Slack Tab -->
+        <app-tab label="Slack">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">Slack Configuration</h2>
                 <p class="hint">Configure Slack integration for operator notifications via Socket Mode. Tokens are encrypted at rest.</p>
                 <div class="form-grid">
-                  <mat-slide-toggle [(ngModel)]="slack.enabled">Enabled</mat-slide-toggle>
-                  <mat-form-field class="full-width">
-                    <mat-label>Bot Token (xoxb-...)</mat-label>
-                    <input matInput type="password" [(ngModel)]="slack.botToken" placeholder="xoxb-...">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>App-Level Token (xapp-...)</mat-label>
-                    <input matInput type="password" [(ngModel)]="slack.appToken" placeholder="xapp-...">
-                  </mat-form-field>
-                  <mat-form-field class="full-width">
-                    <mat-label>Default Channel ID</mat-label>
-                    <input matInput [(ngModel)]="slack.defaultChannelId" placeholder="C0123456789">
-                  </mat-form-field>
+                  <div class="toggle-row">
+                    <app-toggle-switch
+                      label="Enabled"
+                      [checked]="slack.enabled"
+                      (checkedChange)="slack.enabled = $event" />
+                  </div>
+                  <app-form-field label="Bot Token (xoxb-...)">
+                    <input class="text-input" type="password" [(ngModel)]="slack.botToken" placeholder="xoxb-...">
+                  </app-form-field>
+                  <app-form-field label="App-Level Token (xapp-...)">
+                    <input class="text-input" type="password" [(ngModel)]="slack.appToken" placeholder="xapp-...">
+                  </app-form-field>
+                  <app-form-field label="Default Channel ID">
+                    <input class="text-input" [(ngModel)]="slack.defaultChannelId" placeholder="C0123456789">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="saveSlack()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-                <button mat-stroked-button (click)="testSlack()" [disabled]="testing()">
-                  @if (testing()) {
-                    <mat-spinner diameter="18" />
-                  } @else {
-                    <mat-icon>send</mat-icon>
-                  }
-                  Test Connection
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
-      <!-- Prompt Retention Tab -->
-      <mat-tab label="Prompt Retention">
-        <div class="tab-content">
-          @if (loading()) {
-            <div class="spinner-wrapper"><mat-spinner diameter="40" /></div>
-          } @else {
-            <mat-card>
-              <mat-card-header>
-                <mat-card-title>Prompt Retention Policy</mat-card-title>
-              </mat-card-header>
-              <mat-card-content>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveSlack()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="testSlack()" [disabled]="testing()">
+                    @if (testing()) { Testing... } @else { Test Connection }
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
+
+        <!-- Prompt Retention Tab -->
+        <app-tab label="Prompt Retention">
+          <div class="tab-content">
+            @if (loading()) {
+              <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+            } @else {
+              <app-card>
+                <h2 class="section-title">Prompt Retention Policy</h2>
                 <p class="hint">Configure how long full AI prompt/response archives are retained before being summarized and deleted.</p>
                 <div class="form-grid">
-                  <mat-form-field>
-                    <mat-label>Full prompt retention (days)</mat-label>
-                    <input matInput type="number" [(ngModel)]="promptRetention.fullRetentionDays" min="1" placeholder="30">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Summary retention (days after summarization)</mat-label>
-                    <input matInput type="number" [(ngModel)]="promptRetention.summaryRetentionDays" min="1" placeholder="90">
-                  </mat-form-field>
+                  <app-form-field label="Full prompt retention (days)">
+                    <input class="text-input" type="number" [(ngModel)]="promptRetention.fullRetentionDays" min="1" placeholder="30">
+                  </app-form-field>
+                  <app-form-field label="Summary retention (days after summarization)">
+                    <input class="text-input" type="number" [(ngModel)]="promptRetention.summaryRetentionDays" min="1" placeholder="90">
+                  </app-form-field>
                 </div>
-              </mat-card-content>
-              <mat-card-actions>
-                <button mat-raised-button color="primary" (click)="savePromptRetention()" [disabled]="saving()">
-                  <mat-icon>save</mat-icon> Save
-                </button>
-              </mat-card-actions>
-            </mat-card>
-          }
-        </div>
-      </mat-tab>
-    </mat-tab-group>
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="savePromptRetention()" [disabled]="saving()">
+                    Save
+                  </app-bronco-button>
+                </div>
+              </app-card>
+            }
+          </div>
+        </app-tab>
+      </app-tab-group>
+    </div>
   `,
   styles: [`
-    .tab-content {
-      padding: 24px 0;
+    .page-wrapper { max-width: 1200px; }
+    .page-title {
+      margin: 0 0 24px;
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--text-primary);
     }
-    .hint {
-      color: #666;
-      margin-bottom: 16px;
-      font-size: 14px;
-    }
-    .form-grid {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      max-width: 600px;
-    }
-    .full-width {
-      width: 100%;
-    }
-    .spinner-wrapper {
+
+    .tab-content { padding-top: 8px; }
+
+    .loading-wrapper {
       display: flex;
       justify-content: center;
       padding: 48px;
     }
-    mat-card-actions {
-      display: flex;
-      gap: 12px;
-      padding: 16px !important;
+    .loading-text {
+      color: var(--text-tertiary);
+      font-size: 13px;
     }
-    mat-card-actions button mat-spinner {
-      display: inline-block;
-      margin-right: 4px;
+
+    .section-title {
+      margin: 0 0 8px;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .hint {
+      color: var(--text-tertiary);
+      margin-bottom: 16px;
+      font-size: 14px;
+    }
+
+    .form-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: 600px;
+    }
+
+    .toggle-row { margin-bottom: 4px; }
+
+    .text-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+    .text-input:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
     }
   `],
 })

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -1,224 +1,223 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
 import { AuthService } from '../../core/services/auth.service';
 import { UserDialogComponent } from './user-dialog.component';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
   imports: [
     FormsModule,
     DatePipe,
-    MatCardModule,
-    MatButtonModule,
-    MatIconModule,
-    MatChipsModule,
     MatMenuModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatProgressSpinnerModule,
-    MatTooltipModule,
     MatDialogModule,
+    BroncoButtonComponent,
+    CardComponent,
+    FormFieldComponent,
   ],
   template: `
-    <div class="page-header">
-      <h1>User Maintenance</h1>
-      <button mat-raised-button color="primary" (click)="openCreate()">
-        <mat-icon>person_add</mat-icon>
-        Create User
-      </button>
-    </div>
-
-    @if (loading()) {
-      <div class="loading">
-        <mat-spinner diameter="40" />
+    <div class="page-wrapper">
+      <div class="page-header">
+        <h1 class="page-title">User Maintenance</h1>
+        <app-bronco-button variant="primary" (click)="openCreate()">
+          Create User
+        </app-bronco-button>
       </div>
-    } @else {
-      <div class="user-grid">
-        @for (user of users(); track user.id) {
-          <mat-card [class.inactive]="!user.isActive">
-            <mat-card-header>
-              <mat-icon mat-card-avatar class="user-avatar">
-                {{ user.role === 'ADMIN' ? 'admin_panel_settings' : 'person' }}
-              </mat-icon>
-              <mat-card-title>{{ user.name }}</mat-card-title>
-              <mat-card-subtitle>{{ user.email }}</mat-card-subtitle>
-              <button mat-icon-button [matMenuTriggerFor]="menu" class="card-menu">
-                <mat-icon>more_vert</mat-icon>
-              </button>
-              <mat-menu #menu="matMenu">
-                <button mat-menu-item (click)="openEdit(user)">
-                  <mat-icon>edit</mat-icon>
-                  <span>Edit</span>
-                </button>
-                <button mat-menu-item (click)="openResetPassword(user)">
-                  <mat-icon>lock_reset</mat-icon>
-                  <span>Reset Password</span>
-                </button>
-                @if (user.id !== currentUserId()) {
-                  @if (user.isActive) {
-                    <button mat-menu-item (click)="deactivate(user)">
-                      <mat-icon>block</mat-icon>
-                      <span>Deactivate</span>
-                    </button>
-                  } @else {
-                    <button mat-menu-item (click)="activate(user)">
-                      <mat-icon>check_circle</mat-icon>
-                      <span>Activate</span>
-                    </button>
+
+      @if (loading()) {
+        <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+      } @else {
+        <div class="user-grid">
+          @for (user of users(); track user.id) {
+            <div class="user-card" [class.inactive]="!user.isActive">
+              <div class="card-header">
+                <div class="avatar" [class.admin-avatar]="user.role === 'ADMIN'">
+                  {{ user.name.charAt(0).toUpperCase() }}
+                </div>
+                <div class="header-text">
+                  <div class="user-name">{{ user.name }}</div>
+                  <div class="user-email">{{ user.email }}</div>
+                </div>
+                <app-bronco-button variant="icon" size="sm" [matMenuTriggerFor]="menu" class="card-menu" title="Actions">
+                  ...
+                </app-bronco-button>
+                <mat-menu #menu="matMenu">
+                  <button mat-menu-item (click)="openEdit(user)">Edit</button>
+                  <button mat-menu-item (click)="openResetPassword(user)">Reset Password</button>
+                  @if (user.id !== currentUserId()) {
+                    @if (user.isActive) {
+                      <button mat-menu-item (click)="deactivate(user)">Deactivate</button>
+                    } @else {
+                      <button mat-menu-item (click)="activate(user)">Activate</button>
+                    }
                   }
-                }
-              </mat-menu>
-            </mat-card-header>
-            <mat-card-content>
+                </mat-menu>
+              </div>
               <div class="user-details">
                 <div class="detail-row">
-                  <mat-chip-set>
-                    <mat-chip [highlighted]="user.role === 'ADMIN'" [class]="'role-' + user.role.toLowerCase()">
-                      {{ user.role }}
-                    </mat-chip>
-                    @if (!user.isActive) {
-                      <mat-chip class="role-inactive">INACTIVE</mat-chip>
-                    }
-                  </mat-chip-set>
+                  <span class="chip" [class]="'role-' + user.role.toLowerCase()">{{ user.role }}</span>
+                  @if (!user.isActive) {
+                    <span class="chip role-inactive">INACTIVE</span>
+                  }
                 </div>
                 <div class="detail-row muted">
-                  <mat-icon class="detail-icon">schedule</mat-icon>
-                  <span>Last login: {{ user.lastLoginAt ? (user.lastLoginAt | date:'short') : 'Never' }}</span>
+                  Last login: {{ user.lastLoginAt ? (user.lastLoginAt | date:'short') : 'Never' }}
                 </div>
                 <div class="detail-row muted">
-                  <mat-icon class="detail-icon">calendar_today</mat-icon>
-                  <span>Created: {{ user.createdAt | date:'mediumDate' }}</span>
+                  Created: {{ user.createdAt | date:'mediumDate' }}
                 </div>
               </div>
-            </mat-card-content>
-          </mat-card>
-        } @empty {
-          <p class="empty-state">No users found.</p>
-        }
-      </div>
-    }
+            </div>
+          } @empty {
+            <p class="empty-state">No users found.</p>
+          }
+        </div>
+      }
 
-    <!-- Reset Password Dialog (inline) -->
-    @if (resetUser()) {
-      <div class="overlay" (click)="resetUser.set(null)">
-        <mat-card class="reset-dialog" (click)="$event.stopPropagation()">
-          <mat-card-header>
-            <mat-card-title>Reset Password</mat-card-title>
-            <mat-card-subtitle>{{ resetUser()!.name }} ({{ resetUser()!.email }})</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content>
-            <mat-form-field class="full-width">
-              <mat-label>New Password</mat-label>
-              <input matInput [(ngModel)]="resetPassword" type="password" minlength="8">
-              <mat-hint>Minimum 8 characters</mat-hint>
-            </mat-form-field>
-          </mat-card-content>
-          <mat-card-actions align="end">
-            <button mat-button (click)="resetUser.set(null)">Cancel</button>
-            <button mat-raised-button color="primary" (click)="submitResetPassword()" [disabled]="resetPassword.length < 8">
-              Reset
-            </button>
-          </mat-card-actions>
-        </mat-card>
-      </div>
-    }
+      <!-- Reset Password Dialog (inline) -->
+      @if (resetUser()) {
+        <div class="overlay" (click)="resetUser.set(null)">
+          <div class="reset-dialog" (click)="$event.stopPropagation()">
+            <app-card>
+              <h2 class="section-title">Reset Password</h2>
+              <p class="reset-subtitle">{{ resetUser()!.name }} ({{ resetUser()!.email }})</p>
+              <app-form-field label="New Password" hint="Minimum 8 characters">
+                <input class="text-input" [(ngModel)]="resetPassword" type="password" minlength="8">
+              </app-form-field>
+              <div class="card-actions">
+                <app-bronco-button variant="ghost" (click)="resetUser.set(null)">Cancel</app-bronco-button>
+                <app-bronco-button variant="primary" (click)="submitResetPassword()" [disabled]="resetPassword.length < 8">
+                  Reset
+                </app-bronco-button>
+              </div>
+            </app-card>
+          </div>
+        </div>
+      }
+    </div>
   `,
   styles: [`
+    .page-wrapper { max-width: 1200px; }
     .page-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       margin-bottom: 24px;
     }
-    .page-header h1 {
+    .page-title {
       margin: 0;
       font-size: 24px;
-      font-weight: 500;
+      font-weight: 600;
+      color: var(--text-primary);
     }
-    .loading {
+
+    .loading-wrapper {
       display: flex;
       justify-content: center;
       padding: 48px;
     }
+    .loading-text { color: var(--text-tertiary); font-size: 13px; }
+
     .user-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: 16px;
     }
-    mat-card {
+    .user-card {
+      background: var(--bg-card);
+      border-radius: var(--radius-lg);
+      padding: 20px;
+      box-shadow: var(--shadow-card);
       position: relative;
     }
-    mat-card.inactive {
-      opacity: 0.6;
+    .user-card.inactive { opacity: 0.6; }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
     }
-    .user-avatar {
-      font-size: 40px;
+    .avatar {
       width: 40px;
       height: 40px;
-      color: #5c6bc0;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--text-on-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 17px;
+      font-weight: 600;
+      flex-shrink: 0;
     }
-    .card-menu {
-      position: absolute;
-      top: 8px;
-      right: 8px;
+    .admin-avatar { background: #5856d6; }
+    .header-text { flex: 1; min-width: 0; }
+    .user-name {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-primary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
+    .user-email {
+      font-size: 13px;
+      color: var(--text-tertiary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .card-menu { flex-shrink: 0; }
+
     .user-details {
       display: flex;
       flex-direction: column;
       gap: 8px;
-      margin-top: 8px;
     }
     .detail-row {
       display: flex;
       align-items: center;
       gap: 6px;
     }
-    .detail-icon {
-      font-size: 16px;
-      width: 16px;
-      height: 16px;
-    }
     .muted {
-      color: #757575;
+      color: var(--text-tertiary);
       font-size: 13px;
     }
-    .role-admin {
-      background: #e8eaf6 !important;
-      color: #283593 !important;
+
+    .chip {
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 10px;
+      border-radius: var(--radius-pill);
+      text-transform: uppercase;
     }
-    .role-operator {
-      background: #e0f2f1 !important;
-      color: #00695c !important;
-    }
-    .role-inactive {
-      background: #fce4ec !important;
-      color: #c62828 !important;
-    }
+    .role-admin { background: rgba(88, 86, 214, 0.1); color: #5856d6; }
+    .role-operator { background: rgba(52, 199, 89, 0.1); color: var(--color-success); }
+    .role-inactive { background: rgba(255, 59, 48, 0.1); color: var(--color-error); }
+
     .empty-state {
       text-align: center;
-      color: #757575;
+      color: var(--text-tertiary);
       padding: 48px;
     }
+
     .overlay {
       position: fixed;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      background: rgba(0,0,0,0.4);
+      background: rgba(0, 0, 0, 0.4);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -228,8 +227,43 @@ import { UserDialogComponent } from './user-dialog.component';
       width: 400px;
       max-width: 90vw;
     }
-    .full-width {
+    .section-title {
+      margin: 0 0 4px;
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .reset-subtitle {
+      font-size: 13px;
+      color: var(--text-tertiary);
+      margin: 0 0 16px;
+    }
+
+    .text-input {
       width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-card);
+      border: 1px solid var(--border-medium);
+      border-radius: var(--radius-md);
+      padding: 8px 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+      outline: none;
+      transition: border-color 120ms ease, box-shadow 120ms ease;
+    }
+    .text-input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+    }
+
+    .card-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
     }
   `],
 })

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -25,6 +25,15 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
   }
 }
 
+const VALID_PRIORITIES = new Set(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']);
+const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'> = {
+  OPEN: 'open',
+  IN_PROGRESS: 'in_progress',
+  ANALYZING: 'analyzing',
+  RESOLVED: 'resolved',
+  CLOSED: 'closed',
+};
+
 @Component({
   selector: 'app-detail-panel',
   standalone: true,
@@ -564,20 +573,12 @@ export class DetailPanelComponent {
   }
 
   mapPriority(priority: string): 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' {
-    const valid = new Set(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']);
-    return valid.has(priority) ? priority as 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' : 'MEDIUM';
+    return VALID_PRIORITIES.has(priority) ? priority as 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' : 'MEDIUM';
   }
 
   /** Map API ticket status strings to StatusBadge values */
   mapStatus(status: string): 'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed' {
-    const map: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'> = {
-      OPEN: 'open',
-      IN_PROGRESS: 'in_progress',
-      ANALYZING: 'analyzing',
-      RESOLVED: 'resolved',
-      CLOSED: 'closed',
-    };
-    return map[status] ?? 'open';
+    return STATUS_MAP[status] ?? 'open';
   }
 
 }

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1,8 +1,10 @@
 import { Component, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { DatePipe } from '@angular/common';
+import { DatePipe, SlicePipe } from '@angular/common';
 import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
 import { TicketService, Ticket } from '../core/services/ticket.service';
+import { ClientService, Client } from '../core/services/client.service';
+import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service';
 import {
   StatusBadgeComponent,
   PriorityPillComponent,
@@ -28,6 +30,7 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
   standalone: true,
   imports: [
     DatePipe,
+    SlicePipe,
     StatusBadgeComponent,
     PriorityPillComponent,
     CategoryChipComponent,
@@ -37,17 +40,18 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
   template: `
     <aside class="detail-panel">
       <div class="panel-header">
-        @if (ticket(); as t) {
-          <div class="panel-title">
-            <span class="entity-type">Ticket</span>
+        <div class="panel-title">
+          <span class="entity-type">{{ detailPanel.entityType() }}</span>
+          @if (ticket(); as t) {
             <span class="entity-subject">{{ t.subject }}</span>
-          </div>
-        } @else {
-          <div class="panel-title">
-            <span class="entity-type">{{ detailPanel.entityType() }}</span>
+          } @else if (client(); as c) {
+            <span class="entity-subject">{{ c.name }}</span>
+          } @else if (probe(); as p) {
+            <span class="entity-subject">{{ p.name }}</span>
+          } @else {
             <span class="entity-id">{{ detailPanel.entityId() }}</span>
-          </div>
-        }
+          }
+        </div>
         <div class="panel-actions">
           <button class="panel-btn" (click)="expandToFullPage()" title="Open full page" aria-label="Open full page">
             <span class="expand-icon">&#x2197;</span>
@@ -60,6 +64,8 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
 
       @if (loading()) {
         <div class="panel-loading">Loading...</div>
+
+      <!-- TICKET -->
       } @else if (ticket(); as t) {
         <div class="panel-meta">
           <app-status-badge [status]="mapStatus(t.status)" />
@@ -113,6 +119,144 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
             <p class="placeholder-text">Events view coming soon</p>
           </app-tab>
         </app-tab-group>
+
+      <!-- CLIENT -->
+      } @else if (client(); as c) {
+        <div class="panel-meta">
+          @if (c.isActive) {
+            <span class="meta-badge meta-success">Active</span>
+          } @else {
+            <span class="meta-badge meta-muted">Inactive</span>
+          }
+          <span class="meta-badge meta-accent">{{ c.shortCode }}</span>
+        </div>
+
+        <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
+          <app-tab label="Details">
+            <div class="detail-fields">
+              <div class="field-row">
+                <span class="field-label">Short Code</span>
+                <span class="field-value client-code">{{ c.shortCode }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Systems</span>
+                <span class="field-value">{{ c._count?.systems ?? 0 }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Tickets</span>
+                <span class="field-value">{{ c._count?.tickets ?? 0 }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">AI Mode</span>
+                <span class="field-value">{{ c.aiMode ?? 'Default' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Auto Route</span>
+                <span class="field-value">{{ c.autoRouteTickets ? 'Yes' : 'No' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Created</span>
+                <span class="field-value">{{ c.createdAt | date:'medium' }}</span>
+              </div>
+            </div>
+            @if (c.notes) {
+              <div class="detail-section">
+                <span class="section-label">Notes</span>
+                <p class="summary-text">{{ c.notes }}</p>
+              </div>
+            }
+          </app-tab>
+          <app-tab label="Systems">
+            @if (c.systems?.length) {
+              @for (sys of c.systems; track sys.id) {
+                <div class="list-item">
+                  <span class="list-item-name">{{ sys.name }}</span>
+                </div>
+              }
+            } @else {
+              <p class="placeholder-text">No systems</p>
+            }
+          </app-tab>
+        </app-tab-group>
+
+      <!-- PROBE -->
+      } @else if (probe(); as p) {
+        <div class="panel-meta">
+          @if (p.isActive) {
+            <span class="meta-badge meta-success">Active</span>
+          } @else {
+            <span class="meta-badge meta-muted">Inactive</span>
+          }
+          <span class="meta-badge meta-accent">{{ p.action }}</span>
+        </div>
+
+        <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
+          <app-tab label="Details">
+            <div class="detail-fields">
+              <div class="field-row">
+                <span class="field-label">Tool</span>
+                <span class="field-value" style="font-family: ui-monospace, monospace; font-size: 12px;">{{ p.toolName }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Client</span>
+                <span class="field-value">
+                  @if (p.client; as pc) {
+                    @if (pc.shortCode) {
+                      <span class="client-code">{{ pc.shortCode }}</span>
+                    }
+                    {{ pc.name }}
+                  } @else {
+                    —
+                  }
+                </span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Schedule</span>
+                <span class="field-value">{{ p.cronExpression }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Category</span>
+                <span class="field-value">{{ p.category ?? 'Any' }}</span>
+              </div>
+              <div class="field-row">
+                <span class="field-label">Retention</span>
+                <span class="field-value">{{ p.retentionDays }}d / {{ p.retentionMaxRuns }} runs</span>
+              </div>
+            </div>
+            @if (p.description) {
+              <div class="detail-section">
+                <span class="section-label">Description</span>
+                <p class="summary-text">{{ p.description }}</p>
+              </div>
+            }
+          </app-tab>
+          <app-tab label="Last Run">
+            @if (p.lastRunAt) {
+              <div class="detail-fields">
+                <div class="field-row">
+                  <span class="field-label">Status</span>
+                  <span class="field-value">
+                    <span class="run-status" [class]="'run-' + p.lastRunStatus">{{ p.lastRunStatus }}</span>
+                  </span>
+                </div>
+                <div class="field-row">
+                  <span class="field-label">Time</span>
+                  <span class="field-value">{{ p.lastRunAt | date:'medium' }}</span>
+                </div>
+              </div>
+              @if (p.lastRunResult) {
+                <div class="detail-section">
+                  <span class="section-label">Result</span>
+                  <pre class="result-block">{{ p.lastRunResult | slice:0:500 }}</pre>
+                </div>
+              }
+            } @else {
+              <p class="placeholder-text">No runs yet</p>
+            }
+          </app-tab>
+        </app-tab-group>
+
+      <!-- FALLBACK for system, analysis, job -->
       } @else {
         <div class="panel-body">
           <p class="placeholder-text">
@@ -281,14 +425,94 @@ function entityRoute(type: DetailEntityType, id: string): string[] {
       line-height: 1.6;
       margin: 0;
     }
+
+    .meta-badge {
+      font-size: 12px;
+      font-weight: 500;
+      padding: 2px 10px;
+      border-radius: var(--radius-pill);
+    }
+
+    .meta-success {
+      background: rgba(52,199,89,0.08);
+      color: var(--color-success);
+    }
+
+    .meta-muted {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .meta-accent {
+      background: var(--bg-active);
+      color: var(--accent);
+      font-family: ui-monospace, monospace;
+    }
+
+    .list-item {
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-light);
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .list-item:last-child {
+      border-bottom: none;
+    }
+
+    .list-item-name {
+      font-weight: 500;
+      color: var(--text-primary);
+    }
+
+    .run-status {
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+    }
+
+    .run-success {
+      background: rgba(52,199,89,0.08);
+      color: var(--color-success);
+    }
+
+    .run-error {
+      background: rgba(255,59,48,0.08);
+      color: var(--color-error);
+    }
+
+    .run-skipped {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .result-block {
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      background: var(--bg-muted);
+      border-radius: var(--radius-md);
+      padding: 12px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 200px;
+      overflow-y: auto;
+      color: var(--text-secondary);
+      margin: 0;
+    }
   `],
 })
 export class DetailPanelComponent {
   readonly detailPanel = inject(DetailPanelService);
   private readonly router = inject(Router);
   private readonly ticketService = inject(TicketService);
+  private readonly clientService = inject(ClientService);
+  private readonly probeService = inject(ScheduledProbeService);
 
   ticket = signal<Ticket | null>(null);
+  client = signal<Client | null>(null);
+  probe = signal<ScheduledProbe | null>(null);
   selectedTab = signal(0);
   loading = signal(false);
 
@@ -296,10 +520,36 @@ export class DetailPanelComponent {
     effect(() => {
       const type = this.detailPanel.entityType();
       const id = this.detailPanel.entityId();
-      if (type === 'ticket' && id) {
-        this.loadTicket(id);
-      } else {
-        this.ticket.set(null);
+      // Reset all
+      this.ticket.set(null);
+      this.client.set(null);
+      this.probe.set(null);
+      this.selectedTab.set(0);
+
+      if (!type || !id) return;
+      this.loading.set(true);
+
+      switch (type) {
+        case 'ticket':
+          this.ticketService.getTicket(id).subscribe({
+            next: (t) => { this.ticket.set(t); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        case 'client':
+          this.clientService.getClient(id).subscribe({
+            next: (c) => { this.client.set(c); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        case 'probe':
+          this.probeService.getProbe(id).subscribe({
+            next: (p) => { this.probe.set(p); this.loading.set(false); },
+            error: () => { this.loading.set(false); },
+          });
+          break;
+        default:
+          this.loading.set(false);
       }
     });
   }
@@ -330,11 +580,4 @@ export class DetailPanelComponent {
     return map[status] ?? 'open';
   }
 
-  private loadTicket(id: string): void {
-    this.loading.set(true);
-    this.ticketService.getTicket(id).subscribe({
-      next: (t) => { this.ticket.set(t); this.loading.set(false); },
-      error: () => { this.ticket.set(null); this.loading.set(false); },
-    });
-  }
 }


### PR DESCRIPTION
## Summary
- Restyle 5 settings/config pages (Profile, Notification Preferences, System Settings, Settings, Users) replacing Material Design components with custom Bronco design system
- Replace MatCard, MatFormField, MatInput, MatButton, MatIcon, MatTable, MatChips, MatSlideToggle, MatSelect, MatTabs, MatProgressSpinner, MatTooltip, MatDivider with `app-card`, `app-form-field`, `app-data-table`, `app-tab-group`, `app-toggle-switch`, `app-select`, `app-bronco-button`, and CSS variable styling
- Retain MatDialog, MatSnackBar, and MatMenuModule where pages use dialogs, toasts, and context menus

## Test plan
- [ ] Profile page: verify edit profile form and change password form render and save correctly
- [ ] Notification Preferences: verify event notification table with toggles and selects, operational alerts tab with toggle switches
- [ ] System Settings: verify all 6 tabs (SMTP, Azure DevOps, GitHub, IMAP, Slack, Prompt Retention) load, save, and test correctly
- [ ] Settings: verify all 7 tabs (General, Ticket Statuses, Ticket Categories, External Services, Action Safety, Analysis Strategy, Self Analysis) including dialog opens for create/edit
- [ ] Users: verify user card grid renders, menu actions (edit, reset password, activate/deactivate) work, inline reset password dialog works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
