### PR TITLE
Add theme customization system with multiple theme options

### DIFF
--- a/services/control-panel/angular.json
+++ b/services/control-panel/angular.json
@@ -33,6 +33,11 @@
             ],
             "styles": [
               "src/styles/theme.css",
+              "src/styles/themes/linear.css",
+              "src/styles/themes/nvidia.css",
+              "src/styles/themes/sentry.css",
+              "src/styles/themes/supabase.css",
+              "src/styles/themes/vercel.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -23,16 +23,17 @@ const STORAGE_KEY = 'bronco-theme';
 @Injectable({ providedIn: 'root' })
 export class ThemeService {
   readonly themes: readonly ThemeOption[] = THEMES;
-  readonly currentTheme = signal<ThemeOption>(this.resolveInitial());
+  private readonly _currentTheme = signal<ThemeOption>(this.resolveInitial());
+  readonly currentTheme = this._currentTheme.asReadonly();
 
-  constructor() {
+  init(): void {
     this.applyTheme();
   }
 
   setTheme(id: string): void {
     const theme = THEMES.find(t => t.id === id);
     if (!theme) return;
-    this.currentTheme.set(theme);
+    this._currentTheme.set(theme);
     this.applyTheme();
   }
 

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface ThemeOption {
+  id: string;
+  name: string;
+  bodyClass: string;
+  description: string;
+  isDark: boolean;
+  accentColor: string;
+}
+
+const THEMES: ThemeOption[] = [
+  { id: 'apple', name: 'Apple', bodyClass: '', description: 'Clean light theme with blue accent', isDark: false, accentColor: '#0071e3' },
+  { id: 'linear', name: 'Linear', bodyClass: 'theme-linear', description: 'Dark minimal with indigo accent', isDark: true, accentColor: '#5e6ad2' },
+  { id: 'nvidia', name: 'NVIDIA', bodyClass: 'theme-nvidia', description: 'Industrial dark with green accent', isDark: true, accentColor: '#76b900' },
+  { id: 'sentry', name: 'Sentry', bodyClass: 'theme-sentry', description: 'Deep purple with lime highlights', isDark: true, accentColor: '#6a5fc1' },
+  { id: 'supabase', name: 'Supabase', bodyClass: 'theme-supabase', description: 'Dark emerald, border-defined depth', isDark: true, accentColor: '#3ecf8e' },
+  { id: 'vercel', name: 'Vercel', bodyClass: 'theme-vercel', description: 'Precise light with monochrome palette', isDark: false, accentColor: '#171717' },
+];
+
+const STORAGE_KEY = 'bronco-theme';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly themes: readonly ThemeOption[] = THEMES;
+  readonly currentTheme = signal<ThemeOption>(this.resolveInitial());
+
+  constructor() {
+    this.applyTheme();
+  }
+
+  setTheme(id: string): void {
+    const theme = THEMES.find(t => t.id === id);
+    if (!theme) return;
+    this.currentTheme.set(theme);
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    const theme = this.currentTheme();
+    const classList = document.body.classList;
+    const toRemove = Array.from(classList).filter(c => c.startsWith('theme-'));
+    toRemove.forEach(c => classList.remove(c));
+    if (theme.bodyClass) {
+      classList.add(theme.bodyClass);
+    }
+    localStorage.setItem(STORAGE_KEY, theme.id);
+  }
+
+  private resolveInitial(): ThemeOption {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return THEMES.find(t => t.id === saved) ?? THEMES[0];
+  }
+}

--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthService } from '../../core/services/auth.service';
+import { ThemeService } from '../../core/services/theme.service';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -27,6 +28,33 @@ import {
           <div class="field">
             <span class="label">User ID</span>
             <span class="mono">{{ user.id }}</span>
+          </div>
+        </app-card>
+
+        <app-card>
+          <h2 class="section-title">Theme</h2>
+          <div class="theme-grid">
+            @for (theme of themeService.themes; track theme.id) {
+              <button
+                class="theme-card"
+                [class.theme-card-active]="theme.id === themeService.currentTheme().id"
+                (click)="themeService.setTheme(theme.id)">
+                <div class="theme-card-preview" [class.theme-card-dark]="theme.isDark">
+                  <span class="theme-swatch" [style.background]="theme.accentColor"></span>
+                </div>
+                <div class="theme-card-info">
+                  <span class="theme-card-name">{{ theme.name }}</span>
+                  <span class="theme-card-desc">{{ theme.description }}</span>
+                </div>
+                @if (theme.id === themeService.currentTheme().id) {
+                  <span class="theme-check">
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                      <path d="M2.5 7.5L5.5 10.5L11.5 3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                  </span>
+                }
+              </button>
+            }
           </div>
         </app-card>
 
@@ -167,10 +195,87 @@ import {
       padding-top: 16px;
       border-top: 1px solid var(--border-light);
     }
+
+    .theme-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+    }
+    .theme-card {
+      position: relative;
+      background: var(--bg-page);
+      border: 2px solid var(--border-light);
+      border-radius: var(--radius-md);
+      padding: 0;
+      cursor: pointer;
+      text-align: left;
+      font-family: var(--font-primary);
+      overflow: hidden;
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .theme-card:hover {
+      border-color: var(--border-medium);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+    .theme-card-active {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 1px var(--accent);
+    }
+    .theme-card-active:hover {
+      border-color: var(--accent);
+    }
+    .theme-card-preview {
+      height: 48px;
+      background: #f5f5f7;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-bottom: 1px solid var(--border-light);
+    }
+    .theme-card-preview.theme-card-dark {
+      background: #1a1a1a;
+    }
+    .theme-swatch {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    }
+    .theme-card-info {
+      padding: 10px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .theme-card-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .theme-card-desc {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      line-height: 1.3;
+    }
+    .theme-check {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--accent);
+      color: var(--text-on-accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   `],
 })
 export class ProfileComponent implements OnInit {
   authService = inject(AuthService);
+  readonly themeService = inject(ThemeService);
   private snackBar = inject(MatSnackBar);
 
   profileName = '';

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -4,6 +4,7 @@ import { SidebarComponent } from './sidebar.component';
 import { HeaderBarComponent } from './header-bar.component';
 import { DetailPanelComponent } from './detail-panel.component';
 import { DetailPanelService } from '../core/services/detail-panel.service';
+import { ThemeService } from '../core/services/theme.service';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
   dashboard: 'Dashboard',
@@ -74,6 +75,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
 })
 export class AppShellComponent implements OnInit {
   readonly detailPanel = inject(DetailPanelService);
+  private readonly _theme = inject(ThemeService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   readonly pageTitle = signal('Dashboard');

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -75,12 +75,13 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
 })
 export class AppShellComponent implements OnInit {
   readonly detailPanel = inject(DetailPanelService);
-  private readonly _theme = inject(ThemeService);
+  private readonly theme = inject(ThemeService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   readonly pageTitle = signal('Dashboard');
 
   ngOnInit(): void {
+    this.theme.init();
     const params = this.route.snapshot.queryParams;
     this.detailPanel.restoreFromUrl({
       detail: params['detail'],

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AuthService } from '../core/services/auth.service';
+import { ThemeService } from '../core/services/theme.service';
 import { VersionService } from '../core/services/version.service';
 
 @Component({
@@ -62,6 +63,10 @@ import { VersionService } from '../core/services/version.service';
 
       <div class="sidebar-footer">
         <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
+        <a routerLink="/profile" class="theme-indicator">
+          <span class="theme-dot" [style.background]="themeService.currentTheme().accentColor"></span>
+          <span>{{ themeService.currentTheme().name }}</span>
+        </a>
         <span class="version-label">v{{ version() }}</span>
       </div>
     </nav>
@@ -151,6 +156,26 @@ import { VersionService } from '../core/services/version.service';
       border: none;
       font-family: var(--font-primary);
     }
+    .theme-indicator {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 16px;
+      font-size: 12px;
+      color: var(--text-tertiary);
+      text-decoration: none;
+      cursor: pointer;
+      transition: color 120ms ease;
+    }
+    .theme-indicator:hover {
+      color: var(--text-secondary);
+    }
+    .theme-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
     .version-label {
       display: block;
       padding: 2px 16px 8px;
@@ -161,6 +186,7 @@ import { VersionService } from '../core/services/version.service';
 })
 export class SidebarComponent {
   readonly authService = inject(AuthService);
+  readonly themeService = inject(ThemeService);
   private readonly versionService = inject(VersionService);
   readonly version = toSignal(this.versionService.getVersion(), { initialValue: '' });
 }


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive theme customization system to the control panel, allowing users to switch between multiple pre-designed themes with different color schemes and visual styles.

## Key Changes
- **New ThemeService**: Created a centralized service (`theme.service.ts`) that manages theme state using Angular signals, persists user preference to localStorage, and applies theme classes to the document body
- **Theme Options**: Added 6 built-in themes (Apple, Linear, NVIDIA, Sentry, Supabase, Vercel) with distinct visual identities, accent colors, and dark/light variants
- **Profile Theme Selector**: Added a new "Theme" section in the profile component with an interactive grid of theme cards showing previews, descriptions, and visual feedback for the currently selected theme
- **Sidebar Theme Indicator**: Added a theme indicator in the sidebar footer displaying the current theme name and accent color as a visual dot, linking to the profile page
- **Theme CSS Files**: Integrated theme-specific stylesheets into the Angular build configuration for Linear, NVIDIA, Sentry, Supabase, and Vercel themes
- **App Shell Integration**: Injected ThemeService into the app shell to ensure theme initialization on application startup

## Implementation Details
- Theme selection is persisted using localStorage with the key `bronco-theme`, defaulting to the Apple theme on first load
- The theme system uses CSS custom properties (CSS variables) for dynamic styling, with theme-specific classes applied to the body element
- Theme cards feature hover states, active state styling with accent color borders, and a checkmark indicator for the currently selected theme
- The theme indicator in the sidebar provides quick visual feedback and navigation to theme settings

https://claude.ai/code/session_01Q4WWVYnXCprZL3BYXuAsPD