### PR TITLE
Migrate client-detail page to design system + split into per-tab components (refs #131)

### DIFF
--- a/.tmp/.gitignore
+++ b/.tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -12,15 +12,14 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
 import { ClientService, Client } from '../../core/services/client.service';
-import { RepoService, CodeRepo } from '../../core/services/repo.service';
 import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service';
 import { TicketService, Ticket } from '../../core/services/ticket.service';
-import { RepoDialogComponent } from '../repos/repo-dialog.component';
 import { IntegrationDialogComponent } from '../integrations/integration-dialog.component';
 import { TicketDialogComponent } from '../tickets/ticket-dialog.component';
 import { DialogComponent } from '../../shared/components/dialog.component';
 import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
 import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.component';
+import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
 import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
 import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
 import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
@@ -61,10 +60,10 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
-    ClientSystemsTabComponent, ClientContactsTabComponent,
+    ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent,
     DialogComponent, TicketDialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
-    RepoDialogComponent, IntegrationDialogComponent,
+    IntegrationDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -80,42 +79,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Repos">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Code Repositories</h3>
-              <button mat-raised-button color="primary" (click)="addRepo()">
-                <mat-icon>add</mat-icon> Add Repo
-              </button>
-            </div>
-            <table mat-table [dataSource]="repos()" class="full-width">
-              <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Name</th>
-                <td mat-cell *matCellDef="let r">{{ r.name }}</td>
-              </ng-container>
-              <ng-container matColumnDef="repoUrl">
-                <th mat-header-cell *matHeaderCellDef>URL</th>
-                <td mat-cell *matCellDef="let r"><code>{{ r.repoUrl }}</code></td>
-              </ng-container>
-              <ng-container matColumnDef="branch">
-                <th mat-header-cell *matHeaderCellDef>Branch</th>
-                <td mat-cell *matCellDef="let r">{{ r.defaultBranch }}</td>
-              </ng-container>
-              <ng-container matColumnDef="prefix">
-                <th mat-header-cell *matHeaderCellDef>Prefix</th>
-                <td mat-cell *matCellDef="let r">{{ r.branchPrefix }}/</td>
-              </ng-container>
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let r">
-                  <button mat-icon-button aria-label="Edit repository" (click)="editRepo(r)" matTooltip="Edit"><mat-icon>edit</mat-icon></button>
-                  <button mat-icon-button color="warn" aria-label="Delete repository" (click)="deleteRepo(r)" matTooltip="Delete"><mat-icon>delete</mat-icon></button>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="repoColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: repoColumns;"></tr>
-            </table>
-            @if (repos().length === 0) { <p class="empty">No repositories configured.</p> }
-          </div>
+          <app-client-repos-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Integrations">
@@ -577,16 +541,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       </app-dialog>
     }
 
