### PR TITLE
Replace Material Design components with custom Bronco design system

### DIFF
--- a/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
@@ -37,14 +37,14 @@ import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonCo
         <app-text-input
           [value]="'' + inputCostPer1m"
           type="number"
-          (valueChange)="inputCostPer1m = +$event" />
+          (valueChange)="inputCostPer1m = parseCost($event)" />
       </app-form-field>
 
       <app-form-field label="Output Cost ($/1M tokens)">
         <app-text-input
           [value]="'' + outputCostPer1m"
           type="number"
-          (valueChange)="outputCostPer1m = +$event" />
+          (valueChange)="outputCostPer1m = parseCost($event)" />
       </app-form-field>
 
       <label class="checkbox-row">
@@ -106,6 +106,11 @@ export class ModelCostDialogComponent implements OnInit {
       }
       this.providerOptions = providers.map(p => ({ value: p, label: p }));
     });
+  }
+
+  parseCost(val: string): number {
+    const n = parseFloat(val);
+    return Number.isNaN(n) ? 0 : n;
   }
 
   save(): void {

--- a/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
@@ -1,60 +1,68 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { AiUsageService, AiModelCost } from '../../core/services/ai-usage.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-model-cost-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Provider</mat-label>
-      <mat-select [(ngModel)]="provider" [disabled]="isEdit" required>
-        @for (p of catalogProviders; track p) {
-          <mat-option [value]="p">{{ p }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+    <div class="form-grid">
+      <app-form-field label="Provider">
+        <app-select
+          [value]="provider"
+          [options]="providerOptions"
+          [disabled]="isEdit"
+          (valueChange)="provider = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Model ID</mat-label>
-      <input matInput [(ngModel)]="model" [readonly]="isEdit" required placeholder="e.g. claude-sonnet-4-6">
-    </mat-form-field>
+      <app-form-field label="Model ID">
+        <app-text-input
+          [value]="model"
+          [disabled]="isEdit"
+          placeholder="e.g. claude-sonnet-4-6"
+          (valueChange)="model = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Display Name</mat-label>
-      <input matInput [(ngModel)]="displayName" placeholder="e.g. Claude Sonnet 4.6">
-    </mat-form-field>
+      <app-form-field label="Display Name">
+        <app-text-input
+          [value]="displayName"
+          placeholder="e.g. Claude Sonnet 4.6"
+          (valueChange)="displayName = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Input Cost ($/1M tokens)</mat-label>
-      <input matInput type="number" [(ngModel)]="inputCostPer1m" required min="0" step="0.01">
-    </mat-form-field>
+      <app-form-field label="Input Cost ($/1M tokens)">
+        <app-text-input
+          [value]="'' + inputCostPer1m"
+          type="number"
+          (valueChange)="inputCostPer1m = +$event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Output Cost ($/1M tokens)</mat-label>
-      <input matInput type="number" [(ngModel)]="outputCostPer1m" required min="0" step="0.01">
-    </mat-form-field>
+      <app-form-field label="Output Cost ($/1M tokens)">
+        <app-text-input
+          [value]="'' + outputCostPer1m"
+          type="number"
+          (valueChange)="outputCostPer1m = +$event" />
+      </app-form-field>
 
-    <mat-checkbox [(ngModel)]="isCustomCost">
-      Custom cost (protect from AI updates)
-    </mat-checkbox>
+      <label class="checkbox-row">
+        <input type="checkbox" [(ngModel)]="isCustomCost">
+        <span>Custom cost (protect from AI updates)</span>
+      </label>
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!provider || !model">
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!provider || !model" (click)="save()">
         {{ isEdit ? 'Update' : 'Create' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text-secondary); cursor: pointer; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -74,7 +82,7 @@ export class ModelCostDialogComponent implements OnInit {
   outputCostPer1m = 0;
   isCustomCost = true;
 
-  catalogProviders: string[] = [];
+  providerOptions: Array<{ value: string; label: string }> = [];
 
   ngOnInit(): void {
     const c = this.cost();
@@ -89,13 +97,14 @@ export class ModelCostDialogComponent implements OnInit {
     }
 
     this.aiUsageService.getCatalog().subscribe(catalog => {
-      this.catalogProviders = catalog.providers.map(p => p.provider);
-      if (this.provider && !this.catalogProviders.includes(this.provider)) {
-        this.catalogProviders.push(this.provider);
+      let providers = catalog.providers.map(p => p.provider);
+      if (this.provider && !providers.includes(this.provider)) {
+        providers.push(this.provider);
       }
-      if (this.catalogProviders.length === 0) {
-        this.catalogProviders = ['CLAUDE', 'OPENAI', 'LOCAL', 'GROK', 'GOOGLE'];
+      if (providers.length === 0) {
+        providers = ['CLAUDE', 'OPENAI', 'LOCAL', 'GROK', 'GOOGLE'];
       }
+      this.providerOptions = providers.map(p => ({ value: p, label: p }));
     });
   }
 

--- a/services/control-panel/src/app/features/contacts/contact-dialog.component.ts
+++ b/services/control-panel/src/app/features/contacts/contact-dialog.component.ts
@@ -1,48 +1,47 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ContactService } from '../../core/services/contact.service';
 import { Contact } from '../../core/services/client.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-contact-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatCheckboxModule],
+  imports: [FormsModule, FormFieldComponent, TextInputComponent, BroncoButtonComponent],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Name</mat-label>
-      <input matInput [(ngModel)]="form.name" required>
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label>Email</mat-label>
-      <input matInput type="email" [(ngModel)]="form.email" required>
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label>Phone</mat-label>
-      <input matInput [(ngModel)]="form.phone">
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label>Role</mat-label>
-      <input matInput [(ngModel)]="form.role" placeholder="e.g. DBA, Developer, Manager">
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label>Slack User ID</mat-label>
-      <input matInput [(ngModel)]="form.slackUserId" placeholder="U0123456789">
-      <mat-hint>Used to link Slack messages to this contact</mat-hint>
-    </mat-form-field>
-    <mat-checkbox [(ngModel)]="form.isPrimary">Primary contact</mat-checkbox>
+    <div class="form-grid">
+      <app-form-field label="Name">
+        <app-text-input [value]="form.name" (valueChange)="form.name = $event" />
+      </app-form-field>
+      <app-form-field label="Email">
+        <app-text-input [value]="form.email" type="email" (valueChange)="form.email = $event" />
+      </app-form-field>
+      <app-form-field label="Phone">
+        <app-text-input [value]="form.phone" (valueChange)="form.phone = $event" />
+      </app-form-field>
+      <app-form-field label="Role">
+        <app-text-input [value]="form.role" placeholder="e.g. DBA, Developer, Manager" (valueChange)="form.role = $event" />
+      </app-form-field>
+      <app-form-field label="Slack User ID" hint="Used to link Slack messages to this contact">
+        <app-text-input [value]="form.slackUserId" placeholder="U0123456789" (valueChange)="form.slackUserId = $event" />
+      </app-form-field>
+      <label class="checkbox-row">
+        <input type="checkbox" [(ngModel)]="form.isPrimary">
+        <span>Primary contact</span>
+      </label>
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!form.name || !form.email">{{ isEdit ? 'Save' : 'Create' }}</button>
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!form.name || !form.email" (click)="save()">
+        {{ isEdit ? 'Save' : 'Create' }}
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text-secondary); cursor: pointer; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -1,199 +1,175 @@
 import { Component, inject, input, output, OnInit, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatIconModule } from '@angular/material/icon';
 import { IntegrationService } from '../../core/services/integration.service';
 import type { ClientIntegration } from '../../core/services/integration.service';
 import { AuthService } from '../../core/services/auth.service';
 import { McpToolVisibilityDialogComponent } from './mcp-tool-visibility-dialog.component';
 import { ToastService } from '../../core/services/toast.service';
-import { DialogComponent } from '../../shared/components/index.js';
+import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-integration-dialog-content',
   standalone: true,
   imports: [
-    FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatButtonModule,
-    MatSlideToggleModule,
-    MatIconModule,
+    FormFieldComponent,
+    TextInputComponent,
+    TextareaComponent,
+    SelectComponent,
+    ToggleSwitchComponent,
+    BroncoButtonComponent,
     DialogComponent,
     McpToolVisibilityDialogComponent,
   ],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Type</mat-label>
-      <mat-select [(ngModel)]="type" (ngModelChange)="onTypeChange()" [disabled]="editing">
-        <mat-option value="IMAP">IMAP (Email)</mat-option>
-        <mat-option value="AZURE_DEVOPS">Azure DevOps</mat-option>
-        <mat-option value="MCP_DATABASE">MCP Database</mat-option>
-        <mat-option value="SLACK">Slack</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="form-grid">
+      <app-form-field label="Type">
+        <app-select
+          [value]="type"
+          [options]="typeOptions"
+          [disabled]="editing"
+          (valueChange)="type = $event; onTypeChange()" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Label</mat-label>
-      <input matInput [(ngModel)]="label" placeholder="e.g. prod, dev, staging">
-      <mat-hint>Allows multiple integrations of the same type per client</mat-hint>
-    </mat-form-field>
+      <app-form-field label="Label" hint="Allows multiple integrations of the same type per client">
+        <app-text-input
+          [value]="label"
+          placeholder="e.g. prod, dev, staging"
+          (valueChange)="label = $event" />
+      </app-form-field>
 
-    @if (type === 'IMAP') {
-      @if (imapLoopWarning) {
-        <div class="loop-warning">
-          <strong>Warning:</strong> This inbox email matches your login email ({{ currentUserEmail }}).
-          Automated replies sent to this address will be ingested as new tickets, creating an email loop.
-          Use a separate email address for ticket ingestion.
-        </div>
-      }
-      <mat-form-field class="full-width">
-        <mat-label>IMAP Host</mat-label>
-        <input matInput [(ngModel)]="imap.host" placeholder="imap.gmail.com">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>IMAP Port</mat-label>
-        <input matInput type="number" [(ngModel)]="imap.port">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>User</mat-label>
-        <input matInput [(ngModel)]="imap.user" (ngModelChange)="checkImapLoop()">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Password</mat-label>
-        <input matInput type="password" [(ngModel)]="imap.encryptedPassword" [placeholder]="editing ? '(unchanged)' : ''">
-        @if (editing) {
-          <mat-hint>Leave blank to keep existing password</mat-hint>
+      @if (type === 'IMAP') {
+        @if (imapLoopWarning) {
+          <div class="loop-warning">
+            <strong>Warning:</strong> This inbox email matches your login email ({{ currentUserEmail }}).
+            Automated replies sent to this address will be ingested as new tickets, creating an email loop.
+            Use a separate email address for ticket ingestion.
+          </div>
         }
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Poll Interval (seconds)</mat-label>
-        <input matInput type="number" [(ngModel)]="imap.pollIntervalSeconds">
-      </mat-form-field>
-    }
-
-    @if (type === 'AZURE_DEVOPS') {
-      <mat-form-field class="full-width">
-        <mat-label>Organization URL</mat-label>
-        <input matInput [(ngModel)]="azdo.orgUrl" placeholder="https://dev.azure.com/org">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Project</mat-label>
-        <input matInput [(ngModel)]="azdo.project">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Personal Access Token</mat-label>
-        <input matInput type="password" [(ngModel)]="azdo.encryptedPat" [placeholder]="editing ? '(unchanged)' : ''">
-        @if (editing) {
-          <mat-hint>Leave blank to keep existing token</mat-hint>
-        }
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Assigned User</mat-label>
-        <input matInput [(ngModel)]="azdo.assignedUser">
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Poll Interval (seconds)</mat-label>
-        <input matInput type="number" [(ngModel)]="azdo.pollIntervalSeconds">
-      </mat-form-field>
-    }
-
-    @if (type === 'MCP_DATABASE') {
-      <mat-form-field class="full-width">
-        <mat-label>MCP Database URL</mat-label>
-        <input matInput [(ngModel)]="mcp.url" placeholder="mcp-db.example.com:3100">
-        <mat-hint>https:// will be added automatically if omitted</mat-hint>
-      </mat-form-field>
-
-      @if (showAdvanced) {
-        <mat-form-field class="full-width">
-          <mat-label>Health Path</mat-label>
-          <input
-            matInput
-            [ngModel]="mcp.healthPath === null ? '' : mcp.healthPath"
-            (ngModelChange)="mcp.healthPath = $event === '' ? (editing ? null : '') : $event"
-            placeholder="/health">
-          <mat-hint>{{ editing ? 'Leave blank to disable health checks' : 'Default: /health' }}. Enter a custom path to override.</mat-hint>
-        </mat-form-field>
-        <mat-form-field class="full-width">
-          <mat-label>MCP Path</mat-label>
-          <input matInput [(ngModel)]="mcp.mcpPath" placeholder="/mcp">
-          <mat-hint>Streamable HTTP endpoint for MCP protocol calls</mat-hint>
-        </mat-form-field>
-        <mat-form-field class="full-width">
-          <mat-label>API Key</mat-label>
-          <input matInput type="password" [(ngModel)]="mcp.apiKey" [placeholder]="editing ? '(unchanged)' : '(optional)'">
-          @if (editing) {
-            <mat-hint>Leave blank to keep existing key</mat-hint>
-          }
-        </mat-form-field>
-        <mat-form-field class="full-width">
-          <mat-label>Auth Header</mat-label>
-          <mat-select [(ngModel)]="mcp.authHeader">
-            <mat-option value="bearer">Authorization: Bearer (default)</mat-option>
-            <mat-option value="x-api-key">x-api-key</mat-option>
-          </mat-select>
-          <mat-hint>How the API key is sent to the MCP server</mat-hint>
-        </mat-form-field>
+        <app-form-field label="IMAP Host">
+          <app-text-input [value]="imap.host" placeholder="imap.gmail.com" (valueChange)="imap.host = $event" />
+        </app-form-field>
+        <app-form-field label="IMAP Port">
+          <app-text-input [value]="'' + imap.port" type="number" (valueChange)="imap.port = +$event" />
+        </app-form-field>
+        <app-form-field label="User">
+          <app-text-input [value]="imap.user" (valueChange)="imap.user = $event; checkImapLoop()" />
+        </app-form-field>
+        <app-form-field label="Password" [hint]="editing ? 'Leave blank to keep existing password' : ''">
+          <app-text-input
+            [value]="imap.encryptedPassword"
+            type="password"
+            [placeholder]="editing ? '(unchanged)' : ''"
+            (valueChange)="imap.encryptedPassword = $event" />
+        </app-form-field>
+        <app-form-field label="Poll Interval (seconds)">
+          <app-text-input [value]="'' + imap.pollIntervalSeconds" type="number" (valueChange)="imap.pollIntervalSeconds = +$event" />
+        </app-form-field>
       }
 
-      <button mat-button type="button" (click)="showAdvanced = !showAdvanced" class="advanced-toggle">
-        {{ showAdvanced ? 'Hide' : 'Show' }} advanced options
-      </button>
-
-      @if (discoveredTools.length > 0) {
-        <div class="tool-visibility-section">
-          <span class="tool-summary">
-            {{ discoveredTools.length - disabledTools.size }}/{{ discoveredTools.length }} tools enabled
-            @if (disabledTools.size > 0) { <span class="disabled-count">({{ disabledTools.size }} hidden)</span> }
-          </span>
-          <button mat-stroked-button type="button" (click)="openToolVisibility()">
-            <mat-icon>tune</mat-icon> Manage Tools
-          </button>
-        </div>
+      @if (type === 'AZURE_DEVOPS') {
+        <app-form-field label="Organization URL">
+          <app-text-input [value]="azdo.orgUrl" placeholder="https://dev.azure.com/org" (valueChange)="azdo.orgUrl = $event" />
+        </app-form-field>
+        <app-form-field label="Project">
+          <app-text-input [value]="azdo.project" (valueChange)="azdo.project = $event" />
+        </app-form-field>
+        <app-form-field label="Personal Access Token" [hint]="editing ? 'Leave blank to keep existing token' : ''">
+          <app-text-input
+            [value]="azdo.encryptedPat"
+            type="password"
+            [placeholder]="editing ? '(unchanged)' : ''"
+            (valueChange)="azdo.encryptedPat = $event" />
+        </app-form-field>
+        <app-form-field label="Assigned User">
+          <app-text-input [value]="azdo.assignedUser" (valueChange)="azdo.assignedUser = $event" />
+        </app-form-field>
+        <app-form-field label="Poll Interval (seconds)">
+          <app-text-input [value]="'' + azdo.pollIntervalSeconds" type="number" (valueChange)="azdo.pollIntervalSeconds = +$event" />
+        </app-form-field>
       }
-    }
 
-    @if (type === 'SLACK') {
-      <mat-form-field class="full-width">
-        <mat-label>Bot Token</mat-label>
-        <input matInput type="password" [(ngModel)]="slack.encryptedBotToken" [placeholder]="editing ? '(unchanged)' : 'xoxb-...'">
-        @if (editing) {
-          <mat-hint>Leave blank to keep existing token</mat-hint>
+      @if (type === 'MCP_DATABASE') {
+        <app-form-field label="MCP Database URL" hint="https:// will be added automatically if omitted">
+          <app-text-input [value]="mcp.url" placeholder="mcp-db.example.com:3100" (valueChange)="mcp.url = $event" />
+        </app-form-field>
+
+        @if (showAdvanced) {
+          <app-form-field label="Health Path" [hint]="editing ? 'Leave blank to disable health checks' : 'Default: /health'">
+            <app-text-input
+              [value]="mcp.healthPath === null ? '' : mcp.healthPath"
+              placeholder="/health"
+              (valueChange)="mcp.healthPath = $event === '' ? (editing ? null : '') : $event" />
+          </app-form-field>
+          <app-form-field label="MCP Path" hint="Streamable HTTP endpoint for MCP protocol calls">
+            <app-text-input [value]="mcp.mcpPath" placeholder="/mcp" (valueChange)="mcp.mcpPath = $event" />
+          </app-form-field>
+          <app-form-field label="API Key" [hint]="editing ? 'Leave blank to keep existing key' : ''">
+            <app-text-input
+              [value]="mcp.apiKey"
+              type="password"
+              [placeholder]="editing ? '(unchanged)' : '(optional)'"
+              (valueChange)="mcp.apiKey = $event" />
+          </app-form-field>
+          <app-form-field label="Auth Header" hint="How the API key is sent to the MCP server">
+            <app-select [value]="mcp.authHeader" [options]="authHeaderOptions" (valueChange)="mcp.authHeader = $event" />
+          </app-form-field>
         }
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>App-Level Token</mat-label>
-        <input matInput type="password" [(ngModel)]="slack.encryptedAppToken" [placeholder]="editing ? '(unchanged)' : 'xapp-...'">
-        @if (editing) {
-          <mat-hint>Leave blank to keep existing token</mat-hint>
+
+        <app-bronco-button variant="ghost" (click)="showAdvanced = !showAdvanced">
+          {{ showAdvanced ? 'Hide' : 'Show' }} advanced options
+        </app-bronco-button>
+
+        @if (discoveredTools.length > 0) {
+          <div class="tool-visibility-section">
+            <span class="tool-summary">
+              {{ discoveredTools.length - disabledTools.size }}/{{ discoveredTools.length }} tools enabled
+              @if (disabledTools.size > 0) { <span class="disabled-count">({{ disabledTools.size }} hidden)</span> }
+            </span>
+            <app-bronco-button variant="secondary" (click)="openToolVisibility()">Manage Tools</app-bronco-button>
+          </div>
         }
-      </mat-form-field>
-      <mat-form-field class="full-width">
-        <mat-label>Default Channel ID</mat-label>
-        <input matInput [(ngModel)]="slack.defaultChannelId" placeholder="C0123456789">
-        <mat-hint>Channel where ticket updates are posted</mat-hint>
-      </mat-form-field>
-      <mat-slide-toggle [(ngModel)]="slack.enabled">{{ slack.enabled ? 'Enabled' : 'Disabled' }}</mat-slide-toggle>
-    }
+      }
 
-    <mat-form-field class="full-width">
-      <mat-label>Notes</mat-label>
-      <textarea matInput [(ngModel)]="notes" rows="2"></textarea>
-    </mat-form-field>
+      @if (type === 'SLACK') {
+        <app-form-field label="Bot Token" [hint]="editing ? 'Leave blank to keep existing token' : ''">
+          <app-text-input
+            [value]="slack.encryptedBotToken"
+            type="password"
+            [placeholder]="editing ? '(unchanged)' : 'xoxb-...'"
+            (valueChange)="slack.encryptedBotToken = $event" />
+        </app-form-field>
+        <app-form-field label="App-Level Token" [hint]="editing ? 'Leave blank to keep existing token' : ''">
+          <app-text-input
+            [value]="slack.encryptedAppToken"
+            type="password"
+            [placeholder]="editing ? '(unchanged)' : 'xapp-...'"
+            (valueChange)="slack.encryptedAppToken = $event" />
+        </app-form-field>
+        <app-form-field label="Default Channel ID" hint="Channel where ticket updates are posted">
+          <app-text-input [value]="slack.defaultChannelId" placeholder="C0123456789" (valueChange)="slack.defaultChannelId = $event" />
+        </app-form-field>
+        <app-toggle-switch
+          [checked]="slack.enabled"
+          [label]="slack.enabled ? 'Enabled' : 'Disabled'"
+          (checkedChange)="slack.enabled = $event" />
+      }
 
-    @if (editing) {
-      <mat-slide-toggle [(ngModel)]="isActive">{{ isActive ? 'Active' : 'Inactive' }}</mat-slide-toggle>
-    }
+      <app-form-field label="Notes">
+        <app-textarea [value]="notes" [rows]="2" (valueChange)="notes = $event" />
+      </app-form-field>
+
+      @if (editing) {
+        <app-toggle-switch
+          [checked]="isActive"
+          [label]="isActive ? 'Active' : 'Inactive'"
+          (checkedChange)="isActive = $event" />
+      }
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!type">{{ editing ? 'Save' : 'Create' }}</button>
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!type" (click)="save()">
+        {{ editing ? 'Save' : 'Create' }}
+      </app-bronco-button>
     </div>
 
     @if (showToolVisibility()) {
@@ -207,12 +183,11 @@ import { DialogComponent } from '../../shared/components/index.js';
     }
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
-    .advanced-toggle { font-size: 13px; color: #666; margin-bottom: 8px; }
-    .loop-warning { background: #fff3e0; border: 1px solid #ff9800; border-radius: 6px; padding: 10px 14px; margin-bottom: 12px; font-size: 13px; color: #e65100; line-height: 1.4; }
-    .tool-visibility-section { display: flex; align-items: center; gap: 12px; margin-top: 12px; border-top: 1px solid #e0e0e0; padding-top: 12px; }
-    .tool-summary { font-size: 13px; color: #555; flex: 1; }
-    .disabled-count { color: #e65100; margin-left: 4px; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .loop-warning { background: var(--color-warning-subtle); border: 1px solid var(--color-warning); border-radius: var(--radius-md); padding: 10px 14px; font-size: 13px; color: var(--color-error); line-height: 1.4; }
+    .tool-visibility-section { display: flex; align-items: center; gap: 12px; margin-top: 4px; border-top: 1px solid var(--border-light); padding-top: 12px; }
+    .tool-summary { font-size: 13px; color: var(--text-secondary); flex: 1; }
+    .disabled-count { color: var(--color-error); margin-left: 4px; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -243,6 +218,18 @@ export class IntegrationDialogComponent implements OnInit {
   disabledTools = new Set<string>();
   imapLoopWarning = false;
   currentUserEmail = '';
+
+  typeOptions = [
+    { value: 'IMAP', label: 'IMAP (Email)' },
+    { value: 'AZURE_DEVOPS', label: 'Azure DevOps' },
+    { value: 'MCP_DATABASE', label: 'MCP Database' },
+    { value: 'SLACK', label: 'Slack' },
+  ];
+
+  authHeaderOptions = [
+    { value: 'bearer', label: 'Authorization: Bearer (default)' },
+    { value: 'x-api-key', label: 'x-api-key' },
+  ];
 
   private readonly secretFields: Record<string, string[]> = {
     IMAP: ['encryptedPassword'],

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -48,7 +48,7 @@ import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaCompon
           <app-text-input [value]="imap.host" placeholder="imap.gmail.com" (valueChange)="imap.host = $event" />
         </app-form-field>
         <app-form-field label="IMAP Port">
-          <app-text-input [value]="'' + imap.port" type="number" (valueChange)="imap.port = +$event" />
+          <app-text-input [value]="'' + imap.port" type="number" (valueChange)="imap.port = parseIntInput($event, 993)" />
         </app-form-field>
         <app-form-field label="User">
           <app-text-input [value]="imap.user" (valueChange)="imap.user = $event; checkImapLoop()" />
@@ -61,7 +61,7 @@ import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaCompon
             (valueChange)="imap.encryptedPassword = $event" />
         </app-form-field>
         <app-form-field label="Poll Interval (seconds)">
-          <app-text-input [value]="'' + imap.pollIntervalSeconds" type="number" (valueChange)="imap.pollIntervalSeconds = +$event" />
+          <app-text-input [value]="'' + imap.pollIntervalSeconds" type="number" (valueChange)="imap.pollIntervalSeconds = parseIntInput($event, 60)" />
         </app-form-field>
       }
 
@@ -83,7 +83,7 @@ import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaCompon
           <app-text-input [value]="azdo.assignedUser" (valueChange)="azdo.assignedUser = $event" />
         </app-form-field>
         <app-form-field label="Poll Interval (seconds)">
-          <app-text-input [value]="'' + azdo.pollIntervalSeconds" type="number" (valueChange)="azdo.pollIntervalSeconds = +$event" />
+          <app-text-input [value]="'' + azdo.pollIntervalSeconds" type="number" (valueChange)="azdo.pollIntervalSeconds = parseIntInput($event, 120)" />
         </app-form-field>
       }
 
@@ -184,7 +184,7 @@ import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaCompon
   `,
   styles: [`
     .form-grid { display: flex; flex-direction: column; gap: 12px; }
-    .loop-warning { background: var(--color-warning-subtle); border: 1px solid var(--color-warning); border-radius: var(--radius-md); padding: 10px 14px; font-size: 13px; color: var(--color-error); line-height: 1.4; }
+    .loop-warning { background: var(--color-warning-subtle); border: 1px solid var(--color-warning); border-radius: var(--radius-md); padding: 10px 14px; font-size: 13px; color: var(--color-warning); line-height: 1.4; }
     .tool-visibility-section { display: flex; align-items: center; gap: 12px; margin-top: 4px; border-top: 1px solid var(--border-light); padding-top: 12px; }
     .tool-summary { font-size: 13px; color: var(--text-secondary); flex: 1; }
     .disabled-count { color: var(--color-error); margin-left: 4px; }
@@ -298,6 +298,11 @@ export class IntegrationDialogComponent implements OnInit {
   onToolsApplied(result: Set<string>): void {
     this.disabledTools = result;
     this.showToolVisibility.set(false);
+  }
+
+  parseIntInput(val: string, fallback: number): number {
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) ? fallback : n;
   }
 
   checkImapLoop(): void {

--- a/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
@@ -17,7 +17,7 @@ import { FormFieldComponent, SelectComponent, BroncoButtonComponent } from '../.
           @for (name of disabledToolList(); track name) {
             <span class="chip">
               {{ name }}
-              <button type="button" class="chip-remove" (click)="enable(name)">&times;</button>
+              <button type="button" class="chip-remove" [attr.aria-label]="'Enable ' + name" (click)="enable(name)">&times;</button>
             </span>
           }
         </div>

--- a/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
@@ -1,15 +1,10 @@
 import { Component, input, output, OnInit } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatIconModule } from '@angular/material/icon';
+import { FormFieldComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-mcp-tool-visibility-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatFormFieldModule, MatSelectModule, MatButtonModule, MatChipsModule, MatIconModule],
+  imports: [FormFieldComponent, SelectComponent, BroncoButtonComponent],
   template: `
     <p class="summary">
       {{ tools().length - disabledTools.size }} of {{ tools().length }} tools enabled for agentic analysis.
@@ -18,50 +13,43 @@ import { MatIconModule } from '@angular/material/icon';
     @if (disabledTools.size > 0) {
       <div class="disabled-section">
         <p class="section-label">Hidden from AI:</p>
-        <mat-chip-set>
+        <div class="chip-list">
           @for (name of disabledToolList(); track name) {
-            <mat-chip (removed)="enable(name)">
+            <span class="chip">
               {{ name }}
-              <button matChipRemove><mat-icon>cancel</mat-icon></button>
-            </mat-chip>
+              <button type="button" class="chip-remove" (click)="enable(name)">&times;</button>
+            </span>
           }
-        </mat-chip-set>
+        </div>
       </div>
     } @else {
       <p class="all-enabled">All tools are currently enabled.</p>
     }
 
-    @if (enabledTools().length > 0) {
-      <mat-form-field class="add-field">
-        <mat-label>Disable a tool…</mat-label>
-        <mat-select [(ngModel)]="toolToDisable" (ngModelChange)="disableSelected()">
-          @for (tool of enabledTools(); track tool.name) {
-            <mat-option [value]="tool.name">
-              <span class="opt-name">{{ tool.name }}</span>
-              @if (tool.description) {
-                <span class="opt-desc"> — {{ tool.description }}</span>
-              }
-            </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+    @if (enabledToolOptions().length > 0) {
+      <app-form-field label="Disable a tool…">
+        <app-select
+          [value]="toolToDisable"
+          [options]="enabledToolOptions()"
+          (valueChange)="toolToDisable = $event; disableSelected()" />
+      </app-form-field>
     }
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="apply()">Apply</button>
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" (click)="apply()">Apply</app-bronco-button>
     </div>
   `,
   styles: [`
-    .summary { font-size: 13px; color: #555; margin: 0 0 12px; }
-    .section-label { font-size: 12px; color: #777; margin: 0 0 6px; }
+    .summary { font-size: 13px; color: var(--text-secondary); margin: 0 0 12px; }
+    .section-label { font-size: 12px; color: var(--text-secondary); margin: 0 0 6px; }
     .disabled-section { margin-bottom: 16px; }
-    .all-enabled { font-size: 13px; color: #4caf50; margin: 0 0 16px; }
-    .add-field { width: 100%; }
-    .opt-name { font-weight: 500; }
-    .opt-desc { font-size: 12px; color: #888; }
-    mat-chip { font-size: 13px; }
-    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+    .all-enabled { font-size: 13px; color: var(--color-success); margin: 0 0 16px; }
+    .chip-list { display: flex; flex-wrap: wrap; gap: 6px; }
+    .chip { display: inline-flex; align-items: center; gap: 4px; padding: 4px 8px; background: var(--bg-muted); border-radius: var(--radius-pill); font-size: 13px; color: var(--text-primary); }
+    .chip-remove { background: none; border: none; cursor: pointer; color: var(--text-secondary); font-size: 16px; line-height: 1; padding: 0; display: flex; align-items: center; }
+    .chip-remove:hover { color: var(--color-error); }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
   `],
 })
 export class McpToolVisibilityDialogComponent implements OnInit {
@@ -82,8 +70,10 @@ export class McpToolVisibilityDialogComponent implements OnInit {
     return [...this.disabledTools].sort();
   }
 
-  enabledTools(): Array<{ name: string; description: string }> {
-    return this.tools().filter(t => !this.disabledTools.has(t.name));
+  enabledToolOptions(): Array<{ value: string; label: string }> {
+    return this.tools()
+      .filter(t => !this.disabledTools.has(t.name))
+      .map(t => ({ value: t.name, label: t.description ? `${t.name} — ${t.description}` : t.name }));
   }
 
   enable(name: string): void {

--- a/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
@@ -32,7 +32,7 @@ import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonCo
           <app-text-input [value]="emailConfig.host" placeholder="smtp.gmail.com" (valueChange)="emailConfig.host = $event" />
         </app-form-field>
         <app-form-field label="SMTP Port">
-          <app-text-input [value]="'' + emailConfig.port" type="number" (valueChange)="emailConfig.port = +$event" />
+          <app-text-input [value]="'' + emailConfig.port" type="number" (valueChange)="emailConfig.port = parsePort($event)" />
         </app-form-field>
         <app-form-field label="SMTP User">
           <app-text-input [value]="emailConfig.user" (valueChange)="emailConfig.user = $event" />
@@ -129,6 +129,11 @@ export class NotificationChannelDialogComponent implements OnInit {
         };
       }
     }
+  }
+
+  parsePort(val: string): number {
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) ? 587 : n;
   }
 
   save(): void {

--- a/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
@@ -1,95 +1,82 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import {
   NotificationChannelService,
   NotificationChannel,
 } from '../../core/services/notification-channel.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-notification-channel-dialog-content',
   standalone: true,
   imports: [
-    FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatButtonModule,
-    MatProgressSpinnerModule,
+    FormFieldComponent,
+    TextInputComponent,
+    SelectComponent,
+    BroncoButtonComponent,
   ],
   template: `
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Name</mat-label>
-      <input matInput [(ngModel)]="name" placeholder="e.g. My Email, Pushover Mobile" />
-    </mat-form-field>
+    <div class="form-grid">
+      <app-form-field label="Name">
+        <app-text-input [value]="name" placeholder="e.g. My Email, Pushover Mobile" (valueChange)="name = $event" />
+      </app-form-field>
 
-    @if (!isEdit) {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Type</mat-label>
-        <mat-select [(ngModel)]="type">
-          <mat-option value="EMAIL">Email (SMTP)</mat-option>
-          <mat-option value="PUSHOVER">Pushover</mat-option>
-        </mat-select>
-      </mat-form-field>
-    }
+      @if (!isEdit) {
+        <app-form-field label="Type">
+          <app-select [value]="type" [options]="typeOptions" (valueChange)="type = $event" />
+        </app-form-field>
+      }
 
-    @if (type === 'EMAIL') {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>SMTP Host</mat-label>
-        <input matInput [(ngModel)]="emailConfig.host" placeholder="smtp.gmail.com" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="half-width">
-        <mat-label>SMTP Port</mat-label>
-        <input matInput type="number" [(ngModel)]="emailConfig.port" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>SMTP User</mat-label>
-        <input matInput [(ngModel)]="emailConfig.user" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>SMTP Password</mat-label>
-        <input matInput type="password" [(ngModel)]="emailConfig.password" placeholder="{{ isEdit ? '(unchanged)' : '' }}" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>From Address</mat-label>
-        <input matInput [(ngModel)]="emailConfig.from" placeholder="alerts@example.com" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Send Alerts To</mat-label>
-        <input matInput [(ngModel)]="emailConfig.to" placeholder="you@example.com" />
-      </mat-form-field>
-    }
+      @if (type === 'EMAIL') {
+        <app-form-field label="SMTP Host">
+          <app-text-input [value]="emailConfig.host" placeholder="smtp.gmail.com" (valueChange)="emailConfig.host = $event" />
+        </app-form-field>
+        <app-form-field label="SMTP Port">
+          <app-text-input [value]="'' + emailConfig.port" type="number" (valueChange)="emailConfig.port = +$event" />
+        </app-form-field>
+        <app-form-field label="SMTP User">
+          <app-text-input [value]="emailConfig.user" (valueChange)="emailConfig.user = $event" />
+        </app-form-field>
+        <app-form-field label="SMTP Password">
+          <app-text-input
+            [value]="emailConfig.password"
+            type="password"
+            [placeholder]="isEdit ? '(unchanged)' : ''"
+            (valueChange)="emailConfig.password = $event" />
+        </app-form-field>
+        <app-form-field label="From Address">
+          <app-text-input [value]="emailConfig.from" placeholder="alerts@example.com" (valueChange)="emailConfig.from = $event" />
+        </app-form-field>
+        <app-form-field label="Send Alerts To">
+          <app-text-input [value]="emailConfig.to" placeholder="you@example.com" (valueChange)="emailConfig.to = $event" />
+        </app-form-field>
+      }
 
-    @if (type === 'PUSHOVER') {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>App Token</mat-label>
-        <input matInput [(ngModel)]="pushoverConfig.appToken" placeholder="{{ isEdit ? '(unchanged)' : '' }}" />
-      </mat-form-field>
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>User Key</mat-label>
-        <input matInput [(ngModel)]="pushoverConfig.userKey" placeholder="{{ isEdit ? '(unchanged)' : '' }}" />
-      </mat-form-field>
-    }
+      @if (type === 'PUSHOVER') {
+        <app-form-field label="App Token">
+          <app-text-input
+            [value]="pushoverConfig.appToken"
+            [placeholder]="isEdit ? '(unchanged)' : ''"
+            (valueChange)="pushoverConfig.appToken = $event" />
+        </app-form-field>
+        <app-form-field label="User Key">
+          <app-text-input
+            [value]="pushoverConfig.userKey"
+            [placeholder]="isEdit ? '(unchanged)' : ''"
+            (valueChange)="pushoverConfig.userKey = $event" />
+        </app-form-field>
+      }
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="saving">
-        @if (saving) {
-          <mat-spinner diameter="18"></mat-spinner>
-        } @else {
-          {{ isEdit ? 'Save' : 'Create' }}
-        }
-      </button>
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="saving" (click)="save()">
+        {{ saving ? 'Saving…' : (isEdit ? 'Save' : 'Create') }}
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; }
-    .half-width { width: 50%; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -105,6 +92,11 @@ export class NotificationChannelDialogComponent implements OnInit {
   saving = false;
   name = '';
   type: string = 'EMAIL';
+
+  typeOptions = [
+    { value: 'EMAIL', label: 'Email (SMTP)' },
+    { value: 'PUSHOVER', label: 'Pushover' },
+  ];
 
   emailConfig = {
     host: '',

--- a/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
@@ -41,7 +41,7 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButton
       </app-form-field>
 
       <app-form-field label="Sort Order">
-        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = +$event" />
+        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = parseSortOrder($event)" />
       </app-form-field>
 
       @if (!isCreate) {
@@ -94,6 +94,11 @@ export class CategoryConfigDialogComponent implements OnInit {
       this.sortOrder = c.sortOrder;
       this.isActive = c.isActive;
     }
+  }
+
+  parseSortOrder(val: string): number {
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) ? 0 : n;
   }
 
   canSave(): boolean {

--- a/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
@@ -1,78 +1,69 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import {
   SettingsService,
   TicketCategoryConfig,
 } from '../../core/services/settings.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-category-config-dialog-content',
   standalone: true,
   imports: [
     FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatCheckboxModule,
+    FormFieldComponent,
+    TextInputComponent,
+    TextareaComponent,
+    BroncoButtonComponent,
   ],
   template: `
-    @if (isCreate) {
-      <mat-form-field class="full-width">
-        <mat-label>Value</mat-label>
-        <input matInput [(ngModel)]="value" placeholder="e.g. DATABASE_PERF" required>
-        <mat-hint>Must match a valid TicketCategory enum value</mat-hint>
-      </mat-form-field>
-    }
+    <div class="form-grid">
+      @if (isCreate) {
+        <app-form-field label="Value" hint="Must match a valid TicketCategory enum value">
+          <app-text-input [value]="value" placeholder="e.g. DATABASE_PERF" (valueChange)="value = $event" />
+        </app-form-field>
+      }
 
-    <mat-form-field class="full-width">
-      <mat-label>Display Name</mat-label>
-      <input matInput [(ngModel)]="displayName">
-    </mat-form-field>
+      <app-form-field label="Display Name">
+        <app-text-input [value]="displayName" (valueChange)="displayName = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Description</mat-label>
-      <textarea matInput [(ngModel)]="description" rows="2"></textarea>
-    </mat-form-field>
+      <app-form-field label="Description">
+        <app-textarea [value]="description" [rows]="2" (valueChange)="description = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Color</mat-label>
-      <input matInput [(ngModel)]="color" placeholder="#2196f3">
-      <div matSuffix class="color-preview" [style.background]="color"></div>
-    </mat-form-field>
+      <app-form-field label="Color">
+        <div class="color-row">
+          <app-text-input [value]="color" placeholder="#2196f3" (valueChange)="color = $event" />
+          <span class="color-preview" [style.background]="color"></span>
+        </div>
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Sort Order</mat-label>
-      <input matInput type="number" [(ngModel)]="sortOrder" min="0">
-    </mat-form-field>
+      <app-form-field label="Sort Order">
+        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = +$event" />
+      </app-form-field>
 
-    @if (!isCreate) {
-      <mat-checkbox [(ngModel)]="isActive" class="active-checkbox">
-        Active
-      </mat-checkbox>
-    }
+      @if (!isCreate) {
+        <label class="checkbox-row">
+          <input type="checkbox" [(ngModel)]="isActive">
+          <span>Active</span>
+        </label>
+      }
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!canSave()" (click)="save()">
         {{ isCreate ? 'Create' : 'Update' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
-    .active-checkbox { display: block; margin: 8px 0 16px; }
-    .color-preview {
-      width: 24px;
-      height: 24px;
-      border-radius: 4px;
-      border: 1px solid #ccc;
-      display: inline-block;
-    }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .color-row { display: flex; align-items: center; gap: 8px; }
+    .color-preview { width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-medium); display: inline-block; flex-shrink: 0; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text-secondary); cursor: pointer; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })

--- a/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
@@ -33,7 +33,7 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
       </app-form-field>
 
       <app-form-field label="Timeout (ms)">
-        <app-text-input [value]="'' + timeoutMs" type="number" (valueChange)="timeoutMs = +$event" />
+        <app-text-input [value]="'' + timeoutMs" type="number" (valueChange)="timeoutMs = parseTimeout($event)" />
       </app-form-field>
 
       <label class="checkbox-row">
@@ -108,6 +108,11 @@ export class ExternalServiceDialogComponent implements OnInit {
       case 'DOCKER': return 'Docker container name';
       default: return 'Full URL to probe';
     }
+  }
+
+  parseTimeout(val: string): number {
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) || n <= 0 ? 5000 : n;
   }
 
   save(): void {

--- a/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
@@ -1,74 +1,61 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import {
   ExternalServiceService,
   ExternalService,
 } from '../../core/services/external-service.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-external-service-dialog-content',
   standalone: true,
   imports: [
     FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatButtonModule,
-    MatCheckboxModule,
+    FormFieldComponent,
+    TextInputComponent,
+    TextareaComponent,
+    SelectComponent,
+    BroncoButtonComponent,
   ],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Name</mat-label>
-      <input matInput [(ngModel)]="name" placeholder="e.g. Ollama (Local LLM)">
-      <mat-hint>Display name shown on System Status page</mat-hint>
-    </mat-form-field>
+    <div class="form-grid">
+      <app-form-field label="Name" hint="Display name shown on System Status page">
+        <app-text-input [value]="name" placeholder="e.g. Ollama (Local LLM)" (valueChange)="name = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Endpoint</mat-label>
-      <input matInput [(ngModel)]="endpoint" [placeholder]="endpointPlaceholder()">
-      <mat-hint>{{ endpointHint() }}</mat-hint>
-    </mat-form-field>
+      <app-form-field label="Endpoint" [hint]="endpointHint()">
+        <app-text-input [value]="endpoint" [placeholder]="endpointPlaceholder()" (valueChange)="endpoint = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Check Type</mat-label>
-      <mat-select [(ngModel)]="checkType">
-        <mat-option value="HTTP">HTTP — Generic health check</mat-option>
-        <mat-option value="OLLAMA">Ollama — Model info via /api/tags</mat-option>
-        <mat-option value="DOCKER">Docker — Container state check</mat-option>
-      </mat-select>
-      <mat-hint>How to verify the service is healthy</mat-hint>
-    </mat-form-field>
+      <app-form-field label="Check Type" hint="How to verify the service is healthy">
+        <app-select [value]="checkType" [options]="checkTypeOptions" (valueChange)="checkType = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Timeout (ms)</mat-label>
-      <input matInput type="number" [(ngModel)]="timeoutMs" min="1000" max="30000">
-    </mat-form-field>
+      <app-form-field label="Timeout (ms)">
+        <app-text-input [value]="'' + timeoutMs" type="number" (valueChange)="timeoutMs = +$event" />
+      </app-form-field>
 
-    <mat-checkbox [(ngModel)]="isMonitored" class="monitor-checkbox">
-      Include in System Status monitoring
-    </mat-checkbox>
+      <label class="checkbox-row">
+        <input type="checkbox" [(ngModel)]="isMonitored">
+        <span>Include in System Status monitoring</span>
+      </label>
 
-    <mat-form-field class="full-width">
-      <mat-label>Notes</mat-label>
-      <textarea matInput [(ngModel)]="notes" rows="2"></textarea>
-    </mat-form-field>
+      <app-form-field label="Notes">
+        <app-textarea [value]="notes" [rows]="2" (valueChange)="notes = $event" />
+      </app-form-field>
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!name || !endpoint">
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!name || !endpoint" (click)="save()">
         {{ isEdit ? 'Update' : 'Create' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
-    .monitor-checkbox { display: block; margin: 8px 0 16px; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text-secondary); cursor: pointer; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -87,6 +74,12 @@ export class ExternalServiceDialogComponent implements OnInit {
   timeoutMs = 5000;
   isMonitored = true;
   notes = '';
+
+  checkTypeOptions = [
+    { value: 'HTTP', label: 'HTTP — Generic health check' },
+    { value: 'OLLAMA', label: 'Ollama — Model info via /api/tags' },
+    { value: 'DOCKER', label: 'Docker — Container state check' },
+  ];
 
   ngOnInit(): void {
     const s = this.service();

--- a/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
@@ -42,7 +42,7 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
       </app-form-field>
 
       <app-form-field label="Sort Order">
-        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = +$event" />
+        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = parseSortOrder($event)" />
       </app-form-field>
 
       <app-form-field label="Status Class" hint="Determines whether tickets with this status are considered active or terminal">
@@ -106,6 +106,11 @@ export class StatusConfigDialogComponent implements OnInit {
       this.statusClass = (c.statusClass as 'open' | 'closed') ?? 'open';
       this.isActive = c.isActive;
     }
+  }
+
+  parseSortOrder(val: string): number {
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) ? 0 : n;
   }
 
   setStatusClass(val: string): void {

--- a/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
@@ -1,89 +1,74 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCheckboxModule } from '@angular/material/checkbox';
 import {
   SettingsService,
   TicketStatusConfig,
 } from '../../core/services/settings.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-status-config-dialog-content',
   standalone: true,
   imports: [
     FormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatButtonModule,
-    MatCheckboxModule,
+    FormFieldComponent,
+    TextInputComponent,
+    TextareaComponent,
+    SelectComponent,
+    BroncoButtonComponent,
   ],
   template: `
-    @if (isCreate) {
-      <mat-form-field class="full-width">
-        <mat-label>Value</mat-label>
-        <input matInput [(ngModel)]="value" placeholder="e.g. OPEN" required>
-        <mat-hint>Must match a valid TicketStatus enum value</mat-hint>
-      </mat-form-field>
-    }
+    <div class="form-grid">
+      @if (isCreate) {
+        <app-form-field label="Value" hint="Must match a valid TicketStatus enum value">
+          <app-text-input [value]="value" placeholder="e.g. OPEN" (valueChange)="value = $event" />
+        </app-form-field>
+      }
 
-    <mat-form-field class="full-width">
-      <mat-label>Display Name</mat-label>
-      <input matInput [(ngModel)]="displayName">
-    </mat-form-field>
+      <app-form-field label="Display Name">
+        <app-text-input [value]="displayName" (valueChange)="displayName = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Description</mat-label>
-      <textarea matInput [(ngModel)]="description" rows="2"></textarea>
-    </mat-form-field>
+      <app-form-field label="Description">
+        <app-textarea [value]="description" [rows]="2" (valueChange)="description = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Color</mat-label>
-      <input matInput [(ngModel)]="color" placeholder="#2196f3">
-      <div matSuffix class="color-preview" [style.background]="color"></div>
-    </mat-form-field>
+      <app-form-field label="Color">
+        <div class="color-row">
+          <app-text-input [value]="color" placeholder="#2196f3" (valueChange)="color = $event" />
+          <span class="color-preview" [style.background]="color"></span>
+        </div>
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Sort Order</mat-label>
-      <input matInput type="number" [(ngModel)]="sortOrder" min="0">
-    </mat-form-field>
+      <app-form-field label="Sort Order">
+        <app-text-input [value]="'' + sortOrder" type="number" (valueChange)="sortOrder = +$event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Status Class</mat-label>
-      <mat-select [(ngModel)]="statusClass">
-        <mat-option value="open">Open</mat-option>
-        <mat-option value="closed">Closed</mat-option>
-      </mat-select>
-      <mat-hint>Determines whether tickets with this status are considered active or terminal</mat-hint>
-    </mat-form-field>
+      <app-form-field label="Status Class" hint="Determines whether tickets with this status are considered active or terminal">
+        <app-select [value]="statusClass" [options]="statusClassOptions" (valueChange)="setStatusClass($event)" />
+      </app-form-field>
 
-    @if (!isCreate) {
-      <mat-checkbox [(ngModel)]="isActive" class="active-checkbox">
-        Active
-      </mat-checkbox>
-    }
+      @if (!isCreate) {
+        <label class="checkbox-row">
+          <input type="checkbox" [(ngModel)]="isActive">
+          <span>Active</span>
+        </label>
+      }
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!canSave()">
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!canSave()" (click)="save()">
         {{ isCreate ? 'Create' : 'Update' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
-    .active-checkbox { display: block; margin: 8px 0 16px; }
-    .color-preview {
-      width: 24px;
-      height: 24px;
-      border-radius: 4px;
-      border: 1px solid #ccc;
-      display: inline-block;
-    }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
+    .color-row { display: flex; align-items: center; gap: 8px; }
+    .color-preview { width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-medium); display: inline-block; flex-shrink: 0; }
+    .checkbox-row { display: flex; align-items: center; gap: 8px; font-size: 14px; color: var(--text-secondary); cursor: pointer; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -104,6 +89,11 @@ export class StatusConfigDialogComponent implements OnInit {
   statusClass: 'open' | 'closed' = 'open';
   isActive = true;
 
+  statusClassOptions = [
+    { value: 'open', label: 'Open' },
+    { value: 'closed', label: 'Closed' },
+  ];
+
   ngOnInit(): void {
     const c = this.config();
     if (c) {
@@ -116,6 +106,10 @@ export class StatusConfigDialogComponent implements OnInit {
       this.statusClass = (c.statusClass as 'open' | 'closed') ?? 'open';
       this.isActive = c.isActive;
     }
+  }
+
+  setStatusClass(val: string): void {
+    this.statusClass = val as 'open' | 'closed';
   }
 
   canSave(): boolean {

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -84,6 +84,10 @@ export class UserDialogComponent implements OnInit {
 
   save(): void {
     const u = this.user();
+    if (!u && this.password.length < 8) {
+      this.toast.error('Password must be at least 8 characters');
+      return;
+    }
     if (u) {
       this.userService.updateUser(u.id, {
         name: this.name,

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -1,59 +1,50 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatButtonModule } from '@angular/material/button';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-user-dialog-content',
   standalone: true,
-  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatButtonModule, MatSlideToggleModule],
+  imports: [FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Name</mat-label>
-      <input matInput [(ngModel)]="name" required>
-    </mat-form-field>
-    <mat-form-field class="full-width">
-      <mat-label>Email</mat-label>
-      <input matInput [(ngModel)]="email" type="email" required>
-    </mat-form-field>
-    @if (!user()) {
-      <mat-form-field class="full-width">
-        <mat-label>Password</mat-label>
-        <input matInput [(ngModel)]="password" type="password" required minlength="8">
-      </mat-form-field>
-    }
-    <mat-form-field class="full-width">
-      <mat-label>Role</mat-label>
-      <mat-select [(ngModel)]="role">
-        <mat-option value="ADMIN">Admin</mat-option>
-        <mat-option value="OPERATOR">Operator</mat-option>
-      </mat-select>
-    </mat-form-field>
-    @if (role === 'OPERATOR' || role === 'ADMIN') {
-      <mat-form-field class="full-width">
-        <mat-label>Slack User ID</mat-label>
-        <input matInput [(ngModel)]="slackUserId" placeholder="U0123456789">
-        <mat-hint>Click user profile in Slack → More → Copy member ID</mat-hint>
-      </mat-form-field>
-    }
-    @if (user() && !isSelf) {
-      <mat-slide-toggle [(ngModel)]="isActive">{{ isActive ? 'Active' : 'Inactive' }}</mat-slide-toggle>
-    }
+    <div class="form-grid">
+      <app-form-field label="Name">
+        <app-text-input [value]="name" (valueChange)="name = $event" />
+      </app-form-field>
+      <app-form-field label="Email">
+        <app-text-input [value]="email" type="email" (valueChange)="email = $event" />
+      </app-form-field>
+      @if (!user()) {
+        <app-form-field label="Password">
+          <app-text-input [value]="password" type="password" (valueChange)="password = $event" />
+        </app-form-field>
+      }
+      <app-form-field label="Role">
+        <app-select [value]="role" [options]="roleOptions" (valueChange)="role = $event" />
+      </app-form-field>
+      @if (role === 'OPERATOR' || role === 'ADMIN') {
+        <app-form-field label="Slack User ID" hint="Click user profile in Slack → More → Copy member ID">
+          <app-text-input [value]="slackUserId" placeholder="U0123456789" (valueChange)="slackUserId = $event" />
+        </app-form-field>
+      }
+      @if (user() && !isSelf) {
+        <app-toggle-switch
+          [checked]="isActive"
+          [label]="isActive ? 'Active' : 'Inactive'"
+          (checkedChange)="isActive = $event" />
+      }
+    </div>
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="cancelled.emit()">Cancel</button>
-      <button mat-raised-button color="primary" (click)="save()" [disabled]="!name || !email || (!user() && !password)">
+      <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!name || !email || (!user() && !password)" (click)="save()">
         {{ user() ? 'Update' : 'Create' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -73,6 +64,11 @@ export class UserDialogComponent implements OnInit {
   slackUserId = '';
   isActive = true;
   isSelf = false;
+
+  roleOptions = [
+    { value: 'ADMIN', label: 'Admin' },
+    { value: 'OPERATOR', label: 'Operator' },
+  ];
 
   ngOnInit(): void {
     const u = this.user();

--- a/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
@@ -1,16 +1,9 @@
 import { Component, DestroyRef, inject, input, output, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { AiProviderService } from '../../core/services/ai-provider.service';
 import type { AiHelpResponse } from '../../core/services/ticket.service';
 import { ToastService } from '../../core/services/toast.service';
+import { FormFieldComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from './index.js';
 
 /** @deprecated Use AiHelpResponse from ticket.service instead. */
 export type AiHelpDialogResult = AiHelpResponse;
@@ -25,34 +18,35 @@ interface ModelOption {
 @Component({
   selector: 'app-ai-help-dialog-content',
   standalone: true,
-  imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule, MatInputModule, MatButtonModule, MatIconModule, MatProgressBarModule],
+  imports: [FormFieldComponent, TextareaComponent, SelectComponent, BroncoButtonComponent],
   template: `
-    <mat-form-field class="full-width">
-      <mat-label>Model</mat-label>
-      <mat-select [(ngModel)]="selectedModel">
-        <mat-option value="">Default (auto-routed)</mat-option>
-        @for (m of modelOptions(); track m.provider + ':' + m.model) {
-          <mat-option [value]="m.provider + ':' + m.model">{{ m.label }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+    <div class="form-grid">
+      <app-form-field label="Model">
+        <app-select
+          [value]="selectedModel"
+          [options]="modelSelectOptions"
+          [placeholder]="''"
+          (valueChange)="selectedModel = $event" />
+      </app-form-field>
 
-    <mat-form-field class="full-width">
-      <mat-label>Question</mat-label>
-      <textarea matInput [(ngModel)]="question" rows="4"
-        placeholder="e.g. What should I investigate first?"
-        (keydown.meta.enter)="!loading() && submit()"
-        (keydown.control.enter)="!loading() && submit()"></textarea>
-    </mat-form-field>
+      <app-form-field label="Question">
+        <app-textarea
+          [value]="question"
+          [rows]="4"
+          placeholder="e.g. What should I investigate first?"
+          (valueChange)="question = $event"
+          (keydown.meta.enter)="!loading() && submit()"
+          (keydown.control.enter)="!loading() && submit()" />
+      </app-form-field>
+    </div>
 
     @if (loading()) {
-      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+      <div class="progress-bar"><div class="progress-bar-fill"></div></div>
     }
 
     @if (response()) {
       <div class="ai-response">
         <div class="ai-response-header">
-          <mat-icon>auto_awesome</mat-icon>
           <span>AI Response</span>
           <span class="ai-provider">{{ response()!.provider }} / {{ response()!.model }}</span>
         </div>
@@ -65,21 +59,26 @@ interface ModelOption {
     }
 
     <div class="dialog-actions" dialogFooter>
-      <button mat-button (click)="closed.emit()">Close</button>
-      <button mat-raised-button color="accent" (click)="submit()" [disabled]="loading()">
-        <mat-icon>{{ loading() ? 'hourglass_empty' : 'auto_awesome' }}</mat-icon>
+      <app-bronco-button variant="ghost" (click)="closed.emit()">Close</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="loading()" (click)="submit()">
         {{ loading() ? 'Thinking...' : 'Ask AI' }}
-      </button>
+      </app-bronco-button>
     </div>
   `,
   styles: [`
-    .full-width { width: 100%; margin-bottom: 8px; }
-    .ai-response { margin-top: 12px; padding: 12px; background: #f3e5f5; border-radius: 8px; max-height: 400px; overflow-y: auto; }
-    .ai-response-header { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; font-weight: 500; color: #6a1b9a; }
-    .ai-response-header mat-icon { font-size: 18px; width: 18px; height: 18px; }
-    .ai-provider { font-size: 11px; color: #666; font-family: monospace; margin-left: auto; }
+    .form-grid { display: flex; flex-direction: column; gap: 12px; margin-bottom: 12px; }
+    .progress-bar { height: 3px; background: var(--bg-muted); border-radius: 2px; overflow: hidden; margin-bottom: 12px; }
+    .progress-bar-fill { height: 100%; background: var(--accent); animation: progress-indeterminate 1.5s ease-in-out infinite; transform-origin: left; }
+    @keyframes progress-indeterminate {
+      0% { transform: translateX(-100%) scaleX(0.4); }
+      50% { transform: translateX(60%) scaleX(0.4); }
+      100% { transform: translateX(200%) scaleX(0.4); }
+    }
+    .ai-response { margin-top: 12px; padding: 12px; background: var(--color-purple-subtle); border-radius: var(--radius-md); max-height: 400px; overflow-y: auto; }
+    .ai-response-header { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; font-weight: 500; color: var(--color-purple); }
+    .ai-provider { font-size: 11px; color: var(--text-tertiary); font-family: monospace; margin-left: auto; }
     .ai-response-content { white-space: pre-wrap; line-height: 1.6; font-size: 13px; }
-    .error-msg { margin-top: 12px; padding: 8px 12px; background: #ffebee; color: #c62828; border-radius: 4px; font-size: 13px; }
+    .error-msg { margin-top: 12px; padding: 8px 12px; background: var(--color-error-subtle); color: var(--color-error); border-radius: var(--radius-sm); font-size: 13px; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -97,6 +96,13 @@ export class AiHelpDialogComponent implements OnInit {
   loading = signal(false);
   response = signal<AiHelpResponse | null>(null);
   errorMsg = signal<string | null>(null);
+
+  get modelSelectOptions(): Array<{ value: string; label: string }> {
+    return [
+      { value: '', label: 'Default (auto-routed)' },
+      ...this.modelOptions().map(m => ({ value: `${m.provider}:${m.model}`, label: m.label })),
+    ];
+  }
 
   ngOnInit(): void {
     this.providerService.listModels()

--- a/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
@@ -41,7 +41,7 @@ interface ModelOption {
     </div>
 
     @if (loading()) {
-      <div class="progress-bar"><div class="progress-bar-fill"></div></div>
+      <div class="progress-bar" role="progressbar" aria-label="Loading AI response" aria-busy="true"><div class="progress-bar-fill"></div></div>
     }
 
     @if (response()) {


### PR DESCRIPTION
## Summary
This PR migrates the control panel application from Angular Material components to a custom Bronco design system. All dialog components and form-heavy features now use custom form field, input, select, button, and other UI components instead of Material Design equivalents.

## Key Changes

- **Removed Material dependencies**: Eliminated imports of `MatFormFieldModule`, `MatInputModule`, `MatSelectModule`, `MatButtonModule`, `MatSlideToggleModule`, `MatIconModule`, `MatCheckboxModule`, `MatProgressSpinnerModule`, `MatProgressBarModule`, and `MatChipsModule` from all affected components.

- **Introduced Bronco components**: Added imports and usage of custom components:
  - `FormFieldComponent` - replaces `mat-form-field`
  - `TextInputComponent` - replaces `matInput` with `input`
  - `TextareaComponent` - replaces `matInput` with `textarea`
  - `SelectComponent` - replaces `mat-select`
  - `ToggleSwitchComponent` - replaces `mat-slide-toggle`
  - `BroncoButtonComponent` - replaces `mat-button` and `mat-raised-button`

- **Updated form binding patterns**: Converted from two-way binding (`[(ngModel)]`) to one-way binding with `(valueChange)` events for better control and consistency with the new component API.

- **Refactored dialog templates**: Wrapped form fields in `<div class="form-grid">` containers and replaced Material-specific attributes (e.g., `matInput`, `matLabel`, `matSuffix`, `matHint`) with Bronco component properties.

- **Updated button styling**: Replaced Material button variants (`mat-button`, `mat-raised-button`, `mat-stroked-button`) with `BroncoButtonComponent` using `variant` property (e.g., `variant="primary"`, `variant="ghost"`, `variant="secondary"`).

- **Simplified checkbox implementation**: Replaced `mat-checkbox` with native `<input type="checkbox">` wrapped in custom label styling.

- **Removed icon dependencies**: Removed `mat-icon` usage; icons are now handled through CSS or removed where not critical to functionality.

## Affected Components
- Integration dialog
- Notification channel dialog
- Status config dialog
- Model cost dialog
- External service dialog
- Category config dialog
- User dialog
- AI help dialog
- MCP tool visibility dialog
- Contact dialog

## Implementation Details
- Form options (like select dropdowns) are now defined as component properties and passed to `SelectComponent` via `[options]` binding
- Numeric input conversions are handled explicitly in value change handlers (e.g., `+$event` for number conversion)
- Conditional hints are passed directly to `FormFieldComponent` via `[hint]` property
- Color preview elements are now custom spans instead of Material suffixes
- Progress indicators use custom CSS-based progress bars instead of `mat-progress-bar`

https://claude.ai/code/session_01LknmnLN2Fy1hFv3CMXaru8