### PR TITLE
Replace MatPaginator with custom PaginatorComponent in log-viewer

### DIFF
--- a/services/control-panel/src/app/features/logs/log-viewer.component.ts
+++ b/services/control-panel/src/app/features/logs/log-viewer.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, OnInit, signal, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
 import { EMPTY, Subject, switchMap, timer } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
 import { LogService, AppLog } from '../../core/services/log.service';
@@ -19,7 +19,7 @@ import {
   imports: [
     CommonModule,
     FormsModule,
-    MatPaginatorModule,
+    PaginatorComponent,
     BroncoButtonComponent,
     SelectComponent,
     TextInputComponent,
@@ -168,14 +168,12 @@ import {
           }
         }
 
-        <mat-paginator
+        <app-paginator
           [length]="total()"
           [pageSize]="pageSize"
           [pageIndex]="pageIndex"
-          [pageSizeOptions]="[50, 100, 200]"
-          (page)="onPage($event)"
-          showFirstLastButtons>
-        </mat-paginator>
+          [pageSizeOptions]="[20, 50, 100, 200]"
+          (page)="onPage($event)" />
       </div>
     </div>
   `,
@@ -444,7 +442,7 @@ export class LogViewerComponent implements OnInit, OnDestroy {
     this.load();
   }
 
-  onPage(event: PageEvent): void {
+  onPage(event: PaginatorPageEvent): void {
     this.pageSize = event.pageSize;
     this.pageIndex = event.pageIndex;
     this.load();


### PR DESCRIPTION
This pull request updates the `LogViewerComponent` to use a custom paginator component instead of Angular Material's paginator. The changes improve consistency with the application's shared UI components and allow for more flexible pagination options.

**Migration to custom paginator:**

* Replaced `MatPaginatorModule` and `PageEvent` imports with `PaginatorComponent` and `PaginatorPageEvent` from the shared components. (`services/control-panel/src/app/features/logs/log-viewer.component.ts`)
* Updated the component's `imports` array to use `PaginatorComponent` instead of `MatPaginatorModule`.
* Swapped the template's `<mat-paginator>` with `<app-paginator>`, and adjusted the page size options to `[20, 50, 100, 200]`.
* Changed the `onPage` handler to use `PaginatorPageEvent` instead of `PageEvent`.