-    @if (showRepoDialog()) {
-      <app-dialog [open]="true" [title]="editingRepo() ? 'Edit Code Repository' : 'Add Code Repository'" maxWidth="500px" (openChange)="showRepoDialog.set(false)">
-        <app-repo-dialog-content
-          [clientId]="id()"
-          [repo]="editingRepo() ?? undefined"
-          (saved)="onRepoSaved()"
-          (cancelled)="showRepoDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showIntegrationDialog()) {
       <app-dialog [open]="true" [title]="editingIntegration() ? 'Edit Integration' : 'Add Integration'" maxWidth="600px" (openChange)="showIntegrationDialog.set(false)">
         <app-integration-dialog-content
@@ -658,7 +612,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private repoService = inject(RepoService);
   private integrationService = inject(IntegrationService);
   private ticketService = inject(TicketService);
   private memoryService = inject(ClientMemoryService);
@@ -673,7 +626,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  repos = signal<CodeRepo[]>([]);
   integrations = signal<ClientIntegration[]>([]);
   tickets = signal<Ticket[]>([]);
   memories = signal<ClientMemory[]>([]);
@@ -691,7 +643,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  repoColumns = ['name', 'repoUrl', 'branch', 'prefix', 'actions'];
   ticketColumns = ['subject', 'status', 'priority', 'category'];
   clientUserColumns = ['name', 'email', 'userType', 'isActiveUser', 'lastLogin', 'userActions'];
   invoiceColumns = ['invoiceNumber', 'period', 'requests', 'totalBilled', 'invoiceStatus', 'invoiceActions'];
@@ -731,7 +682,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.repoService.getRepos(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(r => this.repos.set(r));
     this.integrationService.getIntegrations(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.integrations.set(i));
     this.ticketService.getTickets({ clientId: cid, limit: 20 }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => this.tickets.set(t));
     this.memoryService.getMemories({ clientId: cid }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(m => { this.memories.set(m); this.filterMemories(); });
@@ -784,34 +734,6 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  addRepo(): void {
-    this.editingRepo.set(null);
-    this.showRepoDialog.set(true);
-  }
-
-  editRepo(repo: CodeRepo): void {
-    this.editingRepo.set(repo);
-    this.showRepoDialog.set(true);
-  }
-
-  onRepoSaved(): void {
-    this.showRepoDialog.set(false);
-    this.load();
-  }
-
-  deleteRepo(repo: CodeRepo): void {
-    if (!confirm(`Delete repo "${repo.name}"?`)) return;
-    this.repoService.deleteRepo(repo.id).subscribe({
-      next: () => {
-        this.toast.success('Repository deleted');
-        this.load();
-      },
-      error: (err) => {
-        this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed');
-      },
-    });
-  }
-
   addIntegration(): void {
     this.editingIntegration.set(null);
     this.showIntegrationDialog.set(true);
@@ -830,8 +752,6 @@ export class ClientDetailComponent implements OnInit {
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-  showRepoDialog = signal(false);
-  editingRepo = signal<CodeRepo | null>(null);
   showIntegrationDialog = signal(false);
   editingIntegration = signal<ClientIntegration | null>(null);
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -19,10 +19,9 @@ import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.componen
 import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component';
 import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component';
 import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component';
+import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
 import { ClientUserDialogComponent } from './client-user-dialog.component';
-import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service';
-import { ClientEnvironmentDialogComponent } from './client-environment-dialog.component';
 import { InvoiceService, type Invoice } from '../../core/services/invoice.service';
 import { GenerateInvoiceDialogComponent } from './generate-invoice-dialog.component';
 import { ClientAiCredentialService, type ClientAiCredential } from '../../core/services/client-ai-credential.service';
@@ -57,9 +56,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
-    ClientTicketsTabComponent, ClientMemoryTabComponent,
+    ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent,
     DialogComponent,
-    ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
+    ClientUserDialogComponent, GenerateInvoiceDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -91,40 +90,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Environments">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Environments</h3>
-              <button mat-raised-button color="primary" (click)="addEnvironment()">
-                <mat-icon>add</mat-icon> Add Environment
-              </button>
-            </div>
-            @for (env of environments(); track env.id) {
-              <mat-card class="env-card" [class.inactive-card]="!env.isActive">
-                <mat-card-content>
-                  <div class="env-header">
-                    <mat-icon>cloud</mat-icon>
-                    <strong>{{ env.name }}</strong>
-                    <span class="tag-chip">{{ env.tag }}</span>
-                    @if (env.isDefault) {
-                      <span class="default-chip">Default</span>
-                    }
-                    <mat-slide-toggle [checked]="env.isActive" (change)="toggleEnvironment(env, $event.checked)">
-                      {{ env.isActive ? 'Active' : 'Inactive' }}
-                    </mat-slide-toggle>
-                    <span class="spacer"></span>
-                    <button mat-icon-button (click)="editEnvironment(env)"><mat-icon>edit</mat-icon></button>
-                    <button mat-icon-button color="warn" (click)="deleteEnvironment(env)"><mat-icon>delete</mat-icon></button>
-                  </div>
-                  @if (env.description) { <p class="env-desc">{{ env.description }}</p> }
-                  @if (env.operationalInstructions) {
-                    <pre class="memory-content">{{ env.operationalInstructions | slice:0:200 }}{{ env.operationalInstructions.length > 200 ? '...' : '' }}</pre>
-                  }
-                </mat-card-content>
-              </mat-card>
-            } @empty {
-              <p class="empty">No environments configured. Add environments (e.g. Production, Development) to group systems, repos, and integrations.</p>
-            }
-          </div>
+          <app-client-environments-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Users">
@@ -367,16 +333,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       <p>Loading...</p>
     }
 
-    @if (showEnvironmentDialog()) {
-      <app-dialog [open]="true" [title]="editingEnvironment() ? 'Edit Environment' : 'Add Environment'" maxWidth="650px" (openChange)="showEnvironmentDialog.set(false)">
-        <app-client-environment-dialog-content
-          [clientId]="id()"
-          [environment]="editingEnvironment() ?? undefined"
-          (saved)="onEnvironmentSaved()"
-          (cancelled)="showEnvironmentDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showUserDialog()) {
       <app-dialog [open]="true" [title]="editingUser() ? 'Edit User' : 'Create Portal User'" maxWidth="500px" (openChange)="showUserDialog.set(false)">
         <app-client-user-dialog-content
@@ -458,7 +414,6 @@ export class ClientDetailComponent implements OnInit {
 
   private clientService = inject(ClientService);
   private clientUserService = inject(ClientUserService);
-  private envService = inject(ClientEnvironmentService);
   private invoiceService = inject(InvoiceService);
   private credentialService = inject(ClientAiCredentialService);
   private aiUsageService = inject(AiUsageService);
@@ -469,7 +424,6 @@ export class ClientDetailComponent implements OnInit {
 
   client = signal<Client | null>(null);
   clientUsers = signal<ClientUser[]>([]);
-  environments = signal<ClientEnvironment[]>([]);
   invoices = signal<Invoice[]>([]);
   aiCredentials = signal<ClientAiCredential[]>([]);
   aiUsageSummary = signal<AiUsageClientSummary | null>(null);
@@ -519,7 +473,6 @@ export class ClientDetailComponent implements OnInit {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
     this.clientUserService.getUsers(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(u => this.clientUsers.set(u));
-    this.envService.getEnvironments(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(e => this.environments.set(e));
     this.invoiceService.getInvoices(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.invoices.set(i));
     this.credentialService.getCredentials(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.aiCredentials.set(c));
   }
@@ -567,48 +520,9 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  showEnvironmentDialog = signal(false);
-  editingEnvironment = signal<ClientEnvironment | null>(null);
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-
-  addEnvironment(): void {
-    this.editingEnvironment.set(null);
-    this.showEnvironmentDialog.set(true);
-  }
-
-  editEnvironment(env: ClientEnvironment): void {
-    this.editingEnvironment.set(env);
-    this.showEnvironmentDialog.set(true);
-  }
-
-  onEnvironmentSaved(): void {
-    this.showEnvironmentDialog.set(false);
-    this.load();
-  }
-
-  toggleEnvironment(env: ClientEnvironment, checked: boolean): void {
-    this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: checked } : e));
-    this.envService.updateEnvironment(this.id(), env.id, { isActive: checked }).subscribe({
-      next: () => this.toast.success(`Environment ${checked ? 'enabled' : 'disabled'}`),
-      error: (err) => {
-        this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: !checked } : e));
-        this.toast.error(err.error?.error ?? err.error?.message ?? 'Toggle failed');
-      },
-    });
-  }
-
-  deleteEnvironment(env: ClientEnvironment): void {
-    if (!confirm(`Delete environment "${env.name}"? Linked integrations, repos, and systems will be unlinked.`)) return;
-    this.envService.deleteEnvironment(this.id(), env.id).subscribe({
-      next: () => {
-        this.toast.success('Environment deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.error ?? err.error?.message ?? 'Delete failed'),
-    });
-  }
 
   addClientUser(): void {
     this.editingUser.set(null);

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -12,17 +12,15 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
 import { ClientService, Client } from '../../core/services/client.service';
-import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service';
 import { TicketService, Ticket } from '../../core/services/ticket.service';
-import { IntegrationDialogComponent } from '../integrations/integration-dialog.component';
 import { TicketDialogComponent } from '../tickets/ticket-dialog.component';
 import { DialogComponent } from '../../shared/components/dialog.component';
 import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
 import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.component';
 import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
+import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component';
 import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
 import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
-import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
 import { ClientUserDialogComponent } from './client-user-dialog.component';
 import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service';
@@ -56,14 +54,13 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
 @Component({
   standalone: true,
   imports: [
-    RouterLink, JsonPipe, DatePipe, SlicePipe, DecimalPipe, MatCardModule, MatButtonModule, MatIconModule,
-    MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
+    RouterLink, DatePipe, SlicePipe, DecimalPipe, MatCardModule, MatButtonModule, MatIconModule,
+    MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule,
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
-    ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent,
+    ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
     DialogComponent, TicketDialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
-    IntegrationDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -83,49 +80,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Integrations">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Integrations</h3>
-              <button mat-raised-button color="primary" (click)="addIntegration()">
-                <mat-icon>add</mat-icon> Add Integration
-              </button>
-            </div>
-            @for (integ of integrations(); track integ.id) {
-              <mat-card class="integration-card">
-                <mat-card-content>
-                  <div class="integ-header">
-                    <mat-icon>{{ integrationIcon(integ.type) }}</mat-icon>
-                    <strong>{{ integ.type }}</strong>
-                    @if (integ.label && integ.label !== 'default') {
-                      <span class="label-chip">{{ integ.label }}</span>
-                    }
-                    <mat-slide-toggle [checked]="integ.isActive" (change)="toggleIntegration(integ, $event.checked)">
-                      {{ integ.isActive ? 'Active' : 'Inactive' }}
-                    </mat-slide-toggle>
-                    <span class="spacer"></span>
-                    <button mat-icon-button (click)="editIntegration(integ)">
-                      <mat-icon>edit</mat-icon>
-                    </button>
-                    <button mat-icon-button color="warn" (click)="deleteIntegration(integ.id)">
-                      <mat-icon>delete</mat-icon>
-                    </button>
-                  </div>
-                  @if (integ.notes) { <p class="integ-notes">{{ integ.notes }}</p> }
-                  @if (integ.type === 'MCP_DATABASE' && integ.metadata) {
-                    <app-mcp-server-info
-                      [metadata]="integ.metadata"
-                      [integrationId]="integ.id"
-                      (verified)="load()"
-                    />
-                  } @else {
-                    <pre class="config-preview">{{ redactConfig(integ.config) | json }}</pre>
-                  }
-                </mat-card-content>
-              </mat-card>
-            } @empty {
-              <p class="empty">No integrations configured. Add IMAP, Azure DevOps, or MCP Database integrations.</p>
-            }
-          </div>
+          <app-client-integrations-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Tickets">
@@ -540,16 +495,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
           (cancelled)="showInvoiceDialog.set(false)" />
       </app-dialog>
     }
-
-    @if (showIntegrationDialog()) {
-      <app-dialog [open]="true" [title]="editingIntegration() ? 'Edit Integration' : 'Add Integration'" maxWidth="600px" (openChange)="showIntegrationDialog.set(false)">
-        <app-integration-dialog-content
-          [clientId]="id()"
-          [integration]="editingIntegration() ?? undefined"
-          (saved)="onIntegrationSaved()"
-          (cancelled)="showIntegrationDialog.set(false)" />
-      </app-dialog>
-    }
   `,
   styles: [`
     .tab-content { padding: 16px 0; }
@@ -612,7 +557,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private integrationService = inject(IntegrationService);
   private ticketService = inject(TicketService);
   private memoryService = inject(ClientMemoryService);
   private clientUserService = inject(ClientUserService);
@@ -626,7 +570,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  integrations = signal<ClientIntegration[]>([]);
   tickets = signal<Ticket[]>([]);
   memories = signal<ClientMemory[]>([]);
   memSourceFilter = '';
@@ -682,7 +625,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.integrationService.getIntegrations(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.integrations.set(i));
     this.ticketService.getTickets({ clientId: cid, limit: 20 }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => this.tickets.set(t));
     this.memoryService.getMemories({ clientId: cid }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(m => { this.memories.set(m); this.filterMemories(); });
     this.clientUserService.getUsers(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(u => this.clientUsers.set(u));
@@ -734,16 +676,6 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  addIntegration(): void {
-    this.editingIntegration.set(null);
-    this.showIntegrationDialog.set(true);
-  }
-
-  onIntegrationSaved(): void {
-    this.showIntegrationDialog.set(false);
-    this.load();
-  }
-
   showTicketDialog = signal(false);
   showMemoryDialog = signal(false);
   editingMemory = signal<ClientMemory | null>(null);
@@ -752,8 +684,6 @@ export class ClientDetailComponent implements OnInit {
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-  showIntegrationDialog = signal(false);
-  editingIntegration = signal<ClientIntegration | null>(null);
 
   createTicket(): void {
     this.showTicketDialog.set(true);
@@ -762,37 +692,6 @@ export class ClientDetailComponent implements OnInit {
   onTicketCreated(_result: { id: string }): void {
     this.showTicketDialog.set(false);
     this.load();
-  }
-
-  toggleIntegration(integ: ClientIntegration, checked: boolean): void {
-    // Optimistic update so toggle doesn't snap back
-    this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: checked } : i));
-    this.integrationService.updateIntegration(integ.id, { isActive: checked }).subscribe({
-      next: () => {
-        this.toast.success(`Integration ${checked ? 'enabled' : 'disabled'}`);
-      },
-      error: (err) => {
-        // Revert optimistic update and reload authoritative state
-        this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: !checked } : i));
-        this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
-        this.load();
-      },
-    });
-  }
-
-  editIntegration(integ: ClientIntegration): void {
-    this.editingIntegration.set(integ);
-    this.showIntegrationDialog.set(true);
-  }
-
-  deleteIntegration(id: string): void {
-    this.integrationService.deleteIntegration(id).subscribe({
-      next: () => {
-        this.toast.success('Integration deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
-    });
   }
 
   filterMemories(): void {
@@ -885,25 +784,6 @@ export class ClientDetailComponent implements OnInit {
       case 'PLAYBOOK': return 'menu_book';
       case 'TOOL_GUIDANCE': return 'build';
       default: return 'psychology';
-    }
-  }
-
-  redactConfig(config: Record<string, unknown>): Record<string, unknown> {
-    const sensitiveKeys = ['encryptedPassword', 'encryptedPat', 'password', 'pat', 'token', 'secret', 'apiKey'];
-    const redacted: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(config)) {
-      redacted[key] = sensitiveKeys.includes(key) ? '********' : value;
-    }
-    return redacted;
-  }
-
-  integrationIcon(type: string): string {
-    switch (type) {
-      case 'IMAP': return 'email';
-      case 'AZURE_DEVOPS': return 'developer_board';
-      case 'MCP_DATABASE': return 'dns';
-      case 'SLACK': return 'chat';
-      default: return 'extension';
     }
   }
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -836,16 +836,16 @@ export class ClientDetailComponent implements OnInit {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
     if (tabParam !== null) {
       const tab = Number(tabParam);
-      if (Number.isInteger(tab) && tab >= 0 && tab <= 7) this.selectedTab.set(tab);
+      if (Number.isInteger(tab) && tab >= 0 && tab <= 10) this.selectedTab.set(tab);
     }
     this.load();
-    if (this.selectedTab() === 7) this.loadAiUsage();
+    if (this.selectedTab() === 10) this.loadAiUsage();
   }
 
   onTabChange(index: number): void {
     this.selectedTab.set(index);
     this.router.navigate([], { queryParams: { tab: index }, queryParamsHandling: 'merge', replaceUrl: true });
-    if (index === 7 && !this.aiUsageSummary()) this.loadAiUsage();
+    if (index === 10 && !this.aiUsageSummary()) this.loadAiUsage();
   }
 
   load(): void {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -11,18 +11,17 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
-import { ClientService, Client, System, Contact } from '../../core/services/client.service';
-import { SystemService } from '../../core/services/system.service';
+import { ClientService, Client, Contact } from '../../core/services/client.service';
 import { ContactService } from '../../core/services/contact.service';
 import { RepoService, CodeRepo } from '../../core/services/repo.service';
 import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service';
 import { TicketService, Ticket } from '../../core/services/ticket.service';
-import { SystemDialogComponent } from '../systems/system-dialog.component';
 import { ContactDialogComponent } from '../contacts/contact-dialog.component';
 import { RepoDialogComponent } from '../repos/repo-dialog.component';
 import { IntegrationDialogComponent } from '../integrations/integration-dialog.component';
 import { TicketDialogComponent } from '../tickets/ticket-dialog.component';
 import { DialogComponent } from '../../shared/components/dialog.component';
+import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
 import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
 import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
 import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
@@ -63,9 +62,10 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
+    ClientSystemsTabComponent,
     DialogComponent, TicketDialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
-    SystemDialogComponent, RepoDialogComponent, ContactDialogComponent, IntegrationDialogComponent,
+    RepoDialogComponent, ContactDialogComponent, IntegrationDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -73,41 +73,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
 
       <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="onTabChange($event)">
         <app-tab label="Systems">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Database Systems</h3>
-              <button mat-raised-button color="primary" (click)="addSystem()">
-                <mat-icon>add</mat-icon> Add System
-              </button>
-            </div>
-            <table mat-table [dataSource]="systems()" class="full-width">
-              <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Name</th>
-                <td mat-cell *matCellDef="let s">{{ s.name }}</td>
-              </ng-container>
-              <ng-container matColumnDef="dbEngine">
-                <th mat-header-cell *matHeaderCellDef>Engine</th>
-                <td mat-cell *matCellDef="let s"><span class="engine-chip">{{ s.dbEngine }}</span></td>
-              </ng-container>
-              <ng-container matColumnDef="host">
-                <th mat-header-cell *matHeaderCellDef>Host</th>
-                <td mat-cell *matCellDef="let s"><code>{{ s.host }}:{{ s.port }}</code></td>
-              </ng-container>
-              <ng-container matColumnDef="environment">
-                <th mat-header-cell *matHeaderCellDef>Env</th>
-                <td mat-cell *matCellDef="let s">{{ s.environment }}</td>
-              </ng-container>
-              <ng-container matColumnDef="status">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let s">
-                  <mat-chip [class.inactive]="!s.isActive">{{ s.isActive ? 'Active' : 'Inactive' }}</mat-chip>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="systemColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: systemColumns;"></tr>
-            </table>
-            @if (systems().length === 0) { <p class="empty">No systems configured.</p> }
-          </div>
+          <app-client-systems-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Contacts">
@@ -649,15 +615,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       </app-dialog>
     }
 
-    @if (showSystemDialog()) {
-      <app-dialog [open]="true" title="Add Database System" maxWidth="600px" (openChange)="showSystemDialog.set(false)">
-        <app-system-dialog-content
-          [clientId]="id()"
-          (saved)="onSystemSaved()"
-          (cancelled)="showSystemDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showRepoDialog()) {
       <app-dialog [open]="true" [title]="editingRepo() ? 'Edit Code Repository' : 'Add Code Repository'" maxWidth="500px" (openChange)="showRepoDialog.set(false)">
         <app-repo-dialog-content
@@ -749,7 +706,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private systemService = inject(SystemService);
   private contactService = inject(ContactService);
   private repoService = inject(RepoService);
   private integrationService = inject(IntegrationService);
@@ -766,7 +722,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  systems = signal<System[]>([]);
   contacts = signal<Contact[]>([]);
   repos = signal<CodeRepo[]>([]);
   integrations = signal<ClientIntegration[]>([]);
@@ -786,7 +741,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  systemColumns = ['name', 'dbEngine', 'host', 'environment', 'status'];
   contactColumns = ['name', 'email', 'role', 'isPrimary', 'actions'];
   repoColumns = ['name', 'repoUrl', 'branch', 'prefix', 'actions'];
   ticketColumns = ['subject', 'status', 'priority', 'category'];
@@ -828,7 +782,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.systemService.getSystems(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(s => this.systems.set(s));
     this.contactService.getContacts(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.contacts.set(c));
     this.repoService.getRepos(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(r => this.repos.set(r));
     this.integrationService.getIntegrations(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.integrations.set(i));
@@ -881,15 +834,6 @@ export class ClientDetailComponent implements OnInit {
 
   onClientUpdated(updated: Client): void {
     this.client.set(updated);
-  }
-
-  addSystem(): void {
-    this.showSystemDialog.set(true);
-  }
-
-  onSystemSaved(): void {
-    this.showSystemDialog.set(false);
-    this.load();
   }
 
   addContact(): void {
@@ -963,7 +907,6 @@ export class ClientDetailComponent implements OnInit {
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-  showSystemDialog = signal(false);
   showRepoDialog = signal(false);
   editingRepo = signal<CodeRepo | null>(null);
   showContactDialog = signal(false);

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -23,12 +23,11 @@ import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environment
 import { ClientUsersTabComponent } from './client-detail/tabs/users-tab.component';
 import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component';
 import { ClientInvoicesTabComponent } from './client-detail/tabs/invoices-tab.component';
+import { ClientAiUsageTabComponent } from './client-detail/tabs/ai-usage-tab.component';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { AiUsageService, type AiUsageClientSummary, type AiUsageLogEntry } from '../../core/services/ai-usage.service';
-import { ToastService } from '../../core/services/toast.service';
 
 const CLIENT_DETAIL_TAB_SLUGS = [
   'systems',
@@ -44,7 +43,6 @@ const CLIENT_DETAIL_TAB_SLUGS = [
   'ai-usage',
 ] as const;
 type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
-const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
 
 @Component({
   standalone: true,
@@ -55,8 +53,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
     ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent, ClientUsersTabComponent,
-    ClientAiCredentialsTabComponent, ClientInvoicesTabComponent,
-    DialogComponent,
+    ClientAiCredentialsTabComponent, ClientInvoicesTabComponent, ClientAiUsageTabComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -103,75 +100,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="AI Usage">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>AI Usage</h3>
-              <button mat-raised-button (click)="loadAiUsage()">
-                <mat-icon>refresh</mat-icon> Refresh
-              </button>
-            </div>
-            @if (aiUsageLoading()) {
-              <p>Loading AI usage data...</p>
-            } @else if (aiUsageSummary()) {
-              <div class="kpi-grid">
-                @for (w of aiUsageSummary()!.windows; track w.label) {
-                  <mat-card class="kpi-card">
-                    <mat-card-header><mat-card-title>{{ w.label }}</mat-card-title></mat-card-header>
-                    <mat-card-content>
-                      <div class="kpi-row"><span class="kpi-label">Tokens In</span><span class="kpi-value">{{ w.inputTokens | number }}</span></div>
-                      <div class="kpi-row"><span class="kpi-label">Tokens Out</span><span class="kpi-value">{{ w.outputTokens | number }}</span></div>
-                      <div class="kpi-row"><span class="kpi-label">Base Cost</span><span class="kpi-value">\${{ w.baseCostUsd | number:'1.4-4' }}</span></div>
-                      <div class="kpi-row"><span class="kpi-label">Billed Cost</span><span class="kpi-value kpi-billed">\${{ w.billedCostUsd | number:'1.4-4' }}</span></div>
-                      <div class="kpi-row"><span class="kpi-label">Requests</span><span class="kpi-value">{{ w.requestCount | number }}</span></div>
-                    </mat-card-content>
-                  </mat-card>
-                }
-              </div>
-              <p class="markup-note">Billing markup: {{ aiUsageSummary()!.billingMarkupPercent }}x</p>
-
-              <h4>Prompt Log</h4>
-              <div class="log-nav">
-                <button mat-button [disabled]="aiUsagePage() <= 0" (click)="aiUsagePrevPage()">Previous</button>
-                <span>Page {{ aiUsagePage() + 1 }} of {{ aiUsageTotalPages() }}</span>
-                <button mat-button [disabled]="aiUsagePage() >= aiUsageTotalPages() - 1" (click)="aiUsageNextPage()">Next</button>
-              </div>
-              <table mat-table [dataSource]="aiUsageLogs()" class="full-width">
-                <ng-container matColumnDef="createdAt">
-                  <th mat-header-cell *matHeaderCellDef>Time</th>
-                  <td mat-cell *matCellDef="let l">{{ l.createdAt | date:'short' }}</td>
-                </ng-container>
-                <ng-container matColumnDef="taskType">
-                  <th mat-header-cell *matHeaderCellDef>Task</th>
-                  <td mat-cell *matCellDef="let l">{{ l.taskType }}</td>
-                </ng-container>
-                <ng-container matColumnDef="model">
-                  <th mat-header-cell *matHeaderCellDef>Model</th>
-                  <td mat-cell *matCellDef="let l">{{ l.model }}</td>
-                </ng-container>
-                <ng-container matColumnDef="provider">
-                  <th mat-header-cell *matHeaderCellDef>Provider</th>
-                  <td mat-cell *matCellDef="let l">{{ l.provider }}</td>
-                </ng-container>
-                <ng-container matColumnDef="inputTokens">
-                  <th mat-header-cell *matHeaderCellDef>In</th>
-                  <td mat-cell *matCellDef="let l">{{ l.inputTokens | number }}</td>
-                </ng-container>
-                <ng-container matColumnDef="outputTokens">
-                  <th mat-header-cell *matHeaderCellDef>Out</th>
-                  <td mat-cell *matCellDef="let l">{{ l.outputTokens | number }}</td>
-                </ng-container>
-                <ng-container matColumnDef="costUsd">
-                  <th mat-header-cell *matHeaderCellDef>Cost</th>
-                  <td mat-cell *matCellDef="let l">{{ l.costUsd != null ? '\$' + (l.costUsd | number:'1.4-4') : '-' }}</td>
-                </ng-container>
-                <tr mat-header-row *matHeaderRowDef="aiUsageLogColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: aiUsageLogColumns;"></tr>
-              </table>
-              @if (aiUsageLogs().length === 0) { <p class="empty">No AI usage logs for this client.</p> }
-            } @else {
-              <p class="empty">No AI usage data available. Click Refresh to load.</p>
-            }
-          </div>
+          <app-client-ai-usage-tab [clientId]="id()" />
         </app-tab>
       </app-tab-group>
     } @else {
@@ -240,23 +169,12 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private aiUsageService = inject(AiUsageService);
   private destroyRef = inject(DestroyRef);
-  private toast = inject(ToastService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  aiUsageSummary = signal<AiUsageClientSummary | null>(null);
-  aiUsageLogs = signal<AiUsageLogEntry[]>([]);
-  aiUsageLoading = signal(false);
-  aiUsagePage = signal(0);
-  aiUsageTotal = signal(0);
-  aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
-
-  aiUsageLogColumns = ['createdAt', 'taskType', 'model', 'provider', 'inputTokens', 'outputTokens', 'costUsd'];
-  private readonly AI_USAGE_PAGE_SIZE = 25;
 
   ngOnInit(): void {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
@@ -273,58 +191,17 @@ export class ClientDetailComponent implements OnInit {
       }
     }
     this.load();
-    if (this.selectedTab() === AI_USAGE_TAB_INDEX) this.loadAiUsage();
   }
 
   onTabChange(index: number): void {
     this.selectedTab.set(index);
     const slug: ClientDetailTabSlug = CLIENT_DETAIL_TAB_SLUGS[index] ?? CLIENT_DETAIL_TAB_SLUGS[0];
     this.router.navigate([], { queryParams: { tab: slug }, queryParamsHandling: 'merge', replaceUrl: true });
-    if (index === AI_USAGE_TAB_INDEX && !this.aiUsageSummary()) this.loadAiUsage();
   }
 
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-  }
-
-  loadAiUsage(): void {
-    const cid = this.id();
-    this.aiUsageLoading.set(true);
-    this.aiUsageService.getClientSummary(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (summary) => {
-        this.aiUsageSummary.set(summary);
-        this.aiUsageLoading.set(false);
-      },
-      error: () => this.aiUsageLoading.set(false),
-    });
-    this.loadAiUsageLogs();
-  }
-
-  private loadAiUsageLogs(): void {
-    const cid = this.id();
-    const page = this.aiUsagePage();
-    this.aiUsageService.getClientLogs(cid, { limit: this.AI_USAGE_PAGE_SIZE, offset: page * this.AI_USAGE_PAGE_SIZE })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((res) => {
-        this.aiUsageLogs.set(res.logs);
-        this.aiUsageTotal.set(res.total);
-        this.aiUsageTotalPages.set(Math.max(1, Math.ceil(res.total / this.AI_USAGE_PAGE_SIZE)));
-      });
-  }
-
-  aiUsagePrevPage(): void {
-    if (this.aiUsagePage() > 0) {
-      this.aiUsagePage.update(p => p - 1);
-      this.loadAiUsageLogs();
-    }
-  }
-
-  aiUsageNextPage(): void {
-    if (this.aiUsagePage() < this.aiUsageTotalPages() - 1) {
-      this.aiUsagePage.update(p => p + 1);
-      this.loadAiUsageLogs();
-    }
   }
 
   onClientUpdated(updated: Client): void {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -40,6 +40,22 @@ import { MatSelectModule } from '@angular/material/select';
 import { AiUsageService, type AiUsageClientSummary, type AiUsageLogEntry } from '../../core/services/ai-usage.service';
 import { ToastService } from '../../core/services/toast.service';
 
+const CLIENT_DETAIL_TAB_SLUGS = [
+  'systems',
+  'contacts',
+  'repos',
+  'integrations',
+  'tickets',
+  'memory',
+  'environments',
+  'users',
+  'ai-credentials',
+  'invoices',
+  'ai-usage',
+] as const;
+type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
+const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
+
 @Component({
   standalone: true,
   imports: [
@@ -835,17 +851,26 @@ export class ClientDetailComponent implements OnInit {
   ngOnInit(): void {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
     if (tabParam !== null) {
-      const tab = Number(tabParam);
-      if (Number.isInteger(tab) && tab >= 0 && tab <= 10) this.selectedTab.set(tab);
+      const slugIdx = (CLIENT_DETAIL_TAB_SLUGS as readonly string[]).indexOf(tabParam);
+      if (slugIdx >= 0) {
+        this.selectedTab.set(slugIdx);
+      } else {
+        // Backwards compat: numeric ?tab=N from older bookmarks.
+        const tab = Number(tabParam);
+        if (Number.isInteger(tab) && tab >= 0 && tab < CLIENT_DETAIL_TAB_SLUGS.length) {
+          this.selectedTab.set(tab);
+        }
+      }
     }
     this.load();
-    if (this.selectedTab() === 10) this.loadAiUsage();
+    if (this.selectedTab() === AI_USAGE_TAB_INDEX) this.loadAiUsage();
   }
 
   onTabChange(index: number): void {
     this.selectedTab.set(index);
-    this.router.navigate([], { queryParams: { tab: index }, queryParamsHandling: 'merge', replaceUrl: true });
-    if (index === 10 && !this.aiUsageSummary()) this.loadAiUsage();
+    const slug: ClientDetailTabSlug = CLIENT_DETAIL_TAB_SLUGS[index] ?? CLIENT_DETAIL_TAB_SLUGS[0];
+    this.router.navigate([], { queryParams: { tab: slug }, queryParamsHandling: 'merge', replaceUrl: true });
+    if (index === AI_USAGE_TAB_INDEX && !this.aiUsageSummary()) this.loadAiUsage();
   }
 
   load(): void {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -12,13 +12,12 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
 import { ClientService, Client } from '../../core/services/client.service';
-import { TicketService, Ticket } from '../../core/services/ticket.service';
-import { TicketDialogComponent } from '../tickets/ticket-dialog.component';
 import { DialogComponent } from '../../shared/components/dialog.component';
 import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
 import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.component';
 import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
 import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component';
+import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component';
 import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
 import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
@@ -59,7 +58,8 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
-    DialogComponent, TicketDialogComponent,
+    ClientTicketsTabComponent,
+    DialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
   ],
   template: `
@@ -84,39 +84,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Tickets">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Tickets</h3>
-              <button mat-raised-button color="primary" (click)="createTicket()">
-                <mat-icon>add</mat-icon> Create Ticket
-              </button>
-            </div>
-            <table mat-table [dataSource]="tickets()" class="full-width">
-              <ng-container matColumnDef="subject">
-                <th mat-header-cell *matHeaderCellDef>Subject</th>
-                <td mat-cell *matCellDef="let t">
-                  <a [routerLink]="['/tickets', t.id]" class="link">{{ t.subject }}</a>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="status">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let t">{{ t.status }}</td>
-              </ng-container>
-              <ng-container matColumnDef="priority">
-                <th mat-header-cell *matHeaderCellDef>Priority</th>
-                <td mat-cell *matCellDef="let t">
-                  <span class="priority priority-{{ t.priority.toLowerCase() }}">{{ t.priority }}</span>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="category">
-                <th mat-header-cell *matHeaderCellDef>Category</th>
-                <td mat-cell *matCellDef="let t">{{ t.category ?? '-' }}</td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="ticketColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: ticketColumns;"></tr>
-            </table>
-            @if (tickets().length === 0) { <p class="empty">No tickets for this client.</p> }
-          </div>
+          <app-client-tickets-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Memory">
@@ -448,15 +416,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       <p>Loading...</p>
     }
 
-    @if (showTicketDialog()) {
-      <app-dialog [open]="true" title="Create Ticket" maxWidth="560px" (openChange)="showTicketDialog.set(false)">
-        <app-ticket-dialog-content
-          [clientId]="id()"
-          (created)="onTicketCreated($event)"
-          (cancelled)="showTicketDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showMemoryDialog()) {
       <app-dialog [open]="true" [title]="editingMemory() ? 'Edit Client Memory' : 'Add Client Memory'" maxWidth="650px" (openChange)="showMemoryDialog.set(false)">
         <app-client-memory-dialog-content
@@ -557,7 +516,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private ticketService = inject(TicketService);
   private memoryService = inject(ClientMemoryService);
   private clientUserService = inject(ClientUserService);
   private envService = inject(ClientEnvironmentService);
@@ -570,7 +528,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  tickets = signal<Ticket[]>([]);
   memories = signal<ClientMemory[]>([]);
   memSourceFilter = '';
   filteredMemories = signal<ClientMemory[]>([]);
@@ -586,7 +543,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  ticketColumns = ['subject', 'status', 'priority', 'category'];
   clientUserColumns = ['name', 'email', 'userType', 'isActiveUser', 'lastLogin', 'userActions'];
   invoiceColumns = ['invoiceNumber', 'period', 'requests', 'totalBilled', 'invoiceStatus', 'invoiceActions'];
   credentialColumns = ['provider', 'label', 'key', 'credStatus', 'credActions'];
@@ -625,7 +581,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.ticketService.getTickets({ clientId: cid, limit: 20 }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => this.tickets.set(t));
     this.memoryService.getMemories({ clientId: cid }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(m => { this.memories.set(m); this.filterMemories(); });
     this.clientUserService.getUsers(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(u => this.clientUsers.set(u));
     this.envService.getEnvironments(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(e => this.environments.set(e));
@@ -676,7 +631,6 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  showTicketDialog = signal(false);
   showMemoryDialog = signal(false);
   editingMemory = signal<ClientMemory | null>(null);
   showEnvironmentDialog = signal(false);
@@ -684,15 +638,6 @@ export class ClientDetailComponent implements OnInit {
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-
-  createTicket(): void {
-    this.showTicketDialog.set(true);
-  }
-
-  onTicketCreated(_result: { id: string }): void {
-    this.showTicketDialog.set(false);
-    this.load();
-  }
 
   filterMemories(): void {
     const all = this.memories();

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -1,18 +1,9 @@
 import { Component, DestroyRef, inject, OnInit, signal, input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { JsonPipe, DatePipe, SlicePipe, DecimalPipe } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatTableModule } from '@angular/material/table';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
 import { ClientService, Client } from '../../core/services/client.service';
-import { DialogComponent } from '../../shared/components/dialog.component';
 import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
 import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.component';
 import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
@@ -24,10 +15,6 @@ import { ClientUsersTabComponent } from './client-detail/tabs/users-tab.componen
 import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component';
 import { ClientInvoicesTabComponent } from './client-detail/tabs/invoices-tab.component';
 import { ClientAiUsageTabComponent } from './client-detail/tabs/ai-usage-tab.component';
-import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
 
 const CLIENT_DETAIL_TAB_SLUGS = [
   'systems',
@@ -47,9 +34,6 @@ type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
 @Component({
   standalone: true,
   imports: [
-    RouterLink, DatePipe, SlicePipe, DecimalPipe, MatCardModule, MatButtonModule, MatIconModule,
-    MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule,
-    FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
     ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent, ClientUsersTabComponent,
@@ -91,6 +75,7 @@ type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
         <app-tab label="Users">
           <app-client-users-tab [clientId]="id()" />
         </app-tab>
+
         <app-tab label="AI Credentials">
           <app-client-ai-credentials-tab [clientId]="id()" />
         </app-tab>
@@ -104,65 +89,19 @@ type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
         </app-tab>
       </app-tab-group>
     } @else {
-      <p>Loading...</p>
+      <p class="loading">Loading…</p>
     }
-
   `,
   styles: [`
-    .tab-content { padding: 16px 0; }
-    .tab-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
-    .tab-header h3 { margin: 0; }
-    .full-width { width: 100%; }
-    .link { text-decoration: none; color: #3f51b5; }
-    .engine-chip { font-size: 11px; padding: 2px 6px; background: #e0f2f1; border-radius: 4px; color: #00695c; font-family: monospace; }
-    .inactive { opacity: 0.5; }
-    .primary-icon { color: #f9a825; font-size: 20px; }
-    .empty { color: #999; padding: 16px; text-align: center; }
-    .integration-card { margin-bottom: 12px; }
-    .integ-header { display: flex; align-items: center; gap: 8px; }
-    .integ-notes { color: #666; margin: 8px 0 4px; }
-    .label-chip { font-size: 11px; padding: 2px 6px; background: #e8f5e9; border-radius: 4px; color: #2e7d32; font-family: monospace; }
-    .config-preview { background: #f5f5f5; padding: 8px 12px; border-radius: 4px; font-size: 12px; overflow-x: auto; }
-    .spacer { flex: 1; }
-    .priority { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 4px; }
-    .priority-critical { background: #ffebee; color: #c62828; }
-    .priority-high { background: #fff3e0; color: #e65100; }
-    .priority-medium { background: #e3f2fd; color: #1565c0; }
-    .priority-low { background: #e8f5e9; color: #2e7d32; }
-    code { font-size: 13px; }
-    .memory-card { margin-bottom: 12px; }
-    .memory-card.inactive-card { opacity: 0.5; }
-    .memory-header { display: flex; align-items: center; gap: 8px; }
-    .type-chip { font-size: 11px; padding: 2px 6px; border-radius: 4px; font-family: monospace; }
-    .type-context { background: #e3f2fd; color: #1565c0; }
-    .type-playbook { background: #fce4ec; color: #c62828; }
-    .type-tool_guidance { background: #f3e5f5; color: #6a1b9a; }
-    .source-badge { font-size: 9px; font-weight: 700; padding: 1px 5px; border-radius: 3px; text-transform: uppercase; letter-spacing: 0.3px; }
-    .source-manual { background: #f5f5f5; color: #999; }
-    .source-ai_learned { background: #ede7f6; color: #6a1b9a; }
-    .category-chip { font-size: 11px; padding: 2px 6px; background: #fff3e0; color: #e65100; border-radius: 4px; }
-    .tags { display: flex; gap: 4px; margin: 8px 0 4px; flex-wrap: wrap; }
-    .tag-chip { font-size: 11px; padding: 2px 6px; background: #f5f5f5; color: #616161; border-radius: 4px; }
-    .memory-content { background: #fafafa; padding: 8px 12px; border-radius: 4px; font-size: 12px; white-space: pre-wrap; word-wrap: break-word; max-height: 200px; overflow-y: auto; }
-    .type-admin { background: #e3f2fd; color: #1565c0; }
-    .env-card { margin-bottom: 12px; }
-    .env-card.inactive-card { opacity: 0.5; }
-    .env-header { display: flex; align-items: center; gap: 8px; }
-    .env-desc { color: #666; margin: 8px 0 4px; }
-    .default-chip { font-size: 11px; padding: 2px 6px; background: #e3f2fd; color: #1565c0; border-radius: 4px; font-weight: 600; }
-    .status-final { background: #e8f5e9; color: #2e7d32; }
-    .add-cred-card { margin-top: 16px; }
-    .add-cred-card h4 { margin: 0 0 12px; }
-    .cred-form { display: flex; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
-    .cred-form mat-form-field { flex: 1; min-width: 160px; }
-    .kpi-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 12px; }
-    .kpi-card { }
-    .kpi-row { display: flex; justify-content: space-between; padding: 2px 0; }
-    .kpi-label { color: #666; font-size: 13px; }
-    .kpi-value { font-weight: 500; font-family: monospace; font-size: 13px; }
-    .kpi-billed { color: #2e7d32; font-weight: 600; }
-    .markup-note { color: #888; font-size: 12px; margin-bottom: 16px; }
-    .log-nav { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+    :host { display: block; }
+
+    .loading {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      padding: 32px 16px;
+      text-align: center;
+    }
   `],
 })
 export class ClientDetailComponent implements OnInit {
@@ -207,6 +146,4 @@ export class ClientDetailComponent implements OnInit {
   onClientUpdated(updated: Client): void {
     this.client.set(updated);
   }
-
-
 }

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -3,13 +3,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { JsonPipe, DatePipe, SlicePipe, DecimalPipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
+import { ClientHeaderComponent } from './client-detail/client-header.component';
 import { ClientService, Client, System, Contact } from '../../core/services/client.service';
 import { SystemService } from '../../core/services/system.service';
 import { ContactService } from '../../core/services/contact.service';
@@ -32,7 +33,6 @@ import { ClientEnvironmentDialogComponent } from './client-environment-dialog.co
 import { InvoiceService, type Invoice } from '../../core/services/invoice.service';
 import { GenerateInvoiceDialogComponent } from './generate-invoice-dialog.component';
 import { ClientAiCredentialService, type ClientAiCredential } from '../../core/services/client-ai-credential.service';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -59,58 +59,20 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
 @Component({
   standalone: true,
   imports: [
-    RouterLink, JsonPipe, DatePipe, SlicePipe, DecimalPipe, MatCardModule, MatTabsModule, MatButtonModule, MatIconModule,
+    RouterLink, JsonPipe, DatePipe, SlicePipe, DecimalPipe, MatCardModule, MatButtonModule, MatIconModule,
     MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
-    MatButtonToggleModule, FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
+    FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
+    TabGroupComponent, TabComponent, ClientHeaderComponent,
     DialogComponent, TicketDialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
     SystemDialogComponent, RepoDialogComponent, ContactDialogComponent, IntegrationDialogComponent,
   ],
   template: `
     @if (client(); as c) {
-      <div class="page-header">
-        <div>
-          <a routerLink="/clients" class="back-link">Clients</a> /
-          <h1 class="inline">{{ c.name }}</h1>
-          <span class="code-chip">{{ c.shortCode }}</span>
-        </div>
-        <div class="header-toggles">
-          <mat-slide-toggle [checked]="c.autoRouteTickets" (change)="toggleAutoRoute(c)">
-            {{ c.autoRouteTickets ? 'Auto-Route' : 'Manual Only' }}
-          </mat-slide-toggle>
-          <mat-slide-toggle [checked]="c.allowSelfRegistration" (change)="toggleSelfRegistration(c)">
-            {{ c.allowSelfRegistration ? 'Self-Registration' : 'No Self-Reg' }}
-          </mat-slide-toggle>
-          <mat-slide-toggle [checked]="c.isActive" (change)="toggleActive(c)">
-            {{ c.isActive ? 'Active' : 'Inactive' }}
-          </mat-slide-toggle>
-          <mat-button-toggle-group [value]="c.aiMode" (change)="setAiMode(c, $event.value)">
-            <mat-button-toggle value="platform">Platform</mat-button-toggle>
-            <mat-button-toggle value="byok">BYOK</mat-button-toggle>
-          </mat-button-toggle-group>
-        </div>
-      </div>
+      <app-client-header [client]="c" (clientChange)="onClientUpdated($event)" />
 
-      @if (c.domainMappings.length) {
-        <p class="domains">Domains: {{ c.domainMappings.join(', ') }}</p>
-      }
-      @if (c.notes) {
-        <p class="notes">{{ c.notes }}</p>
-      }
-
-      <div class="slack-channel-row">
-        <mat-form-field class="slack-channel-field" floatLabel="always">
-          <mat-label>Slack Channel ID</mat-label>
-          <input matInput [ngModel]="c.slackChannelId ?? ''" (ngModelChange)="pendingSlackChannelId = $event" placeholder="C0AQ0ELLGCV">
-          <mat-hint>Right-click channel in Slack → View channel details → scroll to bottom</mat-hint>
-        </mat-form-field>
-        <button mat-stroked-button (click)="saveSlackChannelId(c)" [disabled]="pendingSlackChannelId === undefined">
-          <mat-icon>save</mat-icon> Save
-        </button>
-      </div>
-
-      <mat-tab-group [selectedIndex]="selectedTab()" (selectedTabChange)="onTabChange($event.index)">
-        <mat-tab label="Systems">
+      <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="onTabChange($event)">
+        <app-tab label="Systems">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Database Systems</h3>
@@ -146,9 +108,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (systems().length === 0) { <p class="empty">No systems configured.</p> }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Contacts">
+        <app-tab label="Contacts">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Contacts</h3>
@@ -187,9 +149,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (contacts().length === 0) { <p class="empty">No contacts added.</p> }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Repos">
+        <app-tab label="Repos">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Code Repositories</h3>
@@ -226,9 +188,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (repos().length === 0) { <p class="empty">No repositories configured.</p> }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Integrations">
+        <app-tab label="Integrations">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Integrations</h3>
@@ -272,9 +234,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
               <p class="empty">No integrations configured. Add IMAP, Azure DevOps, or MCP Database integrations.</p>
             }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Tickets">
+        <app-tab label="Tickets">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Tickets</h3>
@@ -308,9 +270,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (tickets().length === 0) { <p class="empty">No tickets for this client.</p> }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Memory">
+        <app-tab label="Memory">
           <div class="tab-content">
             <div class="tab-header">
               <h3>AI Memory</h3>
@@ -360,9 +322,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
               <p class="empty">No memory entries. Add context, playbooks, or tool guidance to help AI analyze tickets for this client.</p>
             }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Environments">
+        <app-tab label="Environments">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Environments</h3>
@@ -397,9 +359,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
               <p class="empty">No environments configured. Add environments (e.g. Production, Development) to group systems, repos, and integrations.</p>
             }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Users">
+        <app-tab label="Users">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Portal Users</h3>
@@ -444,8 +406,8 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (clientUsers().length === 0) { <p class="empty">No portal users for this client.</p> }
           </div>
-        </mat-tab>
-        <mat-tab label="AI Credentials">
+        </app-tab>
+        <app-tab label="AI Credentials">
           <div class="tab-content">
             <div class="tab-header">
               <h3>AI Credentials (BYOK)</h3>
@@ -510,9 +472,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
               </mat-card-content>
             </mat-card>
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="Invoices">
+        <app-tab label="Invoices">
           <div class="tab-content">
             <div class="tab-header">
               <h3>Invoices</h3>
@@ -561,9 +523,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
             </table>
             @if (invoices().length === 0) { <p class="empty">No invoices generated yet.</p> }
           </div>
-        </mat-tab>
+        </app-tab>
 
-        <mat-tab label="AI Usage">
+        <app-tab label="AI Usage">
           <div class="tab-content">
             <div class="tab-header">
               <h3>AI Usage</h3>
@@ -633,8 +595,8 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
               <p class="empty">No AI usage data available. Click Refresh to load.</p>
             }
           </div>
-        </mat-tab>
-      </mat-tab-group>
+        </app-tab>
+      </app-tab-group>
     } @else {
       <p>Loading...</p>
     }
@@ -727,15 +689,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     }
   `,
   styles: [`
-    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
-    .header-toggles { display: flex; align-items: center; gap: 16px; }
-    .back-link { text-decoration: none; color: #666; }
-    .inline { display: inline; margin: 0 8px 0 4px; }
-    .code-chip { font-size: 12px; padding: 2px 8px; background: #e8eaf6; border-radius: 4px; color: #3f51b5; font-family: monospace; }
-    .domains { color: #555; font-family: monospace; font-size: 13px; margin-bottom: 4px; }
-    .notes { color: #666; margin-bottom: 16px; }
-    .slack-channel-row { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 16px; }
-    .slack-channel-field { width: 320px; }
     .tab-content { padding: 16px 0; }
     .tab-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
     .tab-header h3 { margin: 0; }
@@ -832,7 +785,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotal = signal(0);
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
-  pendingSlackChannelId: string | undefined;
 
   systemColumns = ['name', 'dbEngine', 'host', 'environment', 'status'];
   contactColumns = ['name', 'email', 'role', 'isPrimary', 'actions'];
@@ -927,29 +879,8 @@ export class ClientDetailComponent implements OnInit {
     }
   }
 
-  toggleActive(c: Client): void {
-    this.clientService.updateClient(c.id, { isActive: !c.isActive }).subscribe(updated => {
-      this.client.set({ ...c, isActive: updated.isActive });
-    });
-  }
-
-  toggleAutoRoute(c: Client): void {
-    this.clientService.updateClient(c.id, { autoRouteTickets: !c.autoRouteTickets }).subscribe(updated => {
-      this.client.set({ ...c, autoRouteTickets: updated.autoRouteTickets });
-    });
-  }
-
-  saveSlackChannelId(c: Client): void {
-    const value = this.pendingSlackChannelId;
-    if (value === undefined) return;
-    this.clientService.updateClient(c.id, { slackChannelId: value || null } as Partial<Client>).subscribe({
-      next: (updated) => {
-        this.client.set({ ...c, slackChannelId: updated.slackChannelId });
-        this.pendingSlackChannelId = undefined;
-        this.toast.success('Slack Channel ID saved');
-      },
-      error: () => this.toast.error('Failed to save Slack Channel ID'),
-    });
+  onClientUpdated(updated: Client): void {
+    this.client.set(updated);
   }
 
   addSystem(): void {
@@ -1192,12 +1123,6 @@ export class ClientDetailComponent implements OnInit {
     }
   }
 
-  toggleSelfRegistration(c: Client): void {
-    this.clientService.updateClient(c.id, { allowSelfRegistration: !c.allowSelfRegistration }).subscribe(updated => {
-      this.client.set({ ...c, allowSelfRegistration: updated.allowSelfRegistration });
-    });
-  }
-
   addClientUser(): void {
     this.editingUser.set(null);
     this.showUserDialog.set(true);
@@ -1244,13 +1169,6 @@ export class ClientDetailComponent implements OnInit {
         this.load();
       },
       error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
-    });
-  }
-
-  setAiMode(c: Client, mode: string): void {
-    this.clientService.updateClient(c.id, { aiMode: mode } as Partial<Client>).subscribe(updated => {
-      this.client.set({ ...c, aiMode: updated.aiMode });
-      this.toast.info(`AI mode set to ${mode}`);
     });
   }
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -20,8 +20,7 @@ import { ClientIntegrationsTabComponent } from './client-detail/tabs/integration
 import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component';
 import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component';
 import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component';
-import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
-import { ClientUserDialogComponent } from './client-user-dialog.component';
+import { ClientUsersTabComponent } from './client-detail/tabs/users-tab.component';
 import { InvoiceService, type Invoice } from '../../core/services/invoice.service';
 import { GenerateInvoiceDialogComponent } from './generate-invoice-dialog.component';
 import { ClientAiCredentialService, type ClientAiCredential } from '../../core/services/client-ai-credential.service';
@@ -56,9 +55,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
-    ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent,
+    ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent, ClientUsersTabComponent,
     DialogComponent,
-    ClientUserDialogComponent, GenerateInvoiceDialogComponent,
+    GenerateInvoiceDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -94,50 +93,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Users">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Portal Users</h3>
-              <button mat-raised-button color="primary" (click)="addClientUser()">
-                <mat-icon>add</mat-icon> Add User
-              </button>
-            </div>
-            <table mat-table [dataSource]="clientUsers()" class="full-width">
-              <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Name</th>
-                <td mat-cell *matCellDef="let u">{{ u.name }}</td>
-              </ng-container>
-              <ng-container matColumnDef="email">
-                <th mat-header-cell *matHeaderCellDef>Email</th>
-                <td mat-cell *matCellDef="let u">{{ u.email }}</td>
-              </ng-container>
-              <ng-container matColumnDef="userType">
-                <th mat-header-cell *matHeaderCellDef>Type</th>
-                <td mat-cell *matCellDef="let u">
-                  <span class="type-chip" [class.type-admin]="u.userType === 'ADMIN'">{{ u.userType }}</span>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="isActiveUser">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let u">
-                  <mat-chip [class.inactive]="!u.isActive">{{ u.isActive ? 'Active' : 'Inactive' }}</mat-chip>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="lastLogin">
-                <th mat-header-cell *matHeaderCellDef>Last Login</th>
-                <td mat-cell *matCellDef="let u">{{ u.lastLoginAt ? (u.lastLoginAt | date:'short') : 'Never' }}</td>
-              </ng-container>
-              <ng-container matColumnDef="userActions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let u">
-                  <button mat-icon-button (click)="editClientUser(u)"><mat-icon>edit</mat-icon></button>
-                  <button mat-icon-button color="warn" (click)="deleteClientUser(u.id)"><mat-icon>person_off</mat-icon></button>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="clientUserColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: clientUserColumns;"></tr>
-            </table>
-            @if (clientUsers().length === 0) { <p class="empty">No portal users for this client.</p> }
-          </div>
+          <app-client-users-tab [clientId]="id()" />
         </app-tab>
         <app-tab label="AI Credentials">
           <div class="tab-content">
@@ -333,16 +289,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       <p>Loading...</p>
     }
 
-    @if (showUserDialog()) {
-      <app-dialog [open]="true" [title]="editingUser() ? 'Edit User' : 'Create Portal User'" maxWidth="500px" (openChange)="showUserDialog.set(false)">
-        <app-client-user-dialog-content
-          [clientId]="id()"
-          [user]="editingUser() ?? undefined"
-          (saved)="onUserSaved()"
-          (cancelled)="showUserDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showInvoiceDialog()) {
       <app-dialog [open]="true" title="Generate Invoice" maxWidth="400px" (openChange)="showInvoiceDialog.set(false)">
         <app-generate-invoice-dialog-content
@@ -413,7 +359,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private clientUserService = inject(ClientUserService);
   private invoiceService = inject(InvoiceService);
   private credentialService = inject(ClientAiCredentialService);
   private aiUsageService = inject(AiUsageService);
@@ -423,7 +368,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  clientUsers = signal<ClientUser[]>([]);
   invoices = signal<Invoice[]>([]);
   aiCredentials = signal<ClientAiCredential[]>([]);
   aiUsageSummary = signal<AiUsageClientSummary | null>(null);
@@ -434,7 +378,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  clientUserColumns = ['name', 'email', 'userType', 'isActiveUser', 'lastLogin', 'userActions'];
   invoiceColumns = ['invoiceNumber', 'period', 'requests', 'totalBilled', 'invoiceStatus', 'invoiceActions'];
   credentialColumns = ['provider', 'label', 'key', 'credStatus', 'credActions'];
   aiUsageLogColumns = ['createdAt', 'taskType', 'model', 'provider', 'inputTokens', 'outputTokens', 'costUsd'];
@@ -472,7 +415,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.clientUserService.getUsers(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(u => this.clientUsers.set(u));
     this.invoiceService.getInvoices(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.invoices.set(i));
     this.credentialService.getCredentials(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.aiCredentials.set(c));
   }
@@ -520,34 +462,7 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  showUserDialog = signal(false);
-  editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-
-  addClientUser(): void {
-    this.editingUser.set(null);
-    this.showUserDialog.set(true);
-  }
-
-  editClientUser(user: ClientUser): void {
-    this.editingUser.set(user);
-    this.showUserDialog.set(true);
-  }
-
-  onUserSaved(): void {
-    this.showUserDialog.set(false);
-    this.load();
-  }
-
-  deleteClientUser(id: string): void {
-    this.clientUserService.deleteUser(id).subscribe({
-      next: () => {
-        this.toast.success('User deactivated');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Deactivation failed'),
-    });
-  }
 
   openGenerateInvoiceDialog(): void {
     this.showInvoiceDialog.set(true);

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -18,8 +18,7 @@ import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.co
 import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
 import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component';
 import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component';
-import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
-import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
+import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component';
 import { ClientUserService, type ClientUser } from '../../core/services/client-user.service';
 import { ClientUserDialogComponent } from './client-user-dialog.component';
 import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service';
@@ -58,9 +57,9 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
-    ClientTicketsTabComponent,
+    ClientTicketsTabComponent, ClientMemoryTabComponent,
     DialogComponent,
-    ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
+    ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -88,55 +87,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Memory">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>AI Memory</h3>
-              <button mat-raised-button color="primary" (click)="addMemory()">
-                <mat-icon>add</mat-icon> Add Memory
-              </button>
-              <mat-form-field appearance="outline" class="compact-select">
-                <mat-label>Source</mat-label>
-                <mat-select [(ngModel)]="memSourceFilter" (ngModelChange)="filterMemories()">
-                  <mat-option value="">All</mat-option>
-                  <mat-option value="MANUAL">Manual</mat-option>
-                  <mat-option value="AI_LEARNED">AI Learned</mat-option>
-                </mat-select>
-              </mat-form-field>
-            </div>
-            @for (mem of filteredMemories(); track mem.id) {
-              <mat-card class="memory-card" [class.inactive-card]="!mem.isActive">
-                <mat-card-content>
-                  <div class="memory-header">
-                    <mat-icon>{{ memoryTypeIcon(mem.memoryType) }}</mat-icon>
-                    <strong>{{ mem.title }}</strong>
-                    <span class="type-chip type-{{ mem.memoryType.toLowerCase() }}">{{ mem.memoryType }}</span>
-                    <span class="source-badge source-{{ (mem.source ?? 'MANUAL').toLowerCase() }}">
-                      {{ (mem.source ?? 'MANUAL') === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
-                    </span>
-                    @if (mem.category) {
-                      <span class="category-chip">{{ mem.category }}</span>
-                    }
-                    <mat-slide-toggle [checked]="mem.isActive" (change)="toggleMemory(mem, $event.checked)">
-                      {{ mem.isActive ? 'Active' : 'Inactive' }}
-                    </mat-slide-toggle>
-                    <span class="spacer"></span>
-                    <button mat-icon-button (click)="editMemory(mem)"><mat-icon>edit</mat-icon></button>
-                    <button mat-icon-button color="warn" (click)="deleteMemory(mem.id)"><mat-icon>delete</mat-icon></button>
-                  </div>
-                  @if (mem.tags.length) {
-                    <div class="tags">
-                      @for (tag of mem.tags; track tag) {
-                        <span class="tag-chip">{{ tag }}</span>
-                      }
-                    </div>
-                  }
-                  <pre class="memory-content">{{ mem.content }}</pre>
-                </mat-card-content>
-              </mat-card>
-            } @empty {
-              <p class="empty">No memory entries. Add context, playbooks, or tool guidance to help AI analyze tickets for this client.</p>
-            }
-          </div>
+          <app-client-memory-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Environments">
@@ -416,16 +367,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       <p>Loading...</p>
     }
 
-    @if (showMemoryDialog()) {
-      <app-dialog [open]="true" [title]="editingMemory() ? 'Edit Client Memory' : 'Add Client Memory'" maxWidth="650px" (openChange)="showMemoryDialog.set(false)">
-        <app-client-memory-dialog-content
-          [clientId]="id()"
-          [memory]="editingMemory() ?? undefined"
-          (saved)="onMemorySaved()"
-          (cancelled)="showMemoryDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showEnvironmentDialog()) {
       <app-dialog [open]="true" [title]="editingEnvironment() ? 'Edit Environment' : 'Add Environment'" maxWidth="650px" (openChange)="showEnvironmentDialog.set(false)">
         <app-client-environment-dialog-content
@@ -516,7 +457,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private memoryService = inject(ClientMemoryService);
   private clientUserService = inject(ClientUserService);
   private envService = inject(ClientEnvironmentService);
   private invoiceService = inject(InvoiceService);
@@ -528,9 +468,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  memories = signal<ClientMemory[]>([]);
-  memSourceFilter = '';
-  filteredMemories = signal<ClientMemory[]>([]);
   clientUsers = signal<ClientUser[]>([]);
   environments = signal<ClientEnvironment[]>([]);
   invoices = signal<Invoice[]>([]);
@@ -581,7 +518,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.memoryService.getMemories({ clientId: cid }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(m => { this.memories.set(m); this.filterMemories(); });
     this.clientUserService.getUsers(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(u => this.clientUsers.set(u));
     this.envService.getEnvironments(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(e => this.environments.set(e));
     this.invoiceService.getInvoices(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.invoices.set(i));
@@ -631,60 +567,11 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  showMemoryDialog = signal(false);
-  editingMemory = signal<ClientMemory | null>(null);
   showEnvironmentDialog = signal(false);
   editingEnvironment = signal<ClientEnvironment | null>(null);
   showUserDialog = signal(false);
   editingUser = signal<ClientUser | null>(null);
   showInvoiceDialog = signal(false);
-
-  filterMemories(): void {
-    const all = this.memories();
-    if (!this.memSourceFilter) {
-      this.filteredMemories.set(all);
-    } else {
-      this.filteredMemories.set(all.filter(m => (m.source ?? 'MANUAL') === this.memSourceFilter));
-    }
-  }
-
-  addMemory(): void {
-    this.editingMemory.set(null);
-    this.showMemoryDialog.set(true);
-  }
-
-  editMemory(mem: ClientMemory): void {
-    this.editingMemory.set(mem);
-    this.showMemoryDialog.set(true);
-  }
-
-  onMemorySaved(): void {
-    this.showMemoryDialog.set(false);
-    this.load();
-  }
-
-  toggleMemory(mem: ClientMemory, checked: boolean): void {
-    this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: checked } : m));
-    this.filterMemories();
-    this.memoryService.updateMemory(mem.id, { isActive: checked }).subscribe({
-      next: () => this.toast.success(`Memory ${checked ? 'enabled' : 'disabled'}`),
-      error: (err) => {
-        this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: !checked } : m));
-        this.filterMemories();
-        this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
-      },
-    });
-  }
-
-  deleteMemory(id: string): void {
-    this.memoryService.deleteMemory(id).subscribe({
-      next: () => {
-        this.toast.success('Memory entry deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
-    });
-  }
 
   addEnvironment(): void {
     this.editingEnvironment.set(null);
@@ -721,15 +608,6 @@ export class ClientDetailComponent implements OnInit {
       },
       error: (err) => this.toast.error(err.error?.error ?? err.error?.message ?? 'Delete failed'),
     });
-  }
-
-  memoryTypeIcon(type: string): string {
-    switch (type) {
-      case 'CONTEXT': return 'info';
-      case 'PLAYBOOK': return 'menu_book';
-      case 'TOOL_GUIDANCE': return 'build';
-      default: return 'psychology';
-    }
   }
 
   addClientUser(): void {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -11,17 +11,16 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component';
-import { ClientService, Client, Contact } from '../../core/services/client.service';
-import { ContactService } from '../../core/services/contact.service';
+import { ClientService, Client } from '../../core/services/client.service';
 import { RepoService, CodeRepo } from '../../core/services/repo.service';
 import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service';
 import { TicketService, Ticket } from '../../core/services/ticket.service';
-import { ContactDialogComponent } from '../contacts/contact-dialog.component';
 import { RepoDialogComponent } from '../repos/repo-dialog.component';
 import { IntegrationDialogComponent } from '../integrations/integration-dialog.component';
 import { TicketDialogComponent } from '../tickets/ticket-dialog.component';
 import { DialogComponent } from '../../shared/components/dialog.component';
 import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
+import { ClientContactsTabComponent } from './client-detail/tabs/contacts-tab.component';
 import { ClientMemoryService, type ClientMemory } from '../../core/services/client-memory.service';
 import { ClientMemoryDialogComponent } from './client-memory-dialog.component';
 import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
@@ -62,10 +61,10 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     MatTableModule, MatChipsModule, MatSlideToggleModule, MatTooltipModule, McpServerInfoComponent,
     FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule,
     TabGroupComponent, TabComponent, ClientHeaderComponent,
-    ClientSystemsTabComponent,
+    ClientSystemsTabComponent, ClientContactsTabComponent,
     DialogComponent, TicketDialogComponent,
     ClientMemoryDialogComponent, ClientEnvironmentDialogComponent, ClientUserDialogComponent, GenerateInvoiceDialogComponent,
-    RepoDialogComponent, ContactDialogComponent, IntegrationDialogComponent,
+    RepoDialogComponent, IntegrationDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -77,44 +76,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Contacts">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Contacts</h3>
-              <button mat-raised-button color="primary" (click)="addContact()">
-                <mat-icon>add</mat-icon> Add Contact
-              </button>
-            </div>
-            <table mat-table [dataSource]="contacts()" class="full-width">
-              <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Name</th>
-                <td mat-cell *matCellDef="let c">{{ c.name }}</td>
-              </ng-container>
-              <ng-container matColumnDef="email">
-                <th mat-header-cell *matHeaderCellDef>Email</th>
-                <td mat-cell *matCellDef="let c">{{ c.email }}</td>
-              </ng-container>
-              <ng-container matColumnDef="role">
-                <th mat-header-cell *matHeaderCellDef>Role</th>
-                <td mat-cell *matCellDef="let c">{{ c.role ?? '-' }}</td>
-              </ng-container>
-              <ng-container matColumnDef="isPrimary">
-                <th mat-header-cell *matHeaderCellDef>Primary</th>
-                <td mat-cell *matCellDef="let c">
-                  @if (c.isPrimary) { <mat-icon class="primary-icon">star</mat-icon> }
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let c">
-                  <button mat-icon-button (click)="editContact(c)"><mat-icon>edit</mat-icon></button>
-                  <button mat-icon-button color="warn" (click)="deleteContact(c.id)"><mat-icon>delete</mat-icon></button>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="contactColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: contactColumns;"></tr>
-            </table>
-            @if (contacts().length === 0) { <p class="empty">No contacts added.</p> }
-          </div>
+          <app-client-contacts-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Repos">
@@ -625,16 +587,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       </app-dialog>
     }
 
-    @if (showContactDialog()) {
-      <app-dialog [open]="true" [title]="editingContact() ? 'Edit Contact' : 'Add Contact'" maxWidth="500px" (openChange)="showContactDialog.set(false)">
-        <app-contact-dialog-content
-          [clientId]="id()"
-          [contact]="editingContact() ?? undefined"
-          (saved)="onContactSaved()"
-          (cancelled)="showContactDialog.set(false)" />
-      </app-dialog>
-    }
-
     @if (showIntegrationDialog()) {
       <app-dialog [open]="true" [title]="editingIntegration() ? 'Edit Integration' : 'Add Integration'" maxWidth="600px" (openChange)="showIntegrationDialog.set(false)">
         <app-integration-dialog-content
@@ -706,7 +658,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private contactService = inject(ContactService);
   private repoService = inject(RepoService);
   private integrationService = inject(IntegrationService);
   private ticketService = inject(TicketService);
@@ -722,7 +673,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  contacts = signal<Contact[]>([]);
   repos = signal<CodeRepo[]>([]);
   integrations = signal<ClientIntegration[]>([]);
   tickets = signal<Ticket[]>([]);
@@ -741,7 +691,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  contactColumns = ['name', 'email', 'role', 'isPrimary', 'actions'];
   repoColumns = ['name', 'repoUrl', 'branch', 'prefix', 'actions'];
   ticketColumns = ['subject', 'status', 'priority', 'category'];
   clientUserColumns = ['name', 'email', 'userType', 'isActiveUser', 'lastLogin', 'userActions'];
@@ -782,7 +731,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.contactService.getContacts(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.contacts.set(c));
     this.repoService.getRepos(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(r => this.repos.set(r));
     this.integrationService.getIntegrations(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.integrations.set(i));
     this.ticketService.getTickets({ clientId: cid, limit: 20 }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => this.tickets.set(t));
@@ -836,31 +784,6 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  addContact(): void {
-    this.editingContact.set(null);
-    this.showContactDialog.set(true);
-  }
-
-  editContact(contact: Contact): void {
-    this.editingContact.set(contact);
-    this.showContactDialog.set(true);
-  }
-
-  onContactSaved(): void {
-    this.showContactDialog.set(false);
-    this.load();
-  }
-
-  deleteContact(id: string): void {
-    this.contactService.deleteContact(id).subscribe({
-      next: () => {
-        this.toast.success('Contact deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
-    });
-  }
-
   addRepo(): void {
     this.editingRepo.set(null);
     this.showRepoDialog.set(true);
@@ -909,8 +832,6 @@ export class ClientDetailComponent implements OnInit {
   showInvoiceDialog = signal(false);
   showRepoDialog = signal(false);
   editingRepo = signal<CodeRepo | null>(null);
-  showContactDialog = signal(false);
-  editingContact = signal<Contact | null>(null);
   showIntegrationDialog = signal(false);
   editingIntegration = signal<ClientIntegration | null>(null);
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -21,9 +21,9 @@ import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.comp
 import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component';
 import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component';
 import { ClientUsersTabComponent } from './client-detail/tabs/users-tab.component';
+import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component';
 import { InvoiceService, type Invoice } from '../../core/services/invoice.service';
 import { GenerateInvoiceDialogComponent } from './generate-invoice-dialog.component';
-import { ClientAiCredentialService, type ClientAiCredential } from '../../core/services/client-ai-credential.service';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -56,6 +56,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
     ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent, ClientUsersTabComponent,
+    ClientAiCredentialsTabComponent,
     DialogComponent,
     GenerateInvoiceDialogComponent,
   ],
@@ -96,70 +97,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
           <app-client-users-tab [clientId]="id()" />
         </app-tab>
         <app-tab label="AI Credentials">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>AI Credentials (BYOK)</h3>
-            </div>
-            <table mat-table [dataSource]="aiCredentials()" class="full-width">
-              <ng-container matColumnDef="provider">
-                <th mat-header-cell *matHeaderCellDef>Provider</th>
-                <td mat-cell *matCellDef="let cred">{{ cred.provider }}</td>
-              </ng-container>
-              <ng-container matColumnDef="label">
-                <th mat-header-cell *matHeaderCellDef>Label</th>
-                <td mat-cell *matCellDef="let cred">{{ cred.label }}</td>
-              </ng-container>
-              <ng-container matColumnDef="key">
-                <th mat-header-cell *matHeaderCellDef>API Key</th>
-                <td mat-cell *matCellDef="let cred"><code>...{{ cred.last4 }}</code></td>
-              </ng-container>
-              <ng-container matColumnDef="credStatus">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let cred">
-                  <mat-slide-toggle [checked]="cred.isActive" (change)="toggleCredential(cred, $event.checked)">
-                    {{ cred.isActive ? 'Active' : 'Inactive' }}
-                  </mat-slide-toggle>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="credActions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let cred">
-                  <button mat-icon-button matTooltip="Test" (click)="testCredential(cred)"><mat-icon>play_arrow</mat-icon></button>
-                  <button mat-icon-button color="warn" matTooltip="Delete" (click)="deleteCredential(cred)"><mat-icon>delete</mat-icon></button>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="credentialColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: credentialColumns;"></tr>
-            </table>
-            @if (aiCredentials().length === 0) { <p class="empty">No AI credentials configured. Add credentials to use BYOK mode.</p> }
-
-            <mat-card class="add-cred-card">
-              <mat-card-content>
-                <h4>Add Credential</h4>
-                <div class="cred-form">
-                  <mat-form-field>
-                    <mat-label>Provider</mat-label>
-                    <mat-select [(ngModel)]="newCredProvider">
-                      <mat-option value="CLAUDE">CLAUDE</mat-option>
-                      <mat-option value="OPENAI">OPENAI</mat-option>
-                      <mat-option value="GROK">GROK</mat-option>
-                    </mat-select>
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>Label</mat-label>
-                    <input matInput [(ngModel)]="newCredLabel" placeholder="e.g. Production Key">
-                  </mat-form-field>
-                  <mat-form-field>
-                    <mat-label>API Key</mat-label>
-                    <input matInput type="password" [(ngModel)]="newCredApiKey" placeholder="sk-...">
-                  </mat-form-field>
-                  <button mat-raised-button color="primary" (click)="addCredential()" [disabled]="!newCredProvider || !newCredLabel || !newCredApiKey">
-                    <mat-icon>add</mat-icon> Add
-                  </button>
-                </div>
-              </mat-card-content>
-            </mat-card>
-          </div>
+          <app-client-ai-credentials-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="Invoices">
@@ -360,7 +298,6 @@ export class ClientDetailComponent implements OnInit {
 
   private clientService = inject(ClientService);
   private invoiceService = inject(InvoiceService);
-  private credentialService = inject(ClientAiCredentialService);
   private aiUsageService = inject(AiUsageService);
   private destroyRef = inject(DestroyRef);
   private toast = inject(ToastService);
@@ -369,7 +306,6 @@ export class ClientDetailComponent implements OnInit {
 
   client = signal<Client | null>(null);
   invoices = signal<Invoice[]>([]);
-  aiCredentials = signal<ClientAiCredential[]>([]);
   aiUsageSummary = signal<AiUsageClientSummary | null>(null);
   aiUsageLogs = signal<AiUsageLogEntry[]>([]);
   aiUsageLoading = signal(false);
@@ -379,13 +315,8 @@ export class ClientDetailComponent implements OnInit {
   selectedTab = signal(0);
 
   invoiceColumns = ['invoiceNumber', 'period', 'requests', 'totalBilled', 'invoiceStatus', 'invoiceActions'];
-  credentialColumns = ['provider', 'label', 'key', 'credStatus', 'credActions'];
   aiUsageLogColumns = ['createdAt', 'taskType', 'model', 'provider', 'inputTokens', 'outputTokens', 'costUsd'];
   private readonly AI_USAGE_PAGE_SIZE = 25;
-
-  newCredProvider = '';
-  newCredLabel = '';
-  newCredApiKey = '';
 
   ngOnInit(): void {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
@@ -416,7 +347,6 @@ export class ClientDetailComponent implements OnInit {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
     this.invoiceService.getInvoices(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.invoices.set(i));
-    this.credentialService.getCredentials(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.aiCredentials.set(c));
   }
 
   loadAiUsage(): void {
@@ -488,51 +418,4 @@ export class ClientDetailComponent implements OnInit {
     });
   }
 
-  addCredential(): void {
-    const cid = this.id();
-    this.credentialService.createCredential(cid, {
-      provider: this.newCredProvider,
-      apiKey: this.newCredApiKey,
-      label: this.newCredLabel,
-    }).subscribe({
-      next: () => {
-        this.newCredProvider = '';
-        this.newCredLabel = '';
-        this.newCredApiKey = '';
-        this.toast.success('Credential added');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.error ?? 'Failed to add credential'),
-    });
-  }
-
-  toggleCredential(cred: ClientAiCredential, checked: boolean): void {
-    this.aiCredentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: checked } : c));
-    this.credentialService.updateCredential(this.id(), cred.id, { isActive: checked }).subscribe({
-      next: () => this.toast.success(`Credential ${checked ? 'enabled' : 'disabled'}`),
-      error: (err) => {
-        this.aiCredentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: !checked } : c));
-        this.toast.error(err.error?.error ?? 'Toggle failed');
-      },
-    });
-  }
-
-  testCredential(cred: ClientAiCredential): void {
-    this.toast.info('Testing credential...');
-    this.credentialService.testCredential(this.id(), cred.id).subscribe({
-      next: (result) => result.ok ? this.toast.success('Credential is valid') : this.toast.error(`Test failed: ${result.error}`),
-      error: (err) => this.toast.error(err.error?.error ?? 'Test failed'),
-    });
-  }
-
-  deleteCredential(cred: ClientAiCredential): void {
-    if (!confirm(`Delete credential "${cred.label}"?`)) return;
-    this.credentialService.deleteCredential(this.id(), cred.id).subscribe({
-      next: () => {
-        this.toast.success('Credential deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.error ?? 'Delete failed'),
-    });
-  }
 }

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -22,8 +22,7 @@ import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.compon
 import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component';
 import { ClientUsersTabComponent } from './client-detail/tabs/users-tab.component';
 import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component';
-import { InvoiceService, type Invoice } from '../../core/services/invoice.service';
-import { GenerateInvoiceDialogComponent } from './generate-invoice-dialog.component';
+import { ClientInvoicesTabComponent } from './client-detail/tabs/invoices-tab.component';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -56,9 +55,8 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
     TabGroupComponent, TabComponent, ClientHeaderComponent,
     ClientSystemsTabComponent, ClientContactsTabComponent, ClientReposTabComponent, ClientIntegrationsTabComponent,
     ClientTicketsTabComponent, ClientMemoryTabComponent, ClientEnvironmentsTabComponent, ClientUsersTabComponent,
-    ClientAiCredentialsTabComponent,
+    ClientAiCredentialsTabComponent, ClientInvoicesTabComponent,
     DialogComponent,
-    GenerateInvoiceDialogComponent,
   ],
   template: `
     @if (client(); as c) {
@@ -101,54 +99,7 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
         </app-tab>
 
         <app-tab label="Invoices">
-          <div class="tab-content">
-            <div class="tab-header">
-              <h3>Invoices</h3>
-              <button mat-raised-button color="primary" (click)="openGenerateInvoiceDialog()">
-                <mat-icon>receipt_long</mat-icon> Generate Invoice
-              </button>
-            </div>
-            <table mat-table [dataSource]="invoices()" class="full-width">
-              <ng-container matColumnDef="invoiceNumber">
-                <th mat-header-cell *matHeaderCellDef>#</th>
-                <td mat-cell *matCellDef="let inv">{{ inv.invoiceNumber }}</td>
-              </ng-container>
-              <ng-container matColumnDef="period">
-                <th mat-header-cell *matHeaderCellDef>Period</th>
-                <td mat-cell *matCellDef="let inv">
-                  {{ inv.periodStart | date:'mediumDate' }} – {{ inv.periodEnd | date:'mediumDate' }}
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="requests">
-                <th mat-header-cell *matHeaderCellDef>Requests</th>
-                <td mat-cell *matCellDef="let inv">{{ inv.requestCount }}</td>
-              </ng-container>
-              <ng-container matColumnDef="totalBilled">
-                <th mat-header-cell *matHeaderCellDef>Total Billed</th>
-                <td mat-cell *matCellDef="let inv">\${{ inv.totalBilledCostUsd | number:'1.2-2' }}</td>
-              </ng-container>
-              <ng-container matColumnDef="invoiceStatus">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let inv">
-                  <mat-chip [class.status-final]="inv.status === 'final'">{{ inv.status }}</mat-chip>
-                </td>
-              </ng-container>
-              <ng-container matColumnDef="invoiceActions">
-                <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let inv">
-                  <a mat-icon-button [href]="getInvoiceDownloadUrl(inv.id)" target="_blank" rel="noopener noreferrer" matTooltip="Download PDF">
-                    <mat-icon>download</mat-icon>
-                  </a>
-                  <button mat-icon-button color="warn" (click)="deleteInvoice(inv)" matTooltip="Delete">
-                    <mat-icon>delete</mat-icon>
-                  </button>
-                </td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="invoiceColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: invoiceColumns;"></tr>
-            </table>
-            @if (invoices().length === 0) { <p class="empty">No invoices generated yet.</p> }
-          </div>
+          <app-client-invoices-tab [clientId]="id()" />
         </app-tab>
 
         <app-tab label="AI Usage">
@@ -227,14 +178,6 @@ const AI_USAGE_TAB_INDEX = CLIENT_DETAIL_TAB_SLUGS.indexOf('ai-usage');
       <p>Loading...</p>
     }
 
-    @if (showInvoiceDialog()) {
-      <app-dialog [open]="true" title="Generate Invoice" maxWidth="400px" (openChange)="showInvoiceDialog.set(false)">
-        <app-generate-invoice-dialog-content
-          [clientId]="id()"
-          (generated)="onInvoiceGenerated()"
-          (cancelled)="showInvoiceDialog.set(false)" />
-      </app-dialog>
-    }
   `,
   styles: [`
     .tab-content { padding: 16px 0; }
@@ -297,7 +240,6 @@ export class ClientDetailComponent implements OnInit {
   id = input.required<string>();
 
   private clientService = inject(ClientService);
-  private invoiceService = inject(InvoiceService);
   private aiUsageService = inject(AiUsageService);
   private destroyRef = inject(DestroyRef);
   private toast = inject(ToastService);
@@ -305,7 +247,6 @@ export class ClientDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
 
   client = signal<Client | null>(null);
-  invoices = signal<Invoice[]>([]);
   aiUsageSummary = signal<AiUsageClientSummary | null>(null);
   aiUsageLogs = signal<AiUsageLogEntry[]>([]);
   aiUsageLoading = signal(false);
@@ -314,7 +255,6 @@ export class ClientDetailComponent implements OnInit {
   aiUsageTotalPages = signal(1);
   selectedTab = signal(0);
 
-  invoiceColumns = ['invoiceNumber', 'period', 'requests', 'totalBilled', 'invoiceStatus', 'invoiceActions'];
   aiUsageLogColumns = ['createdAt', 'taskType', 'model', 'provider', 'inputTokens', 'outputTokens', 'costUsd'];
   private readonly AI_USAGE_PAGE_SIZE = 25;
 
@@ -346,7 +286,6 @@ export class ClientDetailComponent implements OnInit {
   load(): void {
     const cid = this.id();
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
-    this.invoiceService.getInvoices(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(i => this.invoices.set(i));
   }
 
   loadAiUsage(): void {
@@ -392,30 +331,5 @@ export class ClientDetailComponent implements OnInit {
     this.client.set(updated);
   }
 
-  showInvoiceDialog = signal(false);
-
-  openGenerateInvoiceDialog(): void {
-    this.showInvoiceDialog.set(true);
-  }
-
-  onInvoiceGenerated(): void {
-    this.showInvoiceDialog.set(false);
-    this.load();
-  }
-
-  getInvoiceDownloadUrl(invoiceId: string): string {
-    return this.invoiceService.getDownloadUrl(this.id(), invoiceId);
-  }
-
-  deleteInvoice(inv: Invoice): void {
-    if (!confirm(`Delete invoice #${inv.invoiceNumber}?`)) return;
-    this.invoiceService.deleteInvoice(this.id(), inv.id).subscribe({
-      next: () => {
-        this.toast.success('Invoice deleted');
-        this.load();
-      },
-      error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
-    });
-  }
 
 }

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -177,8 +177,7 @@ export class ClientHeaderComponent {
 
   toggleAiMode(byok: boolean): void {
     const mode = byok ? 'byok' : 'platform';
-    this.update({ aiMode: mode } as Partial<Client>);
-    this.toast.info(`AI mode set to ${mode}`);
+    this.update({ aiMode: mode } as Partial<Client>, `AI mode set to ${mode}`);
   }
 
   saveSlackChannelId(): void {
@@ -196,12 +195,15 @@ export class ClientHeaderComponent {
       });
   }
 
-  private update(patch: Partial<Client>): void {
+  private update(patch: Partial<Client>, successToast?: string): void {
     const current = this.client();
     this.clientService.updateClient(current.id, patch)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (updated) => this.clientChange.emit({ ...current, ...updated }),
+        next: (updated) => {
+          this.clientChange.emit({ ...current, ...updated });
+          if (successToast) this.toast.info(successToast);
+        },
         error: () => this.toast.error('Update failed'),
       });
   }

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -1,0 +1,208 @@
+import { Component, DestroyRef, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { Client, ClientService } from '../../../core/services/client.service';
+import { ToastService } from '../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  ToggleSwitchComponent,
+  FormFieldComponent,
+  TextInputComponent,
+} from '../../../shared/components/index.js';
+
+@Component({
+  selector: 'app-client-header',
+  standalone: true,
+  imports: [
+    RouterLink,
+    BroncoButtonComponent,
+    ToggleSwitchComponent,
+    FormFieldComponent,
+    TextInputComponent,
+  ],
+  template: `
+    @let c = client();
+    <div class="page-header">
+      <div class="header-left">
+        <app-bronco-button variant="ghost" size="sm" routerLink="/clients">&#x2190; Clients</app-bronco-button>
+        <div class="title-row">
+          <h1 class="page-title">{{ c.name }}</h1>
+          <span class="chip chip-code">{{ c.shortCode }}</span>
+        </div>
+      </div>
+      <div class="header-toggles">
+        <app-toggle-switch
+          [checked]="c.autoRouteTickets"
+          [label]="c.autoRouteTickets ? 'Auto-Route' : 'Manual Only'"
+          (checkedChange)="toggleAutoRoute()" />
+        <app-toggle-switch
+          [checked]="c.allowSelfRegistration"
+          [label]="c.allowSelfRegistration ? 'Self-Registration' : 'No Self-Reg'"
+          (checkedChange)="toggleSelfRegistration()" />
+        <app-toggle-switch
+          [checked]="c.isActive"
+          [label]="c.isActive ? 'Active' : 'Inactive'"
+          (checkedChange)="toggleActive()" />
+        <app-toggle-switch
+          [checked]="c.aiMode === 'byok'"
+          [label]="c.aiMode === 'byok' ? 'BYOK' : 'Platform AI'"
+          (checkedChange)="toggleAiMode($event)" />
+      </div>
+    </div>
+
+    @if (c.domainMappings.length) {
+      <p class="domains">Domains: {{ c.domainMappings.join(', ') }}</p>
+    }
+    @if (c.notes) {
+      <p class="notes">{{ c.notes }}</p>
+    }
+
+    <div class="slack-channel-row">
+      <app-form-field label="Slack Channel ID" hint="Right-click channel in Slack → View channel details → scroll to bottom">
+        <app-text-input
+          [value]="slackInputValue()"
+          placeholder="C0AQ0ELLGCV"
+          (valueChange)="onSlackInput($event)" />
+      </app-form-field>
+      <app-bronco-button
+        variant="primary"
+        size="md"
+        [disabled]="pendingSlackChannelId() === null"
+        (click)="saveSlackChannelId()">
+        Save
+      </app-bronco-button>
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .page-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .header-left { display: flex; flex-direction: column; gap: 4px; }
+    .title-row { display: flex; align-items: center; gap: 10px; }
+    .page-title {
+      margin: 6px 0 0;
+      font-family: var(--font-primary);
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--text-primary);
+      letter-spacing: -0.24px;
+      line-height: 1.2;
+    }
+    .header-toggles {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+    .chip-code {
+      background: var(--bg-active);
+      color: var(--accent);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 12px;
+    }
+
+    .domains {
+      color: var(--text-secondary);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 13px;
+      margin: 0 0 4px;
+    }
+    .notes {
+      color: var(--text-secondary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      margin: 0 0 16px;
+      line-height: 1.5;
+    }
+
+    .slack-channel-row {
+      display: flex;
+      align-items: flex-end;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .slack-channel-row app-form-field { flex: 0 0 320px; }
+  `],
+})
+export class ClientHeaderComponent {
+  client = input.required<Client>();
+  clientChange = output<Client>();
+
+  private clientService = inject(ClientService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  // null = no pending edit; '' = user cleared the field
+  pendingSlackChannelId = signal<string | null>(null);
+
+  slackInputValue(): string {
+    const pending = this.pendingSlackChannelId();
+    if (pending !== null) return pending;
+    return this.client().slackChannelId ?? '';
+  }
+
+  onSlackInput(value: string): void {
+    this.pendingSlackChannelId.set(value);
+  }
+
+  toggleActive(): void {
+    this.update({ isActive: !this.client().isActive });
+  }
+
+  toggleAutoRoute(): void {
+    this.update({ autoRouteTickets: !this.client().autoRouteTickets });
+  }
+
+  toggleSelfRegistration(): void {
+    this.update({ allowSelfRegistration: !this.client().allowSelfRegistration });
+  }
+
+  toggleAiMode(byok: boolean): void {
+    const mode = byok ? 'byok' : 'platform';
+    this.update({ aiMode: mode } as Partial<Client>);
+    this.toast.info(`AI mode set to ${mode}`);
+  }
+
+  saveSlackChannelId(): void {
+    const value = this.pendingSlackChannelId();
+    if (value === null) return;
+    this.clientService.updateClient(this.client().id, { slackChannelId: value || null } as Partial<Client>)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.pendingSlackChannelId.set(null);
+          this.clientChange.emit({ ...this.client(), slackChannelId: updated.slackChannelId });
+          this.toast.success('Slack Channel ID saved');
+        },
+        error: () => this.toast.error('Failed to save Slack Channel ID'),
+      });
+  }
+
+  private update(patch: Partial<Client>): void {
+    const current = this.client();
+    this.clientService.updateClient(current.id, patch)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => this.clientChange.emit({ ...current, ...updated }),
+        error: () => this.toast.error('Update failed'),
+      });
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
@@ -1,0 +1,278 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ClientAiCredential, ClientAiCredentialService } from '../../../../core/services/client-ai-credential.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  FormFieldComponent,
+  SelectComponent,
+  TextInputComponent,
+  ToggleSwitchComponent,
+} from '../../../../shared/components/index.js';
+
+const PROVIDER_OPTIONS = [
+  { value: '', label: 'Select provider' },
+  { value: 'CLAUDE', label: 'CLAUDE' },
+  { value: 'OPENAI', label: 'OPENAI' },
+  { value: 'GROK', label: 'GROK' },
+];
+
+@Component({
+  selector: 'app-client-ai-credentials-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    CardComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    FormFieldComponent,
+    SelectComponent,
+    TextInputComponent,
+    ToggleSwitchComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">AI Credentials (BYOK)</h3>
+      </div>
+
+      <app-data-table
+        [data]="credentials()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No AI credentials configured. Add credentials to use BYOK mode.">
+        <app-data-column key="provider" header="Provider" [sortable]="false">
+          <ng-template #cell let-cred>
+            <span class="chip chip-provider">{{ cred.provider }}</span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="label" header="Label" [sortable]="false">
+          <ng-template #cell let-cred>{{ cred.label }}</ng-template>
+        </app-data-column>
+        <app-data-column key="key" header="API Key" [sortable]="false" width="120px">
+          <ng-template #cell let-cred>
+            <code class="key-mask">…{{ cred.last4 }}</code>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="credStatus" header="Status" [sortable]="false" width="140px">
+          <ng-template #cell let-cred>
+            <app-toggle-switch
+              [checked]="cred.isActive"
+              [label]="cred.isActive ? 'Active' : 'Inactive'"
+              (checkedChange)="toggleCredential(cred, $event)" />
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="credActions" header="" [sortable]="false" width="100px">
+          <ng-template #cell let-cred>
+            <div class="row-actions">
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Test credential" (click)="testCredential(cred)">&#x25B6;</app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete credential" (click)="deleteCredential(cred)">&#x1F5D1;</app-bronco-button>
+            </div>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+
+      <app-card padding="md" class="add-cred-card">
+        <h4 class="add-cred-title">Add Credential</h4>
+        <div class="cred-form">
+          <app-form-field label="Provider">
+            <app-select
+              [value]="newProvider()"
+              [options]="providerOptions"
+              placeholder="Select provider"
+              (valueChange)="newProvider.set($event)" />
+          </app-form-field>
+          <app-form-field label="Label">
+            <app-text-input
+              [value]="newLabel()"
+              placeholder="e.g. Production Key"
+              (valueChange)="newLabel.set($event)" />
+          </app-form-field>
+          <app-form-field label="API Key">
+            <app-text-input
+              type="password"
+              [value]="newApiKey()"
+              placeholder="sk-..."
+              (valueChange)="newApiKey.set($event)" />
+          </app-form-field>
+          <div class="add-cred-action">
+            <app-bronco-button
+              variant="primary"
+              size="md"
+              [disabled]="!canAdd()"
+              (click)="addCredential()">+ Add</app-bronco-button>
+          </div>
+        </div>
+      </app-card>
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+
+    .chip-provider {
+      background: var(--color-purple-subtle);
+      color: var(--color-purple);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    }
+
+    .key-mask {
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 12px;
+      color: var(--text-secondary);
+      background: var(--bg-code);
+      padding: 1px 6px;
+      border-radius: var(--radius-sm);
+    }
+
+    .row-actions {
+      display: inline-flex;
+      gap: 4px;
+    }
+
+    .add-cred-card {
+      margin-top: 16px;
+    }
+
+    .add-cred-title {
+      margin: 0 0 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .cred-form {
+      display: grid;
+      grid-template-columns: 1fr 1fr 2fr auto;
+      gap: 12px;
+      align-items: end;
+    }
+
+    .add-cred-action {
+      display: flex;
+      align-items: end;
+    }
+
+    @media (max-width: 720px) {
+      .cred-form {
+        grid-template-columns: 1fr;
+      }
+    }
+  `],
+})
+export class ClientAiCredentialsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private credentialService = inject(ClientAiCredentialService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  credentials = signal<ClientAiCredential[]>([]);
+  newProvider = signal('');
+  newLabel = signal('');
+  newApiKey = signal('');
+
+  readonly providerOptions = PROVIDER_OPTIONS;
+
+  trackById = (c: ClientAiCredential): string => c.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.credentialService.getCredentials(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(c => this.credentials.set(c));
+  }
+
+  canAdd(): boolean {
+    return !!this.newProvider() && !!this.newLabel() && !!this.newApiKey();
+  }
+
+  addCredential(): void {
+    this.credentialService.createCredential(this.clientId(), {
+      provider: this.newProvider(),
+      apiKey: this.newApiKey(),
+      label: this.newLabel(),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.newProvider.set('');
+          this.newLabel.set('');
+          this.newApiKey.set('');
+          this.toast.success('Credential added');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.error ?? 'Failed to add credential'),
+      });
+  }
+
+  toggleCredential(cred: ClientAiCredential, checked: boolean): void {
+    this.credentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: checked } : c));
+    this.credentialService.updateCredential(this.clientId(), cred.id, { isActive: checked })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toast.success(`Credential ${checked ? 'enabled' : 'disabled'}`),
+        error: (err) => {
+          this.credentials.update(list => list.map(c => c.id === cred.id ? { ...c, isActive: !checked } : c));
+          this.toast.error(err.error?.error ?? 'Toggle failed');
+        },
+      });
+  }
+
+  testCredential(cred: ClientAiCredential): void {
+    this.toast.info('Testing credential...');
+    this.credentialService.testCredential(this.clientId(), cred.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => result.ok ? this.toast.success('Credential is valid') : this.toast.error(`Test failed: ${result.error}`),
+        error: (err) => this.toast.error(err.error?.error ?? 'Test failed'),
+      });
+  }
+
+  deleteCredential(cred: ClientAiCredential): void {
+    if (!confirm(`Delete credential "${cred.label}"?`)) return;
+    this.credentialService.deleteCredential(this.clientId(), cred.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Credential deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.error ?? 'Delete failed'),
+      });
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
@@ -1,0 +1,241 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import {
+  AiUsageClientSummary,
+  AiUsageLogEntry,
+  AiUsageService,
+} from '../../../../core/services/ai-usage.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  PaginatorComponent,
+  type PaginatorPageEvent,
+} from '../../../../shared/components/index.js';
+
+const PAGE_SIZE = 25;
+
+@Component({
+  selector: 'app-client-ai-usage-tab',
+  standalone: true,
+  imports: [
+    DatePipe,
+    DecimalPipe,
+    BroncoButtonComponent,
+    CardComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    PaginatorComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">AI Usage</h3>
+        <app-bronco-button variant="secondary" size="sm" (click)="loadAll()">&#x21BB; Refresh</app-bronco-button>
+      </div>
+
+      @if (loading()) {
+        <p class="status-text">Loading AI usage data…</p>
+      } @else if (summary(); as s) {
+        <div class="kpi-grid">
+          @for (w of s.windows; track w.label) {
+            <app-card padding="md" class="kpi-card">
+              <div class="kpi-card-title">{{ w.label }}</div>
+              <div class="kpi-row"><span class="kpi-label">Tokens In</span><span class="kpi-value">{{ w.inputTokens | number }}</span></div>
+              <div class="kpi-row"><span class="kpi-label">Tokens Out</span><span class="kpi-value">{{ w.outputTokens | number }}</span></div>
+              <div class="kpi-row"><span class="kpi-label">Base Cost</span><span class="kpi-value">\${{ w.baseCostUsd | number:'1.4-4' }}</span></div>
+              <div class="kpi-row"><span class="kpi-label">Billed Cost</span><span class="kpi-value kpi-billed">\${{ w.billedCostUsd | number:'1.4-4' }}</span></div>
+              <div class="kpi-row"><span class="kpi-label">Requests</span><span class="kpi-value">{{ w.requestCount | number }}</span></div>
+            </app-card>
+          }
+        </div>
+        <p class="markup-note">Billing markup: {{ s.billingMarkupPercent }}x</p>
+
+        <h4 class="log-title">Prompt Log</h4>
+
+        <app-data-table
+          [data]="logs()"
+          [trackBy]="trackById"
+          [rowClickable]="false"
+          emptyMessage="No AI usage logs for this client.">
+          <app-data-column key="createdAt" header="Time" [sortable]="false" width="150px">
+            <ng-template #cell let-l>{{ l.createdAt | date:'short' }}</ng-template>
+          </app-data-column>
+          <app-data-column key="taskType" header="Task" [sortable]="false">
+            <ng-template #cell let-l>{{ l.taskType }}</ng-template>
+          </app-data-column>
+          <app-data-column key="model" header="Model" [sortable]="false">
+            <ng-template #cell let-l>{{ l.model }}</ng-template>
+          </app-data-column>
+          <app-data-column key="provider" header="Provider" [sortable]="false" width="100px">
+            <ng-template #cell let-l>{{ l.provider }}</ng-template>
+          </app-data-column>
+          <app-data-column key="inputTokens" header="In" [sortable]="false" width="80px">
+            <ng-template #cell let-l>{{ l.inputTokens | number }}</ng-template>
+          </app-data-column>
+          <app-data-column key="outputTokens" header="Out" [sortable]="false" width="80px">
+            <ng-template #cell let-l>{{ l.outputTokens | number }}</ng-template>
+          </app-data-column>
+          <app-data-column key="costUsd" header="Cost" [sortable]="false" width="100px">
+            <ng-template #cell let-l>{{ l.costUsd != null ? '$' + (l.costUsd | number:'1.4-4') : '-' }}</ng-template>
+          </app-data-column>
+        </app-data-table>
+
+        @if (logs().length > 0 || total() > 0) {
+          <app-paginator
+            [length]="total()"
+            [pageSize]="pageSize"
+            [pageIndex]="pageIndex()"
+            [pageSizeOptions]="[25, 50, 100]"
+            (page)="onPageChange($event)" />
+        }
+      } @else {
+        <p class="status-text">No AI usage data available. Click Refresh to load.</p>
+      }
+    </div>
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .status-text {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      padding: 32px 16px;
+      text-align: center;
+    }
+
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+
+    @media (max-width: 1024px) {
+      .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 600px) {
+      .kpi-grid { grid-template-columns: 1fr; }
+    }
+
+    .kpi-card-title {
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      margin-bottom: 10px;
+    }
+
+    .kpi-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 3px 0;
+    }
+
+    .kpi-label {
+      color: var(--text-secondary);
+      font-family: var(--font-primary);
+      font-size: 12px;
+    }
+
+    .kpi-value {
+      font-weight: 500;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 12px;
+      color: var(--text-primary);
+    }
+
+    .kpi-billed {
+      color: var(--color-success);
+      font-weight: 600;
+    }
+
+    .markup-note {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 12px;
+      margin: 0 0 20px;
+    }
+
+    .log-title {
+      margin: 16px 0 12px;
+      font-family: var(--font-primary);
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+  `],
+})
+export class ClientAiUsageTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private aiUsageService = inject(AiUsageService);
+  private destroyRef = inject(DestroyRef);
+
+  summary = signal<AiUsageClientSummary | null>(null);
+  logs = signal<AiUsageLogEntry[]>([]);
+  loading = signal(false);
+  pageIndex = signal(0);
+  total = signal(0);
+
+  readonly pageSize = PAGE_SIZE;
+
+  trackById = (l: AiUsageLogEntry): string => l.id;
+
+  ngOnInit(): void {
+    this.loadAll();
+  }
+
+  loadAll(): void {
+    const cid = this.clientId();
+    this.loading.set(true);
+    this.aiUsageService.getClientSummary(cid)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (summary) => {
+          this.summary.set(summary);
+          this.loading.set(false);
+        },
+        error: () => this.loading.set(false),
+      });
+    this.loadLogs();
+  }
+
+  loadLogs(): void {
+    const cid = this.clientId();
+    const page = this.pageIndex();
+    this.aiUsageService.getClientLogs(cid, { limit: this.pageSize, offset: page * this.pageSize })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((res) => {
+        this.logs.set(res.logs);
+        this.total.set(res.total);
+      });
+  }
+
+  onPageChange(event: PaginatorPageEvent): void {
+    this.pageIndex.set(event.pageIndex);
+    this.loadLogs();
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
@@ -88,7 +88,7 @@ const PAGE_SIZE = 25;
             [length]="total()"
             [pageSize]="pageSize"
             [pageIndex]="pageIndex()"
-            [pageSizeOptions]="[25, 50, 100]"
+            [pageSizeOptions]="[pageSize]"
             (page)="onPageChange($event)" />
         }
       } @else {
@@ -228,9 +228,12 @@ export class ClientAiUsageTabComponent implements OnInit {
     const page = this.pageIndex();
     this.aiUsageService.getClientLogs(cid, { limit: this.pageSize, offset: page * this.pageSize })
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((res) => {
-        this.logs.set(res.logs);
-        this.total.set(res.total);
+      .subscribe({
+        next: (res) => {
+          this.logs.set(res.logs);
+          this.total.set(res.total);
+        },
+        error: () => this.logs.set([]),
       });
   }
 

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/contacts-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/contacts-tab.component.ts
@@ -1,0 +1,158 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Contact } from '../../../../core/services/client.service';
+import { ContactService } from '../../../../core/services/contact.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { ContactDialogComponent } from '../../../contacts/contact-dialog.component';
+
+@Component({
+  selector: 'app-client-contacts-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    ContactDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Contacts</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add Contact</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="contacts()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No contacts added.">
+        <app-data-column key="name" header="Name" [sortable]="false">
+          <ng-template #cell let-c>{{ c.name }}</ng-template>
+        </app-data-column>
+        <app-data-column key="email" header="Email" [sortable]="false">
+          <ng-template #cell let-c>{{ c.email }}</ng-template>
+        </app-data-column>
+        <app-data-column key="role" header="Role" [sortable]="false">
+          <ng-template #cell let-c>{{ c.role ?? '-' }}</ng-template>
+        </app-data-column>
+        <app-data-column key="isPrimary" header="Primary" [sortable]="false" width="80px">
+          <ng-template #cell let-c>
+            @if (c.isPrimary) {
+              <span class="primary-star" title="Primary contact">&#x2605;</span>
+            }
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="actions" header="" [sortable]="false" width="100px">
+          <ng-template #cell let-c>
+            <div class="row-actions">
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Edit contact" (click)="openEditDialog(c)">&#x270E;</app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete contact" (click)="deleteContact(c.id)">&#x1F5D1;</app-bronco-button>
+            </div>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit Contact' : 'Add Contact'"
+        maxWidth="500px"
+        (openChange)="showDialog.set(false)">
+        <app-contact-dialog-content
+          [clientId]="clientId()"
+          [contact]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .primary-star {
+      color: var(--color-warning);
+      font-size: 18px;
+      line-height: 1;
+    }
+
+    .row-actions {
+      display: inline-flex;
+      gap: 4px;
+    }
+  `],
+})
+export class ClientContactsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private contactService = inject(ContactService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  contacts = signal<Contact[]>([]);
+  showDialog = signal(false);
+  editing = signal<Contact | null>(null);
+
+  trackById = (c: Contact): string => c.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.contactService.getContacts(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(c => this.contacts.set(c));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(contact: Contact): void {
+    this.editing.set(contact);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  deleteContact(id: string): void {
+    this.contactService.deleteContact(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Contact deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
+      });
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/environments-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/environments-tab.component.ts
@@ -1,0 +1,237 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ClientEnvironment, ClientEnvironmentService } from '../../../../core/services/client-environment.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  DialogComponent,
+  ToggleSwitchComponent,
+} from '../../../../shared/components/index.js';
+import { ClientEnvironmentDialogComponent } from '../../client-environment-dialog.component';
+
+@Component({
+  selector: 'app-client-environments-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    CardComponent,
+    DialogComponent,
+    ToggleSwitchComponent,
+    ClientEnvironmentDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Environments</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add Environment</app-bronco-button>
+      </div>
+
+      @for (env of environments(); track env.id) {
+        <app-card padding="md" class="env-card" [class.inactive-card]="!env.isActive">
+          <div class="env-header">
+            <span class="env-icon" aria-hidden="true">&#x2601;</span>
+            <strong class="env-name">{{ env.name }}</strong>
+            <span class="chip chip-tag">{{ env.tag }}</span>
+            @if (env.isDefault) {
+              <span class="chip chip-default">Default</span>
+            }
+            <app-toggle-switch
+              [checked]="env.isActive"
+              [label]="env.isActive ? 'Active' : 'Inactive'"
+              (checkedChange)="toggleEnvironment(env, $event)" />
+            <span class="spacer"></span>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Edit environment" (click)="openEditDialog(env)">&#x270E;</app-bronco-button>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Delete environment" (click)="deleteEnvironment(env)">&#x1F5D1;</app-bronco-button>
+          </div>
+          @if (env.description) { <p class="env-desc">{{ env.description }}</p> }
+          @if (env.operationalInstructions) {
+            <pre class="env-instructions">{{ truncate(env.operationalInstructions) }}</pre>
+          }
+        </app-card>
+      } @empty {
+        <p class="empty">No environments configured. Add environments (e.g. Production, Development) to group systems, repos, and integrations.</p>
+      }
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit Environment' : 'Add Environment'"
+        maxWidth="650px"
+        (openChange)="showDialog.set(false)">
+        <app-client-environment-dialog-content
+          [clientId]="clientId()"
+          [environment]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .env-card {
+      margin-bottom: 12px;
+    }
+
+    .env-card.inactive-card {
+      opacity: 0.6;
+    }
+
+    .env-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .env-icon {
+      font-size: 16px;
+      line-height: 1;
+      color: var(--color-info);
+    }
+
+    .env-name {
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+
+    .chip-tag {
+      background: var(--bg-muted);
+      color: var(--text-secondary);
+    }
+
+    .chip-default {
+      background: var(--color-info-subtle);
+      color: var(--color-info);
+    }
+
+    .spacer { flex: 1; }
+
+    .env-desc {
+      color: var(--text-secondary);
+      font-family: var(--font-primary);
+      font-size: 13px;
+      margin: 10px 0 4px;
+      line-height: 1.5;
+    }
+
+    .env-instructions {
+      background: var(--bg-code);
+      color: var(--text-code);
+      padding: 10px 14px;
+      border-radius: var(--radius-md);
+      font-size: 12px;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      max-height: 200px;
+      overflow-y: auto;
+      margin: 10px 0 0;
+    }
+
+    .empty {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      padding: 32px 16px;
+      text-align: center;
+    }
+  `],
+})
+export class ClientEnvironmentsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private envService = inject(ClientEnvironmentService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  environments = signal<ClientEnvironment[]>([]);
+  showDialog = signal(false);
+  editing = signal<ClientEnvironment | null>(null);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.envService.getEnvironments(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(e => this.environments.set(e));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(env: ClientEnvironment): void {
+    this.editing.set(env);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  toggleEnvironment(env: ClientEnvironment, checked: boolean): void {
+    this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: checked } : e));
+    this.envService.updateEnvironment(this.clientId(), env.id, { isActive: checked })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toast.success(`Environment ${checked ? 'enabled' : 'disabled'}`),
+        error: (err) => {
+          this.environments.update(list => list.map(e => e.id === env.id ? { ...e, isActive: !checked } : e));
+          this.toast.error(err.error?.error ?? err.error?.message ?? 'Toggle failed');
+        },
+      });
+  }
+
+  deleteEnvironment(env: ClientEnvironment): void {
+    if (!confirm(`Delete environment "${env.name}"? Linked integrations, repos, and systems will be unlinked.`)) return;
+    this.envService.deleteEnvironment(this.clientId(), env.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Environment deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.error ?? err.error?.message ?? 'Delete failed'),
+      });
+  }
+
+  truncate(text: string, max = 200): string {
+    return text.length > max ? text.slice(0, max) + '...' : text;
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
@@ -1,0 +1,249 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { JsonPipe } from '@angular/common';
+import { ClientIntegration, IntegrationService } from '../../../../core/services/integration.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  ToggleSwitchComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { McpServerInfoComponent } from '../../../../shared/components/mcp-server-info.component';
+import { IntegrationDialogComponent } from '../../../integrations/integration-dialog.component';
+
+const SENSITIVE_KEYS = ['encryptedPassword', 'encryptedPat', 'password', 'pat', 'token', 'secret', 'apiKey'];
+
+@Component({
+  selector: 'app-client-integrations-tab',
+  standalone: true,
+  imports: [
+    JsonPipe,
+    BroncoButtonComponent,
+    CardComponent,
+    ToggleSwitchComponent,
+    DialogComponent,
+    McpServerInfoComponent,
+    IntegrationDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Integrations</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add Integration</app-bronco-button>
+      </div>
+
+      @for (integ of integrations(); track integ.id) {
+        <app-card padding="md" class="integration-card" [class.inactive-card]="!integ.isActive">
+          <div class="integ-header">
+            <span class="type-icon">{{ integrationIcon(integ.type) }}</span>
+            <strong class="integ-type">{{ integ.type }}</strong>
+            @if (integ.label && integ.label !== 'default') {
+              <span class="label-chip">{{ integ.label }}</span>
+            }
+            <app-toggle-switch
+              [checked]="integ.isActive"
+              [label]="integ.isActive ? 'Active' : 'Inactive'"
+              (checkedChange)="toggleIntegration(integ, $event)" />
+            <span class="spacer"></span>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Edit integration" (click)="openEditDialog(integ)">&#x270E;</app-bronco-button>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Delete integration" (click)="deleteIntegration(integ.id)">&#x1F5D1;</app-bronco-button>
+          </div>
+          @if (integ.notes) { <p class="integ-notes">{{ integ.notes }}</p> }
+          @if (integ.type === 'MCP_DATABASE' && integ.metadata) {
+            <app-mcp-server-info
+              [metadata]="integ.metadata"
+              [integrationId]="integ.id"
+              (verified)="load()" />
+          } @else {
+            <pre class="config-preview">{{ redactConfig(integ.config) | json }}</pre>
+          }
+        </app-card>
+      } @empty {
+        <p class="empty">No integrations configured. Add IMAP, Azure DevOps, or MCP Database integrations.</p>
+      }
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit Integration' : 'Add Integration'"
+        maxWidth="600px"
+        (openChange)="showDialog.set(false)">
+        <app-integration-dialog-content
+          [clientId]="clientId()"
+          [integration]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .integration-card {
+      margin-bottom: 12px;
+    }
+
+    .integration-card.inactive-card {
+      opacity: 0.6;
+    }
+
+    .integ-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .type-icon {
+      font-size: 16px;
+      line-height: 1;
+    }
+
+    .integ-type {
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+    }
+
+    .label-chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      background: var(--color-success-subtle);
+      color: var(--color-success);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    }
+
+    .spacer { flex: 1; }
+
+    .integ-notes {
+      color: var(--text-secondary);
+      font-family: var(--font-primary);
+      font-size: 13px;
+      margin: 10px 0 4px;
+      line-height: 1.5;
+    }
+
+    .config-preview {
+      background: var(--bg-code);
+      color: var(--text-code);
+      padding: 10px 14px;
+      border-radius: var(--radius-md);
+      font-size: 12px;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      overflow-x: auto;
+      margin: 10px 0 0;
+    }
+
+    .empty {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      padding: 32px 16px;
+      text-align: center;
+    }
+  `],
+})
+export class ClientIntegrationsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private integrationService = inject(IntegrationService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  integrations = signal<ClientIntegration[]>([]);
+  showDialog = signal(false);
+  editing = signal<ClientIntegration | null>(null);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.integrationService.getIntegrations(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(i => this.integrations.set(i));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(integ: ClientIntegration): void {
+    this.editing.set(integ);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  toggleIntegration(integ: ClientIntegration, checked: boolean): void {
+    // Optimistic update so the toggle doesn't snap back
+    this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: checked } : i));
+    this.integrationService.updateIntegration(integ.id, { isActive: checked })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toast.success(`Integration ${checked ? 'enabled' : 'disabled'}`),
+        error: (err) => {
+          // Revert and reload authoritative state
+          this.integrations.update(list => list.map(i => i.id === integ.id ? { ...i, isActive: !checked } : i));
+          this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
+          this.load();
+        },
+      });
+  }
+
+  deleteIntegration(id: string): void {
+    this.integrationService.deleteIntegration(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Integration deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
+      });
+  }
+
+  integrationIcon(type: string): string {
+    switch (type) {
+      case 'IMAP': return '\u2709';        // ✉
+      case 'AZURE_DEVOPS': return '\u2699'; // ⚙
+      case 'MCP_DATABASE': return '\u{1F5C4}'; // 🗄
+      case 'SLACK': return '\u{1F4AC}';     // 💬
+      default: return '\u{1F50C}';          // 🔌
+    }
+  }
+
+  redactConfig(config: Record<string, unknown>): Record<string, unknown> {
+    const redacted: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      redacted[key] = SENSITIVE_KEYS.includes(key) ? '********' : value;
+    }
+    return redacted;
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/invoices-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/invoices-tab.component.ts
@@ -1,0 +1,199 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { Invoice, InvoiceService } from '../../../../core/services/invoice.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { GenerateInvoiceDialogComponent } from '../../generate-invoice-dialog.component';
+
+@Component({
+  selector: 'app-client-invoices-tab',
+  standalone: true,
+  imports: [
+    DatePipe,
+    DecimalPipe,
+    BroncoButtonComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    GenerateInvoiceDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Invoices</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openGenerateDialog()">+ Generate Invoice</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="invoices()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No invoices generated yet.">
+        <app-data-column key="invoiceNumber" header="#" [sortable]="false" width="80px">
+          <ng-template #cell let-inv>{{ inv.invoiceNumber }}</ng-template>
+        </app-data-column>
+        <app-data-column key="period" header="Period" [sortable]="false" width="220px">
+          <ng-template #cell let-inv>
+            {{ inv.periodStart | date:'mediumDate' }} – {{ inv.periodEnd | date:'mediumDate' }}
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="requests" header="Requests" [sortable]="false" width="100px">
+          <ng-template #cell let-inv>{{ inv.requestCount }}</ng-template>
+        </app-data-column>
+        <app-data-column key="totalBilled" header="Total Billed" [sortable]="false" width="120px">
+          <ng-template #cell let-inv>\${{ inv.totalBilledCostUsd | number:'1.2-2' }}</ng-template>
+        </app-data-column>
+        <app-data-column key="invoiceStatus" header="Status" [sortable]="false" width="100px">
+          <ng-template #cell let-inv>
+            <span class="chip" [class.chip-final]="inv.status === 'final'" [class.chip-draft]="inv.status !== 'final'">
+              {{ inv.status }}
+            </span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="invoiceActions" header="" [sortable]="false" width="100px">
+          <ng-template #cell let-inv>
+            <div class="row-actions">
+              <a class="row-action-link"
+                 [href]="getDownloadUrl(inv.id)"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 aria-label="Download PDF"
+                 title="Download PDF">&#x2B07;</a>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete invoice" (click)="deleteInvoice(inv)">&#x1F5D1;</app-bronco-button>
+            </div>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        title="Generate Invoice"
+        maxWidth="400px"
+        (openChange)="showDialog.set(false)">
+        <app-generate-invoice-dialog-content
+          [clientId]="clientId()"
+          (generated)="onGenerated()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+      text-transform: capitalize;
+    }
+    .chip-final {
+      background: var(--color-success-subtle);
+      color: var(--color-success);
+    }
+    .chip-draft {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .row-actions {
+      display: inline-flex;
+      gap: 4px;
+      align-items: center;
+    }
+
+    .row-action-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: var(--radius-sm);
+      color: var(--text-tertiary);
+      text-decoration: none;
+      font-size: 14px;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .row-action-link:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
+    }
+  `],
+})
+export class ClientInvoicesTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private invoiceService = inject(InvoiceService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  invoices = signal<Invoice[]>([]);
+  showDialog = signal(false);
+
+  trackById = (i: Invoice): string => i.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.invoiceService.getInvoices(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(i => this.invoices.set(i));
+  }
+
+  openGenerateDialog(): void {
+    this.showDialog.set(true);
+  }
+
+  onGenerated(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  getDownloadUrl(invoiceId: string): string {
+    return this.invoiceService.getDownloadUrl(this.clientId(), invoiceId);
+  }
+
+  deleteInvoice(inv: Invoice): void {
+    if (!confirm(`Delete invoice #${inv.invoiceNumber}?`)) return;
+    this.invoiceService.deleteInvoice(this.clientId(), inv.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Invoice deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
+      });
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/memory-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/memory-tab.component.ts
@@ -1,0 +1,313 @@
+import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ClientMemory, ClientMemoryService } from '../../../../core/services/client-memory.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  DialogComponent,
+  SelectComponent,
+  ToggleSwitchComponent,
+} from '../../../../shared/components/index.js';
+import { ClientMemoryDialogComponent } from '../../client-memory-dialog.component';
+
+const SOURCE_OPTIONS = [
+  { value: '', label: 'All sources' },
+  { value: 'MANUAL', label: 'Manual' },
+  { value: 'AI_LEARNED', label: 'AI Learned' },
+];
+
+@Component({
+  selector: 'app-client-memory-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    CardComponent,
+    DialogComponent,
+    SelectComponent,
+    ToggleSwitchComponent,
+    ClientMemoryDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">AI Memory</h3>
+        <div class="header-actions">
+          <app-select
+            class="source-filter"
+            [value]="sourceFilter()"
+            [options]="sourceOptions"
+            placeholder="All sources"
+            (valueChange)="sourceFilter.set($event)" />
+          <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add Memory</app-bronco-button>
+        </div>
+      </div>
+
+      @for (mem of filteredMemories(); track mem.id) {
+        <app-card padding="md" class="memory-card" [class.inactive-card]="!mem.isActive">
+          <div class="memory-header">
+            <span class="type-icon">{{ memoryTypeIcon(mem.memoryType) }}</span>
+            <strong class="memory-title">{{ mem.title }}</strong>
+            <span class="chip chip-type chip-type-{{ mem.memoryType.toLowerCase() }}">{{ mem.memoryType }}</span>
+            <span class="chip chip-source chip-source-{{ (mem.source ?? 'MANUAL').toLowerCase() }}">
+              {{ (mem.source ?? 'MANUAL') === 'AI_LEARNED' ? 'AI' : 'MANUAL' }}
+            </span>
+            @if (mem.category) {
+              <span class="chip chip-category">{{ mem.category }}</span>
+            }
+            <app-toggle-switch
+              [checked]="mem.isActive"
+              [label]="mem.isActive ? 'Active' : 'Inactive'"
+              (checkedChange)="toggleMemory(mem, $event)" />
+            <span class="spacer"></span>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Edit memory" (click)="openEditDialog(mem)">&#x270E;</app-bronco-button>
+            <app-bronco-button variant="icon" size="sm" ariaLabel="Delete memory" (click)="deleteMemory(mem.id)">&#x1F5D1;</app-bronco-button>
+          </div>
+          @if (mem.tags.length) {
+            <div class="tags">
+              @for (tag of mem.tags; track tag) {
+                <span class="chip chip-tag">{{ tag }}</span>
+              }
+            </div>
+          }
+          <pre class="memory-content">{{ mem.content }}</pre>
+        </app-card>
+      } @empty {
+        <p class="empty">No memory entries. Add context, playbooks, or tool guidance to help AI analyze tickets for this client.</p>
+      }
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit Client Memory' : 'Add Client Memory'"
+        maxWidth="650px"
+        (openChange)="showDialog.set(false)">
+        <app-client-memory-dialog-content
+          [clientId]="clientId()"
+          [memory]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+      gap: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .source-filter {
+      display: inline-block;
+      min-width: 160px;
+    }
+
+    .memory-card {
+      margin-bottom: 12px;
+    }
+
+    .memory-card.inactive-card {
+      opacity: 0.6;
+    }
+
+    .memory-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .type-icon {
+      font-size: 16px;
+      line-height: 1;
+    }
+
+    .memory-title {
+      font-family: var(--font-primary);
+      font-size: 14px;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+
+    .chip-type-context {
+      background: var(--color-info-subtle);
+      color: var(--color-info);
+    }
+    .chip-type-playbook {
+      background: var(--color-error-subtle);
+      color: var(--color-error);
+    }
+    .chip-type-tool_guidance {
+      background: var(--color-purple-subtle);
+      color: var(--color-purple);
+    }
+
+    .chip-source {
+      font-size: 9px;
+      font-weight: 700;
+      letter-spacing: 0.3px;
+      padding: 1px 5px;
+      text-transform: uppercase;
+    }
+    .chip-source-manual {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+    .chip-source-ai_learned {
+      background: var(--color-purple-subtle);
+      color: var(--color-purple);
+    }
+
+    .chip-category {
+      background: var(--color-warning-subtle);
+      color: var(--color-warning);
+    }
+
+    .chip-tag {
+      background: var(--bg-muted);
+      color: var(--text-secondary);
+    }
+
+    .spacer { flex: 1; }
+
+    .tags {
+      display: flex;
+      gap: 4px;
+      margin: 10px 0 4px;
+      flex-wrap: wrap;
+    }
+
+    .memory-content {
+      background: var(--bg-code);
+      color: var(--text-code);
+      padding: 10px 14px;
+      border-radius: var(--radius-md);
+      font-size: 12px;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      max-height: 240px;
+      overflow-y: auto;
+      margin: 10px 0 0;
+    }
+
+    .empty {
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+      padding: 32px 16px;
+      text-align: center;
+    }
+  `],
+})
+export class ClientMemoryTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private memoryService = inject(ClientMemoryService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  memories = signal<ClientMemory[]>([]);
+  sourceFilter = signal<string>('');
+  showDialog = signal(false);
+  editing = signal<ClientMemory | null>(null);
+
+  readonly sourceOptions = SOURCE_OPTIONS;
+
+  filteredMemories = computed(() => {
+    const filter = this.sourceFilter();
+    const all = this.memories();
+    if (!filter) return all;
+    return all.filter(m => (m.source ?? 'MANUAL') === filter);
+  });
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.memoryService.getMemories({ clientId: this.clientId() })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(m => this.memories.set(m));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(mem: ClientMemory): void {
+    this.editing.set(mem);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  toggleMemory(mem: ClientMemory, checked: boolean): void {
+    this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: checked } : m));
+    this.memoryService.updateMemory(mem.id, { isActive: checked })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toast.success(`Memory ${checked ? 'enabled' : 'disabled'}`),
+        error: (err) => {
+          this.memories.update(list => list.map(m => m.id === mem.id ? { ...m, isActive: !checked } : m));
+          this.toast.error(err.error?.message ?? err.error?.error ?? 'Toggle failed');
+        },
+      });
+  }
+
+  deleteMemory(id: string): void {
+    this.memoryService.deleteMemory(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Memory entry deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
+      });
+  }
+
+  memoryTypeIcon(type: string): string {
+    switch (type) {
+      case 'CONTEXT': return '\u2139';        // ℹ
+      case 'PLAYBOOK': return '\u{1F4D6}';   // 📖
+      case 'TOOL_GUIDANCE': return '\u{1F527}'; // 🔧
+      default: return '\u{1F9E0}';            // 🧠
+    }
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
@@ -1,0 +1,173 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CodeRepo, RepoService } from '../../../../core/services/repo.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { RepoDialogComponent } from '../../../repos/repo-dialog.component';
+
+@Component({
+  selector: 'app-client-repos-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    RepoDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Code Repositories</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add Repo</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="repos()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No repositories configured.">
+        <app-data-column key="name" header="Name" [sortable]="false">
+          <ng-template #cell let-r>{{ r.name }}</ng-template>
+        </app-data-column>
+        <app-data-column key="repoUrl" header="URL" [sortable]="false">
+          <ng-template #cell let-r>
+            <code class="repo-url">{{ r.repoUrl }}</code>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="branch" header="Branch" [sortable]="false" width="140px">
+          <ng-template #cell let-r>{{ r.defaultBranch }}</ng-template>
+        </app-data-column>
+        <app-data-column key="prefix" header="Prefix" [sortable]="false" width="120px">
+          <ng-template #cell let-r>
+            <span class="prefix-chip">{{ r.branchPrefix }}/</span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="actions" header="" [sortable]="false" width="100px">
+          <ng-template #cell let-r>
+            <div class="row-actions">
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Edit repository" (click)="openEditDialog(r)">&#x270E;</app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete repository" (click)="deleteRepo(r)">&#x1F5D1;</app-bronco-button>
+            </div>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit Code Repository' : 'Add Code Repository'"
+        maxWidth="500px"
+        (openChange)="showDialog.set(false)">
+        <app-repo-dialog-content
+          [clientId]="clientId()"
+          [repo]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .repo-url {
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 12px;
+      color: var(--text-secondary);
+      background: var(--bg-code);
+      padding: 1px 6px;
+      border-radius: var(--radius-sm);
+    }
+
+    .prefix-chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      background: var(--bg-active);
+      color: var(--accent);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    }
+
+    .row-actions {
+      display: inline-flex;
+      gap: 4px;
+    }
+  `],
+})
+export class ClientReposTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private repoService = inject(RepoService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  repos = signal<CodeRepo[]>([]);
+  showDialog = signal(false);
+  editing = signal<CodeRepo | null>(null);
+
+  trackById = (r: CodeRepo): string => r.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.repoService.getRepos(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(r => this.repos.set(r));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(repo: CodeRepo): void {
+    this.editing.set(repo);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  deleteRepo(repo: CodeRepo): void {
+    if (!confirm(`Delete repo "${repo.name}"?`)) return;
+    this.repoService.deleteRepo(repo.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('Repository deleted');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Delete failed'),
+      });
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
@@ -1,0 +1,154 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { System } from '../../../../core/services/client.service';
+import { SystemService } from '../../../../core/services/system.service';
+import {
+  BroncoButtonComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { SystemDialogComponent } from '../../../systems/system-dialog.component';
+
+@Component({
+  selector: 'app-client-systems-tab',
+  standalone: true,
+  imports: [
+    BroncoButtonComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    SystemDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Database Systems</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openDialog()">+ Add System</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="systems()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No systems configured.">
+        <app-data-column key="name" header="Name" [sortable]="false">
+          <ng-template #cell let-s>{{ s.name }}</ng-template>
+        </app-data-column>
+        <app-data-column key="dbEngine" header="Engine" [sortable]="false">
+          <ng-template #cell let-s>
+            <span class="chip chip-engine">{{ s.dbEngine }}</span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="host" header="Host" [sortable]="false">
+          <ng-template #cell let-s>
+            <code class="host">{{ s.host }}:{{ s.port }}</code>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="environment" header="Env" [sortable]="false">
+          <ng-template #cell let-s>{{ s.environment }}</ng-template>
+        </app-data-column>
+        <app-data-column key="status" header="Status" [sortable]="false">
+          <ng-template #cell let-s>
+            <span class="chip" [class.chip-active]="s.isActive" [class.chip-inactive]="!s.isActive">
+              {{ s.isActive ? 'Active' : 'Inactive' }}
+            </span>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog [open]="true" title="Add Database System" maxWidth="600px" (openChange)="showDialog.set(false)">
+        <app-system-dialog-content
+          [clientId]="clientId()"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+    .chip-engine {
+      background: var(--bg-active);
+      color: var(--accent);
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 11px;
+    }
+    .chip-active {
+      background: var(--color-success-subtle);
+      color: var(--color-success);
+    }
+    .chip-inactive {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .host {
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-size: 13px;
+      color: var(--text-secondary);
+      background: var(--bg-code);
+      padding: 1px 6px;
+      border-radius: var(--radius-sm);
+    }
+  `],
+})
+export class ClientSystemsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private systemService = inject(SystemService);
+  private destroyRef = inject(DestroyRef);
+
+  systems = signal<System[]>([]);
+  showDialog = signal(false);
+
+  trackById = (s: System): string => s.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.systemService.getSystems(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(s => this.systems.set(s));
+  }
+
+  openDialog(): void {
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/tickets-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/tickets-tab.component.ts
@@ -1,0 +1,143 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { Ticket, TicketService } from '../../../../core/services/ticket.service';
+import {
+  BroncoButtonComponent,
+  CategoryChipComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+  PriorityPillComponent,
+} from '../../../../shared/components/index.js';
+import { TicketDialogComponent } from '../../../tickets/ticket-dialog.component';
+
+type Priority = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+
+@Component({
+  selector: 'app-client-tickets-tab',
+  standalone: true,
+  imports: [
+    RouterLink,
+    BroncoButtonComponent,
+    CategoryChipComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    PriorityPillComponent,
+    TicketDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Tickets</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openCreateDialog()">+ Create Ticket</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="tickets()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No tickets for this client.">
+        <app-data-column key="subject" header="Subject" [sortable]="false">
+          <ng-template #cell let-t>
+            <a class="link" [routerLink]="['/tickets', t.id]">{{ t.subject }}</a>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="status" header="Status" [sortable]="false" width="120px">
+          <ng-template #cell let-t>{{ t.status }}</ng-template>
+        </app-data-column>
+        <app-data-column key="priority" header="Priority" [sortable]="false" width="100px">
+          <ng-template #cell let-t>
+            <app-priority-pill [priority]="asPriority(t.priority)" />
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="category" header="Category" [sortable]="false" width="160px">
+          <ng-template #cell let-t>
+            @if (t.category) {
+              <app-category-chip [category]="t.category" />
+            } @else {
+              <span class="muted">-</span>
+            }
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog [open]="true" title="Create Ticket" maxWidth="560px" (openChange)="showDialog.set(false)">
+        <app-ticket-dialog-content
+          [clientId]="clientId()"
+          (created)="onCreated()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .link {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .link:hover { text-decoration: underline; }
+
+    .muted { color: var(--text-tertiary); }
+  `],
+})
+export class ClientTicketsTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private ticketService = inject(TicketService);
+  private destroyRef = inject(DestroyRef);
+
+  tickets = signal<Ticket[]>([]);
+  showDialog = signal(false);
+
+  trackById = (t: Ticket): string => t.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.ticketService.getTickets({ clientId: this.clientId(), limit: 20 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(t => this.tickets.set(t));
+  }
+
+  openCreateDialog(): void {
+    this.showDialog.set(true);
+  }
+
+  onCreated(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  asPriority(value: string): Priority {
+    const upper = value.toUpperCase();
+    if (upper === 'CRITICAL' || upper === 'HIGH' || upper === 'MEDIUM' || upper === 'LOW') {
+      return upper;
+    }
+    return 'LOW';
+  }
+}

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/users-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/users-tab.component.ts
@@ -1,0 +1,195 @@
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
+import { ClientUser, ClientUserService } from '../../../../core/services/client-user.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import {
+  BroncoButtonComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../../../shared/components/index.js';
+import { ClientUserDialogComponent } from '../../client-user-dialog.component';
+
+@Component({
+  selector: 'app-client-users-tab',
+  standalone: true,
+  imports: [
+    DatePipe,
+    BroncoButtonComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+    ClientUserDialogComponent,
+  ],
+  template: `
+    <div class="tab-section">
+      <div class="section-header">
+        <h3 class="section-title">Portal Users</h3>
+        <app-bronco-button variant="primary" size="sm" (click)="openAddDialog()">+ Add User</app-bronco-button>
+      </div>
+
+      <app-data-table
+        [data]="users()"
+        [trackBy]="trackById"
+        [rowClickable]="false"
+        emptyMessage="No portal users for this client.">
+        <app-data-column key="name" header="Name" [sortable]="false">
+          <ng-template #cell let-u>{{ u.name }}</ng-template>
+        </app-data-column>
+        <app-data-column key="email" header="Email" [sortable]="false">
+          <ng-template #cell let-u>{{ u.email }}</ng-template>
+        </app-data-column>
+        <app-data-column key="userType" header="Type" [sortable]="false" width="100px">
+          <ng-template #cell let-u>
+            <span class="chip" [class.chip-admin]="u.userType === 'ADMIN'" [class.chip-user]="u.userType !== 'ADMIN'">
+              {{ u.userType }}
+            </span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="isActiveUser" header="Status" [sortable]="false" width="110px">
+          <ng-template #cell let-u>
+            <span class="chip" [class.chip-active]="u.isActive" [class.chip-inactive]="!u.isActive">
+              {{ u.isActive ? 'Active' : 'Inactive' }}
+            </span>
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="lastLogin" header="Last Login" [sortable]="false" width="160px">
+          <ng-template #cell let-u>
+            @if (u.lastLoginAt) {
+              {{ u.lastLoginAt | date:'short' }}
+            } @else {
+              <span class="muted">Never</span>
+            }
+          </ng-template>
+        </app-data-column>
+        <app-data-column key="actions" header="" [sortable]="false" width="100px">
+          <ng-template #cell let-u>
+            <div class="row-actions">
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Edit user" (click)="openEditDialog(u)">&#x270E;</app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Deactivate user" (click)="deleteUser(u.id)">&#x1F6AB;</app-bronco-button>
+            </div>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+    </div>
+
+    @if (showDialog()) {
+      <app-dialog
+        [open]="true"
+        [title]="editing() ? 'Edit User' : 'Create Portal User'"
+        maxWidth="500px"
+        (openChange)="showDialog.set(false)">
+        <app-client-user-dialog-content
+          [clientId]="clientId()"
+          [user]="editing() ?? undefined"
+          (saved)="onSaved()"
+          (cancelled)="showDialog.set(false)" />
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    :host { display: block; }
+
+    .tab-section { padding: 16px 0; }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .section-title {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--radius-sm);
+      font-family: var(--font-primary);
+      white-space: nowrap;
+    }
+    .chip-admin {
+      background: var(--color-info-subtle);
+      color: var(--color-info);
+    }
+    .chip-user {
+      background: var(--bg-muted);
+      color: var(--text-secondary);
+    }
+    .chip-active {
+      background: var(--color-success-subtle);
+      color: var(--color-success);
+    }
+    .chip-inactive {
+      background: var(--bg-muted);
+      color: var(--text-tertiary);
+    }
+
+    .muted { color: var(--text-tertiary); }
+
+    .row-actions {
+      display: inline-flex;
+      gap: 4px;
+    }
+  `],
+})
+export class ClientUsersTabComponent implements OnInit {
+  clientId = input.required<string>();
+
+  private userService = inject(ClientUserService);
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  users = signal<ClientUser[]>([]);
+  showDialog = signal(false);
+  editing = signal<ClientUser | null>(null);
+
+  trackById = (u: ClientUser): string => u.id;
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.userService.getUsers(this.clientId())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(u => this.users.set(u));
+  }
+
+  openAddDialog(): void {
+    this.editing.set(null);
+    this.showDialog.set(true);
+  }
+
+  openEditDialog(user: ClientUser): void {
+    this.editing.set(user);
+    this.showDialog.set(true);
+  }
+
+  onSaved(): void {
+    this.showDialog.set(false);
+    this.load();
+  }
+
+  deleteUser(id: string): void {
+    this.userService.deleteUser(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toast.success('User deactivated');
+          this.load();
+        },
+        error: (err) => this.toast.error(err.error?.message ?? err.error?.error ?? 'Deactivation failed'),
+      });
+  }
+}


### PR DESCRIPTION
## Summary

Migrates `client-detail.component.ts` (1,279 lines, 11 tabs) off Angular Material and onto the custom Bronco design system. Splits the monolith into per-tab sub-components for review-ability and future maintenance. Part of the design system migration epic (#131).

## Approach

This is being shipped as a series of small, individually-reviewable commits rather than one giant rewrite:

| # | Commit | Status |
|---|--------|--------|
| 1 | `fix:` correct tab bounds + AI usage lazy-load index drift | ✅ |
| 2 | `refactor:` switch tab routing from `?tab=N` to `?tab=memory` slugs | ✅ |
| 3 | `refactor:` extract `ClientHeaderComponent`, swap tab shell to `app-tab-group` | ✅ |
| 4 | Extract + migrate **Systems** tab | 🚧 |
| 5 | Extract + migrate **Contacts** tab | ⏳ |
| 6 | Extract + migrate **Repos** tab | ⏳ |
| 7 | Extract + migrate **Integrations** tab | ⏳ |
| 8 | Extract + migrate **Tickets** tab | ⏳ |
| 9 | Extract + migrate **Memory** tab | ⏳ |
| 10 | Extract + migrate **Environments** tab | ⏳ |
| 11 | Extract + migrate **Users** tab | ⏳ |
| 12 | Extract + migrate **AI Credentials** tab | ⏳ |
| 13 | Extract + migrate **Invoices** tab | ⏳ |
| 14 | Extract + migrate **AI Usage** tab | ⏳ |
| 15 | Final cleanup — drop remaining Material imports + dead CSS | ⏳ |

## Bugs found while reading the file

These pre-existed on `design/staging` and are fixed in commits 1 and 2:

- **Tab bounds were 0-7** but the page has 11 tabs (0-10). Any deep link to `?tab=8/9/10` was silently clamped to the default.
- **AI Usage lazy-load fired on index 7**, which became the Users tab after AI Credentials/Invoices/AI Usage were added. Switching to Users was triggering a useless AI usage fetch, and switching to AI Usage never lazy-loaded its data on first visit.
- **`?tab=N` integer routing** is brittle — adding/moving a tab silently breaks any bookmarked deep link. Now uses string slugs (`?tab=memory`, `?tab=ai-usage`, etc.). Numeric form is still accepted on read for backwards compat with existing bookmarks; only slug form is written.

## Architecture

```
features/clients/
├── client-detail.component.ts             ← orchestrator: header + tab shell
└── client-detail/
    ├── client-header.component.ts         ← title, toggles, slack form, ai-mode
    └── tabs/
        ├── systems-tab.component.ts       (incoming)
        ├── contacts-tab.component.ts      (incoming)
        ├── repos-tab.component.ts         (incoming)
        ├── integrations-tab.component.ts  (incoming)
        ├── tickets-tab.component.ts       (incoming)
        ├── memory-tab.component.ts        (incoming)
        ├── environments-tab.component.ts  (incoming)
        ├── users-tab.component.ts         (incoming)
        ├── ai-credentials-tab.component.ts (incoming)
        ├── invoices-tab.component.ts      (incoming)
        └── ai-usage-tab.component.ts      (incoming)
```

Each tab component owns its own data signals, dialog state, and CRUD calls. Parent owns only the Client signal, the `selectedTab` index, and tab routing.

## Test plan

- [ ] Header renders with all four toggles working (auto-route, self-reg, active, BYOK)
- [ ] Slack channel ID save round-trips correctly
- [ ] Each tab still loads its data and renders without console errors
- [ ] Deep linking to `?tab=memory`, `?tab=ai-usage`, etc. lands on the right tab
- [ ] Old `?tab=5` numeric form still works (backwards compat)
- [ ] AI Usage tab lazy-loads its data only when first visited (not on Users tab visit)
- [ ] All 14 dialogs (system/contact/repo/integration/ticket/memory/environment/user/invoice + ai-credential add) still open and save

## Notes

- Each per-tab commit is small and self-contained — feel free to review them individually as they land.
- This PR is **draft** until the full sweep is in. Final cleanup commit will drop the remaining Material imports from the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
