### PR TITLE
Add custom toast service and replace MatSnackBar across all components (#131)

### DIFF
--- a/services/control-panel/src/app/core/services/toast.service.ts
+++ b/services/control-panel/src/app/core/services/toast.service.ts
@@ -16,6 +16,13 @@ const DEFAULT_DURATIONS: Record<Toast['type'], number> = {
 
 const MAX_VISIBLE = 3;
 
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
 @Injectable({ providedIn: 'root' })
 export class ToastService {
   readonly toasts = signal<Toast[]>([]);
@@ -42,7 +49,7 @@ export class ToastService {
 
   private add(message: string, type: Toast['type'], duration?: number): void {
     const toast: Toast = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       message,
       type,
       duration: duration ?? DEFAULT_DURATIONS[type],

--- a/services/control-panel/src/app/core/services/toast.service.ts
+++ b/services/control-panel/src/app/core/services/toast.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: 'success' | 'error' | 'warning' | 'info';
+  duration: number;
+}
+
+const DEFAULT_DURATIONS: Record<Toast['type'], number> = {
+  success: 3000,
+  error: 5000,
+  warning: 8000,
+  info: 3000,
+};
+
+const MAX_VISIBLE = 3;
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  readonly toasts = signal<Toast[]>([]);
+
+  success(message: string, duration?: number): void {
+    this.add(message, 'success', duration);
+  }
+
+  error(message: string, duration?: number): void {
+    this.add(message, 'error', duration);
+  }
+
+  warning(message: string, duration?: number): void {
+    this.add(message, 'warning', duration);
+  }
+
+  info(message: string, duration?: number): void {
+    this.add(message, 'info', duration);
+  }
+
+  dismiss(id: string): void {
+    this.toasts.update(list => list.filter(t => t.id !== id));
+  }
+
+  private add(message: string, type: Toast['type'], duration?: number): void {
+    const toast: Toast = {
+      id: crypto.randomUUID(),
+      message,
+      type,
+      duration: duration ?? DEFAULT_DURATIONS[type],
+    };
+
+    this.toasts.update(list => {
+      const next = [...list, toast];
+      while (next.length > MAX_VISIBLE) {
+        next.shift();
+      }
+      return next;
+    });
+
+    setTimeout(() => this.dismiss(toast.id), toast.duration);
+  }
+}

--- a/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
+++ b/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
@@ -3,9 +3,9 @@ import { NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatPaginatorModule, type PageEvent } from '@angular/material/paginator';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { LogSummaryService, type LogSummary, type LogSummaryType, type AttentionLevel } from '../../core/services/log-summary.service';
 import { BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 const TYPE_META: Record<LogSummaryType, { label: string; color: string }> = {
   TICKET: { label: 'Ticket', color: 'var(--accent)' },
@@ -21,7 +21,6 @@ const TYPE_META: Record<LogSummaryType, { label: string; color: string }> = {
     FormsModule,
     RouterLink,
     MatPaginatorModule,
-    MatSnackBarModule,
     BroncoButtonComponent,
     SelectComponent,
   ],
@@ -178,7 +177,7 @@ const TYPE_META: Record<LogSummaryType, { label: string; color: string }> = {
 })
 export class ActivityFeedComponent implements OnInit, OnDestroy {
   private logSummaryService = inject(LogSummaryService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private refreshInterval: ReturnType<typeof setInterval> | null = null;
 
   summaries = signal<LogSummary[]>([]);
@@ -244,12 +243,12 @@ export class ActivityFeedComponent implements OnInit, OnDestroy {
           result.uncategorizedSummaries && `${result.uncategorizedSummaries} uncategorized`,
         ].filter(Boolean);
         const msg = parts.length > 0 ? `Created ${parts.join(' + ')} summaries` : 'No new summaries to create';
-        this.snackBar.open(msg, 'OK', { duration: 5000 });
+        this.toast.info(msg);
         this.load();
       },
       error: () => {
         this.generating.set(false);
-        this.snackBar.open('Failed to generate summaries', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to generate summaries');
       },
     });
   }

--- a/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
+++ b/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiProviderService, AiProvider, AiProviderModel } from '../../core/services/ai-provider.service';
 import { AiProviderDialogComponent } from '../prompts/ai-provider-dialog.component';
 import { AiModelDialogComponent } from '../prompts/ai-model-dialog.component';
@@ -11,6 +10,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -282,7 +282,7 @@ import {
 export class AiProvidersComponent implements OnInit {
   private aiProviderService = inject(AiProviderService);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   providers = signal<AiProvider[]>([]);
   models = signal<AiProviderModel[]>([]);
@@ -329,24 +329,24 @@ export class AiProvidersComponent implements OnInit {
   toggleProviderActive(config: AiProvider): void {
     this.aiProviderService.updateProvider(config.id, { isActive: !config.isActive }).subscribe({
       next: () => {
-        this.snackBar.open(`Provider ${config.isActive ? 'deactivated' : 'activated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Provider ${config.isActive ? 'deactivated' : 'activated'}`);
         this.loadAll();
       },
-      error: () => this.snackBar.open('Failed to update provider', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update provider'),
     });
   }
 
   testProvider(config: AiProvider): void {
-    this.snackBar.open('Testing connection...', '', { duration: 10000 });
+    this.toast.info('Testing connection...');
     this.aiProviderService.testConnection(config.id).subscribe({
       next: (result) => {
         if (result.success) {
-          this.snackBar.open(result.note ?? 'Connection successful', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+          this.toast.success(result.note ?? 'Connection successful');
         } else {
-          this.snackBar.open(result.error ?? 'Connection failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(result.error ?? 'Connection failed');
         }
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? 'Test failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? 'Test failed'),
     });
   }
 
@@ -354,8 +354,8 @@ export class AiProvidersComponent implements OnInit {
     const modelWarning = config.modelCount > 0 ? ` This will also delete ${config.modelCount} model(s).` : '';
     if (!confirm(`Delete provider "${config.provider}"?${modelWarning}`)) return;
     this.aiProviderService.deleteProvider(config.id).subscribe({
-      next: () => { this.snackBar.open('Provider deleted', 'OK', { duration: 3000 }); this.loadAll(); },
-      error: () => this.snackBar.open('Failed to delete provider', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: () => { this.toast.success('Provider deleted'); this.loadAll(); },
+      error: () => this.toast.error('Failed to delete provider'),
     });
   }
 
@@ -374,18 +374,18 @@ export class AiProvidersComponent implements OnInit {
   toggleModelActive(model: AiProviderModel): void {
     this.aiProviderService.updateModel(model.id, { isActive: !model.isActive }).subscribe({
       next: () => {
-        this.snackBar.open(`Model ${model.isActive ? 'deactivated' : 'activated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Model ${model.isActive ? 'deactivated' : 'activated'}`);
         this.loadAll();
       },
-      error: () => this.snackBar.open('Failed to update model', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update model'),
     });
   }
 
   deleteModel(model: AiProviderModel): void {
     if (!confirm(`Delete model "${model.name}"?`)) return;
     this.aiProviderService.deleteModel(model.id).subscribe({
-      next: () => { this.snackBar.open('Model deleted', 'OK', { duration: 3000 }); this.loadAll(); },
-      error: () => this.snackBar.open('Failed to delete model', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: () => { this.toast.success('Model deleted'); this.loadAll(); },
+      error: () => this.toast.error('Failed to delete model'),
     });
   }
 }

--- a/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject, debounceTime } from 'rxjs';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import {
@@ -19,6 +18,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DatePreset {
   label: string;
@@ -874,7 +874,7 @@ const DATE_PRESETS: DatePreset[] = [
 })
 export class AiUsageComponent implements OnInit {
   private aiUsageService = inject(AiUsageService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
@@ -1019,12 +1019,12 @@ export class AiUsageComponent implements OnInit {
       next: (res) => {
         this.loading.set(false);
         const msg = `Updated ${res.updated} models` + (res.skipped ? `, skipped ${res.skipped} custom` : '');
-        this.snackBar.open(msg, 'OK', { duration: 4000 });
+        this.toast.info(msg);
         this.loadCosts();
       },
       error: (err) => {
         this.loading.set(false);
-        this.snackBar.open(err.error?.error ?? 'Failed to refresh costs', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? 'Failed to refresh costs');
       },
     });
   }
@@ -1042,15 +1042,15 @@ export class AiUsageComponent implements OnInit {
   deleteModel(cost: AiModelCost): void {
     if (!confirm(`Delete cost entry for ${cost.provider}/${cost.model}?`)) return;
     this.aiUsageService.deleteCost(cost.id).subscribe({
-      next: () => { this.snackBar.open('Deleted', 'OK', { duration: 3000 }); this.loadCosts(); },
-      error: () => this.snackBar.open('Failed to delete', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: () => { this.toast.success('Deleted'); this.loadCosts(); },
+      error: () => this.toast.error('Failed to delete'),
     });
   }
 
   clearCustomCost(cost: AiModelCost): void {
     this.aiUsageService.clearCustomCost(cost.id).subscribe({
-      next: () => { this.snackBar.open('Custom cost cleared', 'OK', { duration: 3000 }); this.loadCosts(); },
-      error: () => this.snackBar.open('Failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: () => { this.toast.success('Custom cost cleared'); this.loadCosts(); },
+      error: () => this.toast.error('Failed'),
     });
   }
 
@@ -1108,13 +1108,13 @@ export class AiUsageComponent implements OnInit {
     this.aiUsageService.refreshLogCosts().subscribe({
       next: (res) => {
         this.logLoading.set(false);
-        this.snackBar.open(`Refreshed costs: ${res.updated} of ${res.total} entries updated`, 'OK', { duration: 4000 });
+        this.toast.success(`Refreshed costs: ${res.updated} of ${res.total} entries updated`);
         this.loadLogs();
         this.loadSummary();
       },
       error: () => {
         this.logLoading.set(false);
-        this.snackBar.open('Failed to refresh log costs', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to refresh log costs');
       },
     });
   }
@@ -1166,12 +1166,12 @@ export class AiUsageComponent implements OnInit {
     this.aiUsageService.deleteLogs(body).subscribe({
       next: (res) => {
         this.logLoading.set(false);
-        this.snackBar.open(`Deleted ${res.deleted} log entries`, 'OK', { duration: 4000 });
+        this.toast.success(`Deleted ${res.deleted} log entries`);
         this.resetAndLoadLogs();
       },
       error: () => {
         this.logLoading.set(false);
-        this.snackBar.open('Failed to delete logs', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to delete logs');
       },
     });
   }
@@ -1244,7 +1244,7 @@ export class AiUsageComponent implements OnInit {
         const nextIds = new Set(this.expandedLogIds());
         nextIds.delete(requestedId);
         this.expandedLogIds.set(nextIds);
-        this.snackBar.open('Failed to load log detail', 'OK', { duration: 4000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to load log detail');
       },
     });
   }

--- a/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
@@ -6,8 +6,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiUsageService, AiModelCost } from '../../core/services/ai-usage.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -61,7 +61,7 @@ export class ModelCostDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ModelCostDialogComponent>);
   private data = inject<{ cost?: AiModelCost }>(MAT_DIALOG_DATA);
   private aiUsageService = inject(AiUsageService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.cost;
   provider = this.data.cost?.provider ?? '';
@@ -97,10 +97,10 @@ export class ModelCostDialogComponent implements OnInit {
       isCustomCost: this.isCustomCost,
     }).subscribe({
       next: () => {
-        this.snackBar.open(this.isEdit ? 'Cost updated' : 'Model cost added', 'OK', { duration: 3000 });
+        this.toast.success(this.isEdit ? 'Cost updated' : 'Model cost added');
         this.dialogRef.close(true);
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to save', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? 'Failed to save'),
     });
   }
 }

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -9,7 +9,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ClientService, Client, System, Contact } from '../../core/services/client.service';
@@ -39,6 +38,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { AiUsageService, type AiUsageClientSummary, type AiUsageLogEntry } from '../../core/services/ai-usage.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -703,7 +703,7 @@ export class ClientDetailComponent implements OnInit {
   private aiUsageService = inject(AiUsageService);
   private destroyRef = inject(DestroyRef);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
@@ -832,9 +832,9 @@ export class ClientDetailComponent implements OnInit {
       next: (updated) => {
         this.client.set({ ...c, slackChannelId: updated.slackChannelId });
         this.pendingSlackChannelId = undefined;
-        this.snackBar.open('Slack Channel ID saved', 'OK', { duration: 3000 });
+        this.toast.success('Slack Channel ID saved');
       },
-      error: () => this.snackBar.open('Failed to save Slack Channel ID', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to save Slack Channel ID'),
     });
   }
 
@@ -856,10 +856,10 @@ export class ClientDetailComponent implements OnInit {
   deleteContact(id: string): void {
     this.contactService.deleteContact(id).subscribe({
       next: () => {
-        this.snackBar.open('Contact deleted', 'OK', { duration: 3000 });
+        this.toast.success('Contact deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
     });
   }
 
@@ -877,11 +877,11 @@ export class ClientDetailComponent implements OnInit {
     if (!confirm(`Delete repo "${repo.name}"?`)) return;
     this.repoService.deleteRepo(repo.id).subscribe({
       next: () => {
-        this.snackBar.open('Repository deleted', 'OK', { duration: 3000 });
+        this.toast.success('Repository deleted');
         this.load();
       },
       error: (err) => {
-        this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed');
       },
     });
   }
@@ -901,12 +901,12 @@ export class ClientDetailComponent implements OnInit {
     this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: checked } : i));
     this.integrationService.updateIntegration(integ.id, { isActive: checked }).subscribe({
       next: () => {
-        this.snackBar.open(`Integration ${checked ? 'enabled' : 'disabled'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Integration ${checked ? 'enabled' : 'disabled'}`);
       },
       error: (err) => {
         // Revert optimistic update and reload authoritative state
         this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: !checked } : i));
-        this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Toggle failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
         this.load();
       },
     });
@@ -920,10 +920,10 @@ export class ClientDetailComponent implements OnInit {
   deleteIntegration(id: string): void {
     this.integrationService.deleteIntegration(id).subscribe({
       next: () => {
-        this.snackBar.open('Integration deleted', 'OK', { duration: 3000 });
+        this.toast.success('Integration deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
     });
   }
 
@@ -950,11 +950,11 @@ export class ClientDetailComponent implements OnInit {
     this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: checked } : m));
     this.filterMemories();
     this.memoryService.updateMemory(mem.id, { isActive: checked }).subscribe({
-      next: () => this.snackBar.open(`Memory ${checked ? 'enabled' : 'disabled'}`, 'OK', { duration: 3000 }),
+      next: () => this.toast.success(`Memory ${checked ? 'enabled' : 'disabled'}`),
       error: (err) => {
         this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: !checked } : m));
         this.filterMemories();
-        this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Toggle failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
       },
     });
   }
@@ -962,10 +962,10 @@ export class ClientDetailComponent implements OnInit {
   deleteMemory(id: string): void {
     this.memoryService.deleteMemory(id).subscribe({
       next: () => {
-        this.snackBar.open('Memory entry deleted', 'OK', { duration: 3000 });
+        this.toast.success('Memory entry deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
     });
   }
 
@@ -982,10 +982,10 @@ export class ClientDetailComponent implements OnInit {
   toggleEnvironment(env: ClientEnvironment, checked: boolean): void {
     this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: checked } : e));
     this.envService.updateEnvironment(this.id(), env.id, { isActive: checked }).subscribe({
-      next: () => this.snackBar.open(`Environment ${checked ? 'enabled' : 'disabled'}`, 'OK', { duration: 3000 }),
+      next: () => this.toast.success(`Environment ${checked ? 'enabled' : 'disabled'}`),
       error: (err) => {
         this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: !checked } : e));
-        this.snackBar.open(err.error?.error ?? err.error?.message ?? 'Toggle failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? err.error?.message ?? 'Toggle failed');
       },
     });
   }
@@ -994,10 +994,10 @@ export class ClientDetailComponent implements OnInit {
     if (!confirm(`Delete environment "${env.name}"? Linked integrations, repos, and systems will be unlinked.`)) return;
     this.envService.deleteEnvironment(this.id(), env.id).subscribe({
       next: () => {
-        this.snackBar.open('Environment deleted', 'OK', { duration: 3000 });
+        this.toast.success('Environment deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? err.error?.message ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.error ?? err.error?.message ?? 'Delete failed'),
     });
   }
 
@@ -1048,10 +1048,10 @@ export class ClientDetailComponent implements OnInit {
   deleteClientUser(id: string): void {
     this.clientUserService.deleteUser(id).subscribe({
       next: () => {
-        this.snackBar.open('User deactivated', 'OK', { duration: 3000 });
+        this.toast.success('User deactivated');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Deactivation failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Deactivation failed'),
     });
   }
 
@@ -1068,17 +1068,17 @@ export class ClientDetailComponent implements OnInit {
     if (!confirm(`Delete invoice #${inv.invoiceNumber}?`)) return;
     this.invoiceService.deleteInvoice(this.id(), inv.id).subscribe({
       next: () => {
-        this.snackBar.open('Invoice deleted', 'OK', { duration: 3000 });
+        this.toast.success('Invoice deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
     });
   }
 
   setAiMode(c: Client, mode: string): void {
     this.clientService.updateClient(c.id, { aiMode: mode } as Partial<Client>).subscribe(updated => {
       this.client.set({ ...c, aiMode: updated.aiMode });
-      this.snackBar.open(`AI mode set to ${mode}`, 'OK', { duration: 3000 });
+      this.toast.info(`AI mode set to ${mode}`);
     });
   }
 
@@ -1093,29 +1093,29 @@ export class ClientDetailComponent implements OnInit {
         this.newCredProvider = '';
         this.newCredLabel = '';
         this.newCredApiKey = '';
-        this.snackBar.open('Credential added', 'OK', { duration: 3000 });
+        this.toast.success('Credential added');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Failed to add credential', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Failed to add credential'),
     });
   }
 
   toggleCredential(cred: ClientAiCredential, checked: boolean): void {
     this.aiCredentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: checked } : c));
     this.credentialService.updateCredential(this.id(), cred.id, { isActive: checked }).subscribe({
-      next: () => this.snackBar.open(`Credential ${checked ? 'enabled' : 'disabled'}`, 'OK', { duration: 3000 }),
+      next: () => this.toast.success(`Credential ${checked ? 'enabled' : 'disabled'}`),
       error: (err) => {
         this.aiCredentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: !checked } : c));
-        this.snackBar.open(err.error?.error ?? 'Toggle failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? 'Toggle failed');
       },
     });
   }
 
   testCredential(cred: ClientAiCredential): void {
-    this.snackBar.open('Testing credential...', '', { duration: 10000 });
+    this.toast.info('Testing credential...');
     this.credentialService.testCredential(this.id(), cred.id).subscribe({
-      next: (result) => this.snackBar.open(result.ok ? 'Credential is valid' : `Test failed: ${result.error}`, 'OK', { duration: 5000 }),
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Test failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: (result) => result.ok ? this.toast.success('Credential is valid') : this.toast.error(`Test failed: ${result.error}`),
+      error: (err) => this.toast.error(err.error?.error ?? 'Test failed'),
     });
   }
 
@@ -1123,10 +1123,10 @@ export class ClientDetailComponent implements OnInit {
     if (!confirm(`Delete credential "${cred.label}"?`)) return;
     this.credentialService.deleteCredential(this.id(), cred.id).subscribe({
       next: () => {
-        this.snackBar.open('Credential deleted', 'OK', { duration: 3000 });
+        this.toast.success('Credential deleted');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Delete failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Delete failed'),
     });
   }
 }

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -314,8 +314,8 @@ import { ToastService } from '../../core/services/toast.service';
                     <mat-icon>{{ memoryTypeIcon(mem.memoryType) }}</mat-icon>
                     <strong>{{ mem.title }}</strong>
                     <span class="type-chip type-{{ mem.memoryType.toLowerCase() }}">{{ mem.memoryType }}</span>
-                    <span class="source-badge source-{{ mem.source.toLowerCase() }}">
-                      {{ mem.source === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
+                    <span class="source-badge source-{{ (mem.source ?? 'MANUAL').toLowerCase() }}">
+                      {{ (mem.source ?? 'MANUAL') === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
                     </span>
                     @if (mem.category) {
                       <span class="category-chip">{{ mem.category }}</span>

--- a/services/control-panel/src/app/features/clients/client-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-dialog.component.ts
@@ -4,8 +4,8 @@ import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ClientService } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -41,7 +41,7 @@ import { ClientService } from '../../core/services/client.service';
 export class ClientDialogComponent {
   private dialogRef = inject(MatDialogRef<ClientDialogComponent>);
   private clientService = inject(ClientService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   name = '';
   shortCode = '';
@@ -59,11 +59,11 @@ export class ClientDialogComponent {
       notes: this.notes || undefined,
     }).subscribe({
       next: () => {
-        this.snackBar.open('Client created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Client created');
         this.dialogRef.close(true);
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to create client', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? 'Failed to create client');
       },
     });
   }

--- a/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -63,7 +63,7 @@ export class ClientEnvironmentDialogComponent {
   private dialogRef = inject(MatDialogRef<ClientEnvironmentDialogComponent>);
   data = inject<{ clientId: string; environment?: ClientEnvironment }>(MAT_DIALOG_DATA);
   private envService = inject(ClientEnvironmentService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   name = this.data.environment?.name ?? '';
   tag = this.data.environment?.tag ?? '';
@@ -90,12 +90,12 @@ export class ClientEnvironmentDialogComponent {
 
     op.subscribe({
       next: (result) => {
-        this.snackBar.open(`Environment ${this.data.environment ? 'updated' : 'created'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Environment ${this.data.environment ? 'updated' : 'created'}`);
         this.dialogRef.close(result);
       },
       error: (err) => {
         this.saving = false;
-        this.snackBar.open(err.error?.error ?? err.error?.message ?? 'Save failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? err.error?.message ?? 'Save failed');
       },
     });
   }

--- a/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ClientMemoryService, type ClientMemory, MEMORY_TYPE_OPTIONS, CATEGORY_OPTIONS } from '../../core/services/client-memory.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -71,7 +71,7 @@ export class ClientMemoryDialogComponent {
   private dialogRef = inject(MatDialogRef<ClientMemoryDialogComponent>);
   data = inject<{ clientId: string; memory?: ClientMemory }>(MAT_DIALOG_DATA);
   private memoryService = inject(ClientMemoryService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   memoryTypes = MEMORY_TYPE_OPTIONS;
   categories = CATEGORY_OPTIONS;
@@ -102,12 +102,12 @@ export class ClientMemoryDialogComponent {
 
     op.subscribe({
       next: (result) => {
-        this.snackBar.open(`Memory ${this.data.memory ? 'updated' : 'created'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Memory ${this.data.memory ? 'updated' : 'created'}`);
         this.dialogRef.close(result);
       },
       error: (err) => {
         this.saving = false;
-        this.snackBar.open(err.error?.message ?? 'Save failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? 'Save failed');
       },
     });
   }

--- a/services/control-panel/src/app/features/clients/client-user-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-user-dialog.component.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   clientId: string;
@@ -58,7 +58,7 @@ export class ClientUserDialogComponent {
   private dialogRef = inject(MatDialogRef<ClientUserDialogComponent>);
   data = inject<DialogData>(MAT_DIALOG_DATA);
   private clientUserService = inject(ClientUserService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   name = this.data.user?.name ?? '';
   email = this.data.user?.email ?? '';
@@ -75,10 +75,10 @@ export class ClientUserDialogComponent {
         isActive: this.isActive,
       }).subscribe({
         next: () => {
-          this.snackBar.open('User updated', 'OK', { duration: 3000 });
+          this.toast.success('User updated');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Update failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Update failed'),
       });
     } else {
       this.clientUserService.createUser({
@@ -89,10 +89,10 @@ export class ClientUserDialogComponent {
         userType: this.userType,
       }).subscribe({
         next: () => {
-          this.snackBar.open('User created', 'OK', { duration: 3000 });
+          this.toast.success('User created');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Create failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Create failed'),
       });
     }
   }

--- a/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { InvoiceService } from '../../core/services/invoice.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -37,7 +37,7 @@ export class GenerateInvoiceDialogComponent {
   private dialogRef = inject(MatDialogRef<GenerateInvoiceDialogComponent>);
   private data: { clientId: string } = inject(MAT_DIALOG_DATA);
   private invoiceService = inject(InvoiceService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   periodStart = '';
   periodEnd = '';
@@ -52,12 +52,12 @@ export class GenerateInvoiceDialogComponent {
       finalize: this.finalize,
     }).subscribe({
       next: () => {
-        this.snackBar.open('Invoice generated', 'OK', { duration: 3000 });
+        this.toast.info('Invoice generated');
         this.dialogRef.close(true);
       },
       error: (err) => {
         this.generating = false;
-        this.snackBar.open(err.error?.error ?? 'Generation failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.error ?? 'Generation failed');
       },
     });
   }

--- a/services/control-panel/src/app/features/contacts/contact-dialog.component.ts
+++ b/services/control-panel/src/app/features/contacts/contact-dialog.component.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ContactService } from '../../core/services/contact.service';
 import { Contact } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 export interface ContactDialogData {
   clientId: string;
@@ -54,7 +54,7 @@ export class ContactDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ContactDialogComponent>);
   private data: ContactDialogData = inject(MAT_DIALOG_DATA);
   private contactService = inject(ContactService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = false;
   form = { name: '', email: '', phone: '', role: '', slackUserId: '', isPrimary: false };
@@ -84,10 +84,10 @@ export class ContactDialogComponent implements OnInit {
         isPrimary: this.form.isPrimary,
       }).subscribe({
         next: () => {
-          this.snackBar.open('Contact updated', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+          this.toast.success('Contact updated');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.error ?? 'Update failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.error ?? 'Update failed'),
       });
     } else {
       this.contactService.createContact({
@@ -100,10 +100,10 @@ export class ContactDialogComponent implements OnInit {
         isPrimary: this.form.isPrimary,
       }).subscribe({
         next: () => {
-          this.snackBar.open('Contact created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+          this.toast.success('Contact created');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.error ?? 'Failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
       });
     }
   }

--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Subject, EMPTY, switchMap, timer } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
 import { EmailLogService, EmailProcessingLog, EmailLogStats } from '../../core/services/email-log.service';
@@ -15,6 +14,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -322,7 +322,7 @@ import {
 })
 export class EmailLogComponent implements OnInit, OnDestroy {
   private emailLogService = inject(EmailLogService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private destroy$ = new Subject<void>();
 
   logs = signal<EmailProcessingLog[]>([]);
@@ -379,7 +379,7 @@ export class EmailLogComponent implements OnInit, OnDestroy {
       .getLogs(this.buildFilters())
       .pipe(
         catchError(() => {
-          this.snackBar.open('Failed to load email logs. Please try again.', 'Dismiss', { duration: 5000 });
+          this.toast.error('Failed to load email logs. Please try again.');
           return EMPTY;
         }),
       )
@@ -395,7 +395,7 @@ export class EmailLogComponent implements OnInit, OnDestroy {
       .getStats()
       .pipe(
         catchError(() => {
-          this.snackBar.open('Failed to load email log stats. Please try again.', 'Dismiss', { duration: 5000 });
+          this.toast.error('Failed to load email log stats. Please try again.');
           return EMPTY;
         }),
       )
@@ -420,20 +420,20 @@ export class EmailLogComponent implements OnInit, OnDestroy {
   retryEmail(log: EmailProcessingLog): void {
     this.emailLogService.retry(log.id).subscribe({
       next: (res) => {
-        this.snackBar.open(res.message, 'OK', { duration: 4000 });
+        this.toast.info(res.message);
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Retry failed', 'OK', { duration: 4000 }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Retry failed'),
     });
   }
 
   reclassify(log: EmailProcessingLog, classification: string): void {
     this.emailLogService.reclassify(log.id, classification).subscribe({
       next: () => {
-        this.snackBar.open('Classification updated', 'OK', { duration: 3000 });
+        this.toast.success('Classification updated');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Update failed', 'OK', { duration: 4000 }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Update failed'),
     });
   }
 

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -1,10 +1,10 @@
 import { Component, inject, OnInit, OnDestroy, signal, computed } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import type { Subscription } from 'rxjs';
 import { FailedJobsService, FailedJob } from '../../core/services/failed-jobs.service';
 import { SystemStatusService, QueueStats } from '../../core/services/system-status.service';
 import { BroncoButtonComponent, ToolbarComponent, SelectComponent, CardComponent } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 const ALL_QUEUES = [
   'issue-resolve', 'log-summarize', 'email-ingestion', 'ticket-analysis',
@@ -277,7 +277,7 @@ const ALL_QUEUES = [
 export class FailedJobListComponent implements OnInit, OnDestroy {
   private failedJobsService = inject(FailedJobsService);
   private statusService = inject(SystemStatusService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private refreshInterval: ReturnType<typeof setInterval> | null = null;
   private sub: Subscription | undefined;
@@ -347,7 +347,7 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
       },
       error: () => {
         this.loading.set(false);
-        this.snackBar.open('Failed to load failed jobs', 'Dismiss', { duration: 4000 });
+        this.toast.error('Failed to load failed jobs');
       },
     });
 
@@ -372,7 +372,7 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
       },
       error: () => {
         this.loading.set(false);
-        this.snackBar.open('Failed to load more jobs', 'Dismiss', { duration: 4000 });
+        this.toast.error('Failed to load more jobs');
       },
     });
   }
@@ -382,12 +382,12 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
     this.failedJobsService.retry(job.queue, job.id).subscribe({
       next: () => {
         this.acting.set(false);
-        this.snackBar.open(`Job ${job.id} retried`, 'OK', { duration: 3000 });
+        this.toast.success(`Job ${job.id} retried`);
         this.refresh();
       },
       error: (err) => {
         this.acting.set(false);
-        this.snackBar.open(`Retry failed: ${err.error?.error ?? err.message}`, 'Dismiss', { duration: 4000 });
+        this.toast.error(`Retry failed: ${err.error?.error ?? err.message}`);
       },
     });
   }
@@ -398,12 +398,12 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
     this.failedJobsService.discard(job.queue, job.id).subscribe({
       next: () => {
         this.acting.set(false);
-        this.snackBar.open(`Job ${job.id} discarded`, 'OK', { duration: 3000 });
+        this.toast.success(`Job ${job.id} discarded`);
         this.refresh();
       },
       error: (err) => {
         this.acting.set(false);
-        this.snackBar.open(`Discard failed: ${err.error?.error ?? err.message}`, 'Dismiss', { duration: 4000 });
+        this.toast.error(`Discard failed: ${err.error?.error ?? err.message}`);
       },
     });
   }
@@ -418,12 +418,12 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
         const msg = res.failedCount > 0
           ? `Retried ${res.retriedCount} jobs in ${queue} (${res.failedCount} failed to retry)`
           : `Retried ${res.retriedCount} jobs in ${queue}`;
-        this.snackBar.open(msg, 'OK', { duration: 3000 });
+        this.toast.info(msg);
         this.refresh();
       },
       error: (err) => {
         this.acting.set(false);
-        this.snackBar.open(`Retry all failed: ${err.error?.error ?? err.message}`, 'Dismiss', { duration: 4000 });
+        this.toast.error(`Retry all failed: ${err.error?.error ?? err.message}`);
       },
     });
   }
@@ -436,12 +436,12 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
     this.failedJobsService.discardAll(queue).subscribe({
       next: (res) => {
         this.acting.set(false);
-        this.snackBar.open(`Discarded ${res.removedCount} jobs in ${queue}`, 'OK', { duration: 3000 });
+        this.toast.success(`Discarded ${res.removedCount} jobs in ${queue}`);
         this.refresh();
       },
       error: (err) => {
         this.acting.set(false);
-        this.snackBar.open(`Discard all failed: ${err.error?.error ?? err.message}`, 'Dismiss', { duration: 4000 });
+        this.toast.error(`Discard all failed: ${err.error?.error ?? err.message}`);
       },
     });
   }

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -7,11 +7,11 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { IntegrationService } from '../../core/services/integration.service';
 import type { ClientIntegration } from '../../core/services/integration.service';
 import { AuthService } from '../../core/services/auth.service';
 import { McpToolVisibilityDialogComponent } from './mcp-tool-visibility-dialog.component';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   clientId: string;
@@ -206,7 +206,7 @@ export class IntegrationDialogComponent implements OnInit {
   private data: DialogData = inject(MAT_DIALOG_DATA);
   private integrationService = inject(IntegrationService);
   private authService = inject(AuthService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private matDialog = inject(MatDialog);
 
   editing = false;
@@ -367,10 +367,10 @@ export class IntegrationDialogComponent implements OnInit {
         notes: this.notes || null,
       }).subscribe({
         next: () => {
-          this.snackBar.open('Integration updated', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+          this.toast.success('Integration updated');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Update failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Update failed'),
       });
     } else {
       this.integrationService.createIntegration({
@@ -381,10 +381,10 @@ export class IntegrationDialogComponent implements OnInit {
         notes: this.notes || undefined,
       }).subscribe({
         next: () => {
-          this.snackBar.open('Integration created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+          this.toast.success('Integration created');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed'),
       });
     }
   }

--- a/services/control-panel/src/app/features/login/login.component.ts
+++ b/services/control-panel/src/app/features/login/login.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthService } from '../../core/services/auth.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -70,7 +70,7 @@ import { AuthService } from '../../core/services/auth.service';
 })
 export class LoginComponent {
   private authService = inject(AuthService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   email = '';
   password = '';
@@ -79,7 +79,7 @@ export class LoginComponent {
 
   login(): void {
     if (!this.email || !this.password) {
-      this.snackBar.open('Email and password are required', 'OK', { duration: 3000, panelClass: 'error-snackbar' });
+      this.toast.error('Email and password are required');
       return;
     }
 
@@ -88,7 +88,7 @@ export class LoginComponent {
       error: (err) => {
         this.loading.set(false);
         const message = err.error?.error ?? 'Login failed';
-        this.snackBar.open(message, 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(message);
       },
     });
   }

--- a/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
@@ -5,12 +5,12 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import {
   NotificationChannelService,
   NotificationChannel,
 } from '../../core/services/notification-channel.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -100,7 +100,7 @@ import {
 export class NotificationChannelDialogComponent {
   private channelService = inject(NotificationChannelService);
   private dialogRef = inject(MatDialogRef<NotificationChannelDialogComponent>);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private data: NotificationChannel | null = inject(MAT_DIALOG_DATA);
 
   isEdit = !!this.data;
@@ -128,7 +128,7 @@ export class NotificationChannelDialogComponent {
 
   save(): void {
     if (!this.name.trim()) {
-      this.snackBar.open('Name is required', 'Dismiss', { duration: 3000 });
+      this.toast.info('Name is required');
       return;
     }
 
@@ -143,7 +143,7 @@ export class NotificationChannelDialogComponent {
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.error ?? 'Failed to update', 'Dismiss', { duration: 4000 });
+          this.toast.error(err.error?.error ?? 'Failed to update');
         },
       });
     } else {
@@ -155,7 +155,7 @@ export class NotificationChannelDialogComponent {
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.error ?? 'Failed to create', 'Dismiss', { duration: 4000 });
+          this.toast.error(err.error?.error ?? 'Failed to create');
         },
       });
     }

--- a/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
@@ -5,7 +5,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
@@ -18,6 +17,7 @@ import {
   NotificationChannel,
 } from '../../core/services/notification-channel.service';
 import { NotificationChannelDialogComponent } from './notification-channel-dialog.component';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -199,7 +199,7 @@ import { NotificationChannelDialogComponent } from './notification-channel-dialo
 })
 export class NotificationChannelsComponent implements OnInit {
   private channelService = inject(NotificationChannelService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
 
   channels = signal<NotificationChannel[]>([]);
@@ -236,7 +236,7 @@ export class NotificationChannelsComponent implements OnInit {
     this.channelService.update(channel.id, { isActive: !channel.isActive }).subscribe({
       next: () => this.load(),
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to update', 'Dismiss', { duration: 4000 });
+        this.toast.error(err.error?.error ?? 'Failed to update');
       },
     });
   }
@@ -247,14 +247,14 @@ export class NotificationChannelsComponent implements OnInit {
       next: (res) => {
         this.testing.set(null);
         if (res.success) {
-          this.snackBar.open(res.message ?? 'Test sent!', 'OK', { duration: 4000 });
+          this.toast.success(res.message ?? 'Test sent!');
         } else {
-          this.snackBar.open(`Test failed: ${res.error}`, 'Dismiss', { duration: 6000 });
+          this.toast.error(`Test failed: ${res.error}`);
         }
       },
       error: (err) => {
         this.testing.set(null);
-        this.snackBar.open(err.error?.error ?? 'Test failed', 'Dismiss', { duration: 4000 });
+        this.toast.error(err.error?.error ?? 'Test failed');
       },
     });
   }
@@ -263,11 +263,11 @@ export class NotificationChannelsComponent implements OnInit {
     if (!confirm(`Delete notification channel "${channel.name}"?`)) return;
     this.channelService.delete(channel.id).subscribe({
       next: () => {
-        this.snackBar.open('Channel deleted', 'OK', { duration: 3000 });
+        this.toast.success('Channel deleted');
         this.load();
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to delete', 'Dismiss', { duration: 4000 });
+        this.toast.error(err.error?.error ?? 'Failed to delete');
       },
     });
   }

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -1,7 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { environment } from '../../../environments/environment';
 import {
   DEFAULT_OPERATIONAL_ALERT_CONFIG,
@@ -18,6 +17,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 interface NotificationPreference {
   id: string;
@@ -70,7 +70,6 @@ const EMAIL_TARGET_OPTIONS = [
   standalone: true,
   imports: [
     FormsModule,
-    MatSnackBarModule,
     BroncoButtonComponent,
     CardComponent,
     FormFieldComponent,
@@ -406,7 +405,7 @@ const EMAIL_TARGET_OPTIONS = [
 })
 export class NotificationPreferencesComponent implements OnInit {
   private http = inject(HttpClient);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   selectedTab = signal(0);
   loading = signal(true);
@@ -507,7 +506,7 @@ export class NotificationPreferencesComponent implements OnInit {
         this.loading.set(false);
       },
       error: () => {
-        this.snackBar.open('Failed to load notification preferences', 'Dismiss', { duration: 5000 });
+        this.toast.error('Failed to load notification preferences');
         this.loading.set(false);
       },
     });
@@ -526,11 +525,11 @@ export class NotificationPreferencesComponent implements OnInit {
 
     this.http.put(`${environment.apiUrl}/notification-preferences`, payload).subscribe({
       next: () => {
-        this.snackBar.open('Preferences saved', 'Dismiss', { duration: 3000 });
+        this.toast.success('Preferences saved');
         this.saving.set(false);
       },
       error: () => {
-        this.snackBar.open('Failed to save preferences', 'Dismiss', { duration: 5000 });
+        this.toast.error('Failed to save preferences');
         this.saving.set(false);
       },
     });
@@ -576,11 +575,11 @@ export class NotificationPreferencesComponent implements OnInit {
       next: saved => {
         this.alertConfig.set(saved);
         this.alertsSaving.set(false);
-        this.snackBar.open('Alert configuration saved', 'Dismiss', { duration: 3000 });
+        this.toast.success('Alert configuration saved');
       },
       error: () => {
         this.alertsSaving.set(false);
-        this.snackBar.open('Failed to save alert configuration', 'Dismiss', { duration: 5000 });
+        this.toast.error('Failed to save alert configuration');
       },
     });
   }

--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthService } from '../../core/services/auth.service';
 import { ThemeService } from '../../core/services/theme.service';
 import {
@@ -8,6 +7,7 @@ import {
   CardComponent,
   FormFieldComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -276,7 +276,7 @@ import {
 export class ProfileComponent implements OnInit {
   authService = inject(AuthService);
   readonly themeService = inject(ThemeService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   profileName = '';
   profileEmail = '';
@@ -299,11 +299,11 @@ export class ProfileComponent implements OnInit {
     this.profileSaving = true;
     this.authService.updateProfile({ name: this.profileName, email: this.profileEmail }).subscribe({
       next: () => {
-        this.snackBar.open('Profile updated', 'OK', { duration: 3000 });
+        this.toast.success('Profile updated');
         this.profileSaving = false;
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to update profile', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Failed to update profile');
         this.profileSaving = false;
       },
     });
@@ -311,24 +311,24 @@ export class ProfileComponent implements OnInit {
 
   changePassword(): void {
     if (this.newPassword !== this.confirmPassword) {
-      this.snackBar.open('New passwords do not match', 'OK', { duration: 5000 });
+      this.toast.info('New passwords do not match');
       return;
     }
     if (this.newPassword.length < 8) {
-      this.snackBar.open('Password must be at least 8 characters', 'OK', { duration: 5000 });
+      this.toast.info('Password must be at least 8 characters');
       return;
     }
     this.passwordSaving = true;
     this.authService.changePassword(this.currentPassword, this.newPassword).subscribe({
       next: () => {
-        this.snackBar.open('Password changed successfully', 'OK', { duration: 3000 });
+        this.toast.success('Password changed successfully');
         this.currentPassword = '';
         this.newPassword = '';
         this.confirmPassword = '';
         this.passwordSaving = false;
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to change password', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Failed to change password');
         this.passwordSaving = false;
       },
     });

--- a/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
@@ -5,11 +5,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiConfigService, AiModelConfig } from '../../core/services/ai-config.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service';
 import { AiProviderService, ProviderType } from '../../core/services/ai-provider.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   taskType?: string;
@@ -113,7 +113,7 @@ export class AiConfigDialogComponent implements OnInit {
   private clientService = inject(ClientService);
   private aiUsageService = inject(AiUsageService);
   private aiProviderService = inject(AiProviderService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.config;
   presetTaskType = !this.data.config && !!this.data.taskType;
@@ -149,7 +149,7 @@ export class AiConfigDialogComponent implements OnInit {
       },
       error: () => {
         this.loadingProviders = false;
-        this.snackBar.open('Failed to load provider types', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to load provider types');
       },
     });
 
@@ -196,10 +196,10 @@ export class AiConfigDialogComponent implements OnInit {
         model: this.model.trim(),
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Config updated', 'OK', { duration: 3000 });
+          this.toast.success('Config updated');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update config', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to update config'),
       });
     } else {
       this.aiConfigService.create({
@@ -210,10 +210,10 @@ export class AiConfigDialogComponent implements OnInit {
         model: this.model.trim(),
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Config created', 'OK', { duration: 3000 });
+          this.toast.success('Config created');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create config', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to create config'),
       });
     }
   }

--- a/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
@@ -6,9 +6,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiProviderService, AiProvider, AiProviderModel, AppScopeItem } from '../../core/services/ai-provider.service';
 import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   model?: AiProviderModel;
@@ -101,7 +101,7 @@ export class AiModelDialogComponent implements OnInit {
   data: DialogData = inject(MAT_DIALOG_DATA);
   private providerService = inject(AiProviderService);
   private aiUsageService = inject(AiUsageService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   capabilityLevels = CAPABILITY_LEVELS;
 
@@ -135,7 +135,7 @@ export class AiModelDialogComponent implements OnInit {
     // Fetch app scopes for the "Enabled For" checkboxes
     this.providerService.getAppScopes().subscribe({
       next: (scopes) => this.appScopes = scopes,
-      error: () => this.snackBar.open('Failed to load app scopes', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to load app scopes'),
     });
   }
 
@@ -179,10 +179,10 @@ export class AiModelDialogComponent implements OnInit {
         enabledApps: enabledAppsArray,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Model updated', 'OK', { duration: 3000 });
+          this.toast.success('Model updated');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update model', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to update model'),
       });
     } else {
       this.providerService.createModel({
@@ -193,10 +193,10 @@ export class AiModelDialogComponent implements OnInit {
         enabledApps: enabledAppsArray,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Model created', 'OK', { duration: 3000 });
+          this.toast.success('Model created');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create model', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to create model'),
       });
     }
   }

--- a/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiProviderService, AiProvider, ProviderType } from '../../core/services/ai-provider.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   config?: AiProvider;
@@ -75,7 +75,7 @@ export class AiProviderDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<AiProviderDialogComponent>);
   data: DialogData = inject(MAT_DIALOG_DATA);
   private providerService = inject(AiProviderService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.config;
   provider = this.data.config?.provider ?? '';
@@ -93,7 +93,7 @@ export class AiProviderDialogComponent implements OnInit {
       },
       error: () => {
         this.loadingProviders = false;
-        this.snackBar.open('Failed to load provider types', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to load provider types');
       },
     });
   }
@@ -118,10 +118,10 @@ export class AiProviderDialogComponent implements OnInit {
       if (this.apiKey) data['apiKey'] = this.apiKey;
       this.providerService.updateProvider(this.data.config!.id, data).subscribe({
         next: (result) => {
-          this.snackBar.open('Provider updated', 'OK', { duration: 3000 });
+          this.toast.success('Provider updated');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update provider', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to update provider'),
       });
     } else {
       this.providerService.createProvider({
@@ -130,10 +130,10 @@ export class AiProviderDialogComponent implements OnInit {
         apiKey: this.provider !== 'LOCAL' ? this.apiKey : undefined,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Provider created', 'OK', { duration: 3000 });
+          this.toast.success('Provider created');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create provider', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to create provider'),
       });
     }
   }

--- a/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
@@ -5,8 +5,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { PromptService, PromptKeyword } from '../../core/services/prompt.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   keyword?: PromptKeyword;
@@ -66,7 +66,7 @@ export class KeywordDialogComponent {
   private dialogRef = inject(MatDialogRef<KeywordDialogComponent>);
   data: DialogData = inject(MAT_DIALOG_DATA);
   private promptService = inject(PromptService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.keyword;
   token = this.data.keyword?.token ?? '';
@@ -90,10 +90,10 @@ export class KeywordDialogComponent {
         category: this.category,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Keyword updated', 'OK', { duration: 3000 });
+          this.toast.success('Keyword updated');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update keyword', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to update keyword'),
       });
     } else {
       this.promptService.createKeyword({
@@ -104,10 +104,10 @@ export class KeywordDialogComponent {
         category: this.category,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Keyword created', 'OK', { duration: 3000 });
+          this.toast.success('Keyword created');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create keyword', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to create keyword'),
       });
     }
   }

