### PR TITLE
Add custom dropdown menu component and replace MatMenu (#131)

### DIFF
--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -314,8 +314,8 @@ import { AiUsageService, type AiUsageClientSummary, type AiUsageLogEntry } from 
                     <mat-icon>{{ memoryTypeIcon(mem.memoryType) }}</mat-icon>
                     <strong>{{ mem.title }}</strong>
                     <span class="type-chip type-{{ mem.memoryType.toLowerCase() }}">{{ mem.memoryType }}</span>
-                    <span class="source-badge source-{{ mem.source.toLowerCase() }}">
-                      {{ mem.source === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
+                    <span class="source-badge source-{{ (mem.source ?? 'MANUAL').toLowerCase() }}">
+                      {{ (mem.source ?? 'MANUAL') === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
                     </span>
                     @if (mem.category) {
                       <span class="category-chip">{{ mem.category }}</span>

--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { MatMenuModule } from '@angular/material/menu';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Subject, EMPTY, switchMap, timer } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
@@ -14,6 +13,10 @@ import {
   StatCardComponent,
   DataTableComponent,
   DataTableColumnComponent,
+  DropdownMenuComponent,
+  DropdownItemComponent,
+  DropdownDividerComponent,
+  DropdownLabelComponent,
 } from '../../shared/components/index.js';
 
 @Component({
@@ -23,12 +26,15 @@ import {
     FormsModule,
     RouterLink,
     MatPaginatorModule,
-    MatMenuModule,
     BroncoButtonComponent,
     SelectComponent,
     StatCardComponent,
     DataTableComponent,
     DataTableColumnComponent,
+    DropdownMenuComponent,
+    DropdownItemComponent,
+    DropdownDividerComponent,
+    DropdownLabelComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -135,20 +141,19 @@ import {
 
           <app-data-column key="actions" header="" [sortable]="false" width="48px">
             <ng-template #cell let-log>
-              <button type="button" class="icon-btn" aria-label="Open actions menu" [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">···</button>
-              <mat-menu #menu="matMenu">
+              <button type="button" class="icon-btn" aria-label="Open actions menu" #menuTrigger (click)="$event.stopPropagation(); menu.toggle()">···</button>
+              <app-dropdown-menu #menu [trigger]="menuTrigger">
                 @if (log.status === 'failed' || log.classification === 'NOISE' || log.classification === 'AUTO_REPLY') {
-                  <button mat-menu-item (click)="retryEmail(log)">Retry</button>
+                  <app-dropdown-item (action)="retryEmail(log)">Retry</app-dropdown-item>
                 }
-                <button mat-menu-item [matMenuTriggerFor]="reclassifyMenu">Reclassify</button>
-                <button mat-menu-item (click)="toggleExpand(log.id)">Details</button>
-              </mat-menu>
-              <mat-menu #reclassifyMenu="matMenu">
-                <button mat-menu-item (click)="reclassify(log, 'TICKET_WORTHY')">Ticket Worthy</button>
-                <button mat-menu-item (click)="reclassify(log, 'THREAD_REPLY')">Thread Reply</button>
-                <button mat-menu-item (click)="reclassify(log, 'NOISE')">Noise</button>
-                <button mat-menu-item (click)="reclassify(log, 'AUTO_REPLY')">Auto Reply</button>
-              </mat-menu>
+                <app-dropdown-item (action)="toggleExpand(log.id)">Details</app-dropdown-item>
+                <app-dropdown-divider />
+                <app-dropdown-label>Reclassify as:</app-dropdown-label>
+                <app-dropdown-item (action)="reclassify(log, 'TICKET_WORTHY')">Ticket Worthy</app-dropdown-item>
+                <app-dropdown-item (action)="reclassify(log, 'THREAD_REPLY')">Thread Reply</app-dropdown-item>
+                <app-dropdown-item (action)="reclassify(log, 'NOISE')">Noise</app-dropdown-item>
+                <app-dropdown-item (action)="reclassify(log, 'AUTO_REPLY')">Auto Reply</app-dropdown-item>
+              </app-dropdown-menu>
             </ng-template>
           </app-data-column>
         </app-data-table>

--- a/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
@@ -78,7 +78,7 @@ import {
                   (change)="toggleActive(ch)"
                   matTooltip="Enable/disable this channel"
                 ></mat-slide-toggle>
-                <button type="button" class="icon-btn" #menuTrigger (click)="menu.toggle()">&#x22EE;</button>
+                <button type="button" class="icon-btn" [attr.aria-label]="'Actions for ' + ch.name" #menuTrigger (click)="menu.toggle()">&#x22EE;</button>
                 <app-dropdown-menu #menu [trigger]="menuTrigger">
                   <app-dropdown-item (action)="openDialog(ch)">Edit</app-dropdown-item>
                   <app-dropdown-item (action)="testChannel(ch)">Send Test</app-dropdown-item>

--- a/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
@@ -6,7 +6,6 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { FormsModule } from '@angular/forms';
@@ -18,6 +17,10 @@ import {
   NotificationChannel,
 } from '../../core/services/notification-channel.service';
 import { NotificationChannelDialogComponent } from './notification-channel-dialog.component';
+import {
+  DropdownMenuComponent,
+  DropdownItemComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
@@ -30,8 +33,9 @@ import { NotificationChannelDialogComponent } from './notification-channel-dialo
     MatChipsModule,
     MatTooltipModule,
     MatProgressSpinnerModule,
-    MatMenuModule,
     MatSlideToggleModule,
+    DropdownMenuComponent,
+    DropdownItemComponent,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
@@ -74,20 +78,12 @@ import { NotificationChannelDialogComponent } from './notification-channel-dialo
                   (change)="toggleActive(ch)"
                   matTooltip="Enable/disable this channel"
                 ></mat-slide-toggle>
-                <button mat-icon-button [matMenuTriggerFor]="menu">
-                  <mat-icon>more_vert</mat-icon>
-                </button>
-                <mat-menu #menu="matMenu">
-                  <button mat-menu-item (click)="openDialog(ch)">
-                    <mat-icon>edit</mat-icon> Edit
-                  </button>
-                  <button mat-menu-item (click)="testChannel(ch)">
-                    <mat-icon>send</mat-icon> Send Test
-                  </button>
-                  <button mat-menu-item (click)="deleteChannel(ch)" class="delete-item">
-                    <mat-icon>delete</mat-icon> Delete
-                  </button>
-                </mat-menu>
+                <button type="button" class="icon-btn" #menuTrigger (click)="menu.toggle()">&#x22EE;</button>
+                <app-dropdown-menu #menu [trigger]="menuTrigger">
+                  <app-dropdown-item (action)="openDialog(ch)">Edit</app-dropdown-item>
+                  <app-dropdown-item (action)="testChannel(ch)">Send Test</app-dropdown-item>
+                  <app-dropdown-item (action)="deleteChannel(ch)" [destructive]="true">Delete</app-dropdown-item>
+                </app-dropdown-menu>
               </div>
             </div>
 
@@ -194,7 +190,17 @@ import { NotificationChannelDialogComponent } from './notification-channel-dialo
       color: #666;
     }
 
-    .delete-item { color: #c62828; }
+    .icon-btn {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 18px;
+      color: var(--text-tertiary);
+      padding: 4px 8px;
+      border-radius: var(--radius-sm);
+      line-height: 1;
+    }
+    .icon-btn:hover { background: var(--bg-hover); }
   `],
 })
 export class NotificationChannelsComponent implements OnInit {

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatMenuModule } from '@angular/material/menu';
 import {
   ExternalServiceService,
   ExternalService,
@@ -28,6 +27,8 @@ import {
   TabGroupComponent,
   DataTableComponent,
   DataTableColumnComponent,
+  DropdownMenuComponent,
+  DropdownItemComponent,
 } from '../../shared/components/index.js';
 
 @Component({
@@ -35,7 +36,6 @@ import {
   imports: [
     FormsModule,
     MatDialogModule,
-    MatMenuModule,
     BroncoButtonComponent,
     CardComponent,
     FormFieldComponent,
@@ -45,6 +45,8 @@ import {
     TabGroupComponent,
     DataTableComponent,
     DataTableColumnComponent,
+    DropdownMenuComponent,
+    DropdownItemComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -265,16 +267,16 @@ import {
                 </app-data-column>
                 <app-data-column key="actions" header="" [sortable]="false" width="60px">
                   <ng-template #cell let-svc>
-                    <app-bronco-button variant="icon" size="sm" [matMenuTriggerFor]="svcMenu" title="Actions">
+                    <app-bronco-button variant="icon" size="sm" title="Actions" #svcTrigger (click)="svcMenu.toggle()">
                       ...
                     </app-bronco-button>
-                    <mat-menu #svcMenu="matMenu">
-                      <button mat-menu-item (click)="editService(svc)">Edit</button>
-                      <button mat-menu-item (click)="toggleMonitored(svc)">
+                    <app-dropdown-menu #svcMenu [trigger]="svcTrigger">
+                      <app-dropdown-item (action)="editService(svc)">Edit</app-dropdown-item>
+                      <app-dropdown-item (action)="toggleMonitored(svc)">
                         {{ svc.isMonitored ? 'Disable Monitoring' : 'Enable Monitoring' }}
-                      </button>
-                      <button mat-menu-item (click)="deleteService(svc)" class="delete-action">Delete</button>
-                    </mat-menu>
+                      </app-dropdown-item>
+                      <app-dropdown-item (action)="deleteService(svc)" [destructive]="true">Delete</app-dropdown-item>
+                    </app-dropdown-menu>
                   </ng-template>
                 </app-data-column>
               </app-data-table>

--- a/services/control-panel/src/app/features/system-status/system-status.component.ts
+++ b/services/control-panel/src/app/features/system-status/system-status.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit, OnDestroy, signal, computed } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
 import type { Subscription } from 'rxjs';
 import {
@@ -13,13 +12,18 @@ import type { McpDiscoveryMetadata } from '../../core/services/integration.servi
 import { AiProviderService } from '../../core/services/ai-provider.service';
 import { NotificationChannelsComponent } from '../notification-channels/notification-channels.component';
 import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
+import {
+  DropdownMenuComponent,
+  DropdownItemComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
   imports: [
     RouterLink,
-    MatMenuModule,
     NotificationChannelsComponent,
+    DropdownMenuComponent,
+    DropdownItemComponent,
     McpServerInfoComponent,
   ],
   template: `
@@ -87,24 +91,18 @@ import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.
                   {{ comp.name }}
                 </div>
                 @if (comp.controllable) {
-                  <button type="button" class="btn-icon" [matMenuTriggerFor]="menu" [disabled]="controlling() === serviceKey(comp.name)" [attr.aria-label]="'Service controls for ' + comp.name" title="Service controls">
+                  <button type="button" class="btn-icon" [disabled]="controlling() === serviceKey(comp.name)" [attr.aria-label]="'Service controls for ' + comp.name" title="Service controls" #infraTrigger (click)="infraMenu.toggle()">
                     @if (controlling() === serviceKey(comp.name)) {
                       <span class="spinner-inline"></span>
                     } @else {
                       &#x22EE;
                     }
                   </button>
-                  <mat-menu #menu="matMenu">
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'restart')">
-                      &#x21bb; Restart
-                    </button>
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'stop')">
-                      &#x25A0; Stop
-                    </button>
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'start')">
-                      &#x25B6; Start
-                    </button>
-                  </mat-menu>
+                  <app-dropdown-menu #infraMenu [trigger]="infraTrigger">
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'restart')">&#x21bb; Restart</app-dropdown-item>
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'stop')">&#x25A0; Stop</app-dropdown-item>
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'start')">&#x25B6; Start</app-dropdown-item>
+                  </app-dropdown-menu>
                 }
               </div>
 
@@ -161,24 +159,18 @@ import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.
                   {{ comp.name }}
                 </div>
                 @if (comp.controllable) {
-                  <button type="button" class="btn-icon" [matMenuTriggerFor]="svcMenu" [disabled]="controlling() === serviceKey(comp.name)" [attr.aria-label]="'Service controls for ' + comp.name" title="Service controls">
+                  <button type="button" class="btn-icon" [disabled]="controlling() === serviceKey(comp.name)" [attr.aria-label]="'Service controls for ' + comp.name" title="Service controls" #svcTrigger (click)="svcDropdown.toggle()">
                     @if (controlling() === serviceKey(comp.name)) {
                       <span class="spinner-inline"></span>
                     } @else {
                       &#x22EE;
                     }
                   </button>
-                  <mat-menu #svcMenu="matMenu">
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'restart')">
-                      &#x21bb; Restart
-                    </button>
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'stop')">
-                      &#x25A0; Stop
-                    </button>
-                    <button mat-menu-item (click)="control(serviceKey(comp.name), 'start')">
-                      &#x25B6; Start
-                    </button>
-                  </mat-menu>
+                  <app-dropdown-menu #svcDropdown [trigger]="svcTrigger">
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'restart')">&#x21bb; Restart</app-dropdown-item>
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'stop')">&#x25A0; Stop</app-dropdown-item>
+                    <app-dropdown-item (action)="control(serviceKey(comp.name), 'start')">&#x25B6; Start</app-dropdown-item>
+                  </app-dropdown-menu>
                 }
               </div>
 

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -49,7 +49,7 @@ import {
                   <div class="user-name">{{ user.name }}</div>
                   <div class="user-email">{{ user.email }}</div>
                 </div>
-                <app-bronco-button variant="icon" size="sm" class="card-menu" title="Actions" #menuTrigger (click)="menu.toggle()">
+                <app-bronco-button variant="icon" size="sm" class="card-menu" [attr.aria-label]="'Actions for ' + user.name" #menuTrigger (click)="menu.toggle()">
                   ...
                 </app-bronco-button>
                 <app-dropdown-menu #menu [trigger]="menuTrigger">

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -1,7 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
-import { MatMenuModule } from '@angular/material/menu';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
@@ -11,6 +10,8 @@ import {
   BroncoButtonComponent,
   CardComponent,
   FormFieldComponent,
+  DropdownMenuComponent,
+  DropdownItemComponent,
 } from '../../shared/components/index.js';
 
 @Component({
@@ -18,11 +19,12 @@ import {
   imports: [
     FormsModule,
     DatePipe,
-    MatMenuModule,
     MatDialogModule,
     BroncoButtonComponent,
     CardComponent,
     FormFieldComponent,
+    DropdownMenuComponent,
+    DropdownItemComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -47,20 +49,20 @@ import {
                   <div class="user-name">{{ user.name }}</div>
                   <div class="user-email">{{ user.email }}</div>
                 </div>
-                <app-bronco-button variant="icon" size="sm" [matMenuTriggerFor]="menu" class="card-menu" title="Actions">
+                <app-bronco-button variant="icon" size="sm" class="card-menu" title="Actions" #menuTrigger (click)="menu.toggle()">
                   ...
                 </app-bronco-button>
-                <mat-menu #menu="matMenu">
-                  <button mat-menu-item (click)="openEdit(user)">Edit</button>
-                  <button mat-menu-item (click)="openResetPassword(user)">Reset Password</button>
+                <app-dropdown-menu #menu [trigger]="menuTrigger">
+                  <app-dropdown-item (action)="openEdit(user)">Edit</app-dropdown-item>
+                  <app-dropdown-item (action)="openResetPassword(user)">Reset Password</app-dropdown-item>
                   @if (user.id !== currentUserId()) {
                     @if (user.isActive) {
-                      <button mat-menu-item (click)="deactivate(user)">Deactivate</button>
+                      <app-dropdown-item (action)="deactivate(user)">Deactivate</app-dropdown-item>
                     } @else {
-                      <button mat-menu-item (click)="activate(user)">Activate</button>
+                      <app-dropdown-item (action)="activate(user)">Activate</app-dropdown-item>
                     }
                   }
-                </mat-menu>
+                </app-dropdown-menu>
               </div>
               <div class="user-details">
                 <div class="detail-row">

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -42,7 +42,8 @@ import { DataTableColumnComponent } from './data-table-column.component';
                 [class.clickable]="rowClickable()"
                 [attr.tabindex]="rowClickable() ? 0 : null"
                 (click)="rowClickable() ? rowClick.emit(row) : null"
-                (keydown.enter)="rowClickable() ? rowClick.emit(row) : null">
+                (keydown.enter)="rowClickable() ? rowClick.emit(row) : null"
+                (keydown.space)="rowClickable() ? onRowSpace($event, row) : null">
                 @for (col of columns(); track col.key()) {
                   <td [style.width]="col.width()">
                     <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
@@ -148,5 +149,10 @@ export class DataTableComponent<T = unknown> {
   onSortKey(event: Event, key: string): void {
     event.preventDefault();
     this.onSort(key);
+  }
+
+  onRowSpace(event: Event, row: T): void {
+    event.preventDefault();
+    this.rowClick.emit(row);
   }
 }

--- a/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
+++ b/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
@@ -6,6 +6,7 @@ import {
   signal,
   ElementRef,
   inject,
+  forwardRef,
   OnDestroy,
   HostListener,
   ChangeDetectionStrategy,
@@ -102,9 +103,11 @@ export class DropdownItemComponent {
   @Input() destructive = false;
   @Output() action = new EventEmitter<void>();
 
-  onClick(event: Event): void {
-    event.stopPropagation();
+  private menu = inject(forwardRef(() => DropdownMenuComponent), { optional: true });
+
+  onClick(_event: Event): void {
     this.action.emit();
+    this.menu?.close();
   }
 }
 

--- a/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
+++ b/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
@@ -1,0 +1,227 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  signal,
+  ElementRef,
+  inject,
+  OnDestroy,
+  HostListener,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+
+/* ── Dropdown Divider ─────────────────────────────────────── */
+
+@Component({
+  standalone: true,
+  selector: 'app-dropdown-divider',
+  template: `<div class="divider"></div>`,
+  styles: [`
+    .divider {
+      height: 1px;
+      background: var(--border-light);
+      margin: 4px 0;
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DropdownDividerComponent {}
+
+/* ── Dropdown Label (section header) ──────────────────────── */
+
+@Component({
+  standalone: true,
+  selector: 'app-dropdown-label',
+  template: `<div class="label"><ng-content /></div>`,
+  styles: [`
+    .label {
+      padding: 6px 12px 2px;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      font-family: var(--font-primary);
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DropdownLabelComponent {}
+
+/* ── Dropdown Item ────────────────────────────────────────── */
+
+@Component({
+  standalone: true,
+  selector: 'app-dropdown-item',
+  template: `
+    <button
+      type="button"
+      class="dropdown-item"
+      [class.destructive]="destructive"
+      [class.disabled]="disabled"
+      [disabled]="disabled"
+      (click)="onClick($event)">
+      <ng-content />
+    </button>
+  `,
+  styles: [`
+    :host { display: block; }
+    .dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      height: 32px;
+      padding: 0 12px;
+      border: none;
+      background: none;
+      font-family: var(--font-primary);
+      font-size: 13px;
+      color: var(--text-secondary);
+      cursor: pointer;
+      text-align: left;
+      white-space: nowrap;
+      transition: background 80ms ease;
+    }
+    .dropdown-item:hover:not(:disabled) {
+      background: var(--bg-hover);
+    }
+    .dropdown-item.destructive {
+      color: var(--color-error);
+    }
+    .dropdown-item.disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DropdownItemComponent {
+  @Input() disabled = false;
+  @Input() destructive = false;
+  @Output() action = new EventEmitter<void>();
+
+  onClick(event: Event): void {
+    event.stopPropagation();
+    this.action.emit();
+  }
+}
+
+/* ── Dropdown Menu (container) ────────────────────────────── */
+
+@Component({
+  standalone: true,
+  selector: 'app-dropdown-menu',
+  template: `
+    @if (isOpen()) {
+      <div class="dropdown-backdrop" (click)="close()"></div>
+      <div class="dropdown-panel" [style.top.px]="posY()" [style.left.px]="posX()" (click)="close()">
+        <ng-content />
+      </div>
+    }
+  `,
+  styles: [`
+    .dropdown-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 999;
+    }
+    .dropdown-panel {
+      position: fixed;
+      z-index: 1000;
+      min-width: 160px;
+      padding: 4px 0;
+      background: var(--bg-card);
+      border: 1px solid var(--border-light);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-card), 0 4px 24px rgba(0, 0, 0, 0.08);
+      animation: dropdownIn 120ms ease;
+      transform-origin: top right;
+    }
+
+    @keyframes dropdownIn {
+      from {
+        opacity: 0;
+        transform: scale(0.95);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DropdownMenuComponent implements OnDestroy {
+  private el = inject(ElementRef);
+
+  // Accepts HTMLElement, ElementRef, or a component instance (resolves nativeElement from host)
+  @Input() trigger!: unknown;
+
+  isOpen = signal(false);
+  posX = signal(0);
+  posY = signal(0);
+
+  toggle(): void {
+    if (this.isOpen()) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  private resolveTriggerElement(): HTMLElement | null {
+    const t = this.trigger;
+    if (t instanceof HTMLElement) return t;
+    if (t instanceof ElementRef) return t.nativeElement;
+    // Angular component ref — walk up to find the host element
+    if (t && typeof t === 'object' && 'nativeElement' in (t as object)) {
+      return (t as ElementRef).nativeElement;
+    }
+    return null;
+  }
+
+  open(): void {
+    const triggerEl = this.resolveTriggerElement();
+
+    if (!triggerEl) return;
+
+    const rect: DOMRect = triggerEl.getBoundingClientRect();
+    const menuWidth = 180; // approximate, will adjust after render
+    const viewportWidth = window.innerWidth;
+
+    // Position below trigger, right-aligned by default
+    let x = rect.right - menuWidth;
+    const y = rect.bottom + 4;
+
+    // If would overflow left, flip to left-aligned
+    if (x < 8) {
+      x = rect.left;
+    }
+
+    // If would overflow right, clamp
+    if (x + menuWidth > viewportWidth - 8) {
+      x = viewportWidth - menuWidth - 8;
+    }
+
+    this.posX.set(x);
+    this.posY.set(y);
+    this.isOpen.set(true);
+  }
+
+  close(): void {
+    this.isOpen.set(false);
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.isOpen()) {
+      this.close();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.isOpen.set(false);
+  }
+}

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -15,3 +15,9 @@ export { TabComponent } from './tab.component';
 export { TabGroupComponent } from './tab-group.component';
 export { DialogComponent } from './dialog.component';
 export { ToolbarComponent } from './toolbar.component';
+export {
+  DropdownMenuComponent,
+  DropdownItemComponent,
+  DropdownDividerComponent,
+  DropdownLabelComponent,
+} from './dropdown-menu.component';

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -10,7 +10,7 @@ import { Component, input, output } from '@angular/core';
       [disabled]="disabled()"
       (change)="onChange($event)">
       @if (placeholder()) {
-        <option value="" disabled selected>{{ placeholder() }}</option>
+        <option value="" disabled>{{ placeholder() }}</option>
       }
       @for (opt of options(); track opt.value) {
         <option [value]="opt.value">{{ opt.label }}</option>

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterOutlet, ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { SidebarComponent } from './sidebar.component';
 import { HeaderBarComponent } from './header-bar.component';
@@ -78,6 +79,7 @@ export class AppShellComponent implements OnInit {
   private readonly theme = inject(ThemeService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
   readonly pageTitle = signal('Dashboard');
 
   ngOnInit(): void {
@@ -89,7 +91,7 @@ export class AppShellComponent implements OnInit {
       mode: params['mode'],
     });
     this.updateTitle();
-    this.router.events.subscribe(event => {
+    this.router.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(event => {
       if (event instanceof NavigationEnd) this.updateTitle();
     });
   }


### PR DESCRIPTION
## Summary
- Add `DropdownMenuComponent` to the shared component library — a custom context menu replacing Material's MatMenu
- Replace MatMenu/MatMenuTrigger usage in email-logs, notification-channels, settings, system-status, and user-list components
- Export from shared components index

## Test plan
- [ ] Email logs — verify action menu (retry, reclassify) opens and functions correctly
- [ ] Notification channels — verify channel action menu works
- [ ] Settings — verify any context menus in settings render properly
- [ ] System status — verify service action menus work
- [ ] Users — verify user card action menus (edit, reset password, activate/deactivate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
