### PR TITLE
Add compact detail panel mode for quick ticket preview

### DIFF
--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -40,6 +40,13 @@ export class DetailPanelService {
     });
   }
 
+  /** Reset panel state without navigating — use when another navigation is already in progress. */
+  dismiss(): void {
+    this.entityType.set(null);
+    this.entityId.set(null);
+    this.mode.set('full');
+  }
+
   /** Call from shell on init to restore panel from query param */
   restoreFromUrl(params: { detail?: string; type?: string; mode?: string }): void {
     if (params.detail) {

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -2,10 +2,12 @@ import { Injectable, signal, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
 export type DetailEntityType = 'ticket' | 'client' | 'probe' | 'system' | 'analysis' | 'job';
+export type DetailPanelMode = 'full' | 'compact';
 
 const VALID_ENTITY_TYPES: ReadonlySet<string> = new Set<DetailEntityType>([
   'ticket', 'client', 'probe', 'system', 'analysis', 'job',
 ]);
+const VALID_MODES: ReadonlySet<string> = new Set<DetailPanelMode>(['full', 'compact']);
 
 @Injectable({ providedIn: 'root' })
 export class DetailPanelService {
@@ -13,13 +15,15 @@ export class DetailPanelService {
 
   readonly entityType = signal<DetailEntityType | null>(null);
   readonly entityId = signal<string | null>(null);
+  readonly mode = signal<DetailPanelMode>('full');
   readonly isOpen = computed(() => this.entityId() !== null);
 
-  open(type: DetailEntityType, id: string): void {
+  open(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
+    this.mode.set(mode);
     this.entityType.set(type);
     this.entityId.set(id);
     this.router.navigate([], {
-      queryParams: { detail: id, type },
+      queryParams: { detail: id, type, mode },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
@@ -28,19 +32,22 @@ export class DetailPanelService {
   close(): void {
     this.entityType.set(null);
     this.entityId.set(null);
+    this.mode.set('full');
     this.router.navigate([], {
-      queryParams: { detail: null, type: null },
+      queryParams: { detail: null, type: null, mode: null },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
   }
 
   /** Call from shell on init to restore panel from query param */
-  restoreFromUrl(params: { detail?: string; type?: string }): void {
+  restoreFromUrl(params: { detail?: string; type?: string; mode?: string }): void {
     if (params.detail) {
       const type = VALID_ENTITY_TYPES.has(params.type ?? '') ? (params.type as DetailEntityType) : 'ticket';
+      const mode = VALID_MODES.has(params.mode ?? '') ? (params.mode as DetailPanelMode) : 'full';
       this.entityType.set(type);
       this.entityId.set(params.detail);
+      this.mode.set(mode);
     }
   }
 }

--- a/services/control-panel/src/app/features/dashboard/dashboard.component.ts
+++ b/services/control-panel/src/app/features/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ClientService, Client } from '../../core/services/client.service';
 import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service';
@@ -33,13 +33,11 @@ const UNKNOWN_CLIENT_SHORT_CODE = '_unknown';
         <app-stat-card label="Critical" [value]="criticalTickets() + ''" change="" [changeType]="criticalTickets() > 0 ? 'negative' : 'neutral'" />
         <app-stat-card label="Clients" [value]="clients().length + ''" change="" changeType="neutral" />
         <app-stat-card label="Database Systems" [value]="totalSystems() + ''" change="" changeType="neutral" />
-        @if (statusData(); as status) {
-          <app-stat-card
-            label="Services"
-            [value]="upCount() + '/' + (status.components.length + (status.mcpServers?.length ?? 0) + (status.llmProviders?.length ?? 0))"
-            [change]="status.status === 'UP' ? 'All healthy' : status.status"
-            [changeType]="status.status === 'UP' ? 'positive' : 'negative'" />
-        }
+        <app-stat-card
+          label="Services"
+          [value]="servicesValue()"
+          [change]="servicesChange()"
+          [changeType]="servicesChangeType()" />
         @if (unknownClientTickets() > 0) {
           <app-stat-card
             label="Unassigned Client"
@@ -131,11 +129,33 @@ export class DashboardComponent implements OnInit {
   totalSystems = signal(0);
   statusData = signal<SystemStatusResponse | null>(null);
   upCount = signal(0);
+  servicesError = signal(false);
   unknownClientId = signal('');
   unknownClientTickets = signal(0);
 
   sortColumn = signal('');
   sortDirection = signal<'asc' | 'desc'>('asc');
+
+  servicesValue = computed(() => {
+    const status = this.statusData();
+    if (!status) return '\u2014';
+    const total = status.components.length + (status.mcpServers?.length ?? 0) + (status.llmProviders?.length ?? 0);
+    return this.upCount() + '/' + total;
+  });
+
+  servicesChange = computed(() => {
+    if (this.servicesError()) return 'Unavailable';
+    const status = this.statusData();
+    if (!status) return 'Loading...';
+    return status.status === 'UP' ? 'All healthy' : status.status;
+  });
+
+  servicesChangeType = computed(() => {
+    if (this.servicesError()) return 'negative' as const;
+    const status = this.statusData();
+    if (!status) return 'neutral' as const;
+    return status.status === 'UP' ? 'positive' as const : 'negative' as const;
+  });
 
   trackById = (item: Ticket) => item.id;
 
@@ -170,12 +190,15 @@ export class DashboardComponent implements OnInit {
         const llmUp = res.llmProviders?.filter(l => l.status === 'UP').length ?? 0;
         this.upCount.set(res.components.filter(c => c.status === 'UP').length + mcpUp + llmUp);
       },
-      error: () => {},
+      error: () => {
+        this.statusData.set(null);
+        this.servicesError.set(true);
+      },
     });
   }
 
   onTicketClick(ticket: Ticket): void {
-    this.detailPanel.open('ticket', ticket.id);
+    this.detailPanel.open('ticket', ticket.id, 'compact');
   }
 
   onSortChange(event: { column: string; direction: 'asc' | 'desc' }): void {

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -83,6 +83,7 @@ export class AppShellComponent implements OnInit {
     this.detailPanel.restoreFromUrl({
       detail: params['detail'],
       type: params['type'],
+      mode: params['mode'],
     });
     this.updateTitle();
     this.router.events.subscribe(event => {

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1,8 +1,8 @@
 import { Component, effect, inject, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { DatePipe, SlicePipe } from '@angular/common';
-import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
+import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service.js';
 import { TicketService, Ticket } from '../core/services/ticket.service';
 import { ClientService, Client } from '../core/services/client.service';
 import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service';
@@ -41,6 +41,7 @@ const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolve
   imports: [
     DatePipe,
     SlicePipe,
+    RouterLink,
     StatusBadgeComponent,
     PriorityPillComponent,
     CategoryChipComponent,
@@ -88,6 +89,7 @@ const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolve
           }
         </div>
 
+        @if (detailPanel.mode() === 'full') {
         <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="selectedTab.set($event)">
           <app-tab label="Details">
             <div class="detail-fields">
@@ -132,6 +134,44 @@ const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolve
             <p class="placeholder-text">Events view coming soon</p>
           </app-tab>
         </app-tab-group>
+        } @else {
+        <div class="panel-body">
+          <div class="detail-fields">
+            <div class="field-row">
+              <span class="field-label">Client</span>
+              <span class="field-value">
+                @if (t.client; as c) {
+                  @if (c.shortCode) {
+                    <span class="client-code">{{ c.shortCode }}</span>
+                  }
+                }
+                {{ t.client?.name ?? '—' }}
+              </span>
+            </div>
+            <div class="field-row">
+              <span class="field-label">System</span>
+              <span class="field-value">{{ t.system?.name ?? '—' }}</span>
+            </div>
+            <div class="field-row">
+              <span class="field-label">Source</span>
+              <span class="field-value">{{ t.source }}</span>
+            </div>
+            <div class="field-row">
+              <span class="field-label">Created</span>
+              <span class="field-value">{{ t.createdAt | date:'medium' }}</span>
+            </div>
+          </div>
+          @if (t.summary) {
+            <div class="detail-section">
+              <span class="section-label">Summary</span>
+              <p class="summary-text">{{ t.summary }}</p>
+            </div>
+          }
+          <div class="compact-footer">
+            <a class="view-full-link" [routerLink]="['/tickets', t.id]" (click)="detailPanel.close()">View Full Details</a>
+          </div>
+        </div>
+        }
 
       <!-- CLIENT -->
       } @else if (client(); as c) {
@@ -498,6 +538,25 @@ const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolve
     .run-skipped {
       background: var(--bg-muted);
       color: var(--text-tertiary);
+    }
+
+    .compact-footer {
+      margin-top: 24px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
+    }
+
+    .view-full-link {
+      display: inline-block;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .view-full-link:hover {
+      text-decoration: underline;
     }
 
     .result-block {

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -2,7 +2,7 @@ import { Component, effect, inject, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Router, RouterLink } from '@angular/router';
 import { DatePipe, SlicePipe } from '@angular/common';
-import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service.js';
+import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
 import { TicketService, Ticket } from '../core/services/ticket.service';
 import { ClientService, Client } from '../core/services/client.service';
 import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service';
@@ -168,7 +168,7 @@ const STATUS_MAP: Record<string, 'open' | 'in_progress' | 'analyzing' | 'resolve
             </div>
           }
           <div class="compact-footer">
-            <a class="view-full-link" [routerLink]="['/tickets', t.id]" (click)="detailPanel.close()">View Full Details</a>
+            <a class="view-full-link" [routerLink]="['/tickets', t.id]" (click)="detailPanel.dismiss()">View Full Details</a>
           </div>
         </div>
         }


### PR DESCRIPTION
## Summary
This PR introduces a compact view mode for the detail panel that displays essential ticket information without the full tabbed interface. Users can now preview ticket details in a condensed format and navigate to the full details page if needed.

## Key Changes

- **Detail Panel Service Enhancement**
  - Added `DetailPanelMode` type with 'full' and 'compact' options
  - Extended `open()` method to accept optional `mode` parameter (defaults to 'full')
  - Added mode signal to track current panel display mode
  - Updated URL query parameters to include and restore mode state

- **Detail Panel Component Updates**
  - Added conditional rendering based on panel mode using `@if (detailPanel.mode() === 'full')`
  - Implemented compact view with essential fields: Client, System, Source, Created date, and Summary
  - Added "View Full Details" link in compact mode that navigates to full ticket page
  - Imported `RouterLink` for navigation functionality
  - Added styling for compact footer and view-full link with hover effects

- **Dashboard Component Integration**
  - Updated ticket click handler to open detail panel in 'compact' mode
  - Refactored services stat card logic into computed properties (`servicesValue`, `servicesChange`, `servicesChangeType`)
  - Improved error handling for status data with `servicesError` signal
  - Enhanced loading and error states for services display

- **Shell Component**
  - Updated URL restoration to include mode parameter

## Implementation Details

The compact mode provides a lightweight preview experience while maintaining the ability to access full details. The mode is persisted in URL query parameters, allowing users to share or bookmark specific panel states. The computed properties in the dashboard component improve reactivity and reduce template complexity.

https://claude.ai/code/session_014FpSRVrcK5dh7HxZwFJaRF