--- a/services/control-panel/src/app/features/prompts/override-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/override-dialog.component.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { PromptService, PromptOverride, PromptKeyword } from '../../core/services/prompt.service';
 import { ClientService, Client } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   promptKey: string;
@@ -132,7 +132,7 @@ export class OverrideDialogComponent {
   data: DialogData = inject(MAT_DIALOG_DATA);
   private promptService = inject(PromptService);
   private clientService = inject(ClientService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   @ViewChild('contentTextarea') contentTextareaRef!: ElementRef<HTMLTextAreaElement>;
 
@@ -238,10 +238,10 @@ export class OverrideDialogComponent {
         content: this.content,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Override updated', 'OK', { duration: 3000 });
+          this.toast.success('Override updated');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update override', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to update override'),
       });
     } else {
       this.promptService.createOverride({
@@ -252,10 +252,10 @@ export class OverrideDialogComponent {
         content: this.content,
       }).subscribe({
         next: (result) => {
-          this.snackBar.open('Override created', 'OK', { duration: 3000 });
+          this.toast.success('Override created');
           this.dialogRef.close(result);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create override', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? 'Failed to create override'),
       });
     }
   }

--- a/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
@@ -10,10 +10,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { PromptService, PromptDetail, PromptOverride, PreviewResult } from '../../core/services/prompt.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { OverrideDialogComponent } from './override-dialog.component';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -184,7 +184,7 @@ export class PromptDetailComponent implements OnInit {
   private clientService = inject(ClientService);
   private destroyRef = inject(DestroyRef);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   detail = signal<PromptDetail | null>(null);
   preview = signal<PreviewResult | null>(null);
@@ -239,10 +239,10 @@ export class PromptDetailComponent implements OnInit {
   toggleOverride(override: PromptOverride): void {
     this.promptService.updateOverride(override.id, { isActive: !override.isActive }).subscribe({
       next: () => {
-        this.snackBar.open(`Override ${override.isActive ? 'deactivated' : 'activated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Override ${override.isActive ? 'deactivated' : 'activated'}`);
         this.load();
       },
-      error: () => this.snackBar.open('Failed to update override', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update override'),
     });
   }
 
@@ -250,10 +250,10 @@ export class PromptDetailComponent implements OnInit {
     if (!confirm('Delete this override?')) return;
     this.promptService.deleteOverride(override.id).subscribe({
       next: () => {
-        this.snackBar.open('Override deleted', 'OK', { duration: 3000 });
+        this.toast.success('Override deleted');
         this.load();
       },
-      error: () => this.snackBar.open('Failed to delete override', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to delete override'),
     });
   }
 }

--- a/services/control-panel/src/app/features/prompts/prompt-list.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-list.component.ts
@@ -2,7 +2,6 @@ import { Component, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { PromptService, PromptSummary, PromptKeyword } from '../../core/services/prompt.service';
 import { AiConfigService, TaskTypeDefault, AiModelConfig } from '../../core/services/ai-config.service';
 import { forkJoin } from 'rxjs';
@@ -18,6 +17,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 interface MergedModelRow {
   taskType: string;
@@ -402,7 +402,7 @@ export class PromptListComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   prompts = signal<PromptSummary[]>([]);
   private allPrompts = signal<PromptSummary[]>([]);
@@ -538,12 +538,12 @@ export class PromptListComponent implements OnInit {
     this.promptService.seedKeywords().subscribe({
       next: (result) => {
         this.seeding.set(false);
-        this.snackBar.open(`Seeded ${result.seeded} keywords`, 'OK', { duration: 3000 });
+        this.toast.info(`Seeded ${result.seeded} keywords`);
         this.loadKeywords();
       },
       error: (err) => {
         this.seeding.set(false);
-        this.snackBar.open(err.error?.message ?? 'Failed to seed keywords', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? 'Failed to seed keywords');
       },
     });
   }
@@ -552,10 +552,10 @@ export class PromptListComponent implements OnInit {
     if (!confirm(`Delete keyword "{{${keyword.token}}}"?`)) return;
     this.promptService.deleteKeyword(keyword.id).subscribe({
       next: () => {
-        this.snackBar.open('Keyword deleted', 'OK', { duration: 3000 });
+        this.toast.success('Keyword deleted');
         this.loadKeywords();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to delete keyword', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? 'Failed to delete keyword'),
     });
   }
 
@@ -678,7 +678,7 @@ export class PromptListComponent implements OnInit {
 
   addModelConfig(): void {
     if (this.modelDefaults().length === 0) {
-      this.snackBar.open('Model defaults not loaded yet', 'OK', { duration: 3000 });
+      this.toast.info('Model defaults not loaded yet');
       return;
     }
     const ref = this.dialog.open(AiConfigDialogComponent, {
@@ -712,10 +712,10 @@ export class PromptListComponent implements OnInit {
   toggleModelConfigActiveById(configId: string, currentlyActive: boolean): void {
     this.aiConfigService.update(configId, { isActive: !currentlyActive }).subscribe({
       next: () => {
-        this.snackBar.open(`Config ${currentlyActive ? 'deactivated' : 'activated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Config ${currentlyActive ? 'deactivated' : 'activated'}`);
         this.loadModelData();
       },
-      error: () => this.snackBar.open('Failed to update config', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update config'),
     });
   }
 
@@ -729,10 +729,10 @@ export class PromptListComponent implements OnInit {
     if (!confirm('Delete this model config override?')) return;
     this.aiConfigService.delete(configId).subscribe({
       next: () => {
-        this.snackBar.open('Config deleted', 'OK', { duration: 3000 });
+        this.toast.success('Config deleted');
         this.loadModelData();
       },
-      error: () => this.snackBar.open('Failed to delete config', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to delete config'),
     });
   }
 

--- a/services/control-panel/src/app/features/release-notes/release-notes.component.ts
+++ b/services/control-panel/src/app/features/release-notes/release-notes.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatPaginatorModule, type PageEvent } from '@angular/material/paginator';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { ReleaseNotesService, type ReleaseNote, type ReleaseNoteType } from '../../core/services/release-notes.service';
 import { BackfillDialogComponent } from './backfill-dialog.component';
 import { BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }> = {
   FEATURE: { label: 'Feature', color: 'var(--color-success)' },
@@ -19,7 +19,6 @@ const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }
   imports: [
     FormsModule,
     MatPaginatorModule,
-    MatSnackBarModule,
     MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
@@ -237,7 +236,7 @@ const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }
 })
 export class ReleaseNotesComponent implements OnInit {
   private releaseNotesService = inject(ReleaseNotesService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
 
   notes = signal<ReleaseNote[]>([]);
@@ -319,7 +318,7 @@ export class ReleaseNotesComponent implements OnInit {
       },
       error: () => {
         this.loading.set(false);
-        this.snackBar.open('Failed to load release notes', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load release notes');
       },
     });
   }
@@ -363,7 +362,7 @@ export class ReleaseNotesComponent implements OnInit {
         this.notes.update((list) => list.map((n) => (n.id === updated.id ? updated : n)));
       },
       error: () => {
-        this.snackBar.open('Failed to update visibility', 'OK', { duration: 5000 });
+        this.toast.error('Failed to update visibility');
       },
     });
   }
@@ -376,14 +375,14 @@ export class ReleaseNotesComponent implements OnInit {
       this.releaseNotesService.backfill(result.fromSha, result.toSha).subscribe({
         next: (r) => {
           this.ingestLoading.set(false);
-          this.snackBar.open(`Sync complete — ${r.ingested} ingested, ${r.skipped} skipped`, 'OK', { duration: 5000 });
+          this.toast.success(`Sync complete — ${r.ingested} ingested, ${r.skipped} skipped`);
           this.load();
           this.loadServices();
           this.loadTags();
         },
         error: (err) => {
           this.ingestLoading.set(false);
-          this.snackBar.open(err.error?.error ?? 'Backfill failed', 'OK', { duration: 8000 });
+          this.toast.error(err.error?.error ?? 'Backfill failed');
         },
       });
     });

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -4,8 +4,8 @@ import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/materia
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { RepoService, type CodeRepo } from '../../core/services/repo.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -52,7 +52,7 @@ export class RepoDialogComponent {
   private dialogRef = inject(MatDialogRef<RepoDialogComponent>);
   private data: { clientId: string; repo?: CodeRepo } = inject(MAT_DIALOG_DATA);
   private repoService = inject(RepoService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   title = this.data.repo ? 'Edit Code Repository' : 'Add Code Repository';
   saveLabel = this.data.repo ? 'Save' : 'Create';
@@ -80,10 +80,10 @@ export class RepoDialogComponent {
 
     request$.subscribe({
       next: () => {
-        this.snackBar.open(this.data.repo ? 'Repo updated' : 'Repo created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success(this.data.repo ? 'Repo updated' : 'Repo created');
         this.dialogRef.close(true);
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
     });
   }
 }

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -7,10 +7,10 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { ScheduledProbeService, ScheduledProbe, CreateProbeRequest, UpdateProbeRequest } from '../../core/services/scheduled-probe.service';
 import { IntegrationService, ClientIntegration } from '../../core/services/integration.service';
 import { Client } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface ToolInfo {
   name: string;
@@ -292,7 +292,7 @@ export class ProbeDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ProbeDialogComponent>);
   private probeService = inject(ScheduledProbeService);
   private integrationService = inject(IntegrationService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.probe;
   name = this.data.probe?.name ?? '';
@@ -511,12 +511,12 @@ export class ProbeDialogComponent implements OnInit {
       }
       this.probeService.updateProbe(this.data.probe!.id, updateData).subscribe({
         next: () => {
-          this.snackBar.open('Probe updated', 'OK', { duration: 3000 });
+          this.toast.success('Probe updated');
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to update probe', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to update probe');
         },
       });
     } else {
@@ -541,12 +541,12 @@ export class ProbeDialogComponent implements OnInit {
       }
       this.probeService.createProbe(req).subscribe({
         next: () => {
-          this.snackBar.open('Probe created', 'OK', { duration: 3000 });
+          this.toast.success('Probe created');
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to create probe', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to create probe');
         },
       });
     }

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -164,7 +164,7 @@ export class ProbeListComponent implements OnInit {
 
   filterClientId = signal('');
 
-  trackById = (item: any) => item.id;
+  trackById = (item: ScheduledProbe) => item.id;
 
   clientOptions = computed(() => [
     { value: '', label: 'All Clients' },
@@ -192,7 +192,7 @@ export class ProbeListComponent implements OnInit {
     this.filterClientId.set(value);
   }
 
-  onProbeClick(probe: any): void {
+  onProbeClick(probe: ScheduledProbe): void {
     this.detailPanel.open('probe', probe.id);
   }
 

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
 import {
   DataTableComponent,
@@ -16,6 +15,7 @@ import { ScheduledProbeService, ScheduledProbe } from '../../core/services/sched
 import { ClientService, Client } from '../../core/services/client.service';
 import { CATEGORY_OPTIONS } from '../../core/services/client-memory.service';
 import { ProbeDialogComponent } from './probe-dialog.component';
+import { ToastService } from '../../core/services/toast.service';
 
 const CATEGORIES = CATEGORY_OPTIONS;
 
@@ -155,7 +155,7 @@ export class ProbeListComponent implements OnInit {
   private probeService = inject(ScheduledProbeService);
   private clientService = inject(ClientService);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private detailPanel = inject(DetailPanelService);
 
   probes = signal<ScheduledProbe[]>([]);
@@ -252,17 +252,17 @@ export class ProbeListComponent implements OnInit {
   toggleActive(probe: ScheduledProbe, isActive: boolean): void {
     this.probeService.updateProbe(probe.id, { isActive }).subscribe({
       next: () => {
-        this.snackBar.open(`Probe ${isActive ? 'activated' : 'deactivated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Probe ${isActive ? 'activated' : 'deactivated'}`);
         this.loadProbes();
       },
-      error: () => this.snackBar.open('Failed to update probe', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update probe'),
     });
   }
 
   runNow(probe: ScheduledProbe): void {
     this.probeService.runProbe(probe.id).subscribe({
-      next: () => this.snackBar.open('Probe execution queued', 'OK', { duration: 3000 }),
-      error: () => this.snackBar.open('Failed to queue probe', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      next: () => this.toast.success('Probe execution queued'),
+      error: () => this.toast.error('Failed to queue probe'),
     });
   }
 
@@ -270,10 +270,10 @@ export class ProbeListComponent implements OnInit {
     if (!confirm(`Delete probe "${probe.name}"?`)) return;
     this.probeService.deleteProbe(probe.id).subscribe({
       next: () => {
-        this.snackBar.open('Probe deleted', 'OK', { duration: 3000 });
+        this.toast.success('Probe deleted');
         this.loadProbes();
       },
-      error: () => this.snackBar.open('Failed to delete probe', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to delete probe'),
     });
   }
 }

--- a/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
@@ -11,7 +11,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { DatePipe, DecimalPipe, SlicePipe } from '@angular/common';
 import {
   ScheduledProbeService,
@@ -19,6 +18,7 @@ import {
   ProbeRun,
   ProbeRunStep,
 } from '../../core/services/scheduled-probe.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -442,7 +442,7 @@ import {
 export class ProbeRunsComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private probeService = inject(ScheduledProbeService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private clipboard = inject(Clipboard);
 
   probe = signal<ScheduledProbe | null>(null);
@@ -605,9 +605,9 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
   copyToClipboard(text: string): void {
     const ok = this.clipboard.copy(text);
     if (ok) {
-      this.snackBar.open('Copied to clipboard', 'OK', { duration: 2000 });
+      this.toast.success('Copied to clipboard');
     } else {
-      this.snackBar.open('Failed to copy to clipboard', 'OK', { duration: 4000, panelClass: 'error-snackbar' });
+      this.toast.error('Failed to copy to clipboard');
     }
   }
 
@@ -625,12 +625,12 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
     this.probeService.purgeRuns(this.probeId).subscribe({
       next: (res) => {
         this.purging = false;
-        this.snackBar.open(`Deleted ${res.deleted} runs`, 'OK', { duration: 3000 });
+        this.toast.success(`Deleted ${res.deleted} runs`);
         this.loadRuns();
       },
       error: () => {
         this.purging = false;
-        this.snackBar.open('Failed to purge history', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to purge history');
       },
     });
   }
@@ -657,11 +657,11 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
       next: (p) => {
         this.savingRetention = false;
         this.probe.set(p);
-        this.snackBar.open('Retention settings saved', 'OK', { duration: 3000 });
+        this.toast.success('Retention settings saved');
       },
       error: () => {
         this.savingRetention = false;
-        this.snackBar.open('Failed to save retention settings', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to save retention settings');
       },
     });
   }

--- a/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
@@ -5,11 +5,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import {
   SettingsService,
   TicketCategoryConfig,
 } from '../../core/services/settings.service';
+import { ToastService } from '../../core/services/toast.service';
 
 export interface CategoryConfigDialogData {
   config?: TicketCategoryConfig;
@@ -86,7 +86,7 @@ export class CategoryConfigDialogComponent {
   private dialogRef = inject(MatDialogRef<CategoryConfigDialogComponent>);
   data: CategoryConfigDialogData = inject(MAT_DIALOG_DATA);
   private svc = inject(SettingsService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isCreate = !this.data.config;
 
@@ -115,15 +115,11 @@ export class CategoryConfigDialogComponent {
         })
         .subscribe({
           next: () => {
-            this.snackBar.open('Category created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+            this.toast.success('Category created');
             this.dialogRef.close(true);
           },
           error: (err) =>
-            this.snackBar.open(
-              err.error?.error ?? err.error?.message ?? 'Failed to create',
-              'OK',
-              { duration: 5000 },
-            ),
+            this.toast.error(err.error?.error ?? err.error?.message ?? 'Failed to create'),
         });
     } else {
       this.svc
@@ -136,15 +132,11 @@ export class CategoryConfigDialogComponent {
         })
         .subscribe({
           next: () => {
-            this.snackBar.open('Category updated', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+            this.toast.success('Category updated');
             this.dialogRef.close(true);
           },
           error: (err) =>
-            this.snackBar.open(
-              err.error?.error ?? err.error?.message ?? 'Failed to update',
-              'OK',
-              { duration: 5000 },
-            ),
+            this.toast.error(err.error?.error ?? err.error?.message ?? 'Failed to update'),
         });
     }
   }

--- a/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
@@ -6,11 +6,11 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import {
   ExternalServiceService,
   ExternalService,
 } from '../../core/services/external-service.service';
+import { ToastService } from '../../core/services/toast.service';
 
 export interface ExternalServiceDialogData {
   service?: ExternalService;
@@ -82,7 +82,7 @@ export class ExternalServiceDialogComponent {
   private dialogRef = inject(MatDialogRef<ExternalServiceDialogComponent>);
   private data: ExternalServiceDialogData = inject(MAT_DIALOG_DATA);
   private svc = inject(ExternalServiceService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.service;
 
@@ -125,19 +125,11 @@ export class ExternalServiceDialogComponent {
 
     op$.subscribe({
       next: () => {
-        this.snackBar.open(
-          `External service ${this.isEdit ? 'updated' : 'created'}`,
-          'OK',
-          { duration: 3000, panelClass: 'success-snackbar' },
-        );
+        this.toast.success(`External service ${this.isEdit ? 'updated' : 'created'}`);
         this.dialogRef.close(true);
       },
       error: (err) =>
-        this.snackBar.open(
-          err.error?.error ?? err.error?.message ?? 'Failed',
-          'OK',
-          { duration: 5000, panelClass: 'error-snackbar' },
-        ),
+        this.toast.error(err.error?.error ?? err.error?.message ?? 'Failed'),
     });
   }
 }

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -1,7 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
 import {
@@ -29,6 +28,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -589,7 +589,7 @@ import {
   `],
 })
 export class SettingsComponent implements OnInit {
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
   private extSvc = inject(ExternalServiceService);
   private settingsSvc = inject(SettingsService);
@@ -676,13 +676,13 @@ export class SettingsComponent implements OnInit {
 
   saveKey(): void {
     sessionStorage.setItem('rc_api_key', this.apiKey);
-    this.snackBar.open('API key saved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+    this.toast.success('API key saved');
   }
 
   clearKey(): void {
     this.apiKey = '';
     sessionStorage.removeItem('rc_api_key');
-    this.snackBar.open('API key cleared', 'OK', { duration: 3000 });
+    this.toast.success('API key cleared');
   }
 
   loadUsers(): void {
@@ -700,7 +700,7 @@ export class SettingsComponent implements OnInit {
       error: (err) => {
         this.usersLoading.set(false);
         if (err?.status !== 403) {
-          this.snackBar.open('Failed to load users', 'OK', { duration: 5000 });
+          this.toast.error('Failed to load users');
         }
       },
     });
@@ -715,7 +715,7 @@ export class SettingsComponent implements OnInit {
       },
       error: () => {
         this.superAdminLoading.set(false);
-        this.snackBar.open('Failed to load super admin setting', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load super admin setting');
       },
     });
   }
@@ -726,11 +726,11 @@ export class SettingsComponent implements OnInit {
       next: (result) => {
         this.superAdminUserId = result.userId;
         this.superAdminSaving.set(false);
-        this.snackBar.open('Super admin saved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Super admin saved');
       },
       error: () => {
         this.superAdminSaving.set(false);
-        this.snackBar.open('Failed to save super admin', 'OK', { duration: 5000 });
+        this.toast.error('Failed to save super admin');
       },
     });
   }
@@ -738,7 +738,7 @@ export class SettingsComponent implements OnInit {
   loadServices(): void {
     this.extSvc.getAll().subscribe({
       next: (list) => this.services.set(list),
-      error: () => this.snackBar.open('Failed to load external services', 'OK', { duration: 5000 }),
+      error: () => this.toast.error('Failed to load external services'),
     });
   }
 
@@ -765,14 +765,10 @@ export class SettingsComponent implements OnInit {
   toggleMonitored(svc: ExternalService): void {
     this.extSvc.update(svc.id, { isMonitored: !svc.isMonitored }).subscribe({
       next: () => {
-        this.snackBar.open(
-          `${svc.name} monitoring ${svc.isMonitored ? 'disabled' : 'enabled'}`,
-          'OK',
-          { duration: 3000, panelClass: 'success-snackbar' },
-        );
+        this.toast.success(`${svc.name} monitoring ${svc.isMonitored ? 'disabled' : 'enabled'}`);
         this.loadServices();
       },
-      error: () => this.snackBar.open('Failed to update', 'OK', { duration: 5000 }),
+      error: () => this.toast.error('Failed to update'),
     });
   }
 
@@ -780,10 +776,10 @@ export class SettingsComponent implements OnInit {
     if (!confirm(`Delete "${svc.name}"? This cannot be undone.`)) return;
     this.extSvc.delete(svc.id).subscribe({
       next: () => {
-        this.snackBar.open(`${svc.name} deleted`, 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success(`${svc.name} deleted`);
         this.loadServices();
       },
-      error: () => this.snackBar.open('Failed to delete', 'OK', { duration: 5000 }),
+      error: () => this.toast.error('Failed to delete'),
     });
   }
 
@@ -800,7 +796,7 @@ export class SettingsComponent implements OnInit {
       error: () => {
         this.statusesLoading.set(false);
         this.statusesError.set(true);
-        this.snackBar.open('Failed to load status configs', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load status configs');
       },
     });
   }
@@ -838,7 +834,7 @@ export class SettingsComponent implements OnInit {
       error: () => {
         this.categoriesLoading.set(false);
         this.categoriesError.set(true);
-        this.snackBar.open('Failed to load category configs', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load category configs');
       },
     });
   }
@@ -881,7 +877,7 @@ export class SettingsComponent implements OnInit {
       },
       error: () => {
         this.actionSafetyLoading.set(false);
-        this.snackBar.open('Failed to load action safety config', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load action safety config');
       },
     });
   }
@@ -904,11 +900,11 @@ export class SettingsComponent implements OnInit {
           Object.entries(saved.actions).map(([actionType, level]) => ({ actionType, level }))
         );
         this.actionSafetySaving.set(false);
-        this.snackBar.open('Action safety config saved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Action safety config saved');
       },
       error: () => {
         this.actionSafetySaving.set(false);
-        this.snackBar.open('Failed to save action safety config', 'OK', { duration: 5000 });
+        this.toast.error('Failed to save action safety config');
       },
     });
   }
@@ -939,7 +935,7 @@ export class SettingsComponent implements OnInit {
       },
       error: () => {
         this.analysisStrategyLoading.set(false);
-        this.snackBar.open('Failed to load analysis strategy config', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load analysis strategy config');
       },
     });
   }
@@ -961,11 +957,11 @@ export class SettingsComponent implements OnInit {
         this.analysisStrategy.set(saved.strategy);
         this.analysisMaxParallel.set(saved.maxParallelTasks);
         this.analysisStrategySaving.set(false);
-        this.snackBar.open('Analysis strategy saved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Analysis strategy saved');
       },
       error: () => {
         this.analysisStrategySaving.set(false);
-        this.snackBar.open('Failed to save analysis strategy', 'OK', { duration: 5000 });
+        this.toast.error('Failed to save analysis strategy');
       },
     });
   }
@@ -985,7 +981,7 @@ export class SettingsComponent implements OnInit {
       },
       error: () => {
         this.selfAnalysisLoading.set(false);
-        this.snackBar.open('Failed to load self-analysis config', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load self-analysis config');
       },
     });
   }
@@ -1004,10 +1000,10 @@ export class SettingsComponent implements OnInit {
         this.selfAnalysisScheduled.set(saved.scheduledEnabled);
         this.selfAnalysisCron.set(saved.scheduledCron);
         this.selfAnalysisRepoUrl.set(saved.repoUrl);
-        this.snackBar.open('Self-analysis config saved', 'OK', { duration: 2000, panelClass: 'success-snackbar' });
+        this.toast.success('Self-analysis config saved');
       },
       error: () => {
-        this.snackBar.open('Failed to save self-analysis config', 'OK', { duration: 5000 });
+        this.toast.error('Failed to save self-analysis config');
         this.loadSelfAnalysis();
       },
     });

--- a/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
@@ -6,11 +6,11 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import {
   SettingsService,
   TicketStatusConfig,
 } from '../../core/services/settings.service';
+import { ToastService } from '../../core/services/toast.service';
 
 export interface StatusConfigDialogData {
   config?: TicketStatusConfig;
@@ -97,7 +97,7 @@ export class StatusConfigDialogComponent {
   private dialogRef = inject(MatDialogRef<StatusConfigDialogComponent>);
   data: StatusConfigDialogData = inject(MAT_DIALOG_DATA);
   private svc = inject(SettingsService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isCreate = !this.data.config;
 
@@ -128,15 +128,11 @@ export class StatusConfigDialogComponent {
         })
         .subscribe({
           next: () => {
-            this.snackBar.open('Status created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+            this.toast.success('Status created');
             this.dialogRef.close(true);
           },
           error: (err) =>
-            this.snackBar.open(
-              err.error?.error ?? err.error?.message ?? 'Failed to create',
-              'OK',
-              { duration: 5000 },
-            ),
+            this.toast.error(err.error?.error ?? err.error?.message ?? 'Failed to create'),
         });
     } else {
       this.svc
@@ -150,15 +146,11 @@ export class StatusConfigDialogComponent {
         })
         .subscribe({
           next: () => {
-            this.snackBar.open('Status updated', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+            this.toast.success('Status updated');
             this.dialogRef.close(true);
           },
           error: (err) =>
-            this.snackBar.open(
-              err.error?.error ?? err.error?.message ?? 'Failed to update',
-              'OK',
-              { duration: 5000 },
-            ),
+            this.toast.error(err.error?.error ?? err.error?.message ?? 'Failed to update'),
         });
     }
   }

--- a/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
+++ b/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
@@ -2,7 +2,6 @@ import { Component, inject, OnInit, signal, OnDestroy, computed } from '@angular
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { MatSnackBarModule, MatSnackBar } from '@angular/material/snack-bar';
 import { Subject, EMPTY } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
 import {
@@ -12,6 +11,7 @@ import {
 } from '../../core/services/slack-conversation.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -19,7 +19,6 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
     CommonModule,
     FormsModule,
     MatPaginatorModule,
-    MatSnackBarModule,
     BroncoButtonComponent,
     SelectComponent,
   ],
@@ -262,7 +261,7 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
 export class SlackConversationsComponent implements OnInit, OnDestroy {
   private conversationService = inject(SlackConversationService);
   private clientService = inject(ClientService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private destroy$ = new Subject<void>();
 
   conversations = signal<SlackConversationSummary[]>([]);
@@ -300,7 +299,7 @@ export class SlackConversationsComponent implements OnInit, OnDestroy {
       .getConversations(this.buildFilters())
       .pipe(
         catchError(() => {
-          this.snackBar.open('Failed to load conversations.', 'Dismiss', { duration: 5000 });
+          this.toast.error('Failed to load conversations.');
           return EMPTY;
         }),
       )
@@ -335,7 +334,7 @@ export class SlackConversationsComponent implements OnInit, OnDestroy {
       .getConversation(id)
       .pipe(
         catchError(() => {
-          this.snackBar.open('Failed to load conversation detail.', 'Dismiss', { duration: 5000 });
+          this.toast.error('Failed to load conversation detail.');
           this.loadingDetail.set(false);
           return EMPTY;
         }),

--- a/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
@@ -2,11 +2,11 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatPaginatorModule, type PageEvent } from '@angular/material/paginator';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { SystemAnalysisService, type SystemAnalysis, type SystemAnalysisStats } from '../../core/services/system-analysis.service';
 import { RejectDialogComponent } from './reject-dialog.component';
 import { BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 const STATUS_META: Record<string, { label: string; color: string }> = {
   PENDING: { label: 'Pending Review', color: 'var(--color-warning)' },
@@ -20,7 +20,6 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
     FormsModule,
     RouterLink,
     MatPaginatorModule,
-    MatSnackBarModule,
     MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
@@ -221,7 +220,7 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
 })
 export class SystemAnalysisComponent implements OnInit {
   private analysisService = inject(SystemAnalysisService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
 
   analyses = signal<SystemAnalysis[]>([]);
@@ -263,7 +262,7 @@ export class SystemAnalysisComponent implements OnInit {
       },
       error: () => {
         this.loading.set(false);
-        this.snackBar.open('Failed to load analyses', 'OK', { duration: 5000 });
+        this.toast.error('Failed to load analyses');
       },
     });
   }
@@ -288,12 +287,12 @@ export class SystemAnalysisComponent implements OnInit {
   acknowledge(a: SystemAnalysis): void {
     this.analysisService.acknowledge(a.id).subscribe({
       next: () => {
-        this.snackBar.open('Analysis acknowledged', 'OK', { duration: 3000 });
+        this.toast.info('Analysis acknowledged');
         this.load();
         this.loadStats();
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to acknowledge', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Failed to acknowledge');
       },
     });
   }
@@ -304,12 +303,12 @@ export class SystemAnalysisComponent implements OnInit {
       if (reason) {
         this.analysisService.reject(a.id, reason).subscribe({
           next: () => {
-            this.snackBar.open('Analysis rejected', 'OK', { duration: 3000 });
+            this.toast.success('Analysis rejected');
             this.load();
             this.loadStats();
           },
           error: (err) => {
-            this.snackBar.open(err.error?.error ?? 'Failed to reject', 'OK', { duration: 5000 });
+            this.toast.error(err.error?.error ?? 'Failed to reject');
           },
         });
       }
@@ -319,12 +318,12 @@ export class SystemAnalysisComponent implements OnInit {
   reopen(a: SystemAnalysis): void {
     this.analysisService.reopen(a.id).subscribe({
       next: () => {
-        this.snackBar.open('Analysis reopened', 'OK', { duration: 3000 });
+        this.toast.info('Analysis reopened');
         this.load();
         this.loadStats();
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to reopen', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Failed to reopen');
       },
     });
   }
@@ -333,12 +332,12 @@ export class SystemAnalysisComponent implements OnInit {
     if (!confirm('Delete this analysis permanently?')) return;
     this.analysisService.delete(a.id).subscribe({
       next: () => {
-        this.snackBar.open('Analysis deleted', 'OK', { duration: 3000 });
+        this.toast.success('Analysis deleted');
         this.load();
         this.loadStats();
       },
       error: (err) => {
-        this.snackBar.open(err.error?.error ?? 'Failed to delete', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Failed to delete');
       },
     });
   }
@@ -347,9 +346,9 @@ export class SystemAnalysisComponent implements OnInit {
     const text = `## System Improvement Suggestions\n\nFrom ticket ${a.ticketId}:\n\n${a.suggestions}`;
     try {
       await navigator.clipboard.writeText(text);
-      this.snackBar.open('Suggestions copied to clipboard', 'OK', { duration: 3000 });
+      this.toast.success('Suggestions copied to clipboard');
     } catch {
-      this.snackBar.open('Failed to copy to clipboard', 'OK', { duration: 3000 });
+      this.toast.error('Failed to copy to clipboard');
     }
   }
 

--- a/services/control-panel/src/app/features/system-settings/system-settings.component.ts
+++ b/services/control-panel/src/app/features/system-settings/system-settings.component.ts
@@ -1,8 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import {
   SettingsService,
   SmtpSystemConfig,
@@ -20,12 +18,12 @@ import {
   TabComponent,
   TabGroupComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
   imports: [
     FormsModule,
-    MatSnackBarModule,
     BroncoButtonComponent,
     CardComponent,
     FormFieldComponent,
@@ -335,7 +333,7 @@ import {
 })
 export class SystemSettingsComponent implements OnInit {
   private settingsService = inject(SettingsService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
@@ -403,11 +401,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.updateSmtpConfig(this.smtp).subscribe({
       next: (c) => {
         this.smtp = { ...this.smtp, ...c };
-        this.snackBar.open('SMTP config saved', 'OK', { duration: 3000 });
+        this.toast.success('SMTP config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save SMTP config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save SMTP config');
         this.saving.set(false);
       },
     });
@@ -417,11 +415,11 @@ export class SystemSettingsComponent implements OnInit {
     this.testing.set(true);
     this.settingsService.testSmtpConfig().subscribe({
       next: (r) => {
-        this.snackBar.open(r.success ? (r.message || 'Success') : (r.error || 'Test failed'), 'OK', { duration: 5000 });
+        r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed');
         this.testing.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'SMTP test failed', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'SMTP test failed');
         this.testing.set(false);
       },
     });
@@ -432,11 +430,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.updateDevOpsConfig(this.devops).subscribe({
       next: (c) => {
         this.devops = { ...this.devops, ...c };
-        this.snackBar.open('DevOps config saved', 'OK', { duration: 3000 });
+        this.toast.success('DevOps config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save DevOps config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save DevOps config');
         this.saving.set(false);
       },
     });
@@ -446,11 +444,11 @@ export class SystemSettingsComponent implements OnInit {
     this.testing.set(true);
     this.settingsService.testDevOpsConfig().subscribe({
       next: (r) => {
-        this.snackBar.open(r.success ? (r.message || 'Success') : (r.error || 'Test failed'), 'OK', { duration: 5000 });
+        r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed');
         this.testing.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'DevOps test failed', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'DevOps test failed');
         this.testing.set(false);
       },
     });
@@ -461,11 +459,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.updateGithubConfig(this.github).subscribe({
       next: (c) => {
         this.github = { ...this.github, ...c };
-        this.snackBar.open('GitHub config saved', 'OK', { duration: 3000 });
+        this.toast.success('GitHub config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save GitHub config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save GitHub config');
         this.saving.set(false);
       },
     });
@@ -475,11 +473,11 @@ export class SystemSettingsComponent implements OnInit {
     this.testing.set(true);
     this.settingsService.testGithubConfig().subscribe({
       next: (r) => {
-        this.snackBar.open(r.success ? (r.message || 'Success') : (r.error || 'Test failed'), 'OK', { duration: 5000 });
+        r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed');
         this.testing.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'GitHub test failed', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'GitHub test failed');
         this.testing.set(false);
       },
     });
@@ -490,11 +488,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.saveImapConfig(this.imap).subscribe({
       next: (c) => {
         this.imap = { ...this.imap, ...c };
-        this.snackBar.open('IMAP config saved', 'OK', { duration: 3000 });
+        this.toast.success('IMAP config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save IMAP config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save IMAP config');
         this.saving.set(false);
       },
     });
@@ -504,11 +502,11 @@ export class SystemSettingsComponent implements OnInit {
     this.testing.set(true);
     this.settingsService.testImapConnection().subscribe({
       next: (r) => {
-        this.snackBar.open(r.success ? (r.message || 'Success') : (r.error || 'Test failed'), 'OK', { duration: 5000 });
+        r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed');
         this.testing.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'IMAP test failed', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'IMAP test failed');
         this.testing.set(false);
       },
     });
@@ -519,11 +517,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.saveSlackConfig(this.slack).subscribe({
       next: (c) => {
         this.slack = { ...this.slack, ...c };
-        this.snackBar.open('Slack config saved', 'OK', { duration: 3000 });
+        this.toast.success('Slack config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save Slack config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save Slack config');
         this.saving.set(false);
       },
     });
@@ -533,11 +531,11 @@ export class SystemSettingsComponent implements OnInit {
     this.testing.set(true);
     this.settingsService.testSlackConnection().subscribe({
       next: (r) => {
-        this.snackBar.open(r.success ? (r.message || 'Success') : (r.error || 'Test failed'), 'OK', { duration: 5000 });
+        r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed');
         this.testing.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Slack test failed', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Slack test failed');
         this.testing.set(false);
       },
     });
@@ -548,11 +546,11 @@ export class SystemSettingsComponent implements OnInit {
     this.settingsService.savePromptRetention(this.promptRetention).subscribe({
       next: (c) => {
         this.promptRetention = { ...this.promptRetention, ...c };
-        this.snackBar.open('Prompt retention config saved', 'OK', { duration: 3000 });
+        this.toast.success('Prompt retention config saved');
         this.saving.set(false);
       },
       error: (err) => {
-        this.snackBar.open(err?.error?.message || 'Failed to save prompt retention config', 'OK', { duration: 5000 });
+        this.toast.error(err?.error?.message || 'Failed to save prompt retention config');
         this.saving.set(false);
       },
     });

--- a/services/control-panel/src/app/features/system-status/system-status.component.ts
+++ b/services/control-panel/src/app/features/system-status/system-status.component.ts
@@ -1,5 +1,4 @@
 import { Component, inject, OnInit, OnDestroy, signal, computed } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
 import type { Subscription } from 'rxjs';
@@ -13,6 +12,7 @@ import type { McpDiscoveryMetadata } from '../../core/services/integration.servi
 import { AiProviderService } from '../../core/services/ai-provider.service';
 import { NotificationChannelsComponent } from '../notification-channels/notification-channels.component';
 import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -756,7 +756,7 @@ import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.
 export class SystemStatusComponent implements OnInit, OnDestroy {
   private statusService = inject(SystemStatusService);
   private aiProviderService = inject(AiProviderService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private refreshInterval: ReturnType<typeof setInterval> | null = null;
   private refreshSub: Subscription | undefined;
   private aiProviderSub: Subscription | undefined;
@@ -836,16 +836,12 @@ export class SystemStatusComponent implements OnInit, OnDestroy {
     this.statusService.controlService(service, action).subscribe({
       next: (res) => {
         this.controlling.set(null);
-        this.snackBar.open(res.message, 'OK', { duration: 4000, panelClass: 'success-snackbar' });
+        this.toast.success(res.message);
         setTimeout(() => this.refresh(), 3000);
       },
       error: (err) => {
         this.controlling.set(null);
-        this.snackBar.open(
-          `Failed to ${action} ${service}: ${err.error?.error ?? err.message}`,
-          'Dismiss',
-          { duration: 6000 },
-        );
+        this.toast.error(`Failed to ${action} ${service}: ${err.error?.error ?? err.message}`);
       },
     });
   }

--- a/services/control-panel/src/app/features/systems/system-dialog.component.ts
+++ b/services/control-panel/src/app/features/systems/system-dialog.component.ts
@@ -6,8 +6,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { SystemService } from '../../core/services/system.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -90,7 +90,7 @@ export class SystemDialogComponent {
   private dialogRef = inject(MatDialogRef<SystemDialogComponent>);
   private data: { clientId: string } = inject(MAT_DIALOG_DATA);
   private systemService = inject(SystemService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   form = {
     name: '',
@@ -118,10 +118,10 @@ export class SystemDialogComponent {
       notes: this.form.notes || undefined,
     } as never).subscribe({
       next: () => {
-        this.snackBar.open('System created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('System created');
         this.dialogRef.close(true);
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
     });
   }
 }

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
@@ -6,10 +6,10 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketRouteService, TicketRoute } from '../../core/services/ticket-route.service';
 import type { RouteType } from '../../core/services/ticket-route.service';
 import { Client } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 const SOURCES = [
   { value: 'EMAIL', label: 'Email' },
@@ -114,7 +114,7 @@ export class TicketRouteDialogComponent {
   data = inject<DialogData>(MAT_DIALOG_DATA);
   private dialogRef = inject(MatDialogRef<TicketRouteDialogComponent>);
   private routeService = inject(TicketRouteService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   sources = SOURCES;
 
@@ -145,12 +145,12 @@ export class TicketRouteDialogComponent {
         sortOrder: this.sortOrder,
       }).subscribe({
         next: () => {
-          this.snackBar.open('Route updated', 'OK', { duration: 3000 });
+          this.toast.success('Route updated');
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to update route', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to update route');
         },
       });
     } else {
@@ -166,15 +166,15 @@ export class TicketRouteDialogComponent {
       }).subscribe({
         next: (result) => {
           if (result.warnings?.length) {
-            this.snackBar.open(result.warnings[0], 'OK', { duration: 8000, panelClass: 'warn-snackbar' });
+            this.toast.warning(result.warnings[0]);
           } else {
-            this.snackBar.open('Route created', 'OK', { duration: 3000 });
+            this.toast.success('Route created');
           }
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to create route', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to create route');
         },
       });
     }

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
@@ -2,7 +2,6 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketRouteService, TicketRoute, TicketRouteStep, RouteStepTypeInfo } from '../../core/services/ticket-route.service';
 import type { RouteType } from '../../core/services/ticket-route.service';
 import { ClientService, Client } from '../../core/services/client.service';
@@ -15,6 +14,7 @@ import {
   TabGroupComponent,
   ToggleSwitchComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 const CATEGORIES = [
   { value: 'DATABASE_PERF', label: 'Database Perf' },
@@ -431,7 +431,7 @@ export class TicketRouteListComponent implements OnInit {
   private routeService = inject(TicketRouteService);
   private clientService = inject(ClientService);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   routes = signal<TicketRoute[]>([]);
   ingestionRoutes = signal<TicketRoute[]>([]);
@@ -518,24 +518,24 @@ export class TicketRouteListComponent implements OnInit {
     route.isActive = newState;
     this.routeService.updateRoute(route.id, { isActive: newState }).subscribe({
       next: () => {
-        this.snackBar.open(`Route ${newState ? 'activated' : 'deactivated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Route ${newState ? 'activated' : 'deactivated'}`);
         this.loadRoutes();
       },
       error: () => {
         route.isActive = !newState;
-        this.snackBar.open('Failed to update route', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to update route');
       },
     });
   }
 
   regenerateSummary(route: TicketRoute): void {
-    this.snackBar.open('Generating summary...', '', { duration: 10000 });
+    this.toast.info('Generating summary...');
     this.routeService.regenerateSummary(route.id).subscribe({
       next: () => {
-        this.snackBar.open('Summary updated', 'OK', { duration: 3000 });
+        this.toast.success('Summary updated');
         this.loadRoutes();
       },
-      error: () => this.snackBar.open('Failed to generate summary', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to generate summary'),
     });
   }
 
@@ -543,10 +543,10 @@ export class TicketRouteListComponent implements OnInit {
     if (!confirm(`Delete route "${route.name}"? This will also delete all its steps.`)) return;
     this.routeService.deleteRoute(route.id).subscribe({
       next: () => {
-        this.snackBar.open('Route deleted', 'OK', { duration: 3000 });
+        this.toast.success('Route deleted');
         this.loadRoutes();
       },
-      error: () => this.snackBar.open('Failed to delete route', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to delete route'),
     });
   }
 
@@ -578,12 +578,12 @@ export class TicketRouteListComponent implements OnInit {
     step.isActive = newState;
     this.routeService.updateStep(route.id, step.id, { isActive: newState }).subscribe({
       next: () => {
-        this.snackBar.open(`Step ${newState ? 'activated' : 'deactivated'}`, 'OK', { duration: 3000 });
+        this.toast.success(`Step ${newState ? 'activated' : 'deactivated'}`);
         this.loadRoutes();
       },
       error: () => {
         step.isActive = !newState;
-        this.snackBar.open('Failed to update step', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to update step');
       },
     });
   }
@@ -592,10 +592,10 @@ export class TicketRouteListComponent implements OnInit {
     if (!confirm(`Delete step "${step.name}"?`)) return;
     this.routeService.deleteStep(route.id, step.id).subscribe({
       next: () => {
-        this.snackBar.open('Step deleted', 'OK', { duration: 3000 });
+        this.toast.success('Step deleted');
         this.loadRoutes();
       },
-      error: () => this.snackBar.open('Failed to delete step', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to delete step'),
     });
   }
 }

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
@@ -8,8 +8,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketRouteService, TicketRouteStep, RouteStepTypeInfo, DispatchPreviewEntry, WithWarnings } from '../../core/services/ticket-route.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   routeId: string;
@@ -315,7 +315,7 @@ export class TicketRouteStepDialogComponent implements OnInit {
   data = inject<DialogData>(MAT_DIALOG_DATA);
   private dialogRef = inject(MatDialogRef<TicketRouteStepDialogComponent>);
   private routeService = inject(TicketRouteService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   isEdit = !!this.data.step;
 
@@ -533,15 +533,15 @@ export class TicketRouteStepDialogComponent implements OnInit {
       this.routeService.updateStep(this.data.routeId, this.data.step!.id, updatePayload).subscribe({
         next: (result: WithWarnings<TicketRouteStep>) => {
           if (result.warnings.length > 0) {
-            this.snackBar.open(result.warnings[0], 'Dismiss', { duration: 8000, panelClass: 'warn-snackbar' });
+            this.toast.warning(result.warnings[0]);
           } else {
-            this.snackBar.open('Step updated', 'OK', { duration: 3000 });
+            this.toast.success('Step updated');
           }
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to update step', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to update step');
         },
       });
     } else {
@@ -555,15 +555,15 @@ export class TicketRouteStepDialogComponent implements OnInit {
       }).subscribe({
         next: (result: WithWarnings<TicketRouteStep>) => {
           if (result.warnings.length > 0) {
-            this.snackBar.open(result.warnings[0], 'Dismiss', { duration: 8000, panelClass: 'warn-snackbar' });
+            this.toast.warning(result.warnings[0]);
           } else {
-            this.snackBar.open('Step added', 'OK', { duration: 3000 });
+            this.toast.success('Step added');
           }
           this.dialogRef.close(true);
         },
         error: (err) => {
           this.saving = false;
-          this.snackBar.open(err.error?.message ?? 'Failed to add step', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error(err.error?.message ?? 'Failed to add step');
         },
       });
     }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -10,7 +10,6 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -23,6 +22,7 @@ import { AiHelpDialogComponent, type AiHelpDialogData } from '../../shared/compo
 import { AiLogEntryComponent } from './ai-log-entry.component';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
 import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import { ToastService } from '../../core/services/toast.service';
 
 interface StepGroup {
   stepName: string;
@@ -999,7 +999,7 @@ export class TicketDetailComponent implements OnInit {
   private logSummaryService = inject(LogSummaryService);
   private aiUsageService = inject(AiUsageService);
   private destroyRef = inject(DestroyRef);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
@@ -1477,15 +1477,15 @@ export class TicketDetailComponent implements OnInit {
         next: (result) => {
           this.generatingLogs.set(false);
           if (result.created > 0) {
-            this.snackBar.open('Log summary generated', 'OK', { duration: 3000 });
+            this.toast.info('Log summary generated');
             this.loadLogSummaries();
           } else {
-            this.snackBar.open('No new logs to summarize', 'OK', { duration: 3000 });
+            this.toast.info('No new logs to summarize');
           }
         },
         error: () => {
           this.generatingLogs.set(false);
-          this.snackBar.open('Failed to generate log summary', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+          this.toast.error('Failed to generate log summary');
         },
       });
   }
@@ -1493,20 +1493,20 @@ export class TicketDetailComponent implements OnInit {
   updateStatus(status: string): void {
     this.ticketService.updateTicket(this.id(), { status } as never).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
-        this.snackBar.open('Status updated', 'OK', { duration: 3000 });
+        this.toast.success('Status updated');
         this.load();
       },
-      error: () => this.snackBar.open('Failed to update', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update'),
     });
   }
 
   updateField(field: 'priority' | 'category', value: string | null): void {
     this.ticketService.updateTicket(this.id(), { [field]: value } as never).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
-        this.snackBar.open(`${field.charAt(0).toUpperCase() + field.slice(1)} updated`, 'OK', { duration: 3000 });
+        this.toast.success(`${field.charAt(0).toUpperCase() + field.slice(1)} updated`);
         this.load();
       },
-      error: () => this.snackBar.open(`Failed to update ${field}`, 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error(`Failed to update ${field}`),
     });
   }
 
@@ -1526,10 +1526,10 @@ export class TicketDetailComponent implements OnInit {
       next: () => {
         this.editingKnowledgeDoc.set(false);
         this.knowledgeDocDraft = '';
-        this.snackBar.open('Knowledge doc updated', 'OK', { duration: 3000 });
+        this.toast.success('Knowledge doc updated');
         this.load();
       },
-      error: () => this.snackBar.open('Failed to update knowledge doc', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to update knowledge doc'),
     });
   }
 
@@ -1537,10 +1537,10 @@ export class TicketDetailComponent implements OnInit {
     if (!confirm('This will remove all investigation history. Continue?')) return;
     this.ticketService.updateKnowledgeDoc(this.id(), null).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
-        this.snackBar.open('Knowledge doc cleared', 'OK', { duration: 3000 });
+        this.toast.success('Knowledge doc cleared');
         this.load();
       },
-      error: () => this.snackBar.open('Failed to clear knowledge doc', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to clear knowledge doc'),
     });
   }
 
@@ -1549,12 +1549,12 @@ export class TicketDetailComponent implements OnInit {
     this.ticketService.reanalyze(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
         this.reanalyzing.set(false);
-        this.snackBar.open('Analysis re-queued', 'OK', { duration: 3000 });
+        this.toast.success('Analysis re-queued');
         this.load();
       },
       error: () => {
         this.reanalyzing.set(false);
-        this.snackBar.open('Failed to re-queue analysis', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error('Failed to re-queue analysis');
       },
     });
   }
@@ -1587,7 +1587,7 @@ export class TicketDetailComponent implements OnInit {
         this.newComment = '';
         this.load();
       },
-      error: () => this.snackBar.open('Failed to add comment', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: () => this.toast.error('Failed to add comment'),
     });
   }
 
@@ -1727,11 +1727,11 @@ export class TicketDetailComponent implements OnInit {
     if (!ticketId) return;
     this.ticketService.approvePendingAction(ticketId, actionId).subscribe({
       next: () => {
-        this.snackBar.open('Action approved', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Action approved');
         this.loadPendingActions();
         this.load();
       },
-      error: () => this.snackBar.open('Failed to approve action', 'OK', { duration: 5000 }),
+      error: () => this.toast.error('Failed to approve action'),
     });
   }
 
@@ -1741,11 +1741,11 @@ export class TicketDetailComponent implements OnInit {
     if (!ticketId) return;
     this.ticketService.dismissPendingAction(ticketId, actionId).subscribe({
       next: () => {
-        this.snackBar.open('Action dismissed', 'OK', { duration: 3000 });
+        this.toast.success('Action dismissed');
         this.loadPendingActions();
         this.load();
       },
-      error: () => this.snackBar.open('Failed to dismiss action', 'OK', { duration: 5000 }),
+      error: () => this.toast.error('Failed to dismiss action'),
     });
   }
 

--- a/services/control-panel/src/app/features/tickets/ticket-dialog.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-dialog.component.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketService } from '../../core/services/ticket.service';
 import { ClientService, Client } from '../../core/services/client.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -72,7 +72,7 @@ export class TicketDialogComponent {
   data: { clientId?: string } = inject(MAT_DIALOG_DATA);
   private ticketService = inject(TicketService);
   private clientService = inject(ClientService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   clientId = this.data.clientId ?? '';
   subject = '';
@@ -97,10 +97,10 @@ export class TicketDialogComponent {
       category: this.category || undefined,
     }).subscribe({
       next: (ticket) => {
-        this.snackBar.open('Ticket created', 'OK', { duration: 3000, panelClass: 'success-snackbar' });
+        this.toast.success('Ticket created');
         this.dialogRef.close(ticket);
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to create ticket', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? 'Failed to create ticket'),
     });
   }
 }

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service';
 import { TicketFilterPresetService, TicketFilterPreset } from '../../core/services/ticket-filter-preset.service';
 import { DetailPanelService } from '../../core/services/detail-panel.service';
@@ -18,6 +17,7 @@ import {
   SelectComponent,
   ToggleSwitchComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -215,7 +215,7 @@ export class TicketListComponent implements OnInit {
   private detailPanel = inject(DetailPanelService);
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   tickets = signal<Ticket[]>([]);
   presets = signal<TicketFilterPreset[]>([]);
@@ -322,10 +322,10 @@ export class TicketListComponent implements OnInit {
         clientIdFilter: this.clientIdFilter() || null,
       }).subscribe({
         next: () => {
-          this.snackBar.open(`Preset "${selected.name}" updated`, 'OK', { duration: 2000 });
+          this.toast.success(`Preset "${selected.name}" updated`);
           this.loadPresets();
         },
-        error: (err) => this.snackBar.open(err.error?.error ?? 'Failed to update preset', 'OK', { duration: 3000 }),
+        error: (err) => this.toast.error(err.error?.error ?? 'Failed to update preset'),
       });
     } else {
       const name = window.prompt('Preset name:');
@@ -337,10 +337,10 @@ export class TicketListComponent implements OnInit {
         clientIdFilter: this.clientIdFilter() || null,
       }).subscribe({
         next: (preset) => {
-          this.snackBar.open(`Preset "${preset.name}" created`, 'OK', { duration: 2000 });
+          this.toast.success(`Preset "${preset.name}" created`);
           this.loadPresets({ next: () => { this.selectedPresetId.set(preset.id); } });
         },
-        error: (err) => this.snackBar.open(err.error?.error ?? 'Failed to create preset', 'OK', { duration: 3000 }),
+        error: (err) => this.toast.error(err.error?.error ?? 'Failed to create preset'),
       });
     }
   }
@@ -351,11 +351,11 @@ export class TicketListComponent implements OnInit {
     if (!confirm(`Delete preset "${selected.name}"?`)) return;
     this.presetService.deletePreset(selected.id).subscribe({
       next: () => {
-        this.snackBar.open(`Preset "${selected.name}" deleted`, 'OK', { duration: 2000 });
+        this.toast.success(`Preset "${selected.name}" deleted`);
         this.selectedPresetId.set('');
         this.loadPresets();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Failed to delete preset', 'OK', { duration: 3000 }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Failed to delete preset'),
     });
   }
 
@@ -364,10 +364,10 @@ export class TicketListComponent implements OnInit {
     if (!selected) return;
     this.presetService.updatePreset(selected.id, { isDefault: checked }).subscribe({
       next: () => {
-        this.snackBar.open(checked ? `"${selected.name}" set as default` : 'Default cleared', 'OK', { duration: 2000 });
+        this.toast.success(checked ? `"${selected.name}" set as default` : 'Default cleared');
         this.loadPresets();
       },
-      error: (err) => this.snackBar.open(err.error?.error ?? 'Failed to update preset', 'OK', { duration: 3000 }),
+      error: (err) => this.toast.error(err.error?.error ?? 'Failed to update preset'),
     });
   }
 

--- a/services/control-panel/src/app/features/tickets/ticket-quick-actions-dialog.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-quick-actions-dialog.component.ts
@@ -7,8 +7,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { TicketService, Ticket } from '../../core/services/ticket.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -64,7 +64,7 @@ export class TicketQuickActionsDialogComponent {
   private dialogRef = inject(MatDialogRef<TicketQuickActionsDialogComponent>);
   data: { ticket: Ticket } = inject(MAT_DIALOG_DATA);
   private ticketService = inject(TicketService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private destroyRef = inject(DestroyRef);
 
   status = this.data.ticket.status;
@@ -89,10 +89,10 @@ export class TicketQuickActionsDialogComponent {
 
     this.ticketService.updateTicket(this.data.ticket.id, patch as Partial<Ticket>).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (updated) => {
-        this.snackBar.open('Ticket updated', 'OK', { duration: 3000 });
+        this.toast.success('Ticket updated');
         this.dialogRef.close(updated);
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? 'Failed to update ticket', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? 'Failed to update ticket'),
     });
   }
 }

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -5,9 +5,9 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
+import { ToastService } from '../../core/services/toast.service';
 
 interface DialogData {
   user?: ControlPanelUser;
@@ -65,7 +65,7 @@ export class UserDialogComponent {
   private dialogRef = inject(MatDialogRef<UserDialogComponent>);
   data = inject<DialogData>(MAT_DIALOG_DATA);
   private userService = inject(UserService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   name = this.data.user?.name ?? '';
   email = this.data.user?.email ?? '';
@@ -85,10 +85,10 @@ export class UserDialogComponent {
         ...(this.slackUserId !== undefined && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
-          this.snackBar.open('User updated', 'OK', { duration: 3000 });
+          this.toast.success('User updated');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Update failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Update failed'),
       });
     } else {
       this.userService.createUser({
@@ -99,10 +99,10 @@ export class UserDialogComponent {
         ...(this.slackUserId && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
-          this.snackBar.open('User created', 'OK', { duration: 3000 });
+          this.toast.success('User created');
           this.dialogRef.close(true);
         },
-        error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Create failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Create failed'),
       });
     }
   }

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -2,7 +2,6 @@ import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
 import { AuthService } from '../../core/services/auth.service';
@@ -12,6 +11,7 @@ import {
   CardComponent,
   FormFieldComponent,
 } from '../../shared/components/index.js';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
@@ -270,7 +270,7 @@ import {
 export class UserListComponent implements OnInit {
   private userService = inject(UserService);
   private authService = inject(AuthService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private dialog = inject(MatDialog);
 
   users = signal<ControlPanelUser[]>([]);
@@ -293,7 +293,7 @@ export class UserListComponent implements OnInit {
       },
       error: (err) => {
         this.loading.set(false);
-        this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Failed to load users', 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+        this.toast.error(err.error?.message ?? err.error?.error ?? 'Failed to load users');
       },
     });
   }
@@ -328,31 +328,31 @@ export class UserListComponent implements OnInit {
     if (!user) return;
     this.userService.resetPassword(user.id, this.resetPassword).subscribe({
       next: () => {
-        this.snackBar.open('Password reset successfully', 'OK', { duration: 3000 });
+        this.toast.success('Password reset successfully');
         this.resetUser.set(null);
         this.resetPassword = '';
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Reset failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Reset failed'),
     });
   }
 
   deactivate(user: ControlPanelUser): void {
     this.userService.deleteUser(user.id).subscribe({
       next: () => {
-        this.snackBar.open('User deactivated', 'OK', { duration: 3000 });
+        this.toast.success('User deactivated');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Deactivation failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Deactivation failed'),
     });
   }
 
   activate(user: ControlPanelUser): void {
     this.userService.updateUser(user.id, { isActive: true }).subscribe({
       next: () => {
-        this.snackBar.open('User activated', 'OK', { duration: 3000 });
+        this.toast.success('User activated');
         this.load();
       },
-      error: (err) => this.snackBar.open(err.error?.message ?? err.error?.error ?? 'Activation failed', 'OK', { duration: 5000, panelClass: 'error-snackbar' }),
+      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Activation failed'),
     });
   }
 }

--- a/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
@@ -9,9 +9,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AiProviderService, type AiProviderModel } from '../../core/services/ai-provider.service';
 import type { AiHelpResponse } from '../../core/services/ticket.service';
+import { ToastService } from '../../core/services/toast.service';
 
 /**
  * Data passed to the AI help dialog. The `submitFn` callback is responsible for
@@ -103,7 +103,7 @@ interface ModelOption {
 export class AiHelpDialogComponent implements OnInit {
   data: AiHelpDialogData = inject(MAT_DIALOG_DATA);
   private providerService = inject(AiProviderService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
   private destroyRef = inject(DestroyRef);
 
   modelOptions = signal<ModelOption[]>([]);
@@ -154,7 +154,7 @@ export class AiHelpDialogComponent implements OnInit {
       this.loading.set(false);
       const msg = err?.error?.message ?? err?.message ?? 'AI request failed';
       this.errorMsg.set(msg);
-      this.snackBar.open(msg, 'OK', { duration: 5000, panelClass: 'error-snackbar' });
+      this.toast.error(msg);
     });
   }
 }

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -42,7 +42,8 @@ import { DataTableColumnComponent } from './data-table-column.component';
                 [class.clickable]="rowClickable()"
                 [attr.tabindex]="rowClickable() ? 0 : null"
                 (click)="rowClickable() ? rowClick.emit(row) : null"
-                (keydown.enter)="rowClickable() ? rowClick.emit(row) : null">
+                (keydown.enter)="rowClickable() ? rowClick.emit(row) : null"
+                (keydown.space)="rowClickable() ? onRowSpace($event, row) : null">
                 @for (col of columns(); track col.key()) {
                   <td [style.width]="col.width()">
                     <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
@@ -148,5 +149,10 @@ export class DataTableComponent<T = unknown> {
   onSortKey(event: Event, key: string): void {
     event.preventDefault();
     this.onSort(key);
+  }
+
+  onRowSpace(event: Event, row: T): void {
+    event.preventDefault();
+    this.rowClick.emit(row);
   }
 }

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -15,3 +15,4 @@ export { TabComponent } from './tab.component';
 export { TabGroupComponent } from './tab-group.component';
 export { DialogComponent } from './dialog.component';
 export { ToolbarComponent } from './toolbar.component';
+export { ToastContainerComponent } from './toast-container.component';

--- a/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
+++ b/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
@@ -3,13 +3,13 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { IntegrationService, type McpDiscoveryMetadata } from '../../core/services/integration.service';
+import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   selector: 'app-mcp-server-info',
   standalone: true,
-  imports: [MatIconModule, MatButtonModule, MatTooltipModule, MatProgressSpinnerModule, MatSnackBarModule],
+  imports: [MatIconModule, MatButtonModule, MatTooltipModule, MatProgressSpinnerModule],
   template: `
     <div class="mcp-info">
       <!-- Server identity -->
@@ -170,7 +170,7 @@ export class McpServerInfoComponent {
   verified = output<void>();
 
   private integrationService = inject(IntegrationService);
-  private snackBar = inject(MatSnackBar);
+  private toast = inject(ToastService);
 
   verifying = false;
 
@@ -181,12 +181,12 @@ export class McpServerInfoComponent {
     this.integrationService.verify(id).subscribe({
       next: () => {
         this.verifying = false;
-        this.snackBar.open('Verification job enqueued', 'OK', { duration: 3000 });
+        this.toast.success('Verification job enqueued');
         this.verified.emit();
       },
       error: (err) => {
         this.verifying = false;
-        this.snackBar.open(err.error?.error ?? 'Verification failed', 'OK', { duration: 5000 });
+        this.toast.error(err.error?.error ?? 'Verification failed');
       },
     });
   }

--- a/services/control-panel/src/app/shared/components/toast-container.component.ts
+++ b/services/control-panel/src/app/shared/components/toast-container.component.ts
@@ -1,0 +1,104 @@
+import { Component, inject } from '@angular/core';
+import { ToastService, type Toast } from '../../core/services/toast.service.js';
+
+@Component({
+  selector: 'app-toast-container',
+  standalone: true,
+  template: `
+    <div class="toast-stack">
+      @for (toast of toastService.toasts(); track toast.id) {
+        <div class="toast" [class]="'toast-' + toast.type" @slideIn>
+          <span class="toast-message">{{ toast.message }}</span>
+          <button class="toast-dismiss" (click)="toastService.dismiss(toast.id)" aria-label="Dismiss">&times;</button>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .toast-stack {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 10000;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      pointer-events: none;
+    }
+
+    .toast {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 280px;
+      max-width: 420px;
+      padding: 12px 16px;
+      border-radius: 8px;
+      border-left: 4px solid;
+      background: var(--bg-card);
+      box-shadow: var(--shadow-card);
+      color: var(--text-primary);
+      font-size: 13px;
+      font-family: var(--font-primary);
+      pointer-events: auto;
+      animation: toastSlideIn 0.25s ease-out;
+    }
+
+    .toast-success {
+      border-left-color: var(--color-success);
+      background: color-mix(in srgb, var(--color-success) 8%, var(--bg-card));
+    }
+
+    .toast-error {
+      border-left-color: var(--color-error);
+      background: color-mix(in srgb, var(--color-error) 8%, var(--bg-card));
+    }
+
+    .toast-warning {
+      border-left-color: var(--color-warning);
+      background: color-mix(in srgb, var(--color-warning) 8%, var(--bg-card));
+    }
+
+    .toast-info {
+      border-left-color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
+    }
+
+    .toast-message {
+      flex: 1;
+      line-height: 1.4;
+      letter-spacing: -0.1px;
+    }
+
+    .toast-dismiss {
+      flex-shrink: 0;
+      background: none;
+      border: none;
+      color: var(--text-secondary);
+      font-size: 18px;
+      cursor: pointer;
+      padding: 0 2px;
+      line-height: 1;
+      opacity: 0.6;
+      transition: opacity 0.15s ease;
+    }
+
+    .toast-dismiss:hover {
+      opacity: 1;
+    }
+
+    @keyframes toastSlideIn {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+  `],
+})
+export class ToastContainerComponent {
+  readonly toastService = inject(ToastService);
+}

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -5,6 +5,7 @@ import { HeaderBarComponent } from './header-bar.component';
 import { DetailPanelComponent } from './detail-panel.component';
 import { DetailPanelService } from '../core/services/detail-panel.service';
 import { ThemeService } from '../core/services/theme.service';
+import { ToastContainerComponent } from '../shared/components/toast-container.component';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
   dashboard: 'Dashboard',
@@ -35,7 +36,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent],
+  imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent, ToastContainerComponent],
   template: `
     <div class="shell">
       <app-sidebar />
@@ -49,6 +50,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
         <app-detail-panel />
       }
     </div>
+    <app-toast-container />
   `,
   styles: [`
     .shell {

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -27,20 +27,6 @@ html, body {
   flex: 1 1 auto;
 }
 
-.mat-mdc-snack-bar-container {
-  &.error-snackbar {
-    --mdc-snackbar-container-color: #d32f2f;
-    --mdc-snackbar-supporting-text-color: white;
-  }
-  &.success-snackbar {
-    --mdc-snackbar-container-color: #388e3c;
-    --mdc-snackbar-supporting-text-color: white;
-  }
-  &.warn-snackbar {
-    --mdc-snackbar-container-color: #f57c00;
-    --mdc-snackbar-supporting-text-color: white;
-  }
-}
 
 @media (max-width: 767px) {
   .mat-mdc-table {


### PR DESCRIPTION
## Summary
- Add `ToastService` and `ToastContainerComponent` — a custom toast/notification system replacing Material's MatSnackBar
- Replace MatSnackBar usage across ~50 components (all feature pages, dialogs, and shared components)
- Toast container mounted in app shell for global toast rendering
- Supports success, error, info, and warning toast variants

## Test plan
- [ ] Verify toast notifications appear for all CRUD operations (create, update, delete) across major pages
- [ ] Verify error toasts appear on API failures
- [ ] Verify toasts auto-dismiss after timeout
- [ ] Verify login page error handling still works
- [ ] Spot-check: tickets, clients, settings, probes, prompts, users pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
