### PR TITLE
feat: migrate client, prompt, and operations dialogs from MatDialog to app-dialog (refs #131)

### DIFF
--- a/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
+++ b/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
@@ -1,6 +1,5 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { AiProviderService, AiProvider, AiProviderModel } from '../../core/services/ai-provider.service';
 import { AiProviderDialogComponent } from '../prompts/ai-provider-dialog.component';
 import { AiModelDialogComponent } from '../prompts/ai-model-dialog.component';
@@ -9,12 +8,13 @@ import {
   ToggleSwitchComponent,
   DataTableComponent,
   DataTableColumnComponent,
+  DialogComponent,
 } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
-  imports: [FormsModule, MatDialogModule, BroncoButtonComponent, ToggleSwitchComponent, DataTableComponent, DataTableColumnComponent],
+  imports: [FormsModule, BroncoButtonComponent, ToggleSwitchComponent, DataTableComponent, DataTableColumnComponent, DialogComponent, AiProviderDialogComponent, AiModelDialogComponent],
   template: `
     <div class="page-wrapper">
       <div class="page-header">
@@ -162,6 +162,25 @@ import { ToastService } from '../../core/services/toast.service';
         </app-data-table>
       </div>
     </div>
+
+    @if (showProviderDialog()) {
+      <app-dialog [open]="true" [title]="editingProvider() ? 'Edit Provider' : 'Add Provider'" maxWidth="500px" (openChange)="showProviderDialog.set(false)">
+        <app-ai-provider-dialog-content
+          [config]="editingProvider() ?? undefined"
+          (saved)="onProviderSaved()"
+          (cancelled)="showProviderDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showModelDialog()) {
+      <app-dialog [open]="true" [title]="editingModel() ? 'Edit Model' : 'Add Model'" maxWidth="500px" (openChange)="showModelDialog.set(false)">
+        <app-ai-model-dialog-content
+          [model]="editingModel() ?? undefined"
+          [providers]="providers()"
+          (saved)="onModelSaved()"
+          (cancelled)="showModelDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-wrapper { max-width: 1200px; }
@@ -281,11 +300,16 @@ import { ToastService } from '../../core/services/toast.service';
 })
 export class AiProvidersComponent implements OnInit {
   private aiProviderService = inject(AiProviderService);
-  private dialog = inject(MatDialog);
   private toast = inject(ToastService);
 
   providers = signal<AiProvider[]>([]);
   models = signal<AiProviderModel[]>([]);
+
+  // Dialog state
+  showProviderDialog = signal(false);
+  editingProvider = signal<AiProvider | null>(null);
+  showModelDialog = signal(false);
+  editingModel = signal<AiProviderModel | null>(null);
 
   private appScopeLabels = signal<Record<string, string>>({});
 
@@ -317,13 +341,18 @@ export class AiProvidersComponent implements OnInit {
   // --- Provider actions ---
 
   addProvider(): void {
-    const ref = this.dialog.open(AiProviderDialogComponent, { width: '500px', data: {} });
-    ref.afterClosed().subscribe(result => { if (result) this.loadAll(); });
+    this.editingProvider.set(null);
+    this.showProviderDialog.set(true);
   }
 
   editProvider(config: AiProvider): void {
-    const ref = this.dialog.open(AiProviderDialogComponent, { width: '500px', data: { config } });
-    ref.afterClosed().subscribe(result => { if (result) this.loadAll(); });
+    this.editingProvider.set(config);
+    this.showProviderDialog.set(true);
+  }
+
+  onProviderSaved(): void {
+    this.showProviderDialog.set(false);
+    this.loadAll();
   }
 
   toggleProviderActive(config: AiProvider): void {
@@ -362,13 +391,18 @@ export class AiProvidersComponent implements OnInit {
   // --- Model actions ---
 
   addModel(): void {
-    const ref = this.dialog.open(AiModelDialogComponent, { width: '500px', data: { providers: this.providers() } });
-    ref.afterClosed().subscribe(result => { if (result) this.loadAll(); });
+    this.editingModel.set(null);
+    this.showModelDialog.set(true);
   }
 
   editModel(model: AiProviderModel): void {
-    const ref = this.dialog.open(AiModelDialogComponent, { width: '500px', data: { model, providers: this.providers() } });
-    ref.afterClosed().subscribe(result => { if (result) this.loadAll(); });
+    this.editingModel.set(model);
+    this.showModelDialog.set(true);
+  }
+
+  onModelSaved(): void {
+    this.showModelDialog.set(false);
+    this.loadAll();
   }
 
   toggleModelActive(model: AiProviderModel): void {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -48,6 +48,8 @@ import { ToastService } from '../../core/services/toast.service';
     MatTableModule, MatChipsModule, MatDialogModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
     MatButtonToggleModule, FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     DialogComponent, TicketDialogComponent,
+    ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
+    SystemDialogComponent, RepoDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -630,6 +632,64 @@ import { ToastService } from '../../core/services/toast.service';
           (cancelled)="showTicketDialog.set(false)" />
       </app-dialog>
     }
+
+    @if (showMemoryDialog()) {
+      <app-dialog [open]="true" [title]="editingMemory() ? 'Edit Client Memory' : 'Add Client Memory'" maxWidth="650px" (openChange)="showMemoryDialog.set(false)">
+        <app-client-memory-dialog-content
+          [clientId]="id()"
+          [memory]="editingMemory() ?? undefined"
+          (saved)="onMemorySaved()"
+          (cancelled)="showMemoryDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showEnvironmentDialog()) {
+      <app-dialog [open]="true" [title]="editingEnvironment() ? 'Edit Environment' : 'Add Environment'" maxWidth="650px" (openChange)="showEnvironmentDialog.set(false)">
+        <app-client-environment-dialog-content
+          [clientId]="id()"
+          [environment]="editingEnvironment() ?? undefined"
+          (saved)="onEnvironmentSaved()"
+          (cancelled)="showEnvironmentDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showUserDialog()) {
+      <app-dialog [open]="true" [title]="editingUser() ? 'Edit User' : 'Create Portal User'" maxWidth="500px" (openChange)="showUserDialog.set(false)">
+        <app-client-user-dialog-content
+          [clientId]="id()"
+          [user]="editingUser() ?? undefined"
+          (saved)="onUserSaved()"
+          (cancelled)="showUserDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showInvoiceDialog()) {
+      <app-dialog [open]="true" title="Generate Invoice" maxWidth="400px" (openChange)="showInvoiceDialog.set(false)">
+        <app-generate-invoice-dialog-content
+          [clientId]="id()"
+          (generated)="onInvoiceGenerated()"
+          (cancelled)="showInvoiceDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showSystemDialog()) {
+      <app-dialog [open]="true" title="Add Database System" maxWidth="600px" (openChange)="showSystemDialog.set(false)">
+        <app-system-dialog-content
+          [clientId]="id()"
+          (saved)="onSystemSaved()"
+          (cancelled)="showSystemDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showRepoDialog()) {
+      <app-dialog [open]="true" [title]="editingRepo() ? 'Edit Code Repository' : 'Add Code Repository'" maxWidth="500px" (openChange)="showRepoDialog.set(false)">
+        <app-repo-dialog-content
+          [clientId]="id()"
+          [repo]="editingRepo() ?? undefined"
+          (saved)="onRepoSaved()"
+          (cancelled)="showRepoDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
@@ -850,8 +910,12 @@ export class ClientDetailComponent implements OnInit {
   }
 
   addSystem(): void {
-    const ref = this.dialog.open(SystemDialogComponent, { width: '600px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.showSystemDialog.set(true);
+  }
+
+  onSystemSaved(): void {
+    this.showSystemDialog.set(false);
+    this.load();
   }
 
   addContact(): void {
@@ -875,13 +939,18 @@ export class ClientDetailComponent implements OnInit {
   }
 
   addRepo(): void {
-    const ref = this.dialog.open(RepoDialogComponent, { width: '500px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingRepo.set(null);
+    this.showRepoDialog.set(true);
   }
 
   editRepo(repo: CodeRepo): void {
-    const ref = this.dialog.open(RepoDialogComponent, { width: '500px', data: { clientId: this.id(), repo } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingRepo.set(repo);
+    this.showRepoDialog.set(true);
+  }
+
+  onRepoSaved(): void {
+    this.showRepoDialog.set(false);
+    this.load();
   }
 
   deleteRepo(repo: CodeRepo): void {
@@ -903,6 +972,16 @@ export class ClientDetailComponent implements OnInit {
   }
 
   showTicketDialog = signal(false);
+  showMemoryDialog = signal(false);
+  editingMemory = signal<ClientMemory | null>(null);
+  showEnvironmentDialog = signal(false);
+  editingEnvironment = signal<ClientEnvironment | null>(null);
+  showUserDialog = signal(false);
+  editingUser = signal<ClientUser | null>(null);
+  showInvoiceDialog = signal(false);
+  showSystemDialog = signal(false);
+  showRepoDialog = signal(false);
+  editingRepo = signal<CodeRepo | null>(null);
 
   createTicket(): void {
     this.showTicketDialog.set(true);
@@ -954,13 +1033,18 @@ export class ClientDetailComponent implements OnInit {
   }
 
   addMemory(): void {
-    const ref = this.dialog.open(ClientMemoryDialogComponent, { width: '650px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingMemory.set(null);
+    this.showMemoryDialog.set(true);
   }
 
   editMemory(mem: ClientMemory): void {
-    const ref = this.dialog.open(ClientMemoryDialogComponent, { width: '650px', data: { clientId: this.id(), memory: mem } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingMemory.set(mem);
+    this.showMemoryDialog.set(true);
+  }
+
+  onMemorySaved(): void {
+    this.showMemoryDialog.set(false);
+    this.load();
   }
 
   toggleMemory(mem: ClientMemory, checked: boolean): void {
@@ -987,13 +1071,18 @@ export class ClientDetailComponent implements OnInit {
   }
 
   addEnvironment(): void {
-    const ref = this.dialog.open(ClientEnvironmentDialogComponent, { width: '650px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingEnvironment.set(null);
+    this.showEnvironmentDialog.set(true);
   }
 
   editEnvironment(env: ClientEnvironment): void {
-    const ref = this.dialog.open(ClientEnvironmentDialogComponent, { width: '650px', data: { clientId: this.id(), environment: env } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingEnvironment.set(env);
+    this.showEnvironmentDialog.set(true);
+  }
+
+  onEnvironmentSaved(): void {
+    this.showEnvironmentDialog.set(false);
+    this.load();
   }
 
   toggleEnvironment(env: ClientEnvironment, checked: boolean): void {
@@ -1053,13 +1142,18 @@ export class ClientDetailComponent implements OnInit {
   }
 
   addClientUser(): void {
-    const ref = this.dialog.open(ClientUserDialogComponent, { width: '500px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingUser.set(null);
+    this.showUserDialog.set(true);
   }
 
   editClientUser(user: ClientUser): void {
-    const ref = this.dialog.open(ClientUserDialogComponent, { width: '500px', data: { clientId: this.id(), user } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.editingUser.set(user);
+    this.showUserDialog.set(true);
+  }
+
+  onUserSaved(): void {
+    this.showUserDialog.set(false);
+    this.load();
   }
 
   deleteClientUser(id: string): void {
@@ -1073,8 +1167,12 @@ export class ClientDetailComponent implements OnInit {
   }
 
   openGenerateInvoiceDialog(): void {
-    const ref = this.dialog.open(GenerateInvoiceDialogComponent, { width: '400px', data: { clientId: this.id() } });
-    ref.afterClosed().subscribe(result => { if (result) this.load(); });
+    this.showInvoiceDialog.set(true);
+  }
+
+  onInvoiceGenerated(): void {
+    this.showInvoiceDialog.set(false);
+    this.load();
   }
 
   getInvoiceDownloadUrl(invoiceId: string): string {

--- a/services/control-panel/src/app/features/clients/client-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -8,40 +7,41 @@ import { ClientService } from '../../core/services/client.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-client-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>New Client</h2>
-    <mat-dialog-content>
-      <mat-form-field class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" required>
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Short Code</mat-label>
-        <input matInput [(ngModel)]="shortCode" required placeholder="e.g. ACME">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Domain Mappings</mat-label>
-        <input matInput [(ngModel)]="domainMappingsStr" placeholder="e.g. acme.com, acme.org">
-        <mat-hint>Comma-separated email domains to auto-route to this client</mat-hint>
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Notes</mat-label>
-        <textarea matInput [(ngModel)]="notes" rows="3"></textarea>
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <mat-form-field class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required>
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Short Code</mat-label>
+      <input matInput [(ngModel)]="shortCode" required placeholder="e.g. ACME">
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Domain Mappings</mat-label>
+      <input matInput [(ngModel)]="domainMappingsStr" placeholder="e.g. acme.com, acme.org">
+      <mat-hint>Comma-separated email domains to auto-route to this client</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Notes</mat-label>
+      <textarea matInput [(ngModel)]="notes" rows="3"></textarea>
+    </mat-form-field>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!name || !shortCode">Create</button>
-    </mat-dialog-actions>
+    </div>
   `,
-  styles: [`.full-width { width: 100%; margin-bottom: 8px; }`],
+  styles: [`.full-width { width: 100%; margin-bottom: 8px; } .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }`],
 })
 export class ClientDialogComponent {
-  private dialogRef = inject(MatDialogRef<ClientDialogComponent>);
   private clientService = inject(ClientService);
   private toast = inject(ToastService);
+
+  created = output<boolean>();
+  cancelled = output<void>();
 
   name = '';
   shortCode = '';
@@ -60,7 +60,7 @@ export class ClientDialogComponent {
     }).subscribe({
       next: () => {
         this.toast.success('Client created');
-        this.dialogRef.close(true);
+        this.created.emit(true);
       },
       error: (err) => {
         this.toast.error(err.error?.error ?? 'Failed to create client');

--- a/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -9,69 +8,84 @@ import { ClientEnvironmentService, type ClientEnvironment } from '../../core/ser
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-client-environment-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>{{ data.environment ? 'Edit' : 'Add' }} Environment</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" placeholder="e.g. Production">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" placeholder="e.g. Production">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Tag</mat-label>
+      <input matInput [(ngModel)]="tag" placeholder="e.g. production">
+      <mat-hint>Lowercase alphanumeric with hyphens only</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Description</mat-label>
+      <textarea matInput [(ngModel)]="description" rows="2" placeholder="Brief description of this environment"></textarea>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Operational Instructions (Markdown)</mat-label>
+      <textarea matInput [(ngModel)]="operationalInstructions" rows="8"
+        placeholder="Instructions injected into AI prompts when analyzing tickets scoped to this environment."></textarea>
+    </mat-form-field>
+
+    <div class="row">
+      <mat-form-field appearance="outline" class="half-width">
+        <mat-label>Sort Order</mat-label>
+        <input matInput type="number" [(ngModel)]="sortOrder">
       </mat-form-field>
+      <mat-checkbox [(ngModel)]="isDefault">Default environment</mat-checkbox>
+    </div>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Tag</mat-label>
-        <input matInput [(ngModel)]="tag" placeholder="e.g. production">
-        <mat-hint>Lowercase alphanumeric with hyphens only</mat-hint>
-      </mat-form-field>
-
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Description</mat-label>
-        <textarea matInput [(ngModel)]="description" rows="2" placeholder="Brief description of this environment"></textarea>
-      </mat-form-field>
-
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Operational Instructions (Markdown)</mat-label>
-        <textarea matInput [(ngModel)]="operationalInstructions" rows="8"
-          placeholder="Instructions injected into AI prompts when analyzing tickets scoped to this environment."></textarea>
-      </mat-form-field>
-
-      <div class="row">
-        <mat-form-field appearance="outline" class="half-width">
-          <mat-label>Sort Order</mat-label>
-          <input matInput type="number" [(ngModel)]="sortOrder">
-        </mat-form-field>
-        <mat-checkbox [(ngModel)]="isDefault">Default environment</mat-checkbox>
-      </div>
-    </mat-dialog-content>
-
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!name.trim() || !tag.trim() || saving">
-        {{ saving ? 'Saving...' : (data.environment ? 'Update' : 'Create') }}
+        {{ saving ? 'Saving...' : (environment() ? 'Update' : 'Create') }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; }
     .half-width { width: 50%; }
     .row { display: flex; align-items: center; gap: 16px; }
-    mat-dialog-content { display: flex; flex-direction: column; min-width: 500px; }
+    :host { display: flex; flex-direction: column; min-width: 500px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class ClientEnvironmentDialogComponent {
-  private dialogRef = inject(MatDialogRef<ClientEnvironmentDialogComponent>);
-  data = inject<{ clientId: string; environment?: ClientEnvironment }>(MAT_DIALOG_DATA);
+export class ClientEnvironmentDialogComponent implements OnInit {
   private envService = inject(ClientEnvironmentService);
   private toast = inject(ToastService);
 
-  name = this.data.environment?.name ?? '';
-  tag = this.data.environment?.tag ?? '';
-  description = this.data.environment?.description ?? '';
-  operationalInstructions = this.data.environment?.operationalInstructions ?? '';
-  sortOrder = this.data.environment?.sortOrder ?? 0;
-  isDefault = this.data.environment?.isDefault ?? false;
+  clientId = input.required<string>();
+  environment = input<ClientEnvironment>();
+
+  saved = output<ClientEnvironment>();
+  cancelled = output<void>();
+
+  name = '';
+  tag = '';
+  description = '';
+  operationalInstructions = '';
+  sortOrder = 0;
+  isDefault = false;
   saving = false;
+
+  ngOnInit(): void {
+    const env = this.environment();
+    if (env) {
+      this.name = env.name ?? '';
+      this.tag = env.tag ?? '';
+      this.description = env.description ?? '';
+      this.operationalInstructions = env.operationalInstructions ?? '';
+      this.sortOrder = env.sortOrder ?? 0;
+      this.isDefault = env.isDefault ?? false;
+    }
+  }
 
   save(): void {
     this.saving = true;
@@ -84,14 +98,15 @@ export class ClientEnvironmentDialogComponent {
       isDefault: this.isDefault,
     };
 
-    const op = this.data.environment
-      ? this.envService.updateEnvironment(this.data.clientId, this.data.environment.id, payload)
-      : this.envService.createEnvironment(this.data.clientId, payload);
+    const env = this.environment();
+    const op = env
+      ? this.envService.updateEnvironment(this.clientId(), env.id, payload)
+      : this.envService.createEnvironment(this.clientId(), payload);
 
     op.subscribe({
       next: (result) => {
-        this.toast.success(`Environment ${this.data.environment ? 'updated' : 'created'}`);
-        this.dialogRef.close(result);
+        this.toast.success(`Environment ${env ? 'updated' : 'created'}`);
+        this.saved.emit(result);
       },
       error: (err) => {
         this.saving = false;

--- a/services/control-panel/src/app/features/clients/client-list.component.ts
+++ b/services/control-panel/src/app/features/clients/client-list.component.ts
@@ -1,18 +1,17 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { ClientService, Client } from '../../core/services/client.service.js';
 import { ClientDialogComponent } from './client-dialog.component.js';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
-import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent } from '../../shared/components/index.js';
+import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, DialogComponent } from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
-  imports: [MatDialogModule, DataTableComponent, DataTableColumnComponent, BroncoButtonComponent],
+  imports: [DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, DialogComponent, ClientDialogComponent],
   template: `
     <div class="client-list-page">
       <div class="page-header">
         <h1 class="page-title">Clients</h1>
-        <app-bronco-button variant="primary" (click)="createClient()">+ New Client</app-bronco-button>
+        <app-bronco-button variant="primary" (click)="showClientDialog.set(true)">+ New Client</app-bronco-button>
       </div>
 
       <app-data-table
@@ -59,6 +58,14 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent } f
 
       </app-data-table>
     </div>
+
+    @if (showClientDialog()) {
+      <app-dialog [open]="true" title="New Client" maxWidth="500px" (openChange)="showClientDialog.set(false)">
+        <app-client-dialog-content
+          (created)="onClientCreated()"
+          (cancelled)="showClientDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .client-list-page { max-width: 1200px; }
@@ -68,10 +75,10 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent } f
 })
 export class ClientListComponent implements OnInit {
   private clientService = inject(ClientService);
-  private dialog = inject(MatDialog);
   private detailPanel = inject(DetailPanelService);
 
   clients = signal<Client[]>([]);
+  showClientDialog = signal(false);
   trackById = (item: Client) => item.id;
 
   ngOnInit(): void {
@@ -86,10 +93,8 @@ export class ClientListComponent implements OnInit {
     this.detailPanel.open('client', client.id);
   }
 
-  createClient(): void {
-    const dialogRef = this.dialog.open(ClientDialogComponent, { width: '500px' });
-    dialogRef.afterClosed().subscribe(result => {
-      if (result) this.load();
-    });
+  onClientCreated(): void {
+    this.showClientDialog.set(false);
+    this.load();
   }
 }

--- a/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -9,80 +8,95 @@ import { ClientMemoryService, type ClientMemory, MEMORY_TYPE_OPTIONS, CATEGORY_O
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-client-memory-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ data.memory ? 'Edit' : 'Add' }} Client Memory</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Title</mat-label>
-        <input matInput [(ngModel)]="title" placeholder="e.g. Blocking Sessions Playbook">
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Title</mat-label>
+      <input matInput [(ngModel)]="title" placeholder="e.g. Blocking Sessions Playbook">
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Memory Type</mat-label>
-        <mat-select [(ngModel)]="memoryType">
-          @for (mt of memoryTypes; track mt.value) {
-            <mat-option [value]="mt.value">{{ mt.label }} — {{ mt.description }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Memory Type</mat-label>
+      <mat-select [(ngModel)]="memoryType">
+        @for (mt of memoryTypes; track mt.value) {
+          <mat-option [value]="mt.value">{{ mt.label }} — {{ mt.description }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Category Scope</mat-label>
-        <mat-select [(ngModel)]="category">
-          @for (cat of categories; track cat.value) {
-            <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Category Scope</mat-label>
+      <mat-select [(ngModel)]="category">
+        @for (cat of categories; track cat.value) {
+          <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Tags (comma-separated)</mat-label>
-        <input matInput [(ngModel)]="tagsInput" placeholder="blocking, deadlocks, azure-sql">
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Tags (comma-separated)</mat-label>
+      <input matInput [(ngModel)]="tagsInput" placeholder="blocking, deadlocks, azure-sql">
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Content (Markdown)</mat-label>
-        <textarea matInput [(ngModel)]="content" rows="12"
-          placeholder="Write operational knowledge here. This will be injected into AI prompts when analyzing tickets for this client."></textarea>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Content (Markdown)</mat-label>
+      <textarea matInput [(ngModel)]="content" rows="12"
+        placeholder="Write operational knowledge here. This will be injected into AI prompts when analyzing tickets for this client."></textarea>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="half-width">
-        <mat-label>Sort Order</mat-label>
-        <input matInput type="number" [(ngModel)]="sortOrder">
-      </mat-form-field>
-    </mat-dialog-content>
+    <mat-form-field appearance="outline" class="half-width">
+      <mat-label>Sort Order</mat-label>
+      <input matInput type="number" [(ngModel)]="sortOrder">
+    </mat-form-field>
 
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!title.trim() || !content.trim() || saving">
-        {{ saving ? 'Saving...' : (data.memory ? 'Update' : 'Create') }}
+        {{ saving ? 'Saving...' : (memory() ? 'Update' : 'Create') }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; }
     .half-width { width: 50%; }
-    mat-dialog-content { display: flex; flex-direction: column; min-width: 500px; }
+    :host { display: flex; flex-direction: column; min-width: 500px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class ClientMemoryDialogComponent {
-  private dialogRef = inject(MatDialogRef<ClientMemoryDialogComponent>);
-  data = inject<{ clientId: string; memory?: ClientMemory }>(MAT_DIALOG_DATA);
+export class ClientMemoryDialogComponent implements OnInit {
   private memoryService = inject(ClientMemoryService);
   private toast = inject(ToastService);
+
+  clientId = input.required<string>();
+  memory = input<ClientMemory>();
+
+  saved = output<ClientMemory>();
+  cancelled = output<void>();
 
   memoryTypes = MEMORY_TYPE_OPTIONS;
   categories = CATEGORY_OPTIONS;
 
-  title = this.data.memory?.title ?? '';
-  memoryType = this.data.memory?.memoryType ?? 'CONTEXT';
-  category = this.data.memory?.category ?? '';
-  tagsInput = this.data.memory?.tags?.join(', ') ?? '';
-  content = this.data.memory?.content ?? '';
-  sortOrder = this.data.memory?.sortOrder ?? 0;
+  title = '';
+  memoryType = 'CONTEXT';
+  category = '';
+  tagsInput = '';
+  content = '';
+  sortOrder = 0;
   saving = false;
+
+  ngOnInit(): void {
+    const mem = this.memory();
+    if (mem) {
+      this.title = mem.title ?? '';
+      this.memoryType = mem.memoryType ?? 'CONTEXT';
+      this.category = mem.category ?? '';
+      this.tagsInput = mem.tags?.join(', ') ?? '';
+      this.content = mem.content ?? '';
+      this.sortOrder = mem.sortOrder ?? 0;
+    }
+  }
 
   save(): void {
     this.saving = true;
@@ -96,14 +110,15 @@ export class ClientMemoryDialogComponent {
       sortOrder: this.sortOrder,
     };
 
-    const op = this.data.memory
-      ? this.memoryService.updateMemory(this.data.memory.id, payload)
-      : this.memoryService.createMemory({ ...payload, clientId: this.data.clientId });
+    const mem = this.memory();
+    const op = mem
+      ? this.memoryService.updateMemory(mem.id, payload)
+      : this.memoryService.createMemory({ ...payload, clientId: this.clientId() });
 
     op.subscribe({
       next: (result) => {
-        this.toast.success(`Memory ${this.data.memory ? 'updated' : 'created'}`);
-        this.dialogRef.close(result);
+        this.toast.success(`Memory ${mem ? 'updated' : 'created'}`);
+        this.saved.emit(result);
       },
       error: (err) => {
         this.saving = false;

--- a/services/control-panel/src/app/features/clients/client-user-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-user-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -9,66 +8,75 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  clientId: string;
-  user?: ClientUser;
-}
-
 @Component({
+  selector: 'app-client-user-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule],
   template: `
-    <h2 mat-dialog-title>{{ data.user ? 'Edit User' : 'Create Portal User' }}</h2>
-    <mat-dialog-content>
+    <mat-form-field class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required>
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Email</mat-label>
+      <input matInput [(ngModel)]="email" type="email" required>
+    </mat-form-field>
+    @if (!user()) {
       <mat-form-field class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" required>
+        <mat-label>Password</mat-label>
+        <input matInput [(ngModel)]="password" type="password" required minlength="8">
       </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Email</mat-label>
-        <input matInput [(ngModel)]="email" type="email" required>
-      </mat-form-field>
-      @if (!data.user) {
-        <mat-form-field class="full-width">
-          <mat-label>Password</mat-label>
-          <input matInput [(ngModel)]="password" type="password" required minlength="8">
-        </mat-form-field>
-      }
-      <mat-form-field class="full-width">
-        <mat-label>User Type</mat-label>
-        <mat-select [(ngModel)]="userType">
-          <mat-option value="USER">User</mat-option>
-          <mat-option value="ADMIN">Admin</mat-option>
-        </mat-select>
-      </mat-form-field>
-      @if (data.user) {
-        <mat-slide-toggle [(ngModel)]="isActive">{{ isActive ? 'Active' : 'Inactive' }}</mat-slide-toggle>
-      }
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!name || !email || (!data.user && !password)">
-        {{ data.user ? 'Update' : 'Create' }}
+    }
+    <mat-form-field class="full-width">
+      <mat-label>User Type</mat-label>
+      <mat-select [(ngModel)]="userType">
+        <mat-option value="USER">User</mat-option>
+        <mat-option value="ADMIN">Admin</mat-option>
+      </mat-select>
+    </mat-form-field>
+    @if (user()) {
+      <mat-slide-toggle [(ngModel)]="isActive">{{ isActive ? 'Active' : 'Inactive' }}</mat-slide-toggle>
+    }
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
+      <button mat-raised-button color="primary" (click)="save()" [disabled]="!name || !email || (!user() && !password)">
+        {{ user() ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
-  styles: [`.full-width { width: 100%; margin-bottom: 8px; }`],
+  styles: [`.full-width { width: 100%; margin-bottom: 8px; } .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }`],
 })
-export class ClientUserDialogComponent {
-  private dialogRef = inject(MatDialogRef<ClientUserDialogComponent>);
-  data = inject<DialogData>(MAT_DIALOG_DATA);
+export class ClientUserDialogComponent implements OnInit {
   private clientUserService = inject(ClientUserService);
   private toast = inject(ToastService);
 
-  name = this.data.user?.name ?? '';
-  email = this.data.user?.email ?? '';
+  clientId = input.required<string>();
+  user = input<ClientUser>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
+
+  name = '';
+  email = '';
   password = '';
-  userType = this.data.user?.userType ?? 'USER';
-  isActive = this.data.user?.isActive ?? true;
+  userType = 'USER';
+  isActive = true;
+
+  ngOnInit(): void {
+    const u = this.user();
+    if (u) {
+      this.name = u.name ?? '';
+      this.email = u.email ?? '';
+      this.userType = u.userType ?? 'USER';
+      this.isActive = u.isActive ?? true;
+    }
+  }
 
   save(): void {
-    if (this.data.user) {
-      this.clientUserService.updateUser(this.data.user.id, {
+    const u = this.user();
+    if (u) {
+      this.clientUserService.updateUser(u.id, {
         name: this.name,
         email: this.email,
         userType: this.userType,
@@ -76,13 +84,13 @@ export class ClientUserDialogComponent {
       }).subscribe({
         next: () => {
           this.toast.success('User updated');
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Update failed'),
       });
     } else {
       this.clientUserService.createUser({
-        clientId: this.data.clientId,
+        clientId: this.clientId(),
         email: this.email,
         password: this.password,
         name: this.name,
@@ -90,7 +98,7 @@ export class ClientUserDialogComponent {
       }).subscribe({
         next: () => {
           this.toast.success('User created');
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Create failed'),
       });

--- a/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
@@ -53,6 +53,7 @@ export class GenerateInvoiceDialogComponent {
       finalize: this.finalize,
     }).subscribe({
       next: () => {
+        this.generating = false;
         this.toast.info('Invoice generated');
         this.generated.emit(true);
       },

--- a/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -9,35 +8,37 @@ import { InvoiceService } from '../../core/services/invoice.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-generate-invoice-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>Generate Invoice</h2>
-    <mat-dialog-content>
-      <mat-form-field class="full-width">
-        <mat-label>Period Start</mat-label>
-        <input matInput type="date" [(ngModel)]="periodStart" required>
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Period End</mat-label>
-        <input matInput type="date" [(ngModel)]="periodEnd" required>
-      </mat-form-field>
-      <mat-checkbox [(ngModel)]="finalize">Mark as Final</mat-checkbox>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <mat-form-field class="full-width">
+      <mat-label>Period Start</mat-label>
+      <input matInput type="date" [(ngModel)]="periodStart" required>
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Period End</mat-label>
+      <input matInput type="date" [(ngModel)]="periodEnd" required>
+    </mat-form-field>
+    <mat-checkbox [(ngModel)]="finalize">Mark as Final</mat-checkbox>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" [disabled]="!periodStart || !periodEnd || generating" (click)="generate()">
         {{ generating ? 'Generating...' : 'Generate' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
-  styles: [`.full-width { width: 100%; margin-bottom: 8px; }`],
+  styles: [`.full-width { width: 100%; margin-bottom: 8px; } .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }`],
 })
 export class GenerateInvoiceDialogComponent {
-  private dialogRef = inject(MatDialogRef<GenerateInvoiceDialogComponent>);
-  private data: { clientId: string } = inject(MAT_DIALOG_DATA);
   private invoiceService = inject(InvoiceService);
   private toast = inject(ToastService);
+
+  clientId = input.required<string>();
+
+  generated = output<boolean>();
+  cancelled = output<void>();
 
   periodStart = '';
   periodEnd = '';
@@ -46,14 +47,14 @@ export class GenerateInvoiceDialogComponent {
 
   generate(): void {
     this.generating = true;
-    this.invoiceService.generateInvoice(this.data.clientId, {
+    this.invoiceService.generateInvoice(this.clientId(), {
       periodStart: this.periodStart,
       periodEnd: this.periodEnd,
       finalize: this.finalize,
     }).subscribe({
       next: () => {
         this.toast.info('Invoice generated');
-        this.dialogRef.close(true);
+        this.generated.emit(true);
       },
       error: (err) => {
         this.generating = false;

--- a/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -11,91 +10,83 @@ import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.servi
 import { AiProviderService, ProviderType } from '../../core/services/ai-provider.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  taskType?: string;
-  config?: AiModelConfig;
-  taskTypes?: string[];
-  codeDefault?: { provider: string; model: string };
-}
-
 @Component({
+  selector: 'app-ai-config-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit' : 'Add' }} AI Model Config</h2>
-    <mat-dialog-content>
-      @if (isEdit && codeDefault) {
-        <div class="code-default-info">
-          <span class="info-label">Code default:</span>
-          <span class="info-value">{{ codeDefault.provider }} / {{ codeDefault.model }}</span>
-        </div>
-      }
-      @if (isEdit || presetTaskType) {
-        <div class="field-label">
-          <span class="info-label">Task Type</span>
-          <span class="code-chip">{{ taskType }}</span>
-        </div>
-      } @else {
-        <mat-form-field class="full-width">
-          <mat-label>Task Type</mat-label>
-          <mat-select [(ngModel)]="taskType" required>
-            @for (tt of taskTypes; track tt) {
-              <mat-option [value]="tt">{{ tt }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-      }
-
+    @if (isEdit && codeDefaultVal) {
+      <div class="code-default-info">
+        <span class="info-label">Code default:</span>
+        <span class="info-value">{{ codeDefaultVal.provider }} / {{ codeDefaultVal.model }}</span>
+      </div>
+    }
+    @if (isEdit || presetTaskType()) {
+      <div class="field-label">
+        <span class="info-label">Task Type</span>
+        <span class="code-chip">{{ taskType }}</span>
+      </div>
+    } @else {
       <mat-form-field class="full-width">
-        <mat-label>Scope</mat-label>
-        <mat-select [(ngModel)]="scope" [disabled]="isEdit" (ngModelChange)="onScopeChange()">
-          <mat-option value="APP_WIDE">APP_WIDE (system-wide)</mat-option>
-          <mat-option value="CLIENT">CLIENT (per-client)</mat-option>
-        </mat-select>
-      </mat-form-field>
-
-      @if (scope === 'CLIENT') {
-        <mat-form-field class="full-width">
-          <mat-label>Client</mat-label>
-          <mat-select [(ngModel)]="clientId" [disabled]="isEdit" required>
-            @for (c of clients; track c.id) {
-              <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-      }
-
-      <mat-form-field class="full-width">
-        <mat-label>Provider</mat-label>
-        <mat-select [(ngModel)]="provider" required (ngModelChange)="onProviderChange()">
-          @if (loadingProviders) {
-            <mat-option disabled>Loading providers...</mat-option>
-          }
-          @for (p of providerTypes; track p.value) {
-            <mat-option [value]="p.value" [disabled]="!p.routable">{{ p.label }}{{ p.routable ? '' : ' (not yet supported)' }}</mat-option>
+        <mat-label>Task Type</mat-label>
+        <mat-select [(ngModel)]="taskType" required>
+          @for (tt of taskTypesList; track tt) {
+            <mat-option [value]="tt">{{ tt }}</mat-option>
           }
         </mat-select>
       </mat-form-field>
+    }
 
+    <mat-form-field class="full-width">
+      <mat-label>Scope</mat-label>
+      <mat-select [(ngModel)]="scope" [disabled]="isEdit" (ngModelChange)="onScopeChange()">
+        <mat-option value="APP_WIDE">APP_WIDE (system-wide)</mat-option>
+        <mat-option value="CLIENT">CLIENT (per-client)</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    @if (scope === 'CLIENT') {
       <mat-form-field class="full-width">
-        <mat-label>Model</mat-label>
-        @if (modelsForProvider.length > 0) {
-          <mat-select [(ngModel)]="model" required>
-            @for (m of modelsForProvider; track m.model) {
-              <mat-option [value]="m.model">{{ m.displayName || m.model }}</mat-option>
-            }
-          </mat-select>
-        } @else {
-          <input matInput [(ngModel)]="model" required placeholder="e.g. llama3.1:8b or claude-sonnet-4-6">
+        <mat-label>Client</mat-label>
+        <mat-select [(ngModel)]="clientId" [disabled]="isEdit" required>
+          @for (c of clients; track c.id) {
+            <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    <mat-form-field class="full-width">
+      <mat-label>Provider</mat-label>
+      <mat-select [(ngModel)]="provider" required (ngModelChange)="onProviderChange()">
+        @if (loadingProviders) {
+          <mat-option disabled>Loading providers...</mat-option>
         }
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+        @for (p of providerTypes; track p.value) {
+          <mat-option [value]="p.value" [disabled]="!p.routable">{{ p.label }}{{ p.routable ? '' : ' (not yet supported)' }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Model</mat-label>
+      @if (modelsForProvider.length > 0) {
+        <mat-select [(ngModel)]="model" required>
+          @for (m of modelsForProvider; track m.model) {
+            <mat-option [value]="m.model">{{ m.displayName || m.model }}</mat-option>
+          }
+        </mat-select>
+      } @else {
+        <input matInput [(ngModel)]="model" required placeholder="e.g. llama3.1:8b or claude-sonnet-4-6">
+      }
+    </mat-form-field>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
         {{ isEdit ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
@@ -104,44 +95,57 @@ interface DialogData {
     .info-value { font-family: monospace; color: #333; }
     .field-label { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
     .code-chip { font-size: 12px; padding: 2px 8px; background: #e8eaf6; border-radius: 4px; color: #3f51b5; font-family: monospace; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class AiConfigDialogComponent implements OnInit {
-  private dialogRef = inject(MatDialogRef<AiConfigDialogComponent>);
-  data: DialogData = inject(MAT_DIALOG_DATA);
   private aiConfigService = inject(AiConfigService);
   private clientService = inject(ClientService);
   private aiUsageService = inject(AiUsageService);
   private aiProviderService = inject(AiProviderService);
   private toast = inject(ToastService);
 
-  isEdit = !!this.data.config;
-  presetTaskType = !this.data.config && !!this.data.taskType;
-  taskType = this.data.config?.taskType ?? this.data.taskType ?? '';
-  scope = this.data.config?.scope ?? 'APP_WIDE';
-  clientId = this.data.config?.clientId ?? '';
-  provider = this.data.config?.provider ?? '';
-  model = this.data.config?.model ?? '';
+  config = input<AiModelConfig>();
+  presetTaskType = input<string>();
+  taskTypes = input<string[]>([]);
+  codeDefault = input<{ provider: string; model: string }>();
+
+  saved = output<AiModelConfig>();
+  cancelled = output<void>();
+
+  isEdit = false;
+  taskType = '';
+  scope = 'APP_WIDE';
+  clientId = '';
+  provider = '';
+  model = '';
   clients: Client[] = [];
-  taskTypes: string[] = this.data.taskTypes ?? [];
-  codeDefault = this.data.codeDefault ?? null;
+  taskTypesList: string[] = [];
+  codeDefaultVal: { provider: string; model: string } | null = null;
 
   loadingProviders = true;
   providerTypes: ProviderType[] = [];
   private catalogMap = new Map<string, CatalogModel[]>();
   modelsForProvider: CatalogModel[] = [];
 
-  constructor() {
+  ngOnInit(): void {
+    const cfg = this.config();
+    this.isEdit = !!cfg;
+    this.taskType = cfg?.taskType ?? this.presetTaskType() ?? '';
+    this.scope = cfg?.scope ?? 'APP_WIDE';
+    this.clientId = cfg?.clientId ?? '';
+    this.provider = cfg?.provider ?? '';
+    this.model = cfg?.model ?? '';
+    this.taskTypesList = this.taskTypes() ?? [];
+    this.codeDefaultVal = this.codeDefault() ?? null;
+
     if (this.scope === 'CLIENT' || !this.isEdit) {
       this.clientService.getClients().subscribe(c => this.clients = c);
     }
-  }
 
-  ngOnInit(): void {
     this.aiProviderService.getTypes().subscribe({
       next: (types) => {
         this.providerTypes = types;
-        // If editing, ensure the current provider is in the list
         if (this.provider && !types.some(t => t.value === this.provider)) {
           this.providerTypes = [{ value: this.provider, label: this.provider, routable: false }, ...types];
         }
@@ -191,13 +195,13 @@ export class AiConfigDialogComponent implements OnInit {
 
   save(): void {
     if (this.isEdit) {
-      this.aiConfigService.update(this.data.config!.id, {
+      this.aiConfigService.update(this.config()!.id, {
         provider: this.provider,
         model: this.model.trim(),
       }).subscribe({
         next: (result) => {
           this.toast.success('Config updated');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to update config'),
       });
@@ -211,7 +215,7 @@ export class AiConfigDialogComponent implements OnInit {
       }).subscribe({
         next: (result) => {
           this.toast.success('Config created');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to create config'),
       });

--- a/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -9,11 +8,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { AiProviderService, AiProvider, AiProviderModel, AppScopeItem } from '../../core/services/ai-provider.service';
 import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service';
 import { ToastService } from '../../core/services/toast.service';
-
-interface DialogData {
-  model?: AiProviderModel;
-  providers: AiProvider[];
-}
 
 const CAPABILITY_LEVELS = [
   { value: 'SIMPLE', label: 'Simple — classification, tagging' },
@@ -24,69 +18,68 @@ const CAPABILITY_LEVELS = [
 ];
 
 @Component({
+  selector: 'app-ai-model-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit' : 'Add' }} Model</h2>
-    <mat-dialog-content>
-      <mat-form-field class="full-width">
-        <mat-label>Provider</mat-label>
-        <mat-select [(ngModel)]="providerId" required (ngModelChange)="onProviderChange()">
-          @for (p of availableProviders; track p.id) {
-            <mat-option [value]="p.id">
-              {{ p.provider }}{{ p.isActive ? '' : ' (disabled)' }}
-            </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" required placeholder="e.g. Claude Sonnet Production, Ollama Fast">
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <mat-label>Model</mat-label>
-        @if (modelsForProvider.length > 0) {
-          <mat-select [(ngModel)]="model" required>
-            @for (m of modelsForProvider; track m.model) {
-              <mat-option [value]="m.model">{{ m.displayName || m.model }}</mat-option>
-            }
-          </mat-select>
-        } @else {
-          <input matInput [(ngModel)]="model" required placeholder="e.g. llama3.1:8b or claude-sonnet-4-6">
+    <mat-form-field class="full-width">
+      <mat-label>Provider</mat-label>
+      <mat-select [(ngModel)]="providerId" required (ngModelChange)="onProviderChange()">
+        @for (p of availableProviders; track p.id) {
+          <mat-option [value]="p.id">
+            {{ p.provider }}{{ p.isActive ? '' : ' (disabled)' }}
+          </mat-option>
         }
-      </mat-form-field>
+      </mat-select>
+    </mat-form-field>
 
-      <mat-form-field class="full-width">
-        <mat-label>Capability Level</mat-label>
-        <mat-select [(ngModel)]="capabilityLevel" required>
-          @for (lvl of capabilityLevels; track lvl.value) {
-            <mat-option [value]="lvl.value">{{ lvl.label }}</mat-option>
+    <mat-form-field class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required placeholder="e.g. Claude Sonnet Production, Ollama Fast">
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Model</mat-label>
+      @if (modelsForProvider.length > 0) {
+        <mat-select [(ngModel)]="modelId" required>
+          @for (m of modelsForProvider; track m.model) {
+            <mat-option [value]="m.model">{{ m.displayName || m.model }}</mat-option>
           }
         </mat-select>
-      </mat-form-field>
+      } @else {
+        <input matInput [(ngModel)]="modelId" required placeholder="e.g. llama3.1:8b or claude-sonnet-4-6">
+      }
+    </mat-form-field>
 
-      <div class="enabled-apps-section">
-        <div class="section-label">Enabled For</div>
-        <div class="section-hint">Leave unchecked to allow all apps. Check specific apps to restrict availability.</div>
-        <div class="checkbox-group">
-          @for (scope of appScopes; track scope.value) {
-            <mat-checkbox
-              [checked]="enabledApps.has(scope.value)"
-              (change)="toggleAppScope(scope.value, $event.checked)">
-              {{ scope.label }}
-            </mat-checkbox>
-          }
-        </div>
+    <mat-form-field class="full-width">
+      <mat-label>Capability Level</mat-label>
+      <mat-select [(ngModel)]="capabilityLevel" required>
+        @for (lvl of capabilityLevels; track lvl.value) {
+          <mat-option [value]="lvl.value">{{ lvl.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <div class="enabled-apps-section">
+      <div class="section-label">Enabled For</div>
+      <div class="section-hint">Leave unchecked to allow all apps. Check specific apps to restrict availability.</div>
+      <div class="checkbox-group">
+        @for (scope of appScopes; track scope.value) {
+          <mat-checkbox
+            [checked]="enabledApps.has(scope.value)"
+            (change)="toggleAppScope(scope.value, $event.checked)">
+            {{ scope.label }}
+          </mat-checkbox>
+        }
       </div>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    </div>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
         {{ isEdit ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
@@ -94,37 +87,49 @@ const CAPABILITY_LEVELS = [
     .section-label { font-size: 13px; font-weight: 600; color: #666; margin-bottom: 4px; }
     .section-hint { font-size: 12px; color: #999; margin-bottom: 8px; }
     .checkbox-group { display: flex; flex-wrap: wrap; gap: 12px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class AiModelDialogComponent implements OnInit {
-  private dialogRef = inject(MatDialogRef<AiModelDialogComponent>);
-  data: DialogData = inject(MAT_DIALOG_DATA);
   private providerService = inject(AiProviderService);
   private aiUsageService = inject(AiUsageService);
   private toast = inject(ToastService);
 
+  model = input<AiProviderModel>();
+  providers = input.required<AiProvider[]>();
+
+  saved = output<AiProviderModel>();
+  cancelled = output<void>();
+
   capabilityLevels = CAPABILITY_LEVELS;
 
-  isEdit = !!this.data.model;
-  availableProviders = this.data.providers;
-  providerId = this.data.model?.providerId ?? (this.data.providers.length === 1 ? this.data.providers[0].id : '');
-  name = this.data.model?.name ?? '';
-  model = this.data.model?.model ?? '';
-  capabilityLevel = this.data.model?.capabilityLevel ?? 'STANDARD';
-  enabledApps = new Set<string>(this.data.model?.enabledApps ?? []);
+  isEdit = false;
+  availableProviders: AiProvider[] = [];
+  providerId = '';
+  name = '';
+  modelId = '';
+  capabilityLevel = 'STANDARD';
+  enabledApps = new Set<string>();
   appScopes: AppScopeItem[] = [];
 
   private catalogMap = new Map<string, CatalogModel[]>();
   modelsForProvider: CatalogModel[] = [];
 
-  /** Resolve provider type string from selected providerId. */
   private getSelectedProviderType(): string {
     const p = this.availableProviders.find((pr) => pr.id === this.providerId);
     return p?.provider ?? '';
   }
 
   ngOnInit(): void {
-    // Fetch model catalog for the model dropdown
+    const m = this.model();
+    this.isEdit = !!m;
+    this.availableProviders = this.providers();
+    this.providerId = m?.providerId ?? (this.availableProviders.length === 1 ? this.availableProviders[0].id : '');
+    this.name = m?.name ?? '';
+    this.modelId = m?.model ?? '';
+    this.capabilityLevel = m?.capabilityLevel ?? 'STANDARD';
+    this.enabledApps = new Set<string>(m?.enabledApps ?? []);
+
     this.aiUsageService.getCatalog().subscribe(catalog => {
       for (const p of catalog.providers) {
         this.catalogMap.set(p.provider, p.models);
@@ -132,7 +137,6 @@ export class AiModelDialogComponent implements OnInit {
       this.updateModelsForProvider();
     });
 
-    // Fetch app scopes for the "Enabled For" checkboxes
     this.providerService.getAppScopes().subscribe({
       next: (scopes) => this.appScopes = scopes,
       error: () => this.toast.error('Failed to load app scopes'),
@@ -142,7 +146,7 @@ export class AiModelDialogComponent implements OnInit {
   onProviderChange(): void {
     this.updateModelsForProvider();
     if (!this.isEdit) {
-      this.model = '';
+      this.modelId = '';
     }
   }
 
@@ -157,30 +161,29 @@ export class AiModelDialogComponent implements OnInit {
   private updateModelsForProvider(): void {
     const providerType = this.getSelectedProviderType();
     this.modelsForProvider = this.catalogMap.get(providerType) ?? [];
-    // If editing and current model isn't in the catalog, add it
-    if (this.model && !this.modelsForProvider.some(m => m.model === this.model)) {
-      this.modelsForProvider = [{ model: this.model, displayName: this.model, contextLength: null, maxCompletionTokens: null, modality: null }, ...this.modelsForProvider];
+    if (this.modelId && !this.modelsForProvider.some(m => m.model === this.modelId)) {
+      this.modelsForProvider = [{ model: this.modelId, displayName: this.modelId, contextLength: null, maxCompletionTokens: null, modality: null }, ...this.modelsForProvider];
     }
   }
 
   canSave(): boolean {
-    if (!this.providerId || !this.name.trim() || !this.model.trim()) return false;
+    if (!this.providerId || !this.name.trim() || !this.modelId.trim()) return false;
     return true;
   }
 
   save(): void {
     const enabledAppsArray = [...this.enabledApps];
     if (this.isEdit) {
-      this.providerService.updateModel(this.data.model!.id, {
+      this.providerService.updateModel(this.model()!.id, {
         providerId: this.providerId,
         name: this.name.trim(),
-        model: this.model.trim(),
+        model: this.modelId.trim(),
         capabilityLevel: this.capabilityLevel,
         enabledApps: enabledAppsArray,
       }).subscribe({
         next: (result) => {
           this.toast.success('Model updated');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to update model'),
       });
@@ -188,13 +191,13 @@ export class AiModelDialogComponent implements OnInit {
       this.providerService.createModel({
         providerId: this.providerId,
         name: this.name.trim(),
-        model: this.model.trim(),
+        model: this.modelId.trim(),
         capabilityLevel: this.capabilityLevel,
         enabledApps: enabledAppsArray,
       }).subscribe({
         next: (result) => {
           this.toast.success('Model created');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to create model'),
       });

--- a/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -8,56 +7,51 @@ import { MatButtonModule } from '@angular/material/button';
 import { AiProviderService, AiProvider, ProviderType } from '../../core/services/ai-provider.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  config?: AiProvider;
-}
-
 @Component({
+  selector: 'app-ai-provider-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit' : 'Add' }} Provider</h2>
-    <mat-dialog-content>
-      @if (!isEdit) {
-        <mat-form-field class="full-width">
-          <mat-label>Provider</mat-label>
-          <mat-select [(ngModel)]="provider" required (ngModelChange)="onProviderChange()">
-            @if (loadingProviders) {
-              <mat-option disabled>Loading providers...</mat-option>
-            }
-            @for (p of selectableProviders; track p.value) {
-              <mat-option [value]="p.value" [disabled]="!p.routable">{{ p.label }}{{ p.routable ? '' : ' (not yet supported)' }}</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
-      } @else {
-        <div class="provider-display">
-          <span class="label">Provider:</span>
-          <span class="provider-chip provider-{{ provider.toLowerCase() }}">{{ provider }}</span>
-        </div>
-      }
+    @if (!isEdit) {
+      <mat-form-field class="full-width">
+        <mat-label>Provider</mat-label>
+        <mat-select [(ngModel)]="providerVal" required (ngModelChange)="onProviderChange()">
+          @if (loadingProviders) {
+            <mat-option disabled>Loading providers...</mat-option>
+          }
+          @for (p of selectableProviders; track p.value) {
+            <mat-option [value]="p.value" [disabled]="!p.routable">{{ p.label }}{{ p.routable ? '' : ' (not yet supported)' }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    } @else {
+      <div class="provider-display">
+        <span class="label">Provider:</span>
+        <span class="provider-chip provider-{{ providerVal.toLowerCase() }}">{{ providerVal }}</span>
+      </div>
+    }
 
-      @if (provider === 'LOCAL') {
-        <mat-form-field class="full-width">
-          <mat-label>Base URL</mat-label>
-          <input matInput [(ngModel)]="baseUrl" required placeholder="http://localhost:11434">
-        </mat-form-field>
-      }
+    @if (providerVal === 'LOCAL') {
+      <mat-form-field class="full-width">
+        <mat-label>Base URL</mat-label>
+        <input matInput [(ngModel)]="baseUrl" required placeholder="http://localhost:11434">
+      </mat-form-field>
+    }
 
-      @if (provider && provider !== 'LOCAL') {
-        <mat-form-field class="full-width">
-          <mat-label>API Key</mat-label>
-          <input matInput [(ngModel)]="apiKey" type="password"
-            [required]="!isEdit" [placeholder]="isEdit ? '(unchanged)' : 'sk-...'">
-        </mat-form-field>
-      }
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    @if (providerVal && providerVal !== 'LOCAL') {
+      <mat-form-field class="full-width">
+        <mat-label>API Key</mat-label>
+        <input matInput [(ngModel)]="apiKey" type="password"
+          [required]="!isEdit" [placeholder]="isEdit ? '(unchanged)' : 'sk-...'">
+      </mat-form-field>
+    }
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
         {{ isEdit ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
@@ -69,23 +63,32 @@ interface DialogData {
     .provider-openai { background: #e3f2fd; color: #1565c0; }
     .provider-grok { background: #fff3e0; color: #e65100; }
     .provider-google { background: #e8f5e9; color: #1b5e20; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class AiProviderDialogComponent implements OnInit {
-  private dialogRef = inject(MatDialogRef<AiProviderDialogComponent>);
-  data: DialogData = inject(MAT_DIALOG_DATA);
   private providerService = inject(AiProviderService);
   private toast = inject(ToastService);
 
-  isEdit = !!this.data.config;
-  provider = this.data.config?.provider ?? '';
-  baseUrl = this.data.config?.baseUrl ?? '';
+  config = input<AiProvider>();
+
+  saved = output<AiProvider>();
+  cancelled = output<void>();
+
+  isEdit = false;
+  providerVal = '';
+  baseUrl = '';
   apiKey = '';
 
   loadingProviders = true;
   selectableProviders: ProviderType[] = [];
 
   ngOnInit(): void {
+    const cfg = this.config();
+    this.isEdit = !!cfg;
+    this.providerVal = cfg?.provider ?? '';
+    this.baseUrl = cfg?.baseUrl ?? '';
+
     this.providerService.getTypes().subscribe({
       next: (types) => {
         this.selectableProviders = types;
@@ -99,39 +102,39 @@ export class AiProviderDialogComponent implements OnInit {
   }
 
   onProviderChange(): void {
-    if (this.provider === 'LOCAL' && !this.baseUrl) {
+    if (this.providerVal === 'LOCAL' && !this.baseUrl) {
       this.baseUrl = 'http://localhost:11434';
     }
   }
 
   canSave(): boolean {
-    if (!this.provider) return false;
-    if (this.provider === 'LOCAL' && !this.baseUrl.trim()) return false;
-    if (this.provider !== 'LOCAL' && !this.isEdit && !this.apiKey.trim()) return false;
+    if (!this.providerVal) return false;
+    if (this.providerVal === 'LOCAL' && !this.baseUrl.trim()) return false;
+    if (this.providerVal !== 'LOCAL' && !this.isEdit && !this.apiKey.trim()) return false;
     return true;
   }
 
   save(): void {
     if (this.isEdit) {
       const data: Record<string, unknown> = {};
-      if (this.provider === 'LOCAL') data['baseUrl'] = this.baseUrl.trim();
+      if (this.providerVal === 'LOCAL') data['baseUrl'] = this.baseUrl.trim();
       if (this.apiKey) data['apiKey'] = this.apiKey;
-      this.providerService.updateProvider(this.data.config!.id, data).subscribe({
+      this.providerService.updateProvider(this.config()!.id, data).subscribe({
         next: (result) => {
           this.toast.success('Provider updated');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to update provider'),
       });
     } else {
       this.providerService.createProvider({
-        provider: this.provider,
-        baseUrl: this.provider === 'LOCAL' ? this.baseUrl.trim() : undefined,
-        apiKey: this.provider !== 'LOCAL' ? this.apiKey : undefined,
+        provider: this.providerVal,
+        baseUrl: this.providerVal === 'LOCAL' ? this.baseUrl.trim() : undefined,
+        apiKey: this.providerVal !== 'LOCAL' ? this.apiKey : undefined,
       }).subscribe({
         next: (result) => {
           this.toast.success('Provider created');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to create provider'),
       });

--- a/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -8,74 +7,84 @@ import { MatButtonModule } from '@angular/material/button';
 import { PromptService, PromptKeyword } from '../../core/services/prompt.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  keyword?: PromptKeyword;
-}
-
 const CATEGORIES = ['TICKET', 'EMAIL', 'DEVOPS', 'CODE', 'DATABASE', 'GENERAL'];
 
 @Component({
+  selector: 'app-keyword-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit' : 'Add' }} Keyword</h2>
-    <mat-dialog-content>
-      <mat-form-field class="full-width">
-        <mat-label>Token</mat-label>
-        <input matInput [(ngModel)]="token" [readonly]="isEdit" required placeholder="e.g. ticketSubject">
-        @if (!isEdit) {
-          <mat-hint>Used as {{ tokenHint }} in prompts</mat-hint>
+    <mat-form-field class="full-width">
+      <mat-label>Token</mat-label>
+      <input matInput [(ngModel)]="token" [readonly]="isEdit" required placeholder="e.g. ticketSubject">
+      @if (!isEdit) {
+        <mat-hint>Used as {{ tokenHint }} in prompts</mat-hint>
+      }
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Label</mat-label>
+      <input matInput [(ngModel)]="label" required>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Description</mat-label>
+      <textarea matInput [(ngModel)]="description" rows="2" required></textarea>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Sample Value</mat-label>
+      <textarea matInput [(ngModel)]="sampleValue" rows="2"></textarea>
+      <mat-hint>Used in preview when no runtime value is available</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Category</mat-label>
+      <mat-select [(ngModel)]="category" required>
+        @for (c of categories; track c) {
+          <mat-option [value]="c">{{ c }}</mat-option>
         }
-      </mat-form-field>
+      </mat-select>
+    </mat-form-field>
 
-      <mat-form-field class="full-width">
-        <mat-label>Label</mat-label>
-        <input matInput [(ngModel)]="label" required>
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <mat-label>Description</mat-label>
-        <textarea matInput [(ngModel)]="description" rows="2" required></textarea>
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <mat-label>Sample Value</mat-label>
-        <textarea matInput [(ngModel)]="sampleValue" rows="2"></textarea>
-        <mat-hint>Used in preview when no runtime value is available</mat-hint>
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <mat-label>Category</mat-label>
-        <mat-select [(ngModel)]="category" required>
-          @for (c of categories; track c) {
-            <mat-option [value]="c">{{ c }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
         {{ isEdit ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
-  styles: [`.full-width { width: 100%; margin-bottom: 8px; }`],
+  styles: [`.full-width { width: 100%; margin-bottom: 8px; } .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }`],
 })
-export class KeywordDialogComponent {
-  private dialogRef = inject(MatDialogRef<KeywordDialogComponent>);
-  data: DialogData = inject(MAT_DIALOG_DATA);
+export class KeywordDialogComponent implements OnInit {
   private promptService = inject(PromptService);
   private toast = inject(ToastService);
 
-  isEdit = !!this.data.keyword;
-  token = this.data.keyword?.token ?? '';
-  label = this.data.keyword?.label ?? '';
-  description = this.data.keyword?.description ?? '';
-  sampleValue = this.data.keyword?.sampleValue ?? '';
-  category = this.data.keyword?.category ?? 'GENERAL';
+  keyword = input<PromptKeyword>();
+
+  saved = output<PromptKeyword>();
+  cancelled = output<void>();
+
+  isEdit = false;
+  token = '';
+  label = '';
+  description = '';
+  sampleValue = '';
+  category = 'GENERAL';
   tokenHint = '{{token}}';
   categories = CATEGORIES;
+
+  ngOnInit(): void {
+    const kw = this.keyword();
+    if (kw) {
+      this.isEdit = true;
+      this.token = kw.token ?? '';
+      this.label = kw.label ?? '';
+      this.description = kw.description ?? '';
+      this.sampleValue = kw.sampleValue ?? '';
+      this.category = kw.category ?? 'GENERAL';
+    }
+  }
 
   canSave(): boolean {
     return !!this.token.trim() && !!this.label.trim() && !!this.description.trim() && !!this.category;
@@ -83,7 +92,7 @@ export class KeywordDialogComponent {
 
   save(): void {
     if (this.isEdit) {
-      this.promptService.updateKeyword(this.data.keyword!.id, {
+      this.promptService.updateKeyword(this.keyword()!.id, {
         label: this.label,
         description: this.description,
         sampleValue: this.sampleValue || null,
@@ -91,7 +100,7 @@ export class KeywordDialogComponent {
       }).subscribe({
         next: (result) => {
           this.toast.success('Keyword updated');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to update keyword'),
       });
@@ -105,7 +114,7 @@ export class KeywordDialogComponent {
       }).subscribe({
         next: (result) => {
           this.toast.success('Keyword created');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to create keyword'),
       });

--- a/services/control-panel/src/app/features/prompts/override-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/override-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, ViewChild, ElementRef } from '@angular/core';
+import { Component, inject, ViewChild, ElementRef, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -9,74 +8,68 @@ import { PromptService, PromptOverride, PromptKeyword } from '../../core/service
 import { ClientService, Client } from '../../core/services/client.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  promptKey: string;
-  override?: PromptOverride;
-}
-
 @Component({
+  selector: 'app-override-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit' : 'Add' }} Override</h2>
-    <mat-dialog-content>
+    <mat-form-field class="full-width">
+      <mat-label>Scope</mat-label>
+      <mat-select [(ngModel)]="scope" [disabled]="isEdit" (ngModelChange)="onScopeChange()">
+        <mat-option value="APP_WIDE">APP_WIDE</mat-option>
+        <mat-option value="CLIENT">CLIENT</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    @if (scope === 'CLIENT') {
       <mat-form-field class="full-width">
-        <mat-label>Scope</mat-label>
-        <mat-select [(ngModel)]="scope" [disabled]="isEdit" (ngModelChange)="onScopeChange()">
-          <mat-option value="APP_WIDE">APP_WIDE</mat-option>
-          <mat-option value="CLIENT">CLIENT</mat-option>
+        <mat-label>Client</mat-label>
+        <mat-select [(ngModel)]="clientId" [disabled]="isEdit" required>
+          @for (c of clients; track c.id) {
+            <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
+          }
         </mat-select>
       </mat-form-field>
+    }
 
-      @if (scope === 'CLIENT') {
-        <mat-form-field class="full-width">
-          <mat-label>Client</mat-label>
-          <mat-select [(ngModel)]="clientId" [disabled]="isEdit" required>
-            @for (c of clients; track c.id) {
-              <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Position</mat-label>
+      <mat-select [(ngModel)]="position">
+        <mat-option value="PREPEND">PREPEND</mat-option>
+        <mat-option value="APPEND">APPEND</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <div class="textarea-wrapper">
+      <mat-form-field class="full-width">
+        <mat-label>Content</mat-label>
+        <textarea matInput [(ngModel)]="content" rows="8" required
+          #contentTextarea
+          (input)="onContentInput($event)"
+          (keydown)="onContentKeydown($event)"></textarea>
+      </mat-form-field>
+      @if (showKeywordPopup) {
+        <div class="keyword-popup">
+          @for (kw of filteredKeywords; track kw.id) {
+            <div class="keyword-row" (mousedown)="insertKeyword(kw, $event)">
+              <span class="keyword-token">{{ kw.token }}</span>
+              <span class="keyword-label">{{ kw.label }}</span>
+              <span class="keyword-category">{{ kw.category }}</span>
+            </div>
+          }
+          @if (filteredKeywords.length === 0) {
+            <div class="keyword-row keyword-empty">No matching keywords</div>
+          }
+        </div>
       }
+    </div>
 
-      <mat-form-field class="full-width">
-        <mat-label>Position</mat-label>
-        <mat-select [(ngModel)]="position">
-          <mat-option value="PREPEND">PREPEND</mat-option>
-          <mat-option value="APPEND">APPEND</mat-option>
-        </mat-select>
-      </mat-form-field>
-
-      <div class="textarea-wrapper">
-        <mat-form-field class="full-width">
-          <mat-label>Content</mat-label>
-          <textarea matInput [(ngModel)]="content" rows="8" required
-            #contentTextarea
-            (input)="onContentInput($event)"
-            (keydown)="onContentKeydown($event)"></textarea>
-        </mat-form-field>
-        @if (showKeywordPopup) {
-          <div class="keyword-popup">
-            @for (kw of filteredKeywords; track kw.id) {
-              <div class="keyword-row" (mousedown)="insertKeyword(kw, $event)">
-                <span class="keyword-token">{{ kw.token }}</span>
-                <span class="keyword-label">{{ kw.label }}</span>
-                <span class="keyword-category">{{ kw.category }}</span>
-              </div>
-            }
-            @if (filteredKeywords.length === 0) {
-              <div class="keyword-row keyword-empty">No matching keywords</div>
-            }
-          </div>
-        }
-      </div>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
         {{ isEdit ? 'Update' : 'Create' }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
@@ -125,22 +118,27 @@ interface DialogData {
       font-style: italic;
       cursor: default;
     }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class OverrideDialogComponent {
-  private dialogRef = inject(MatDialogRef<OverrideDialogComponent>);
-  data: DialogData = inject(MAT_DIALOG_DATA);
+export class OverrideDialogComponent implements OnInit {
   private promptService = inject(PromptService);
   private clientService = inject(ClientService);
   private toast = inject(ToastService);
 
+  promptKey = input.required<string>();
+  override = input<PromptOverride>();
+
+  saved = output<PromptOverride>();
+  cancelled = output<void>();
+
   @ViewChild('contentTextarea') contentTextareaRef!: ElementRef<HTMLTextAreaElement>;
 
-  isEdit = !!this.data.override;
-  scope = this.data.override?.scope ?? 'APP_WIDE';
-  clientId = this.data.override?.clientId ?? '';
-  position = this.data.override?.position ?? 'APPEND';
-  content = this.data.override?.content ?? '';
+  isEdit = false;
+  scope = 'APP_WIDE';
+  clientId = '';
+  position = 'APPEND';
+  content = '';
   clients: Client[] = [];
 
   keywords: PromptKeyword[] = [];
@@ -148,7 +146,16 @@ export class OverrideDialogComponent {
   showKeywordPopup = false;
   keywordSearchStart = -1;
 
-  constructor() {
+  ngOnInit(): void {
+    const o = this.override();
+    if (o) {
+      this.isEdit = true;
+      this.scope = o.scope ?? 'APP_WIDE';
+      this.clientId = o.clientId ?? '';
+      this.position = o.position ?? 'APPEND';
+      this.content = o.content ?? '';
+    }
+
     if (this.scope === 'CLIENT' || !this.isEdit) {
       this.clientService.getClients().subscribe(c => this.clients = c);
     }
@@ -170,7 +177,6 @@ export class OverrideDialogComponent {
     const cursorPos = textarea.selectionStart;
     const textBefore = this.content.slice(0, cursorPos);
 
-    // Find the last `{{` that doesn't have a closing `}}`
     const lastOpen = textBefore.lastIndexOf('{{');
     if (lastOpen === -1) {
       this.showKeywordPopup = false;
@@ -178,13 +184,11 @@ export class OverrideDialogComponent {
     }
 
     const afterOpen = textBefore.slice(lastOpen + 2);
-    // If there's a `}}` after the `{{`, the token is already closed
     if (afterOpen.includes('}}')) {
       this.showKeywordPopup = false;
       return;
     }
 
-    // Don't trigger if there's a newline between `{{` and cursor
     if (afterOpen.includes('\n')) {
       this.showKeywordPopup = false;
       return;
@@ -206,7 +210,7 @@ export class OverrideDialogComponent {
   }
 
   insertKeyword(keyword: PromptKeyword, event: MouseEvent): void {
-    event.preventDefault(); // prevent textarea blur
+    event.preventDefault();
     const textarea = this.contentTextareaRef?.nativeElement;
     if (!textarea) return;
 
@@ -217,7 +221,6 @@ export class OverrideDialogComponent {
     this.content = before + replacement + after;
     this.showKeywordPopup = false;
 
-    // Restore focus and cursor position after the inserted token
     const newCursor = before.length + replacement.length;
     setTimeout(() => {
       textarea.focus();
@@ -233,19 +236,19 @@ export class OverrideDialogComponent {
 
   save(): void {
     if (this.isEdit) {
-      this.promptService.updateOverride(this.data.override!.id, {
+      this.promptService.updateOverride(this.override()!.id, {
         position: this.position,
         content: this.content,
       }).subscribe({
         next: (result) => {
           this.toast.success('Override updated');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to update override'),
       });
     } else {
       this.promptService.createOverride({
-        promptKey: this.data.promptKey,
+        promptKey: this.promptKey(),
         scope: this.scope,
         clientId: this.scope === 'CLIENT' ? this.clientId : undefined,
         position: this.position,
@@ -253,7 +256,7 @@ export class OverrideDialogComponent {
       }).subscribe({
         next: (result) => {
           this.toast.success('Override created');
-          this.dialogRef.close(result);
+          this.saved.emit(result);
         },
         error: (err) => this.toast.error(err.error?.message ?? 'Failed to create override'),
       });

--- a/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
@@ -9,15 +9,15 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { PromptService, PromptDetail, PromptOverride, PreviewResult } from '../../core/services/prompt.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { OverrideDialogComponent } from './override-dialog.component';
+import { DialogComponent } from '../../shared/components/dialog.component';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   standalone: true,
-  imports: [RouterLink, FormsModule, MatCardModule, MatButtonModule, MatIconModule, MatChipsModule, MatFormFieldModule, MatSelectModule, MatSlideToggleModule, MatDialogModule],
+  imports: [RouterLink, FormsModule, MatCardModule, MatButtonModule, MatIconModule, MatChipsModule, MatFormFieldModule, MatSelectModule, MatSlideToggleModule, DialogComponent, OverrideDialogComponent],
   template: `
     @if (detail(); as d) {
       <div class="page-header">
@@ -144,6 +144,16 @@ import { ToastService } from '../../core/services/toast.service';
     } @else {
       <p>Loading...</p>
     }
+
+    @if (showOverrideDialog()) {
+      <app-dialog [open]="true" [title]="editingOverride() ? 'Edit Override' : 'Add Override'" maxWidth="600px" (openChange)="showOverrideDialog.set(false)">
+        <app-override-dialog-content
+          [promptKey]="key()"
+          [override]="editingOverride() ?? undefined"
+          (saved)="onOverrideSaved()"
+          (cancelled)="showOverrideDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-header { margin-bottom: 16px; }
@@ -183,13 +193,15 @@ export class PromptDetailComponent implements OnInit {
   private promptService = inject(PromptService);
   private clientService = inject(ClientService);
   private destroyRef = inject(DestroyRef);
-  private dialog = inject(MatDialog);
   private toast = inject(ToastService);
 
   detail = signal<PromptDetail | null>(null);
   preview = signal<PreviewResult | null>(null);
   clients = signal<Client[]>([]);
   selectedClientId = '';
+
+  showOverrideDialog = signal(false);
+  editingOverride = signal<PromptOverride | null>(null);
 
   ngOnInit(): void {
     this.load();
@@ -217,23 +229,18 @@ export class PromptDetailComponent implements OnInit {
   }
 
   addOverride(): void {
-    const ref = this.dialog.open(OverrideDialogComponent, {
-      width: '600px',
-      data: { promptKey: this.key() },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.load();
-    });
+    this.editingOverride.set(null);
+    this.showOverrideDialog.set(true);
   }
 
   editOverride(override: PromptOverride): void {
-    const ref = this.dialog.open(OverrideDialogComponent, {
-      width: '600px',
-      data: { promptKey: this.key(), override },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.load();
-    });
+    this.editingOverride.set(override);
+    this.showOverrideDialog.set(true);
+  }
+
+  onOverrideSaved(): void {
+    this.showOverrideDialog.set(false);
+    this.load();
   }
 
   toggleOverride(override: PromptOverride): void {

--- a/services/control-panel/src/app/features/prompts/prompt-list.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-list.component.ts
@@ -1,7 +1,6 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { PromptService, PromptSummary, PromptKeyword } from '../../core/services/prompt.service';
 import { AiConfigService, TaskTypeDefault, AiModelConfig } from '../../core/services/ai-config.service';
 import { forkJoin } from 'rxjs';
@@ -16,6 +15,7 @@ import {
   TabComponent,
   DataTableComponent,
   DataTableColumnComponent,
+  DialogComponent,
 } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
@@ -37,7 +37,6 @@ interface MergedModelRow {
   imports: [
     RouterLink,
     FormsModule,
-    MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
     TextInputComponent,
@@ -46,6 +45,9 @@ interface MergedModelRow {
     TabComponent,
     DataTableComponent,
     DataTableColumnComponent,
+    DialogComponent,
+    KeywordDialogComponent,
+    AiConfigDialogComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -133,7 +135,7 @@ interface MergedModelRow {
                 placeholder="Search keywords..."
                 (valueChange)="keywordSearchFilter = $event; loadKeywords()">
               </app-text-input>
-              <app-bronco-button variant="primary" (click)="addKeyword()">+ Add Keyword</app-bronco-button>
+              <app-bronco-button variant="primary" (click)="showKeywordDialog.set(true)">+ Add Keyword</app-bronco-button>
               <app-bronco-button variant="secondary" [disabled]="seeding()" (click)="seedKeywords()">
                 {{ seeding() ? 'Seeding...' : 'Seed Defaults' }}
               </app-bronco-button>
@@ -253,6 +255,27 @@ interface MergedModelRow {
         </app-tab>
       </app-tab-group>
     </div>
+
+    @if (showKeywordDialog()) {
+      <app-dialog [open]="true" [title]="editingKeyword() ? 'Edit Keyword' : 'Add Keyword'" maxWidth="500px" (openChange)="showKeywordDialog.set(false)">
+        <app-keyword-dialog-content
+          [keyword]="editingKeyword() ?? undefined"
+          (saved)="onKeywordSaved()"
+          (cancelled)="showKeywordDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showAiConfigDialog()) {
+      <app-dialog [open]="true" [title]="editingConfig() ? 'Edit AI Model Config' : 'Add AI Model Config'" maxWidth="500px" (openChange)="showAiConfigDialog.set(false)">
+        <app-ai-config-dialog-content
+          [config]="editingConfig() ?? undefined"
+          [presetTaskType]="configPresetTaskType()"
+          [taskTypes]="modelTaskTypes()"
+          [codeDefault]="configCodeDefault() ?? undefined"
+          (saved)="onConfigSaved()"
+          (cancelled)="showAiConfigDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-wrapper { max-width: 1200px; }
@@ -401,7 +424,6 @@ export class PromptListComponent implements OnInit {
   private aiConfigService = inject(AiConfigService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
-  private dialog = inject(MatDialog);
   private toast = inject(ToastService);
 
   prompts = signal<PromptSummary[]>([]);
@@ -415,9 +437,18 @@ export class PromptListComponent implements OnInit {
   modelDefaults = signal<TaskTypeDefault[]>([]);
   modelConfigs = signal<AiModelConfig[]>([]);
   mergedModelRows = signal<MergedModelRow[]>([]);
+  modelTaskTypes = computed(() => this.modelDefaults().map(d => d.taskType));
 
   selectedTab = signal(0);
   seeding = signal(false);
+
+  // Dialog state
+  showKeywordDialog = signal(false);
+  editingKeyword = signal<PromptKeyword | null>(null);
+  showAiConfigDialog = signal(false);
+  editingConfig = signal<AiModelConfig | null>(null);
+  configPresetTaskType = signal<string | undefined>(undefined);
+  configCodeDefault = signal<{ provider: string; model: string } | null>(null);
 
   taskTypeFilter = '';
   promptSearchFilter = '';
@@ -514,23 +545,18 @@ export class PromptListComponent implements OnInit {
   }
 
   addKeyword(): void {
-    const ref = this.dialog.open(KeywordDialogComponent, {
-      width: '500px',
-      data: {},
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.loadKeywords();
-    });
+    this.editingKeyword.set(null);
+    this.showKeywordDialog.set(true);
   }
 
   editKeyword(keyword: PromptKeyword): void {
-    const ref = this.dialog.open(KeywordDialogComponent, {
-      width: '500px',
-      data: { keyword },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.loadKeywords();
-    });
+    this.editingKeyword.set(keyword);
+    this.showKeywordDialog.set(true);
+  }
+
+  onKeywordSaved(): void {
+    this.showKeywordDialog.set(false);
+    this.loadKeywords();
   }
 
   seedKeywords(): void {
@@ -561,12 +587,6 @@ export class PromptListComponent implements OnInit {
 
   // ─── AI Models ───────────────────────────────────────────────────────
 
-  /**
-   * Load both defaults and overrides, then merge into a single flat list.
-   * For each task type the primary row shows the effective config (APP_WIDE
-   * override if active, otherwise the hardcoded default). CLIENT-scoped
-   * overrides appear as indented sub-rows beneath their task type.
-   */
   loadModelData(): void {
     forkJoin({
       defaults: this.aiConfigService.getDefaults(),
@@ -578,15 +598,6 @@ export class PromptListComponent implements OnInit {
     });
   }
 
-  /**
-   * Build a single flat list with one primary row per task type showing
-   * the effective setting, followed by any CLIENT sub-rows.
-   *
-   * - Active APP_WIDE override → replaces default values, flagged as overridden
-   * - Inactive APP_WIDE override → shows default values, references override for actions
-   * - No APP_WIDE override → shows default values, no actions on primary row
-   * - CLIENT overrides → indented sub-rows beneath the task type
-   */
   private rebuildMergedRows(): void {
     const defaults = this.modelDefaults();
     const configs = this.modelConfigs();
@@ -600,7 +611,6 @@ export class PromptListComponent implements OnInit {
       const clientOverrides = overrides.filter(c => c.scope === 'CLIENT');
 
       if (appWide?.isActive) {
-        // Active APP_WIDE override replaces the default row
         rows.push({
           taskType: d.taskType,
           provider: appWide.provider,
@@ -614,7 +624,6 @@ export class PromptListComponent implements OnInit {
           defaultModel: d.model,
         });
       } else if (appWide && !appWide.isActive) {
-        // Inactive APP_WIDE override — show default but reference the override
         rows.push({
           taskType: d.taskType,
           provider: d.provider,
@@ -628,7 +637,6 @@ export class PromptListComponent implements OnInit {
           defaultModel: d.model,
         });
       } else {
-        // No APP_WIDE override — pure default
         rows.push({
           taskType: d.taskType,
           provider: d.provider,
@@ -643,7 +651,6 @@ export class PromptListComponent implements OnInit {
         });
       }
 
-      // CLIENT overrides as sub-rows
       for (const c of clientOverrides) {
         rows.push({
           taskType: d.taskType,
@@ -664,16 +671,10 @@ export class PromptListComponent implements OnInit {
   }
 
   addModelConfigForTask(taskType: string): void {
-    const ref = this.dialog.open(AiConfigDialogComponent, {
-      width: '500px',
-      data: {
-        taskType,
-        taskTypes: this.modelDefaults().map(d => d.taskType),
-      },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.loadModelData();
-    });
+    this.editingConfig.set(null);
+    this.configPresetTaskType.set(taskType);
+    this.configCodeDefault.set(null);
+    this.showAiConfigDialog.set(true);
   }
 
   addModelConfig(): void {
@@ -681,32 +682,25 @@ export class PromptListComponent implements OnInit {
       this.toast.info('Model defaults not loaded yet');
       return;
     }
-    const ref = this.dialog.open(AiConfigDialogComponent, {
-      width: '500px',
-      data: {
-        taskTypes: this.modelDefaults().map(d => d.taskType),
-      },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.loadModelData();
-    });
+    this.editingConfig.set(null);
+    this.configPresetTaskType.set(undefined);
+    this.configCodeDefault.set(null);
+    this.showAiConfigDialog.set(true);
   }
 
   editModelConfigById(configId: string): void {
     const config = this.modelConfigs().find(c => c.id === configId);
     if (!config) return;
     const codeDefault = this.modelDefaults().find(d => d.taskType === config.taskType);
-    const ref = this.dialog.open(AiConfigDialogComponent, {
-      width: '500px',
-      data: {
-        config,
-        taskTypes: this.modelDefaults().map(d => d.taskType),
-        codeDefault: codeDefault ? { provider: codeDefault.provider, model: codeDefault.model } : undefined,
-      },
-    });
-    ref.afterClosed().subscribe(result => {
-      if (result) this.loadModelData();
-    });
+    this.editingConfig.set(config);
+    this.configPresetTaskType.set(undefined);
+    this.configCodeDefault.set(codeDefault ? { provider: codeDefault.provider, model: codeDefault.model } : null);
+    this.showAiConfigDialog.set(true);
+  }
+
+  onConfigSaved(): void {
+    this.showAiConfigDialog.set(false);
+    this.loadModelData();
   }
 
   toggleModelConfigActiveById(configId: string, currentlyActive: boolean): void {

--- a/services/control-panel/src/app/features/release-notes/backfill-dialog.component.ts
+++ b/services/control-panel/src/app/features/release-notes/backfill-dialog.component.ts
@@ -1,60 +1,53 @@
-import { Component, inject } from '@angular/core';
+import { Component, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 
 @Component({
+  selector: 'app-backfill-dialog-content',
   standalone: true,
   imports: [
     FormsModule,
-    MatDialogModule,
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
   ],
   template: `
-    <h2 mat-dialog-title>Sync History</h2>
-    <mat-dialog-content>
-      <p>Fetch commits from GitHub and generate release notes for a range of commits.</p>
-      <mat-form-field class="full-width">
-        <mat-label>From SHA (base)</mat-label>
-        <input matInput [(ngModel)]="fromSha" placeholder="e.g. abc1234">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>To SHA / branch</mat-label>
-        <input matInput [(ngModel)]="toSha" placeholder="e.g. def5678 or master">
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="cancel()">Cancel</button>
+    <p>Fetch commits from GitHub and generate release notes for a range of commits.</p>
+    <mat-form-field class="full-width">
+      <mat-label>From SHA (base)</mat-label>
+      <input matInput [(ngModel)]="fromSha" placeholder="e.g. abc1234">
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>To SHA / branch</mat-label>
+      <input matInput [(ngModel)]="toSha" placeholder="e.g. def5678 or master">
+    </mat-form-field>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" [disabled]="!fromSha.trim() || !toSha.trim()" (click)="confirm()">
         Sync
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; }
-    mat-dialog-content { display: flex; flex-direction: column; gap: 8px; min-width: 360px; }
     p { color: #666; font-size: 14px; margin-top: 0; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class BackfillDialogComponent {
-  private dialogRef = inject(MatDialogRef<BackfillDialogComponent>);
+  submitted = output<{ fromSha: string; toSha?: string }>();
+  cancelled = output<void>();
 
   fromSha = '';
   toSha = 'master';
 
-  cancel(): void {
-    this.dialogRef.close();
-  }
-
   confirm(): void {
-    const result = {
+    this.submitted.emit({
       fromSha: this.fromSha.trim(),
       toSha: this.toSha.trim(),
-    };
-    this.dialogRef.close(result);
+    });
   }
 }

--- a/services/control-panel/src/app/features/release-notes/release-notes.component.ts
+++ b/services/control-panel/src/app/features/release-notes/release-notes.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { ReleaseNotesService, type ReleaseNote, type ReleaseNoteType } from '../../core/services/release-notes.service';
 import { BackfillDialogComponent } from './backfill-dialog.component';
+import { DialogComponent } from '../../shared/components/dialog.component';
 import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
@@ -17,10 +17,11 @@ const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }
   standalone: true,
   imports: [
     FormsModule,
-    MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
     PaginatorComponent,
+    DialogComponent,
+    BackfillDialogComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -137,6 +138,14 @@ const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }
         [pageSizeOptions]="[25, 50, 100]"
         (page)="onPage($event)" />
     </div>
+
+    @if (showBackfillDialog()) {
+      <app-dialog [open]="true" title="Sync History" maxWidth="480px" (openChange)="showBackfillDialog.set(false)">
+        <app-backfill-dialog-content
+          (submitted)="onBackfillSubmitted($event)"
+          (cancelled)="showBackfillDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-wrapper { max-width: 1200px; }
@@ -234,7 +243,7 @@ const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }
 export class ReleaseNotesComponent implements OnInit {
   private releaseNotesService = inject(ReleaseNotesService);
   private toast = inject(ToastService);
-  private dialog = inject(MatDialog);
+  showBackfillDialog = signal(false);
 
   notes = signal<ReleaseNote[]>([]);
   availableServices = signal<string[]>([]);
@@ -365,23 +374,24 @@ export class ReleaseNotesComponent implements OnInit {
   }
 
   openBackfillDialog(): void {
-    const ref = this.dialog.open(BackfillDialogComponent, { width: '480px' });
-    ref.afterClosed().subscribe((result: { fromSha: string; toSha?: string } | undefined) => {
-      if (!result) return;
-      this.ingestLoading.set(true);
-      this.releaseNotesService.backfill(result.fromSha, result.toSha).subscribe({
-        next: (r) => {
-          this.ingestLoading.set(false);
-          this.toast.success(`Sync complete — ${r.ingested} ingested, ${r.skipped} skipped`);
-          this.load();
-          this.loadServices();
-          this.loadTags();
-        },
-        error: (err) => {
-          this.ingestLoading.set(false);
-          this.toast.error(err.error?.error ?? 'Backfill failed');
-        },
-      });
+    this.showBackfillDialog.set(true);
+  }
+
+  onBackfillSubmitted(result: { fromSha: string; toSha?: string }): void {
+    this.showBackfillDialog.set(false);
+    this.ingestLoading.set(true);
+    this.releaseNotesService.backfill(result.fromSha, result.toSha).subscribe({
+      next: (r) => {
+        this.ingestLoading.set(false);
+        this.toast.success(`Sync complete — ${r.ingested} ingested, ${r.skipped} skipped`);
+        this.load();
+        this.loadServices();
+        this.loadTags();
+      },
+      error: (err) => {
+        this.ingestLoading.set(false);
+        this.toast.error(err.error?.error ?? 'Backfill failed');
+      },
     });
   }
 

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -8,62 +7,81 @@ import { RepoService, type CodeRepo } from '../../core/services/repo.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-repo-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
   template: `
-    <h2 mat-dialog-title>{{ title }}</h2>
-    <mat-dialog-content>
-      <mat-form-field class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="form.name" required>
+    <mat-form-field class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="form.name" required>
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Repository URL</mat-label>
+      <input matInput [(ngModel)]="form.repoUrl" required placeholder="https://github.com/org/repo.git">
+    </mat-form-field>
+    <mat-form-field class="full-width">
+      <mat-label>Description (helps AI understand repo contents)</mat-label>
+      <textarea matInput [(ngModel)]="form.description" rows="2"
+        placeholder="SQL Server stored procedures, table schemas, and ETL jobs for..."></textarea>
+    </mat-form-field>
+    <div class="row">
+      <mat-form-field class="flex">
+        <mat-label>Default Branch</mat-label>
+        <input matInput [(ngModel)]="form.defaultBranch">
       </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Repository URL</mat-label>
-        <input matInput [(ngModel)]="form.repoUrl" required placeholder="https://github.com/org/repo.git">
+      <mat-form-field class="flex">
+        <mat-label>Branch Prefix</mat-label>
+        <input matInput [(ngModel)]="form.branchPrefix">
       </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Description (helps AI understand repo contents)</mat-label>
-        <textarea matInput [(ngModel)]="form.description" rows="2"
-          placeholder="SQL Server stored procedures, table schemas, and ETL jobs for..."></textarea>
-      </mat-form-field>
-      <div class="row">
-        <mat-form-field class="flex">
-          <mat-label>Default Branch</mat-label>
-          <input matInput [(ngModel)]="form.defaultBranch">
-        </mat-form-field>
-        <mat-form-field class="flex">
-          <mat-label>Branch Prefix</mat-label>
-          <input matInput [(ngModel)]="form.branchPrefix">
-        </mat-form-field>
-      </div>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    </div>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!form.name || !form.repoUrl">{{ saveLabel }}</button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
     .row { display: flex; gap: 12px; }
     .flex { flex: 1; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class RepoDialogComponent {
-  private dialogRef = inject(MatDialogRef<RepoDialogComponent>);
-  private data: { clientId: string; repo?: CodeRepo } = inject(MAT_DIALOG_DATA);
+export class RepoDialogComponent implements OnInit {
   private repoService = inject(RepoService);
   private toast = inject(ToastService);
 
-  title = this.data.repo ? 'Edit Code Repository' : 'Add Code Repository';
-  saveLabel = this.data.repo ? 'Save' : 'Create';
+  clientId = input.required<string>();
+  repo = input<CodeRepo>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
+
+  isEdit = false;
+  saveLabel = 'Create';
 
   form = {
-    name: this.data.repo?.name ?? '',
-    repoUrl: this.data.repo?.repoUrl ?? '',
-    description: this.data.repo?.description ?? '',
-    defaultBranch: this.data.repo?.defaultBranch ?? 'master',
-    branchPrefix: this.data.repo?.branchPrefix ?? 'claude',
+    name: '',
+    repoUrl: '',
+    description: '',
+    defaultBranch: 'master',
+    branchPrefix: 'claude',
   };
+
+  ngOnInit(): void {
+    const r = this.repo();
+    if (r) {
+      this.isEdit = true;
+      this.saveLabel = 'Save';
+      this.form = {
+        name: r.name ?? '',
+        repoUrl: r.repoUrl ?? '',
+        description: r.description ?? '',
+        defaultBranch: r.defaultBranch ?? 'master',
+        branchPrefix: r.branchPrefix ?? 'claude',
+      };
+    }
+  }
 
   save(): void {
     const payload = {
@@ -74,14 +92,15 @@ export class RepoDialogComponent {
       branchPrefix: this.form.branchPrefix,
     };
 
-    const request$ = this.data.repo
-      ? this.repoService.updateRepo(this.data.repo.id, payload)
-      : this.repoService.createRepo({ ...payload, clientId: this.data.clientId });
+    const r = this.repo();
+    const request$ = r
+      ? this.repoService.updateRepo(r.id, payload)
+      : this.repoService.createRepo({ ...payload, clientId: this.clientId() });
 
     request$.subscribe({
       next: () => {
-        this.toast.success(this.data.repo ? 'Repo updated' : 'Repo created');
-        this.dialogRef.close(true);
+        this.toast.success(r ? 'Repo updated' : 'Repo created');
+        this.saved.emit(true);
       },
       error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
     });

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -16,12 +15,6 @@ interface ToolInfo {
   name: string;
   description: string;
   inputSchema?: Record<string, unknown>;
-}
-
-interface DialogData {
-  probe?: ScheduledProbe;
-  clients: Client[];
-  categories: Array<{ value: string; label: string }>;
 }
 
 const ACTIONS = [
@@ -58,11 +51,11 @@ const COMMON_TIMEZONES = [
 ];
 
 @Component({
+  selector: 'app-probe-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit Probe' : 'Create Probe' }}</h2>
-    <mat-dialog-content class="dialog-content">
+    <div class="dialog-content">
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Name</mat-label>
         <input matInput [(ngModel)]="name" required placeholder="e.g. Daily Blocking Check">
@@ -77,7 +70,7 @@ const COMMON_TIMEZONES = [
         <mat-form-field appearance="outline" class="full-width">
           <mat-label>Client</mat-label>
           <mat-select [(ngModel)]="clientId" (selectionChange)="onClientChange()" required>
-            @for (c of data.clients; track c.id) {
+            @for (c of clientsList; track c.id) {
               <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
             }
           </mat-select>
@@ -237,7 +230,7 @@ const COMMON_TIMEZONES = [
           <mat-label>Category</mat-label>
           <mat-select [(ngModel)]="category">
             <mat-option [value]="null">None</mat-option>
-            @for (cat of data.categories; track cat.value) {
+            @for (cat of categoriesList; track cat.value) {
               <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
             }
           </mat-select>
@@ -260,14 +253,14 @@ const COMMON_TIMEZONES = [
           </div>
         </div>
       }
-    </mat-dialog-content>
+    </div>
 
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave() || saving">
         {{ saving ? 'Saving...' : (isEdit ? 'Update' : 'Create') }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .dialog-content { min-width: 450px; }
@@ -285,38 +278,43 @@ const COMMON_TIMEZONES = [
     .retention-section h4 { margin: 0 0 8px; font-size: 14px; color: #555; }
     .retention-row { display: flex; gap: 12px; }
     .retention-field { flex: 1; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class ProbeDialogComponent implements OnInit {
-  data = inject<DialogData>(MAT_DIALOG_DATA);
-  private dialogRef = inject(MatDialogRef<ProbeDialogComponent>);
   private probeService = inject(ScheduledProbeService);
   private integrationService = inject(IntegrationService);
   private toast = inject(ToastService);
 
-  isEdit = !!this.data.probe;
-  name = this.data.probe?.name ?? '';
-  description = this.data.probe?.description ?? '';
-  clientId = this.data.probe?.clientId ?? '';
-  integrationId = this.data.probe?.integrationId ?? '';
-  toolName = this.data.probe?.toolName ?? '';
-  toolParams: Record<string, unknown> = { ...(this.data.probe?.toolParams ?? {}) };
-  cronExpression = this.data.probe?.cronExpression ?? '0 * * * *';
+  probe = input<ScheduledProbe>();
+  clients = input.required<Client[]>();
+  categories = input.required<ReadonlyArray<{ readonly value: string; readonly label: string }>>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
+
+  isEdit = false;
+  name = '';
+  description = '';
+  clientId = '';
+  integrationId = '';
+  toolName = '';
+  toolParams: Record<string, unknown> = {};
+  cronExpression = '0 * * * *';
   cronPreset = '';
-  category: string | null = this.data.probe?.category ?? null;
-  action = this.data.probe?.action ?? 'create_ticket';
+  category: string | null = null;
+  action = 'create_ticket';
   operatorEmail = '';
   emailTo = '';
   emailSubject = '';
-  retentionDays = this.data.probe?.retentionDays ?? 30;
-  retentionMaxRuns = this.data.probe?.retentionMaxRuns ?? 100;
+  retentionDays = 30;
+  retentionMaxRuns = 100;
   saving = false;
 
-  // Schedule type: 'time' for timezone-based, 'cron' for raw cron
-  scheduleType: 'time' | 'cron' = !this.data.probe ? 'time' : (this.data.probe.scheduleTimezone ? 'time' : 'cron');
-  scheduleHour = this.data.probe?.scheduleHour ?? 8;
-  scheduleMinute = this.data.probe?.scheduleMinute ?? 0;
-  scheduleTimezone = this.data.probe?.scheduleTimezone ?? 'America/Chicago';
+  scheduleType: 'time' | 'cron' = 'time';
+  scheduleHour = 8;
+  scheduleMinute = 0;
+  scheduleTimezone = 'America/Chicago';
   selectedDays: boolean[] = [false, false, false, false, false, false, false];
 
   actions = ACTIONS;
@@ -334,6 +332,9 @@ export class ProbeDialogComponent implements OnInit {
   availableTools: ToolInfo[] = [];
   toolParamFields: Array<{ name: string; type: string; description: string }> = [];
 
+  clientsList: Client[] = [];
+  categoriesList: ReadonlyArray<{ readonly value: string; readonly label: string }> = [];
+
   get cronHumanReadable(): string {
     return describeCron(this.cronExpression);
   }
@@ -343,39 +344,60 @@ export class ProbeDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Load action config from existing probe
-    if (this.data.probe?.actionConfig) {
-      const cfg = this.data.probe.actionConfig;
-      this.operatorEmail = typeof cfg['operatorEmail'] === 'string' ? cfg['operatorEmail'] : '';
-      this.emailTo = typeof cfg['emailTo'] === 'string' ? cfg['emailTo'] : '';
-      this.emailSubject = typeof cfg['emailSubject'] === 'string' ? cfg['emailSubject'] : '';
-    }
+    this.clientsList = this.clients();
+    this.categoriesList = this.categories();
 
-    // Populate days of week from existing probe
-    if (this.data.probe?.scheduleDaysOfWeek) {
-      const days = this.data.probe.scheduleDaysOfWeek.split(',').map(Number);
-      for (const d of days) {
-        if (d >= 0 && d <= 6) this.selectedDays[d] = true;
+    const p = this.probe();
+    this.isEdit = !!p;
+
+    if (p) {
+      this.name = p.name ?? '';
+      this.description = p.description ?? '';
+      this.clientId = p.clientId ?? '';
+      this.integrationId = p.integrationId ?? '';
+      this.toolName = p.toolName ?? '';
+      this.toolParams = { ...(p.toolParams ?? {}) };
+      this.cronExpression = p.cronExpression ?? '0 * * * *';
+      this.category = p.category ?? null;
+      this.action = p.action ?? 'create_ticket';
+      this.retentionDays = p.retentionDays ?? 30;
+      this.retentionMaxRuns = p.retentionMaxRuns ?? 100;
+      this.scheduleType = p.scheduleTimezone ? 'time' : 'cron';
+      this.scheduleHour = p.scheduleHour ?? 8;
+      this.scheduleMinute = p.scheduleMinute ?? 0;
+      this.scheduleTimezone = p.scheduleTimezone ?? 'America/Chicago';
+
+      // Load action config
+      if (p.actionConfig) {
+        const cfg = p.actionConfig;
+        this.operatorEmail = typeof cfg['operatorEmail'] === 'string' ? cfg['operatorEmail'] : '';
+        this.emailTo = typeof cfg['emailTo'] === 'string' ? cfg['emailTo'] : '';
+        this.emailSubject = typeof cfg['emailSubject'] === 'string' ? cfg['emailSubject'] : '';
+      }
+
+      // Populate days of week
+      if (p.scheduleDaysOfWeek) {
+        const days = p.scheduleDaysOfWeek.split(',').map(Number);
+        for (const d of days) {
+          if (d >= 0 && d <= 6) this.selectedDays[d] = true;
+        }
       }
     }
 
     // Set cron preset if it matches
-    const match = CRON_PRESETS.find((p) => p.value === this.cronExpression);
+    const match = CRON_PRESETS.find((pr) => pr.value === this.cronExpression);
     this.cronPreset = match ? match.value : '';
 
     // Load built-in tools
     this.probeService.getBuiltinTools().subscribe((tools) => {
       this.builtinTools = tools;
-      // If editing and the tool is built-in, select that source
       if (this.isEdit && this.toolName && tools.some((t) => t.name === this.toolName)) {
         this.toolSource = 'builtin';
         this.availableTools = this.builtinTools;
-        // Rebuild param fields but preserve existing values
         const existingParams = this.toolParams;
         this.onToolChange();
         if (existingParams) this.toolParams = existingParams;
       } else if (this.toolSource === 'builtin') {
-        // Create mode: user already switched to builtin before load finished
         this.availableTools = this.builtinTools;
       }
     });
@@ -509,10 +531,10 @@ export class ProbeDialogComponent implements OnInit {
         updateData.cronExpression = this.cronExpression;
         updateData.scheduleTimezone = null;
       }
-      this.probeService.updateProbe(this.data.probe!.id, updateData).subscribe({
+      this.probeService.updateProbe(this.probe()!.id, updateData).subscribe({
         next: () => {
           this.toast.success('Probe updated');
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;
@@ -542,7 +564,7 @@ export class ProbeDialogComponent implements OnInit {
       this.probeService.createProbe(req).subscribe({
         next: () => {
           this.toast.success('Probe created');
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;
@@ -604,20 +626,13 @@ function describeCron(expr: string): string {
   return expr;
 }
 
-/**
- * Client-side UTC preview: compute what UTC time the local schedule maps to.
- * Uses the same Intl.DateTimeFormat approach as the server-side buildUtcCron.
- */
 function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[], timezone: string): string {
   try {
-    // Create a date in the target timezone for today
     const now = new Date();
     const localStr = now.toLocaleDateString('en-US', { timeZone: timezone, year: 'numeric', month: '2-digit', day: '2-digit' });
     const [month, day, year] = localStr.split('/').map(Number);
-    // Build a date at the desired local time
     const target = new Date(Date.UTC(year, month - 1, day, hour, minute));
 
-    // Get offset by comparing UTC formatted vs local formatted, including the date
     const utcParts = new Intl.DateTimeFormat('en-US', {
       timeZone: 'UTC',
       year: 'numeric',
@@ -645,13 +660,11 @@ function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[]
     const toUtcMillis = (parts: Intl.DateTimeFormatPart[]) =>
       Date.UTC(getVal(parts, 'year'), getVal(parts, 'month') - 1, getVal(parts, 'day'), getVal(parts, 'hour'), getVal(parts, 'minute'));
 
-    // Compute the offset (local - UTC) in minutes using full date/time
     const offsetMinutes = Math.round((toUtcMillis(localParts) - toUtcMillis(utcParts)) / 60000);
     let resultMinutes = (hour * 60 + minute) - offsetMinutes;
     if (resultMinutes < 0) resultMinutes += 24 * 60;
     if (resultMinutes >= 24 * 60) resultMinutes -= 24 * 60;
 
-    // Track day shift using the same carry logic as buildUtcCron
     let utcMinute = minute - (offsetMinutes % 60);
     let utcHour = hour - Math.trunc(offsetMinutes / 60);
     if (utcMinute < 0) { utcMinute += 60; utcHour -= 1; }
@@ -663,7 +676,6 @@ function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[]
     const rH = Math.floor(resultMinutes / 60);
     const rM = resultMinutes % 60;
 
-    // Build days string, applying dayShift to selected days
     const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
     const anySelected = selectedDays.some(Boolean);
     let displayDays = selectedDays.map((c, i) => c ? i : -1).filter((i) => i >= 0);

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { NgClass } from '@angular/common';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { RouterLink } from '@angular/router';
 import {
   DataTableComponent,
@@ -10,6 +9,7 @@ import {
   SelectComponent,
   ToggleSwitchComponent,
 } from '../../shared/components/index.js';
+import { DialogComponent } from '../../shared/components/dialog.component';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
 import { ScheduledProbeService, ScheduledProbe } from '../../core/services/scheduled-probe.service';
 import { ClientService, Client } from '../../core/services/client.service';
@@ -29,13 +29,14 @@ const ACTION_LABELS: Record<string, string> = {
   standalone: true,
   imports: [
     NgClass,
-    MatDialogModule,
     RouterLink,
     DataTableComponent,
     DataTableColumnComponent,
     BroncoButtonComponent,
     ToolbarComponent,
     SelectComponent,
+    DialogComponent,
+    ProbeDialogComponent,
     ToggleSwitchComponent,
   ],
   template: `
@@ -136,6 +137,17 @@ const ACTION_LABELS: Record<string, string> = {
 
       </app-data-table>
     </div>
+
+    @if (showProbeDialog()) {
+      <app-dialog [open]="true" [title]="editingProbe() ? 'Edit Probe' : 'Create Probe'" maxWidth="600px" (openChange)="showProbeDialog.set(false)">
+        <app-probe-dialog-content
+          [probe]="editingProbe() ?? undefined"
+          [clients]="clients()"
+          [categories]="categories"
+          (saved)="onProbeSaved()"
+          (cancelled)="showProbeDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .probe-list-page { max-width: 1200px; }
@@ -154,9 +166,12 @@ const ACTION_LABELS: Record<string, string> = {
 export class ProbeListComponent implements OnInit {
   private probeService = inject(ScheduledProbeService);
   private clientService = inject(ClientService);
-  private dialog = inject(MatDialog);
   private toast = inject(ToastService);
   private detailPanel = inject(DetailPanelService);
+
+  showProbeDialog = signal(false);
+  editingProbe = signal<ScheduledProbe | null>(null);
+  categories = CATEGORIES;
 
   probes = signal<ScheduledProbe[]>([]);
   clients = signal<Client[]>([]);
@@ -230,23 +245,18 @@ export class ProbeListComponent implements OnInit {
   }
 
   addProbe(): void {
-    const ref = this.dialog.open(ProbeDialogComponent, {
-      width: '600px',
-      data: { clients: this.clients(), categories: CATEGORIES },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadProbes();
-    });
+    this.editingProbe.set(null);
+    this.showProbeDialog.set(true);
   }
 
   editProbe(probe: ScheduledProbe): void {
-    const ref = this.dialog.open(ProbeDialogComponent, {
-      width: '600px',
-      data: { probe, clients: this.clients(), categories: CATEGORIES },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadProbes();
-    });
+    this.editingProbe.set(probe);
+    this.showProbeDialog.set(true);
+  }
+
+  onProbeSaved(): void {
+    this.showProbeDialog.set(false);
+    this.loadProbes();
   }
 
   toggleActive(probe: ScheduledProbe, isActive: boolean): void {

--- a/services/control-panel/src/app/features/system-analysis/reject-dialog.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/reject-dialog.component.ts
@@ -1,46 +1,44 @@
-import { Component, inject } from '@angular/core';
+import { Component, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
+  selector: 'app-reject-dialog-content',
   standalone: true,
   imports: [
     FormsModule,
-    MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
   ],
   template: `
-    <h2 mat-dialog-title>Reject Analysis</h2>
-    <mat-dialog-content>
-      <p>Provide a reason for rejecting this analysis. This will be used as context to avoid suggesting similar improvements in the future.</p>
-      <mat-form-field class="full-width">
-        <mat-label>Rejection Reason</mat-label>
-        <textarea matInput [(ngModel)]="reason" rows="4" placeholder="e.g., Not applicable to our setup, already handled by..."></textarea>
-      </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <p>Provide a reason for rejecting this analysis. This will be used as context to avoid suggesting similar improvements in the future.</p>
+    <mat-form-field class="full-width">
+      <mat-label>Rejection Reason</mat-label>
+      <textarea matInput [(ngModel)]="reason" rows="4" placeholder="e.g., Not applicable to our setup, already handled by..."></textarea>
+    </mat-form-field>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="warn" [disabled]="!reason.trim()" (click)="submit()">Reject</button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
-    .full-width {
-      width: 100%;
-    }
+    .full-width { width: 100%; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class RejectDialogComponent {
-  private dialogRef = inject(MatDialogRef<RejectDialogComponent>);
+  rejected = output<string>();
+  cancelled = output<void>();
+
   reason = '';
 
   submit(): void {
     if (this.reason.trim()) {
-      this.dialogRef.close(this.reason.trim());
+      this.rejected.emit(this.reason.trim());
     }
   }
 }

--- a/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { SystemAnalysisService, type SystemAnalysis, type SystemAnalysisStats } from '../../core/services/system-analysis.service';
 import { RejectDialogComponent } from './reject-dialog.component';
+import { DialogComponent } from '../../shared/components/dialog.component';
 import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
@@ -18,10 +18,11 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
   imports: [
     FormsModule,
     RouterLink,
-    MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
     PaginatorComponent,
+    DialogComponent,
+    RejectDialogComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -139,6 +140,14 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
         [pageSizeOptions]="[10, 25, 50]"
         (page)="onPage($event)" />
     </div>
+
+    @if (showRejectDialog()) {
+      <app-dialog [open]="true" title="Reject Analysis" maxWidth="500px" (openChange)="showRejectDialog.set(false)">
+        <app-reject-dialog-content
+          (rejected)="onRejected($event)"
+          (cancelled)="showRejectDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-wrapper { max-width: 1200px; }
@@ -218,12 +227,13 @@ const STATUS_META: Record<string, { label: string; color: string }> = {
 export class SystemAnalysisComponent implements OnInit {
   private analysisService = inject(SystemAnalysisService);
   private toast = inject(ToastService);
-  private dialog = inject(MatDialog);
-
   analyses = signal<SystemAnalysis[]>([]);
   stats = signal<SystemAnalysisStats | null>(null);
   total = signal(0);
   loading = signal(false);
+
+  showRejectDialog = signal(false);
+  rejectingAnalysis = signal<SystemAnalysis | null>(null);
 
   statusFilter = '';
   pageSize = 10;
@@ -295,20 +305,23 @@ export class SystemAnalysisComponent implements OnInit {
   }
 
   openRejectDialog(a: SystemAnalysis): void {
-    const ref = this.dialog.open(RejectDialogComponent, { width: '500px' });
-    ref.afterClosed().subscribe((reason: string | undefined) => {
-      if (reason) {
-        this.analysisService.reject(a.id, reason).subscribe({
-          next: () => {
-            this.toast.success('Analysis rejected');
-            this.load();
-            this.loadStats();
-          },
-          error: (err) => {
-            this.toast.error(err.error?.error ?? 'Failed to reject');
-          },
-        });
-      }
+    this.rejectingAnalysis.set(a);
+    this.showRejectDialog.set(true);
+  }
+
+  onRejected(reason: string): void {
+    const a = this.rejectingAnalysis();
+    if (!a) return;
+    this.showRejectDialog.set(false);
+    this.analysisService.reject(a.id, reason).subscribe({
+      next: () => {
+        this.toast.success('Analysis rejected');
+        this.load();
+        this.loadStats();
+      },
+      error: (err) => {
+        this.toast.error(err.error?.error ?? 'Failed to reject');
+      },
     });
   }
 

--- a/services/control-panel/src/app/features/systems/system-dialog.component.ts
+++ b/services/control-panel/src/app/features/systems/system-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -10,87 +9,90 @@ import { SystemService } from '../../core/services/system.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
+  selector: 'app-system-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>Add Database System</h2>
-    <mat-dialog-content>
-      <div class="row">
-        <mat-form-field class="flex">
-          <mat-label>Name</mat-label>
-          <input matInput [(ngModel)]="form.name" required>
-        </mat-form-field>
-        <mat-form-field class="flex">
-          <mat-label>Engine</mat-label>
-          <mat-select [(ngModel)]="form.dbEngine">
-            <mat-option value="MSSQL">MSSQL</mat-option>
-            <mat-option value="AZURE_SQL_MI">Azure SQL MI</mat-option>
-            <mat-option value="POSTGRESQL">PostgreSQL</mat-option>
-            <mat-option value="MYSQL">MySQL</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <mat-form-field class="flex">
-          <mat-label>Host</mat-label>
-          <input matInput [(ngModel)]="form.host" required>
-        </mat-form-field>
-        <mat-form-field style="width: 120px">
-          <mat-label>Port</mat-label>
-          <input matInput type="number" [(ngModel)]="form.port" min="1" max="65535">
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <mat-form-field class="flex">
-          <mat-label>Username</mat-label>
-          <input matInput [(ngModel)]="form.username">
-        </mat-form-field>
-        <mat-form-field class="flex">
-          <mat-label>Default Database</mat-label>
-          <input matInput [(ngModel)]="form.defaultDatabase">
-        </mat-form-field>
-      </div>
-      <div class="row">
-        <mat-form-field class="flex">
-          <mat-label>Environment</mat-label>
-          <mat-select [(ngModel)]="form.environment">
-            <mat-option value="PRODUCTION">Production</mat-option>
-            <mat-option value="STAGING">Staging</mat-option>
-            <mat-option value="DEVELOPMENT">Development</mat-option>
-            <mat-option value="DR">DR</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="flex">
-          <mat-label>Auth Method</mat-label>
-          <mat-select [(ngModel)]="form.authMethod">
-            <mat-option value="SQL_AUTH">SQL Auth</mat-option>
-            <mat-option value="WINDOWS_AUTH">Windows Auth</mat-option>
-            <mat-option value="AZURE_AD">Azure AD</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
-      <mat-form-field class="full-width">
-        <mat-label>Notes</mat-label>
-        <textarea matInput [(ngModel)]="form.notes" rows="2"></textarea>
+    <div class="row">
+      <mat-form-field class="flex">
+        <mat-label>Name</mat-label>
+        <input matInput [(ngModel)]="form.name" required>
       </mat-form-field>
-    </mat-dialog-content>
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+      <mat-form-field class="flex">
+        <mat-label>Engine</mat-label>
+        <mat-select [(ngModel)]="form.dbEngine">
+          <mat-option value="MSSQL">MSSQL</mat-option>
+          <mat-option value="AZURE_SQL_MI">Azure SQL MI</mat-option>
+          <mat-option value="POSTGRESQL">PostgreSQL</mat-option>
+          <mat-option value="MYSQL">MySQL</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="row">
+      <mat-form-field class="flex">
+        <mat-label>Host</mat-label>
+        <input matInput [(ngModel)]="form.host" required>
+      </mat-form-field>
+      <mat-form-field style="width: 120px">
+        <mat-label>Port</mat-label>
+        <input matInput type="number" [(ngModel)]="form.port" min="1" max="65535">
+      </mat-form-field>
+    </div>
+    <div class="row">
+      <mat-form-field class="flex">
+        <mat-label>Username</mat-label>
+        <input matInput [(ngModel)]="form.username">
+      </mat-form-field>
+      <mat-form-field class="flex">
+        <mat-label>Default Database</mat-label>
+        <input matInput [(ngModel)]="form.defaultDatabase">
+      </mat-form-field>
+    </div>
+    <div class="row">
+      <mat-form-field class="flex">
+        <mat-label>Environment</mat-label>
+        <mat-select [(ngModel)]="form.environment">
+          <mat-option value="PRODUCTION">Production</mat-option>
+          <mat-option value="STAGING">Staging</mat-option>
+          <mat-option value="DEVELOPMENT">Development</mat-option>
+          <mat-option value="DR">DR</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field class="flex">
+        <mat-label>Auth Method</mat-label>
+        <mat-select [(ngModel)]="form.authMethod">
+          <mat-option value="SQL_AUTH">SQL Auth</mat-option>
+          <mat-option value="WINDOWS_AUTH">Windows Auth</mat-option>
+          <mat-option value="AZURE_AD">Azure AD</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <mat-form-field class="full-width">
+      <mat-label>Notes</mat-label>
+      <textarea matInput [(ngModel)]="form.notes" rows="2"></textarea>
+    </mat-form-field>
+
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!form.name || !form.host || form.port < 1 || form.port > 65535">Create</button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .row { display: flex; gap: 12px; }
     .flex { flex: 1; }
     .full-width { width: 100%; }
     mat-form-field { margin-bottom: 4px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class SystemDialogComponent {
-  private dialogRef = inject(MatDialogRef<SystemDialogComponent>);
-  private data: { clientId: string } = inject(MAT_DIALOG_DATA);
   private systemService = inject(SystemService);
   private toast = inject(ToastService);
+
+  clientId = input.required<string>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
 
   form = {
     name: '',
@@ -106,7 +108,7 @@ export class SystemDialogComponent {
 
   save(): void {
     this.systemService.createSystem({
-      clientId: this.data.clientId,
+      clientId: this.clientId(),
       name: this.form.name,
       host: this.form.host,
       port: this.form.port,
@@ -119,7 +121,7 @@ export class SystemDialogComponent {
     } as never).subscribe({
       next: () => {
         this.toast.success('System created');
-        this.dialogRef.close(true);
+        this.saved.emit(true);
       },
       error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
     });

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -19,122 +18,142 @@ const SOURCES = [
   { value: 'AI_DETECTED', label: 'AI Detected' },
 ];
 
-interface DialogData {
-  route?: TicketRoute;
-  clients: Client[];
-  categories: Array<{ value: string; label: string }>;
-  /** Pre-set route type when creating from a specific tab. */
-  routeType?: RouteType;
-}
-
 @Component({
+  selector: 'app-ticket-route-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit Route' : 'Create Route' }}</h2>
-    <mat-dialog-content>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" required placeholder="e.g. Database Performance Pipeline">
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required placeholder="e.g. Database Performance Pipeline">
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Description</mat-label>
-        <textarea matInput [(ngModel)]="description" rows="2" placeholder="Optional description of this route"></textarea>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Description</mat-label>
+      <textarea matInput [(ngModel)]="description" rows="2" placeholder="Optional description of this route"></textarea>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Route Type</mat-label>
-        <mat-select [(ngModel)]="routeType">
-          <mat-option value="ANALYSIS">Analysis</mat-option>
-          <mat-option value="INGESTION">Ingestion</mat-option>
-        </mat-select>
-        <mat-hint>Ingestion routes enrich + create tickets from a source. Analysis routes investigate existing tickets.</mat-hint>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Route Type</mat-label>
+      <mat-select [(ngModel)]="routeType">
+        <mat-option value="ANALYSIS">Analysis</mat-option>
+        <mat-option value="INGESTION">Ingestion</mat-option>
+      </mat-select>
+      <mat-hint>Ingestion routes enrich + create tickets from a source. Analysis routes investigate existing tickets.</mat-hint>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Source Filter</mat-label>
-        <mat-select [(ngModel)]="source">
-          <mat-option [value]="null">Any Source</mat-option>
-          @for (s of sources; track s.value) {
-            <mat-option [value]="s.value">{{ s.label }}</mat-option>
-          }
-        </mat-select>
-        <mat-hint>{{ routeType === 'INGESTION' ? 'Ingestion routes should target a specific source.' : 'Optionally restrict this route to tickets from a specific source.' }}</mat-hint>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Source Filter</mat-label>
+      <mat-select [(ngModel)]="source">
+        <mat-option [value]="null">Any Source</mat-option>
+        @for (s of sources; track s.value) {
+          <mat-option [value]="s.value">{{ s.label }}</mat-option>
+        }
+      </mat-select>
+      <mat-hint>{{ routeType === 'INGESTION' ? 'Ingestion routes should target a specific source.' : 'Optionally restrict this route to tickets from a specific source.' }}</mat-hint>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Category</mat-label>
-        <mat-select [(ngModel)]="category">
-          <mat-option [value]="null">Any (catch-all)</mat-option>
-          @for (cat of data.categories; track cat.value) {
-            <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
-          }
-        </mat-select>
-        <mat-hint>Routes with a category match tickets of that type. "Any" routes are selected by AI or used as default.</mat-hint>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Category</mat-label>
+      <mat-select [(ngModel)]="category">
+        <mat-option [value]="null">Any (catch-all)</mat-option>
+        @for (cat of categoriesList; track cat.value) {
+          <mat-option [value]="cat.value">{{ cat.label }}</mat-option>
+        }
+      </mat-select>
+      <mat-hint>Routes with a category match tickets of that type. "Any" routes are selected by AI or used as default.</mat-hint>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Client</mat-label>
-        <mat-select [(ngModel)]="clientId">
-          <mat-option [value]="null">Global (all clients)</mat-option>
-          @for (c of data.clients; track c.id) {
-            <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
-          }
-        </mat-select>
-        <mat-hint>Client-specific routes take priority over global routes.</mat-hint>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Client</mat-label>
+      <mat-select [(ngModel)]="clientId">
+        <mat-option [value]="null">Global (all clients)</mat-option>
+        @for (c of clientsList; track c.id) {
+          <mat-option [value]="c.id">{{ c.name }} ({{ c.shortCode }})</mat-option>
+        }
+      </mat-select>
+      <mat-hint>Client-specific routes take priority over global routes.</mat-hint>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Sort Order</mat-label>
-        <input matInput type="number" [(ngModel)]="sortOrder" min="0">
-        <mat-hint>Lower numbers are evaluated first.</mat-hint>
-      </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Sort Order</mat-label>
+      <input matInput type="number" [(ngModel)]="sortOrder" min="0">
+      <mat-hint>Lower numbers are evaluated first.</mat-hint>
+    </mat-form-field>
 
-      <div class="toggle-row">
-        <mat-slide-toggle [(ngModel)]="isDefault" color="primary">Default route</mat-slide-toggle>
-        <span class="toggle-hint">Used when no category or AI-based match is found.</span>
-      </div>
-    </mat-dialog-content>
+    <div class="toggle-row">
+      <mat-slide-toggle [(ngModel)]="isDefault" color="primary">Default route</mat-slide-toggle>
+      <span class="toggle-hint">Used when no category or AI-based match is found.</span>
+    </div>
 
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!name.trim() || saving">
         {{ saving ? 'Saving...' : (isEdit ? 'Update' : 'Create') }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
     .toggle-row { display: flex; align-items: center; gap: 12px; margin: 8px 0 16px; }
     .toggle-hint { font-size: 12px; color: #666; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class TicketRouteDialogComponent {
-  data = inject<DialogData>(MAT_DIALOG_DATA);
-  private dialogRef = inject(MatDialogRef<TicketRouteDialogComponent>);
+export class TicketRouteDialogComponent implements OnInit {
   private routeService = inject(TicketRouteService);
   private toast = inject(ToastService);
 
+  route = input<TicketRoute>();
+  clients = input.required<Client[]>();
+  categories = input.required<Array<{ value: string; label: string }>>();
+  presetRouteType = input<RouteType>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
+
   sources = SOURCES;
 
-  isEdit = !!this.data.route;
-  name = this.data.route?.name ?? '';
-  description = this.data.route?.description ?? '';
-  routeType: RouteType = this.data.route?.routeType ?? this.data.routeType ?? 'ANALYSIS';
-  source: string | null = this.data.route?.source ?? null;
-  category = this.data.route?.category ?? null;
-  clientId = this.data.route?.clientId ?? null;
-  isDefault = this.data.route?.isDefault ?? false;
-  sortOrder = this.data.route?.sortOrder ?? 0;
+  isEdit = false;
+  name = '';
+  description = '';
+  routeType: RouteType = 'ANALYSIS';
+  source: string | null = null;
+  category: string | null = null;
+  clientId: string | null = null;
+  isDefault = false;
+  sortOrder = 0;
   saving = false;
+
+  clientsList: Client[] = [];
+  categoriesList: Array<{ value: string; label: string }> = [];
+
+  ngOnInit(): void {
+    this.clientsList = this.clients();
+    this.categoriesList = this.categories();
+
+    const r = this.route();
+    if (r) {
+      this.isEdit = true;
+      this.name = r.name ?? '';
+      this.description = r.description ?? '';
+      this.routeType = r.routeType ?? 'ANALYSIS';
+      this.source = r.source ?? null;
+      this.category = r.category ?? null;
+      this.clientId = r.clientId ?? null;
+      this.isDefault = r.isDefault ?? false;
+      this.sortOrder = r.sortOrder ?? 0;
+    } else {
+      this.routeType = this.presetRouteType() ?? 'ANALYSIS';
+    }
+  }
 
   save(): void {
     if (!this.name.trim()) return;
     this.saving = true;
 
     if (this.isEdit) {
-      this.routeService.updateRoute(this.data.route!.id, {
+      this.routeService.updateRoute(this.route()!.id, {
         name: this.name.trim(),
         description: this.description.trim() || undefined,
         routeType: this.routeType,
@@ -146,7 +165,7 @@ export class TicketRouteDialogComponent {
       }).subscribe({
         next: () => {
           this.toast.success('Route updated');
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;
@@ -170,7 +189,7 @@ export class TicketRouteDialogComponent {
           } else {
             this.toast.success('Route created');
           }
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
@@ -1,12 +1,12 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { TicketRouteService, TicketRoute, TicketRouteStep, RouteStepTypeInfo } from '../../core/services/ticket-route.service';
 import type { RouteType } from '../../core/services/ticket-route.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { TicketRouteDialogComponent } from './ticket-route-dialog.component';
 import { TicketRouteStepDialogComponent } from './ticket-route-step-dialog.component';
+import { DialogComponent } from '../../shared/components/dialog.component';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -31,12 +31,14 @@ const CATEGORIES = [
   imports: [
     NgTemplateOutlet,
     FormsModule,
-    MatDialogModule,
     BroncoButtonComponent,
     SelectComponent,
     TabComponent,
     TabGroupComponent,
     ToggleSwitchComponent,
+    DialogComponent,
+    TicketRouteDialogComponent,
+    TicketRouteStepDialogComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -202,6 +204,30 @@ const CATEGORIES = [
         }
       </ng-template>
     </div>
+
+    @if (showRouteDialog()) {
+      <app-dialog [open]="true" [title]="editingRoute() ? 'Edit Route' : 'Create Route'" maxWidth="550px" (openChange)="showRouteDialog.set(false)">
+        <app-ticket-route-dialog-content
+          [route]="editingRoute() ?? undefined"
+          [clients]="clients()"
+          [categories]="categories"
+          [presetRouteType]="routeDialogType()"
+          (saved)="onRouteSaved()"
+          (cancelled)="showRouteDialog.set(false)" />
+      </app-dialog>
+    }
+
+    @if (showStepDialog()) {
+      <app-dialog [open]="true" [title]="editingStep() ? 'Edit Step' : 'Add Step'" maxWidth="550px" (openChange)="showStepDialog.set(false)">
+        <app-ticket-route-step-dialog-content
+          [routeId]="stepDialogRouteId()"
+          [step]="editingStep() ?? undefined"
+          [stepTypes]="stepTypes()"
+          [nextOrder]="stepDialogNextOrder()"
+          (saved)="onStepSaved()"
+          (cancelled)="showStepDialog.set(false)" />
+      </app-dialog>
+    }
   `,
   styles: [`
     .page-wrapper { max-width: 1200px; }
@@ -430,8 +456,18 @@ const CATEGORIES = [
 export class TicketRouteListComponent implements OnInit {
   private routeService = inject(TicketRouteService);
   private clientService = inject(ClientService);
-  private dialog = inject(MatDialog);
   private toast = inject(ToastService);
+
+  // Route dialog state
+  showRouteDialog = signal(false);
+  editingRoute = signal<TicketRoute | null>(null);
+  routeDialogType = signal<RouteType>('ANALYSIS');
+
+  // Step dialog state
+  showStepDialog = signal(false);
+  editingStep = signal<TicketRouteStep | null>(null);
+  stepDialogRouteId = signal('');
+  stepDialogNextOrder = signal<number | undefined>(undefined);
 
   routes = signal<TicketRoute[]>([]);
   ingestionRoutes = signal<TicketRoute[]>([]);
@@ -494,23 +530,19 @@ export class TicketRouteListComponent implements OnInit {
   }
 
   addRoute(routeType: RouteType = 'ANALYSIS'): void {
-    const ref = this.dialog.open(TicketRouteDialogComponent, {
-      width: '550px',
-      data: { clients: this.clients(), categories: CATEGORIES, routeType },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadRoutes();
-    });
+    this.editingRoute.set(null);
+    this.routeDialogType.set(routeType);
+    this.showRouteDialog.set(true);
   }
 
   editRoute(route: TicketRoute): void {
-    const ref = this.dialog.open(TicketRouteDialogComponent, {
-      width: '550px',
-      data: { route, clients: this.clients(), categories: CATEGORIES },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadRoutes();
-    });
+    this.editingRoute.set(route);
+    this.showRouteDialog.set(true);
+  }
+
+  onRouteSaved(): void {
+    this.showRouteDialog.set(false);
+    this.loadRoutes();
   }
 
   toggleActive(route: TicketRoute): void {
@@ -554,23 +586,22 @@ export class TicketRouteListComponent implements OnInit {
     const nextOrder = route.steps.length > 0
       ? Math.max(...route.steps.map((s) => s.stepOrder)) + 1
       : 1;
-    const ref = this.dialog.open(TicketRouteStepDialogComponent, {
-      width: '550px',
-      data: { routeId: route.id, stepTypes: this.stepTypes(), nextOrder },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadRoutes();
-    });
+    this.editingStep.set(null);
+    this.stepDialogRouteId.set(route.id);
+    this.stepDialogNextOrder.set(nextOrder);
+    this.showStepDialog.set(true);
   }
 
   editStep(route: TicketRoute, step: TicketRouteStep): void {
-    const ref = this.dialog.open(TicketRouteStepDialogComponent, {
-      width: '550px',
-      data: { routeId: route.id, step, stepTypes: this.stepTypes() },
-    });
-    ref.afterClosed().subscribe((result) => {
-      if (result) this.loadRoutes();
-    });
+    this.editingStep.set(step);
+    this.stepDialogRouteId.set(route.id);
+    this.stepDialogNextOrder.set(undefined);
+    this.showStepDialog.set(true);
+  }
+
+  onStepSaved(): void {
+    this.showStepDialog.set(false);
+    this.loadRoutes();
   }
 
   toggleStepActive(route: TicketRoute, step: TicketRouteStep): void {

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
@@ -1,6 +1,5 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit, signal, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -11,273 +10,264 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TicketRouteService, TicketRouteStep, RouteStepTypeInfo, DispatchPreviewEntry, WithWarnings } from '../../core/services/ticket-route.service';
 import { ToastService } from '../../core/services/toast.service';
 
-interface DialogData {
-  routeId: string;
-  step?: TicketRouteStep;
-  stepTypes: RouteStepTypeInfo[];
-  nextOrder?: number;
-}
-
 @Component({
+  selector: 'app-ticket-route-step-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatRadioModule, MatIconModule, MatCheckboxModule],
+  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatRadioModule, MatIconModule, MatCheckboxModule],
   template: `
-    <h2 mat-dialog-title>{{ isEdit ? 'Edit Step' : 'Add Step' }}</h2>
-    <mat-dialog-content>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Step Type</mat-label>
+      <mat-select [(ngModel)]="stepType" (selectionChange)="onStepTypeChange()" [disabled]="isEdit">
+        <mat-optgroup label="Ingestion Steps">
+          @for (st of ingestionTypes(); track st.type) {
+            <mat-option [value]="st.type">{{ st.name }}</mat-option>
+          }
+        </mat-optgroup>
+        <mat-optgroup label="Analysis Steps">
+          @for (st of analysisTypes(); track st.type) {
+            <mat-option [value]="st.type">{{ st.name }}</mat-option>
+          }
+        </mat-optgroup>
+        <mat-optgroup label="Dispatch Steps">
+          @for (st of dispatchTypes(); track st.type) {
+            <mat-option [value]="st.type">{{ st.name }}</mat-option>
+          }
+        </mat-optgroup>
+      </mat-select>
+    </mat-form-field>
+
+    @if (selectedInfo()) {
+      <p class="step-desc">{{ selectedInfo()!.description }}</p>
+      @if (selectedInfo()!.defaultTaskType) {
+        <p class="step-defaults">
+          Default task: <code>{{ selectedInfo()!.defaultTaskType }}</code>
+          @if (selectedInfo()!.defaultPromptKey) {
+            · Prompt: <code>{{ selectedInfo()!.defaultPromptKey }}</code>
+          }
+        </p>
+      }
+    }
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required placeholder="Display name for this step">
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Step Order</mat-label>
+      <input matInput type="number" [(ngModel)]="stepOrder" min="0" required>
+      <mat-hint>Execution order within the route (lower = earlier).</mat-hint>
+    </mat-form-field>
+
+    @if (selectedInfo()?.defaultTaskType) {
       <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Step Type</mat-label>
-        <mat-select [(ngModel)]="stepType" (selectionChange)="onStepTypeChange()" [disabled]="isEdit">
-          <mat-optgroup label="Ingestion Steps">
-            @for (st of ingestionTypes(); track st.type) {
-              <mat-option [value]="st.type">{{ st.name }}</mat-option>
-            }
-          </mat-optgroup>
-          <mat-optgroup label="Analysis Steps">
-            @for (st of analysisTypes(); track st.type) {
-              <mat-option [value]="st.type">{{ st.name }}</mat-option>
-            }
-          </mat-optgroup>
-          <mat-optgroup label="Dispatch Steps">
-            @for (st of dispatchTypes(); track st.type) {
-              <mat-option [value]="st.type">{{ st.name }}</mat-option>
-            }
-          </mat-optgroup>
+        <mat-label>Task Type Override</mat-label>
+        <input matInput [(ngModel)]="taskTypeOverride" placeholder="e.g. BUG_ANALYSIS">
+        <mat-hint>Leave empty to use the step's default AI task type.</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Prompt Key Override</mat-label>
+        <input matInput [(ngModel)]="promptKeyOverride" placeholder="e.g. custom.analysis.system">
+        <mat-hint>Leave empty to use the step's default prompt key.</mat-hint>
+      </mat-form-field>
+    }
+
+    @if (stepType === 'ADD_FOLLOWER') {
+      <h4 class="config-heading">Add Follower Config</h4>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Email Address</mat-label>
+        <input matInput type="email" [(ngModel)]="followerEmail" placeholder="user@example.com">
+        <mat-hint>Exact email address to add as follower. Leave empty to use Email Domain instead.</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Email Domain</mat-label>
+        <input matInput [(ngModel)]="followerEmailDomain" placeholder="example.com">
+        <mat-hint>Match all contacts with this domain (e.g. "acme.com"). Ignored if Email Address is set.</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Follower Type</mat-label>
+        <mat-select [(ngModel)]="followerType">
+          <mat-option value="FOLLOWER">Follower</mat-option>
+          <mat-option value="REQUESTER">Requester</mat-option>
         </mat-select>
+        <mat-hint>REQUESTER is the primary contact; FOLLOWER receives notifications.</mat-hint>
+      </mat-form-field>
+    }
+
+    @if (stepType === 'AGENTIC_ANALYSIS') {
+      <h4 class="config-heading">Agentic Analysis Config</h4>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Max Iterations</mat-label>
+        <input matInput type="number" [(ngModel)]="agenticMaxIterations" min="1" max="50">
+        <mat-hint>Maximum tool-use loop iterations (default: 10).</mat-hint>
       </mat-form-field>
 
-      @if (selectedInfo()) {
-        <p class="step-desc">{{ selectedInfo()!.description }}</p>
-        @if (selectedInfo()!.defaultTaskType) {
-          <p class="step-defaults">
-            Default task: <code>{{ selectedInfo()!.defaultTaskType }}</code>
-            @if (selectedInfo()!.defaultPromptKey) {
-              · Prompt: <code>{{ selectedInfo()!.defaultPromptKey }}</code>
-            }
-          </p>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>System Prompt Override</mat-label>
+        <textarea matInput [(ngModel)]="agenticSystemPromptOverride" rows="3"
+          placeholder="Additional instructions appended to the default system prompt"></textarea>
+        <mat-hint>Optional. Appended to the built-in investigation prompt.</mat-hint>
+      </mat-form-field>
+    }
+
+    @if (stepType === 'CUSTOM_AI_QUERY') {
+      <h4 class="config-heading">Custom AI Query Config</h4>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Prompt / Instructions</mat-label>
+        <textarea matInput [(ngModel)]="customQueryPrompt" rows="5" required
+          placeholder="Write custom instructions for the AI query..."></textarea>
+        <mat-hint>The prompt sent to the AI. Context sources selected below are prepended automatically.</mat-hint>
+      </mat-form-field>
+
+      <h4 class="subsection-heading">Include Pipeline Context</h4>
+      <div class="context-checkboxes">
+        <mat-checkbox [(ngModel)]="customIncludeTicket">Ticket info (subject, body, category, priority)</mat-checkbox>
+        <mat-checkbox [(ngModel)]="customIncludeClientContext">Client context (from Load Client Context step)</mat-checkbox>
+        <mat-checkbox [(ngModel)]="customIncludeCodeContext">Code context (from Gather Repo Context step)</mat-checkbox>
+        <mat-checkbox [(ngModel)]="customIncludeDbContext">Database context (from Gather DB Context step)</mat-checkbox>
+        <mat-checkbox [(ngModel)]="customIncludeFacts">Extracted facts (from Extract Facts step)</mat-checkbox>
+        <mat-checkbox [(ngModel)]="customIncludeAnalysis">Prior analysis results</mat-checkbox>
+      </div>
+
+      <h4 class="subsection-heading">Fresh MCP Queries (optional)</h4>
+      <div class="queries-list">
+        @for (mq of customMcpQueries; track $index) {
+          <div class="query-row">
+            <mat-form-field class="query-tool-field">
+              <mat-label>Tool</mat-label>
+              <mat-select [(ngModel)]="mq.toolName">
+                @for (t of mcpToolNames; track t) {
+                  <mat-option [value]="t">{{ t }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field class="query-params-field">
+              <mat-label>Params (JSON)</mat-label>
+              <textarea matInput [(ngModel)]="mq.paramsJson" rows="1"
+                placeholder='{"query": "SELECT ..."}' ></textarea>
+            </mat-form-field>
+            <button mat-icon-button color="warn" aria-label="Remove query" (click)="removeCustomMcpQuery($index)"><mat-icon>delete</mat-icon></button>
+          </div>
         }
-      }
+        <button mat-button (click)="addCustomMcpQuery()">+ Add MCP Query</button>
+      </div>
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Name</mat-label>
-        <input matInput [(ngModel)]="name" required placeholder="Display name for this step">
-      </mat-form-field>
+      <h4 class="subsection-heading">Fresh Repo Searches (optional)</h4>
+      <div class="queries-list">
+        @for (rs of customRepoSearches; track $index) {
+          <div class="query-row repo-row">
+            <mat-form-field class="query-tool-field">
+              <mat-label>Repo Name</mat-label>
+              <input matInput [(ngModel)]="rs.repoName" placeholder="(all repos if blank)">
+            </mat-form-field>
+            <mat-form-field class="query-params-field">
+              <mat-label>Search Terms</mat-label>
+              <input matInput [(ngModel)]="rs.searchTerms" placeholder="term1, term2">
+              <mat-hint>Comma-separated git grep terms.</mat-hint>
+            </mat-form-field>
+            <mat-form-field class="query-params-field">
+              <mat-label>File Paths</mat-label>
+              <input matInput [(ngModel)]="rs.filePaths" placeholder="src/foo.ts, src/bar.ts">
+              <mat-hint>Comma-separated file paths to read.</mat-hint>
+            </mat-form-field>
+            <button mat-icon-button color="warn" aria-label="Remove search" (click)="removeCustomRepoSearch($index)"><mat-icon>delete</mat-icon></button>
+          </div>
+        }
+        <button mat-button (click)="addCustomRepoSearch()">+ Add Repo Search</button>
+      </div>
+    }
 
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Step Order</mat-label>
-        <input matInput type="number" [(ngModel)]="stepOrder" min="0" required>
-        <mat-hint>Execution order within the route (lower = earlier).</mat-hint>
-      </mat-form-field>
+    @if (stepType === 'DISPATCH_TO_ROUTE') {
+      <h4 class="config-heading">Dispatch Configuration</h4>
 
-      @if (selectedInfo()?.defaultTaskType) {
+      <mat-radio-group [(ngModel)]="dispatchMode" class="mode-group">
+        <mat-radio-button value="auto">Auto-resolve</mat-radio-button>
+        <mat-radio-button value="pin">Pin to route</mat-radio-button>
+        <mat-radio-button value="rules">Conditional rules</mat-radio-button>
+      </mat-radio-group>
+
+      @if (dispatchMode === 'pin') {
         <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Task Type Override</mat-label>
-          <input matInput [(ngModel)]="taskTypeOverride" placeholder="e.g. BUG_ANALYSIS">
-          <mat-hint>Leave empty to use the step's default AI task type.</mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Prompt Key Override</mat-label>
-          <input matInput [(ngModel)]="promptKeyOverride" placeholder="e.g. custom.analysis.system">
-          <mat-hint>Leave empty to use the step's default prompt key.</mat-hint>
-        </mat-form-field>
-      }
-
-      @if (stepType === 'ADD_FOLLOWER') {
-        <h4 class="config-heading">Add Follower Config</h4>
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Email Address</mat-label>
-          <input matInput type="email" [(ngModel)]="followerEmail" placeholder="user@example.com">
-          <mat-hint>Exact email address to add as follower. Leave empty to use Email Domain instead.</mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Email Domain</mat-label>
-          <input matInput [(ngModel)]="followerEmailDomain" placeholder="example.com">
-          <mat-hint>Match all contacts with this domain (e.g. "acme.com"). Ignored if Email Address is set.</mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Follower Type</mat-label>
-          <mat-select [(ngModel)]="followerType">
-            <mat-option value="FOLLOWER">Follower</mat-option>
-            <mat-option value="REQUESTER">Requester</mat-option>
+          <mat-label>Target Route</mat-label>
+          <mat-select [(ngModel)]="dispatchTargetRouteId">
+            @for (r of availableRoutes; track r.id) {
+              <mat-option [value]="r.id">
+                {{ r.name }}
+                @if (r.category) { <span class="badge cat">{{ r.category }}</span> }
+                <span class="badge scope">{{ r.clientId ? 'Client' : 'Global' }}</span>
+              </mat-option>
+            }
           </mat-select>
-          <mat-hint>REQUESTER is the primary contact; FOLLOWER receives notifications.</mat-hint>
         </mat-form-field>
       }
 
-      @if (stepType === 'AGENTIC_ANALYSIS') {
-        <h4 class="config-heading">Agentic Analysis Config</h4>
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Max Iterations</mat-label>
-          <input matInput type="number" [(ngModel)]="agenticMaxIterations" min="1" max="50">
-          <mat-hint>Maximum tool-use loop iterations (default: 10).</mat-hint>
-        </mat-form-field>
-
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>System Prompt Override</mat-label>
-          <textarea matInput [(ngModel)]="agenticSystemPromptOverride" rows="3"
-            placeholder="Additional instructions appended to the default system prompt"></textarea>
-          <mat-hint>Optional. Appended to the built-in investigation prompt.</mat-hint>
-        </mat-form-field>
-      }
-
-      @if (stepType === 'CUSTOM_AI_QUERY') {
-        <h4 class="config-heading">Custom AI Query Config</h4>
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Prompt / Instructions</mat-label>
-          <textarea matInput [(ngModel)]="customQueryPrompt" rows="5" required
-            placeholder="Write custom instructions for the AI query..."></textarea>
-          <mat-hint>The prompt sent to the AI. Context sources selected below are prepended automatically.</mat-hint>
-        </mat-form-field>
-
-        <h4 class="subsection-heading">Include Pipeline Context</h4>
-        <div class="context-checkboxes">
-          <mat-checkbox [(ngModel)]="customIncludeTicket">Ticket info (subject, body, category, priority)</mat-checkbox>
-          <mat-checkbox [(ngModel)]="customIncludeClientContext">Client context (from Load Client Context step)</mat-checkbox>
-          <mat-checkbox [(ngModel)]="customIncludeCodeContext">Code context (from Gather Repo Context step)</mat-checkbox>
-          <mat-checkbox [(ngModel)]="customIncludeDbContext">Database context (from Gather DB Context step)</mat-checkbox>
-          <mat-checkbox [(ngModel)]="customIncludeFacts">Extracted facts (from Extract Facts step)</mat-checkbox>
-          <mat-checkbox [(ngModel)]="customIncludeAnalysis">Prior analysis results</mat-checkbox>
-        </div>
-
-        <h4 class="subsection-heading">Fresh MCP Queries (optional)</h4>
-        <div class="queries-list">
-          @for (mq of customMcpQueries; track $index) {
-            <div class="query-row">
-              <mat-form-field class="query-tool-field">
-                <mat-label>Tool</mat-label>
-                <mat-select [(ngModel)]="mq.toolName">
-                  @for (t of mcpToolNames; track t) {
-                    <mat-option [value]="t">{{ t }}</mat-option>
+      @if (dispatchMode === 'rules') {
+        <div class="rules-list">
+          @for (rule of dispatchRules; track $index) {
+            <div class="rule-row">
+              <mat-form-field class="rule-field">
+                <mat-label>Category</mat-label>
+                <mat-select [(ngModel)]="rule.category">
+                  @for (cat of categoryValues; track cat) {
+                    <mat-option [value]="cat">{{ cat }}</mat-option>
                   }
                 </mat-select>
               </mat-form-field>
-              <mat-form-field class="query-params-field">
-                <mat-label>Params (JSON)</mat-label>
-                <textarea matInput [(ngModel)]="mq.paramsJson" rows="1"
-                  placeholder='{"query": "SELECT ..."}' ></textarea>
+              <mat-form-field class="rule-field">
+                <mat-label>Route</mat-label>
+                <mat-select [(ngModel)]="rule.targetRouteId">
+                  @for (r of availableRoutes; track r.id) {
+                    <mat-option [value]="r.id">{{ r.name }}</mat-option>
+                  }
+                </mat-select>
               </mat-form-field>
-              <button mat-icon-button color="warn" aria-label="Remove query" (click)="removeCustomMcpQuery($index)"><mat-icon>delete</mat-icon></button>
+              <button mat-icon-button color="warn" aria-label="Remove rule" (click)="removeRule($index)"><mat-icon>delete</mat-icon></button>
             </div>
           }
-          <button mat-button (click)="addCustomMcpQuery()">+ Add MCP Query</button>
+          <button mat-button (click)="addRule()">+ Add Rule</button>
         </div>
 
-        <h4 class="subsection-heading">Fresh Repo Searches (optional)</h4>
-        <div class="queries-list">
-          @for (rs of customRepoSearches; track $index) {
-            <div class="query-row repo-row">
-              <mat-form-field class="query-tool-field">
-                <mat-label>Repo Name</mat-label>
-                <input matInput [(ngModel)]="rs.repoName" placeholder="(all repos if blank)">
-              </mat-form-field>
-              <mat-form-field class="query-params-field">
-                <mat-label>Search Terms</mat-label>
-                <input matInput [(ngModel)]="rs.searchTerms" placeholder="term1, term2">
-                <mat-hint>Comma-separated git grep terms.</mat-hint>
-              </mat-form-field>
-              <mat-form-field class="query-params-field">
-                <mat-label>File Paths</mat-label>
-                <input matInput [(ngModel)]="rs.filePaths" placeholder="src/foo.ts, src/bar.ts">
-                <mat-hint>Comma-separated file paths to read.</mat-hint>
-              </mat-form-field>
-              <button mat-icon-button color="warn" aria-label="Remove search" (click)="removeCustomRepoSearch($index)"><mat-icon>delete</mat-icon></button>
-            </div>
-          }
-          <button mat-button (click)="addCustomRepoSearch()">+ Add Repo Search</button>
-        </div>
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>When no rule matches</mat-label>
+          <mat-select [(ngModel)]="dispatchFallback">
+            <mat-option value="auto">Auto-resolve</mat-option>
+            <mat-option value="stop">Continue current route</mat-option>
+          </mat-select>
+        </mat-form-field>
       }
 
-      @if (stepType === 'DISPATCH_TO_ROUTE') {
-        <h4 class="config-heading">Dispatch Configuration</h4>
-
-        <mat-radio-group [(ngModel)]="dispatchMode" class="mode-group">
-          <mat-radio-button value="auto">Auto-resolve</mat-radio-button>
-          <mat-radio-button value="pin">Pin to route</mat-radio-button>
-          <mat-radio-button value="rules">Conditional rules</mat-radio-button>
-        </mat-radio-group>
-
-        @if (dispatchMode === 'pin') {
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Target Route</mat-label>
-            <mat-select [(ngModel)]="dispatchTargetRouteId">
-              @for (r of availableRoutes; track r.id) {
-                <mat-option [value]="r.id">
-                  {{ r.name }}
-                  @if (r.category) { <span class="badge cat">{{ r.category }}</span> }
-                  <span class="badge scope">{{ r.clientId ? 'Client' : 'Global' }}</span>
-                </mat-option>
+      <div class="preview-panel">
+        <h4 class="preview-heading">Resolution Preview</h4>
+        @if (dispatchMode === 'pin' && dispatchTargetRouteId) {
+          <p class="preview-pin">Always dispatches to: <strong>{{ getRouteName(dispatchTargetRouteId) }}</strong></p>
+        } @else if (dispatchMode === 'pin') {
+          <p class="preview-muted">Select a target route above</p>
+        } @else {
+          <table class="preview-table">
+            <thead><tr><th>Category</th><th>Would dispatch to</th><th>Scope</th></tr></thead>
+            <tbody>
+              @for (entry of dispatchPreview; track entry.category) {
+                <tr>
+                  <td>{{ entry.category }}</td>
+                  <td [class.muted]="!entry.routeName">{{ entry.routeName ?? 'No match — continues current route' }}</td>
+                  <td>{{ entry.routeId ? (entry.clientScoped ? 'Client' : 'Global') : '—' }}</td>
+                </tr>
               }
-            </mat-select>
-          </mat-form-field>
+            </tbody>
+          </table>
         }
+      </div>
+    }
 
-        @if (dispatchMode === 'rules') {
-          <div class="rules-list">
-            @for (rule of dispatchRules; track $index) {
-              <div class="rule-row">
-                <mat-form-field class="rule-field">
-                  <mat-label>Category</mat-label>
-                  <mat-select [(ngModel)]="rule.category">
-                    @for (cat of categories; track cat) {
-                      <mat-option [value]="cat">{{ cat }}</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
-                <mat-form-field class="rule-field">
-                  <mat-label>Route</mat-label>
-                  <mat-select [(ngModel)]="rule.targetRouteId">
-                    @for (r of availableRoutes; track r.id) {
-                      <mat-option [value]="r.id">{{ r.name }}</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
-                <button mat-icon-button color="warn" aria-label="Remove rule" (click)="removeRule($index)"><mat-icon>delete</mat-icon></button>
-              </div>
-            }
-            <button mat-button (click)="addRule()">+ Add Rule</button>
-          </div>
-
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>When no rule matches</mat-label>
-            <mat-select [(ngModel)]="dispatchFallback">
-              <mat-option value="auto">Auto-resolve</mat-option>
-              <mat-option value="stop">Continue current route</mat-option>
-            </mat-select>
-          </mat-form-field>
-        }
-
-        <div class="preview-panel">
-          <h4 class="preview-heading">Resolution Preview</h4>
-          @if (dispatchMode === 'pin' && dispatchTargetRouteId) {
-            <p class="preview-pin">Always dispatches to: <strong>{{ getRouteName(dispatchTargetRouteId) }}</strong></p>
-          } @else if (dispatchMode === 'pin') {
-            <p class="preview-muted">Select a target route above</p>
-          } @else {
-            <table class="preview-table">
-              <thead><tr><th>Category</th><th>Would dispatch to</th><th>Scope</th></tr></thead>
-              <tbody>
-                @for (entry of dispatchPreview; track entry.category) {
-                  <tr>
-                    <td>{{ entry.category }}</td>
-                    <td [class.muted]="!entry.routeName">{{ entry.routeName ?? 'No match — continues current route' }}</td>
-                    <td>{{ entry.routeId ? (entry.clientScoped ? 'Client' : 'Global') : '—' }}</td>
-                  </tr>
-                }
-              </tbody>
-            </table>
-          }
-        </div>
-      }
-    </mat-dialog-content>
-
-    <mat-dialog-actions align="end">
-      <button mat-button mat-dialog-close>Cancel</button>
+    <div class="dialog-actions" dialogFooter>
+      <button mat-button (click)="cancelled.emit()">Cancel</button>
       <button mat-raised-button color="primary" (click)="save()" [disabled]="!stepType || !name.trim() || saving || (stepType === 'CUSTOM_AI_QUERY' && !customQueryPrompt.trim()) || (stepType === 'ADD_FOLLOWER' && !followerEmail.trim() && !followerEmailDomain.trim())">
         {{ saving ? 'Saving...' : (isEdit ? 'Update' : 'Add') }}
       </button>
-    </mat-dialog-actions>
+    </div>
   `,
   styles: [`
     .full-width { width: 100%; margin-bottom: 8px; }
@@ -309,60 +299,54 @@ interface DialogData {
     .query-row.repo-row { flex-wrap: wrap; }
     .query-tool-field { flex: 0 0 180px; }
     .query-params-field { flex: 1; min-width: 150px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
 export class TicketRouteStepDialogComponent implements OnInit {
-  data = inject<DialogData>(MAT_DIALOG_DATA);
-  private dialogRef = inject(MatDialogRef<TicketRouteStepDialogComponent>);
   private routeService = inject(TicketRouteService);
   private toast = inject(ToastService);
 
-  isEdit = !!this.data.step;
+  routeId = input.required<string>();
+  step = input<TicketRouteStep>();
+  stepTypes = input.required<RouteStepTypeInfo[]>();
+  nextOrder = input<number>();
+
+  saved = output<boolean>();
+  cancelled = output<void>();
+
+  isEdit = false;
 
   ingestionTypes = signal<RouteStepTypeInfo[]>([]);
   analysisTypes = signal<RouteStepTypeInfo[]>([]);
   dispatchTypes = signal<RouteStepTypeInfo[]>([]);
   selectedInfo = signal<RouteStepTypeInfo | null>(null);
 
-  stepType = this.data.step?.stepType ?? '';
-  name = this.data.step?.name ?? '';
-  stepOrder = this.data.step?.stepOrder ?? this.data.nextOrder ?? 1;
-  taskTypeOverride = this.data.step?.taskTypeOverride ?? '';
-  promptKeyOverride = this.data.step?.promptKeyOverride ?? '';
+  stepType = '';
+  name = '';
+  stepOrder = 1;
+  taskTypeOverride = '';
+  promptKeyOverride = '';
   saving = false;
 
   // Add Follower config
-  followerEmail = (() => { const v = (this.data.step?.config as Record<string, unknown> | null)?.['email']; return typeof v === 'string' ? v : ''; })();
-  followerEmailDomain = (() => { const v = (this.data.step?.config as Record<string, unknown> | null)?.['emailDomain']; return typeof v === 'string' ? v : ''; })();
-  followerType: 'REQUESTER' | 'FOLLOWER' = (this.data.step?.config as Record<string, unknown> | null)?.['followerType'] === 'REQUESTER' ? 'REQUESTER' : 'FOLLOWER';
+  followerEmail = '';
+  followerEmailDomain = '';
+  followerType: 'REQUESTER' | 'FOLLOWER' = 'FOLLOWER';
 
   // Agentic analysis config
-  agenticMaxIterations = (this.data.step?.config as Record<string, unknown> | null)?.['maxIterations'] as number ?? 10;
-  agenticSystemPromptOverride = (this.data.step?.config as Record<string, unknown> | null)?.['systemPromptOverride'] as string ?? '';
+  agenticMaxIterations = 10;
+  agenticSystemPromptOverride = '';
 
   // Custom AI Query config
-  customQueryPrompt = (this.data.step?.config as Record<string, unknown> | null)?.['prompt'] as string ?? '';
-  private _customIncCtx = ((this.data.step?.config as Record<string, unknown> | null)?.['includeContext'] ?? {}) as Record<string, boolean>;
-  customIncludeTicket = this._customIncCtx['ticket'] ?? false;
-  customIncludeClientContext = this._customIncCtx['clientContext'] ?? false;
-  customIncludeCodeContext = this._customIncCtx['codeContext'] ?? false;
-  customIncludeDbContext = this._customIncCtx['dbContext'] ?? false;
-  customIncludeFacts = this._customIncCtx['facts'] ?? false;
-  customIncludeAnalysis = this._customIncCtx['analysis'] ?? false;
-  customMcpQueries: Array<{ toolName: string; paramsJson: string }> = (() => {
-    const raw = (this.data.step?.config as Record<string, unknown> | null)?.['mcpQueries'];
-    if (!Array.isArray(raw)) return [];
-    return raw.map((q: any) => ({ toolName: q.toolName ?? '', paramsJson: q.params ? JSON.stringify(q.params) : '' }));
-  })();
-  customRepoSearches: Array<{ repoName: string; searchTerms: string; filePaths: string }> = (() => {
-    const raw = (this.data.step?.config as Record<string, unknown> | null)?.['repoSearches'];
-    if (!Array.isArray(raw)) return [];
-    return raw.map((s: any) => ({
-      repoName: s.repoName ?? '',
-      searchTerms: Array.isArray(s.searchTerms) ? s.searchTerms.join(', ') : '',
-      filePaths: Array.isArray(s.filePaths) ? s.filePaths.join(', ') : '',
-    }));
-  })();
+  customQueryPrompt = '';
+  customIncludeTicket = false;
+  customIncludeClientContext = false;
+  customIncludeCodeContext = false;
+  customIncludeDbContext = false;
+  customIncludeFacts = false;
+  customIncludeAnalysis = false;
+  customMcpQueries: Array<{ toolName: string; paramsJson: string }> = [];
+  customRepoSearches: Array<{ repoName: string; searchTerms: string; filePaths: string }> = [];
   mcpToolNames = ['run_query', 'inspect_schema', 'list_indexes', 'get_blocking_tree', 'get_wait_stats', 'get_database_health'];
 
   // Dispatch config
@@ -374,29 +358,86 @@ export class TicketRouteStepDialogComponent implements OnInit {
   // Data for dropdowns and preview
   availableRoutes: Array<{ id: string; name: string; category: string | null; clientId: string | null }> = [];
   dispatchPreview: DispatchPreviewEntry[] = [];
-  categories = ['DATABASE_PERF', 'BUG_FIX', 'FEATURE_REQUEST', 'SCHEMA_CHANGE', 'CODE_REVIEW', 'ARCHITECTURE', 'GENERAL'];
+  categoryValues = ['DATABASE_PERF', 'BUG_FIX', 'FEATURE_REQUEST', 'SCHEMA_CHANGE', 'CODE_REVIEW', 'ARCHITECTURE', 'GENERAL'];
 
   ngOnInit(): void {
-    this.ingestionTypes.set(this.data.stepTypes.filter((t) => t.phase === 'ingestion'));
-    this.analysisTypes.set(this.data.stepTypes.filter((t) => t.phase === 'analysis'));
-    this.dispatchTypes.set(this.data.stepTypes.filter((t) => t.phase === 'dispatch'));
+    const types = this.stepTypes();
+    this.ingestionTypes.set(types.filter((t) => t.phase === 'ingestion'));
+    this.analysisTypes.set(types.filter((t) => t.phase === 'analysis'));
+    this.dispatchTypes.set(types.filter((t) => t.phase === 'dispatch'));
+
+    const s = this.step();
+    this.isEdit = !!s;
+    this.stepType = s?.stepType ?? '';
+    this.name = s?.name ?? '';
+    this.stepOrder = s?.stepOrder ?? this.nextOrder() ?? 1;
+    this.taskTypeOverride = s?.taskTypeOverride ?? '';
+    this.promptKeyOverride = s?.promptKeyOverride ?? '';
+
     if (this.stepType) {
-      this.selectedInfo.set(this.data.stepTypes.find((t) => t.type === this.stepType) ?? null);
+      this.selectedInfo.set(types.find((t) => t.type === this.stepType) ?? null);
     }
+
+    // Extract config from existing step
+    if (s) {
+      const cfg = s.config as Record<string, unknown> | null;
+      if (cfg) {
+        // Add Follower
+        const email = cfg['email'];
+        this.followerEmail = typeof email === 'string' ? email : '';
+        const emailDomain = cfg['emailDomain'];
+        this.followerEmailDomain = typeof emailDomain === 'string' ? emailDomain : '';
+        this.followerType = cfg['followerType'] === 'REQUESTER' ? 'REQUESTER' : 'FOLLOWER';
+
+        // Agentic analysis
+        this.agenticMaxIterations = (cfg['maxIterations'] as number) ?? 10;
+        this.agenticSystemPromptOverride = (cfg['systemPromptOverride'] as string) ?? '';
+
+        // Custom AI Query
+        this.customQueryPrompt = (cfg['prompt'] as string) ?? '';
+        const includeCtx = (cfg['includeContext'] ?? {}) as Record<string, boolean>;
+        this.customIncludeTicket = includeCtx['ticket'] ?? false;
+        this.customIncludeClientContext = includeCtx['clientContext'] ?? false;
+        this.customIncludeCodeContext = includeCtx['codeContext'] ?? false;
+        this.customIncludeDbContext = includeCtx['dbContext'] ?? false;
+        this.customIncludeFacts = includeCtx['facts'] ?? false;
+        this.customIncludeAnalysis = includeCtx['analysis'] ?? false;
+
+        const rawMcpQueries = cfg['mcpQueries'];
+        if (Array.isArray(rawMcpQueries)) {
+          this.customMcpQueries = rawMcpQueries.map((q: any) => ({
+            toolName: q.toolName ?? '',
+            paramsJson: q.params ? JSON.stringify(q.params) : '',
+          }));
+        }
+
+        const rawRepoSearches = cfg['repoSearches'];
+        if (Array.isArray(rawRepoSearches)) {
+          this.customRepoSearches = rawRepoSearches.map((rs: any) => ({
+            repoName: rs.repoName ?? '',
+            searchTerms: Array.isArray(rs.searchTerms) ? rs.searchTerms.join(', ') : '',
+            filePaths: Array.isArray(rs.filePaths) ? rs.filePaths.join(', ') : '',
+          }));
+        }
+
+        // Dispatch config
+        if (this.stepType === 'DISPATCH_TO_ROUTE') {
+          this.dispatchMode = (cfg['mode'] as 'auto' | 'pin' | 'rules') ?? 'auto';
+          this.dispatchTargetRouteId = (cfg['targetRouteId'] as string) ?? '';
+          this.dispatchRules = Array.isArray(cfg['rules']) ? (cfg['rules'] as Array<{ category: string; targetRouteId: string }>) : [];
+          this.dispatchFallback = (cfg['fallback'] as 'auto' | 'stop') ?? 'auto';
+        }
+      }
+    }
+
     if (this.stepType === 'DISPATCH_TO_ROUTE') {
       this.loadDispatchData();
-      const cfg = this.data.step?.config as Record<string, unknown> | null;
-      if (cfg) {
-        this.dispatchMode = (cfg['mode'] as 'auto' | 'pin' | 'rules') ?? 'auto';
-        this.dispatchTargetRouteId = (cfg['targetRouteId'] as string) ?? '';
-        this.dispatchRules = Array.isArray(cfg['rules']) ? (cfg['rules'] as Array<{ category: string; targetRouteId: string }>) : [];
-        this.dispatchFallback = (cfg['fallback'] as 'auto' | 'stop') ?? 'auto';
-      }
     }
   }
 
   onStepTypeChange(): void {
-    const info = this.data.stepTypes.find((t) => t.type === this.stepType);
+    const types = this.stepTypes();
+    const info = types.find((t) => t.type === this.stepType);
     this.selectedInfo.set(info ?? null);
     if (info && !this.name) {
       this.name = info.name;
@@ -435,13 +476,14 @@ export class TicketRouteStepDialogComponent implements OnInit {
   }
 
   private loadDispatchData(): void {
+    const rid = this.routeId();
     this.routeService.getRoutes({ isActive: 'true' }).subscribe((routes) => {
       this.availableRoutes = routes
-        .filter((r: any) => r.id !== this.data.routeId)
+        .filter((r: any) => r.id !== rid)
         .map((r: any) => ({ id: r.id, name: r.name, category: r.category, clientId: r.clientId }));
     });
-    this.routeService.getRoute(this.data.routeId).subscribe((route: any) => {
-      this.routeService.getDispatchPreview(this.data.routeId, route.clientId ?? undefined).subscribe((preview) => {
+    this.routeService.getRoute(rid).subscribe((route: any) => {
+      this.routeService.getDispatchPreview(rid, route.clientId ?? undefined).subscribe((preview) => {
         this.dispatchPreview = preview.categories;
       });
     });
@@ -519,6 +561,7 @@ export class TicketRouteStepDialogComponent implements OnInit {
     if (!this.stepType || !this.name.trim()) return;
     this.saving = true;
     const config = this.buildStepConfig();
+    const rid = this.routeId();
 
     if (this.isEdit) {
       const updatePayload: Record<string, unknown> = {
@@ -530,14 +573,14 @@ export class TicketRouteStepDialogComponent implements OnInit {
       if (this.stepType === 'ADD_FOLLOWER' || this.stepType === 'AGENTIC_ANALYSIS' || this.stepType === 'DISPATCH_TO_ROUTE' || this.stepType === 'CUSTOM_AI_QUERY') {
         updatePayload['config'] = config ?? null;
       }
-      this.routeService.updateStep(this.data.routeId, this.data.step!.id, updatePayload).subscribe({
+      this.routeService.updateStep(rid, this.step()!.id, updatePayload).subscribe({
         next: (result: WithWarnings<TicketRouteStep>) => {
           if (result.warnings.length > 0) {
             this.toast.warning(result.warnings[0]);
           } else {
             this.toast.success('Step updated');
           }
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;
@@ -545,7 +588,7 @@ export class TicketRouteStepDialogComponent implements OnInit {
         },
       });
     } else {
-      this.routeService.addStep(this.data.routeId, {
+      this.routeService.addStep(rid, {
         name: this.name.trim(),
         stepType: this.stepType,
         stepOrder: this.stepOrder,
@@ -559,7 +602,7 @@ export class TicketRouteStepDialogComponent implements OnInit {
           } else {
             this.toast.success('Step added');
           }
-          this.dialogRef.close(true);
+          this.saved.emit(true);
         },
         error: (err) => {
           this.saving = false;

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { Component, ElementRef, effect, input, output, viewChild } from '@angular/core';
 
 @Component({
   selector: 'app-dialog',
@@ -6,18 +6,22 @@ import { Component, input, output } from '@angular/core';
   template: `
     @if (open()) {
       <div class="dialog-backdrop" (click)="close()">
-        <div class="dialog-panel" role="dialog" aria-modal="true" [attr.aria-label]="title() || 'Dialog'" [style.max-width]="maxWidth()" (click)="$event.stopPropagation()">
+        <div
+          #panel
+          class="dialog-panel"
+          role="dialog"
+          aria-modal="true"
+          [attr.aria-label]="title() || 'Dialog'"
+          [style.max-width]="maxWidth()"
+          (click)="$event.stopPropagation()">
           <div class="dialog-header">
             @if (title()) {
               <h2 class="dialog-title">{{ title() }}</h2>
             }
-            <button class="dialog-close" aria-label="Close dialog" (click)="close()">&times;</button>
+            <button type="button" class="dialog-close" aria-label="Close dialog" (click)="close()">&times;</button>
           </div>
           <div class="dialog-body">
             <ng-content />
-          </div>
-          <div class="dialog-footer">
-            <ng-content select="[dialogFooter]" />
           </div>
         </div>
       </div>
@@ -84,18 +88,6 @@ import { Component, input, output } from '@angular/core';
       padding: 20px;
     }
 
-    .dialog-footer {
-      padding: 12px 20px;
-      border-top: 1px solid var(--border-light);
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-    }
-
-    .dialog-footer:empty {
-      display: none;
-    }
-
     @keyframes fadeIn {
       from { opacity: 0; }
       to { opacity: 1; }
@@ -113,6 +105,50 @@ export class DialogComponent {
   maxWidth = input<string>('480px');
 
   openChange = output<boolean>();
+
+  private panelRef = viewChild<ElementRef<HTMLElement>>('panel');
+  private previouslyFocused: HTMLElement | null = null;
+
+  constructor() {
+    // Manage Escape key + focus restore while the dialog is open.
+    effect((onCleanup) => {
+      if (!this.open()) return;
+
+      this.previouslyFocused = (typeof document !== 'undefined'
+        ? (document.activeElement as HTMLElement | null)
+        : null);
+
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+          this.close();
+        }
+      };
+      document.addEventListener('keydown', onKeyDown);
+
+      onCleanup(() => {
+        document.removeEventListener('keydown', onKeyDown);
+        // Restore focus to whatever was focused before the dialog opened.
+        if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
+          this.previouslyFocused.focus();
+        }
+        this.previouslyFocused = null;
+      });
+    });
+
+    // Auto-focus the first focusable element when the dialog panel mounts.
+    effect(() => {
+      if (!this.open()) return;
+      const panel = this.panelRef()?.nativeElement;
+      if (!panel) return;
+      queueMicrotask(() => {
+        const focusable = panel.querySelector<HTMLElement>(
+          'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        focusable?.focus();
+      });
+    });
+  }
 
   close(): void {
     this.openChange.emit(false);

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -27,6 +27,27 @@ html, body {
   flex: 1 1 auto;
 }
 
+/*
+ * app-dialog footer styling.
+ *
+ * The DialogComponent renders a single body slot via <ng-content />. Action
+ * buttons live inside *-dialog-content components (one level deeper than
+ * <app-dialog>'s direct children), so a dedicated footer projection slot
+ * cannot reach them via Angular's content projection. Instead we mark those
+ * action containers with the `dialogFooter` attribute and style them globally
+ * to mimic a real footer (top border, padding extending to the body edges).
+ * Global styles work here because they bypass component view encapsulation
+ * and reach into projected content.
+ */
+app-dialog .dialog-body [dialogFooter] {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 16px -20px -20px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border-light);
+}
+
 
 @media (max-width: 767px) {
   .mat-mdc-table {


### PR DESCRIPTION
Convert dialog components across clients, prompts, and operations from MatDialog to the custom app-dialog @Input/@Output pattern. Update all parent components to use signal-based dialog rendering.