### PR TITLE
Rewrite ticket detail page with Bronco components (refs #131)

### DIFF
--- a/.tmp/.gitignore
+++ b/.tmp/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything in this directory except .gitignore itself
+*
+!.gitignore

--- a/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
@@ -1,0 +1,192 @@
+import { Component, input, signal } from '@angular/core';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { CardComponent, BroncoButtonComponent } from '../../shared/components/index.js';
+import { type TicketCostResponse } from '../../core/services/ai-usage.service';
+
+@Component({
+  selector: 'app-ticket-detail-cost',
+  standalone: true,
+  imports: [DatePipe, DecimalPipe, CardComponent, BroncoButtonComponent],
+  template: `
+    @if (cost(); as c) {
+      @if (c.callCount > 0) {
+        <app-card padding="md" class="cost-card">
+          <div class="card-title-row">
+            <span class="card-title-icon" aria-hidden="true">&#9783;</span>
+            <h3 class="card-title">AI Cost</h3>
+          </div>
+          <div class="cost-summary">
+            <div class="cost-item">
+              <span class="cost-label">Total Cost</span>
+              <span class="cost-value">\${{ c.totalCostUsd | number:'1.4-4' }}</span>
+            </div>
+            <div class="cost-item">
+              <span class="cost-label">AI Calls</span>
+              <span class="cost-value">{{ c.callCount | number }}</span>
+            </div>
+            <div class="cost-item">
+              <span class="cost-label">Input Tokens</span>
+              <span class="cost-value">{{ c.totalInputTokens | number }}</span>
+            </div>
+            <div class="cost-item">
+              <span class="cost-label">Output Tokens</span>
+              <span class="cost-value">{{ c.totalOutputTokens | number }}</span>
+            </div>
+          </div>
+
+          @if (c.breakdown.length > 0) {
+            <app-bronco-button variant="ghost" size="sm" (click)="toggleDetails()">
+              {{ detailsExpanded() ? 'Hide details' : 'Show details' }}
+              <span aria-hidden="true">{{ detailsExpanded() ? '\u25B4' : '\u25BE' }}</span>
+            </app-bronco-button>
+          }
+
+          @if (detailsExpanded()) {
+            <div class="cost-breakdown">
+              @for (item of c.breakdown; track item.provider + ':' + item.model) {
+                <div class="breakdown-group">
+                  <div class="breakdown-header">
+                    <span class="provider-chip provider-{{ item.provider.toLowerCase() }}">{{ item.provider }}</span>
+                    <code class="model-name">{{ item.model }}</code>
+                    <span class="breakdown-stats">
+                      {{ item.callCount }} calls &middot;
+                      \${{ item.totalCostUsd | number:'1.4-4' }}
+                    </span>
+                  </div>
+                  @if (item.calls && item.calls.length > 0) {
+                    <div class="call-list">
+                      @for (call of item.calls; track call.id) {
+                        <div class="call-row">
+                          <span class="call-task">{{ call.taskType }}</span>
+                          <span class="call-tokens">{{ call.inputTokens | number }}in / {{ call.outputTokens | number }}out</span>
+                          @if (call.costUsd != null) {
+                            <span class="call-cost">\${{ call.costUsd | number:'1.4-4' }}</span>
+                          }
+                          @if (call.durationMs != null) {
+                            <span class="call-duration">{{ call.durationMs }}ms</span>
+                          }
+                          <span class="call-time">{{ call.createdAt | date:'shortTime' }}</span>
+                        </div>
+                      }
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+          }
+        </app-card>
+      }
+    }
+  `,
+  styles: [`
+    :host {
+      display: block;
+      margin-bottom: 16px;
+      font-family: var(--font-primary);
+    }
+    .cost-card {
+      background: var(--color-success-subtle);
+    }
+    .card-title-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .card-title-icon {
+      font-size: 18px;
+      color: var(--color-success);
+    }
+    .card-title {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .cost-summary {
+      display: flex;
+      gap: 24px;
+      flex-wrap: wrap;
+    }
+    .cost-item {
+      display: flex;
+      flex-direction: column;
+    }
+    .cost-label {
+      font-size: 11px;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+      letter-spacing: 0.5px;
+    }
+    .cost-value {
+      font-size: 20px;
+      font-weight: 600;
+      font-family: var(--font-primary);
+      color: var(--text-primary);
+    }
+    .cost-breakdown {
+      margin-top: 12px;
+      border-top: 1px solid var(--border-light);
+      padding-top: 12px;
+    }
+    .breakdown-group { margin-bottom: 12px; }
+    .breakdown-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+    .breakdown-stats {
+      font-size: 12px;
+      color: var(--text-tertiary);
+      margin-left: auto;
+    }
+    .call-list { padding-left: 16px; }
+    .call-row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      font-size: 12px;
+      padding: 2px 0;
+      color: var(--text-secondary);
+    }
+    .call-task {
+      font-weight: 500;
+      color: var(--text-primary);
+      min-width: 140px;
+    }
+    .call-tokens { color: var(--text-tertiary); }
+    .call-cost { color: var(--color-success); font-weight: 500; }
+    .call-duration { color: var(--text-tertiary); }
+    .call-time { color: var(--text-tertiary); margin-left: auto; }
+
+    .provider-chip {
+      font-weight: 600;
+      font-size: 10px;
+      padding: 1px 6px;
+      border-radius: var(--radius-sm);
+      background: var(--bg-muted);
+      color: var(--text-primary);
+    }
+    .provider-local { background: var(--color-success-subtle); color: var(--color-success); }
+    .provider-claude { background: var(--color-purple-subtle); color: var(--color-purple); }
+    .provider-openai { background: var(--color-info-subtle); color: var(--color-info); }
+    .provider-grok { background: var(--color-warning-subtle); color: var(--color-warning); }
+    .provider-google { background: var(--color-success-subtle); color: var(--color-success); }
+    .model-name {
+      font-size: 12px;
+      background: var(--bg-muted);
+      padding: 2px 6px;
+      border-radius: var(--radius-sm);
+      color: var(--text-primary);
+    }
+  `],
+})
+export class TicketDetailCostComponent {
+  cost = input<TicketCostResponse | null>(null);
+  detailsExpanded = signal(false);
+
+  toggleDetails(): void {
+    this.detailsExpanded.update(v => !v);
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-details.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-details.component.ts
@@ -1,0 +1,60 @@
+import { Component, input, signal } from '@angular/core';
+import { BroncoButtonComponent } from '../../shared/components/index.js';
+
+@Component({
+  selector: 'app-ticket-detail-details',
+  standalone: true,
+  imports: [BroncoButtonComponent],
+  template: `
+    @if (description()) {
+      <p class="description">{{ truncatedDescription() }}</p>
+      @if ((description() ?? '').length > 300) {
+        <app-bronco-button variant="ghost" size="sm" (click)="toggleExpanded()">
+          {{ expanded() ? 'Show less' : 'Show more' }}
+        </app-bronco-button>
+      }
+    }
+    @if (systemName()) { <p class="meta-line"><strong>System:</strong> {{ systemName() }}</p> }
+    @if (clientName()) { <p class="meta-line"><strong>Client:</strong> {{ clientName() }}</p> }
+  `,
+  styles: [`
+    :host {
+      display: block;
+      color: var(--text-primary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+    }
+    .description {
+      white-space: pre-wrap;
+      line-height: 1.5;
+      margin: 0 0 8px;
+      color: var(--text-primary);
+    }
+    .meta-line {
+      margin: 4px 0;
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+    .meta-line strong {
+      color: var(--text-primary);
+      font-weight: 600;
+    }
+  `],
+})
+export class TicketDetailDetailsComponent {
+  description = input<string | null>(null);
+  systemName = input<string | null>(null);
+  clientName = input<string | null>(null);
+
+  expanded = signal(false);
+
+  truncatedDescription(): string {
+    const desc = this.description() ?? '';
+    if (this.expanded() || desc.length <= 300) return desc;
+    return desc.slice(0, 300) + '...';
+  }
+
+  toggleExpanded(): void {
+    this.expanded.update(v => !v);
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-flow.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-flow.component.ts
@@ -1,0 +1,140 @@
+import { Component, input } from '@angular/core';
+import { CardComponent } from '../../shared/components/index.js';
+
+export interface FlowNode {
+  label: string;
+  icon: string;
+  type: 'start' | 'action' | 'ai' | 'email' | 'status' | 'end';
+  children?: FlowNode[];
+}
+
+@Component({
+  selector: 'app-ticket-detail-flow',
+  standalone: true,
+  imports: [CardComponent],
+  template: `
+    <app-card padding="md" class="flow-card">
+      <div class="card-title-row">
+        <span class="card-title-icon" aria-hidden="true">&#9783;</span>
+        <h3 class="card-title">Process Flow</h3>
+      </div>
+      <div class="flow-container">
+        @for (node of nodes(); track node.type + ':' + node.label + ':' + $index; let i = $index) {
+          <div class="flow-node flow-{{ node.type }}">
+            <span class="flow-icon" aria-hidden="true">{{ glyphFor(node.icon) }}</span>
+            <span class="flow-label">{{ node.label }}</span>
+          </div>
+          @if (node.children && node.children.length > 0) {
+            <div class="flow-branch">
+              @for (child of node.children; track child.type + ':' + child.label + ':' + $index; let j = $index) {
+                <div class="flow-branch-row">
+                  <div class="flow-connector"></div>
+                  <div class="flow-node flow-{{ child.type }}">
+                    <span class="flow-icon" aria-hidden="true">{{ glyphFor(child.icon) }}</span>
+                    <span class="flow-label">{{ child.label }}</span>
+                  </div>
+                  @if (child.children && child.children.length > 0) {
+                    @for (grandchild of child.children; track grandchild.type + ':' + grandchild.label + ':' + $index) {
+                      <div class="flow-connector"></div>
+                      <div class="flow-node flow-{{ grandchild.type }}">
+                        <span class="flow-icon" aria-hidden="true">{{ glyphFor(grandchild.icon) }}</span>
+                        <span class="flow-label">{{ grandchild.label }}</span>
+                      </div>
+                    }
+                  }
+                </div>
+              }
+            </div>
+          }
+          @if (i < nodes().length - 1 && !node.children?.length) {
+            <span class="flow-arrow" aria-hidden="true">&rarr;</span>
+          }
+        }
+      </div>
+    </app-card>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      margin-bottom: 16px;
+      font-family: var(--font-primary);
+    }
+    .card-title-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .card-title-icon {
+      font-size: 18px;
+      color: var(--text-tertiary);
+    }
+    .card-title {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+    .flow-container {
+      display: flex;
+      align-items: flex-start;
+      gap: 4px;
+      flex-wrap: wrap;
+      padding: 8px 0;
+      overflow-x: auto;
+    }
+    .flow-node {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 10px;
+      border-radius: var(--radius-pill);
+      font-size: 11px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .flow-start  { background: var(--color-info-subtle);    color: var(--color-info); }
+    .flow-action { background: var(--color-purple-subtle);  color: var(--color-purple); }
+    .flow-ai     { background: var(--color-error-subtle);   color: var(--color-error); }
+    .flow-email  { background: var(--color-success-subtle); color: var(--color-success); }
+    .flow-status { background: var(--color-warning-subtle); color: var(--color-warning); }
+    .flow-end    { background: var(--bg-muted);             color: var(--text-tertiary); }
+    .flow-icon { font-size: 12px; }
+    .flow-arrow {
+      color: var(--text-tertiary);
+      display: flex;
+      align-items: center;
+      font-size: 16px;
+    }
+    .flow-branch {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin-left: 8px;
+      padding-left: 8px;
+      border-left: 2px solid var(--border-light);
+    }
+    .flow-branch-row { display: flex; align-items: center; gap: 4px; }
+    .flow-connector {
+      width: 12px;
+      height: 2px;
+      background: var(--border-light);
+    }
+  `],
+})
+export class TicketDetailFlowComponent {
+  nodes = input.required<FlowNode[]>();
+
+  glyphFor(icon: string): string {
+    const map: Record<string, string> = {
+      email: '\u2709',
+      send: '\u27a4',
+      psychology: '\u26ac',
+      lightbulb: '\u2731',
+      swap_horiz: '\u21c4',
+      account_tree: '\u22ee',
+      sync: '\u21bb',
+    };
+    return map[icon] ?? '\u25CF';
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
@@ -1,0 +1,118 @@
+import { Component, input, output, signal, effect } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BroncoButtonComponent, TextareaComponent } from '../../shared/components/index.js';
+import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+
+@Component({
+  selector: 'app-ticket-detail-knowledge',
+  standalone: true,
+  imports: [FormsModule, BroncoButtonComponent, TextareaComponent, MarkdownPipe],
+  template: `
+    <div class="knowledge-doc">
+      @if (editing()) {
+        <app-textarea
+          [value]="draft()"
+          [rows]="20"
+          (valueChange)="draft.set($event)" />
+        <div class="knowledge-actions">
+          <app-bronco-button variant="primary" (click)="onSave()">Save</app-bronco-button>
+          <app-bronco-button variant="secondary" (click)="onCancel()">Cancel</app-bronco-button>
+        </div>
+      } @else {
+        <div class="knowledge-actions">
+          <app-bronco-button variant="secondary" (click)="onStartEdit()">
+            <span aria-hidden="true">&#9998;</span> Edit
+          </app-bronco-button>
+          <app-bronco-button variant="destructive" (click)="onClear()">
+            <span aria-hidden="true">&#128465;</span> Clear
+          </app-bronco-button>
+        </div>
+        @if (knowledgeDoc()) {
+          <div class="knowledge-body" [innerHTML]="knowledgeDoc() | markdown"></div>
+        }
+      }
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      font-family: var(--font-primary);
+      color: var(--text-primary);
+    }
+    .knowledge-doc {
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    .knowledge-doc h3 {
+      margin-top: 16px;
+      margin-bottom: 8px;
+      font-size: 16px;
+      color: var(--text-primary);
+      border-bottom: 1px solid var(--border-light);
+      padding-bottom: 4px;
+    }
+    .knowledge-doc h4 {
+      margin-top: 12px;
+      margin-bottom: 6px;
+      font-size: 14px;
+      color: var(--text-secondary);
+    }
+    .knowledge-doc pre {
+      background: var(--bg-code);
+      color: var(--text-code);
+      padding: 8px 12px;
+      border-radius: var(--radius-sm);
+      overflow-x: auto;
+      font-size: 12px;
+    }
+    .knowledge-doc code {
+      background: var(--bg-muted);
+      padding: 1px 4px;
+      border-radius: var(--radius-sm);
+      font-size: 12px;
+    }
+    .knowledge-actions {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+  `],
+})
+export class TicketDetailKnowledgeComponent {
+  knowledgeDoc = input<string | null>(null);
+  editing = input<boolean>(false);
+
+  startEdit = output<void>();
+  cancelEdit = output<void>();
+  save = output<string>();
+  clear = output<void>();
+
+  draft = signal('');
+
+  constructor() {
+    // Sync draft with knowledgeDoc when entering edit mode
+    effect(() => {
+      if (this.editing()) {
+        this.draft.set(this.knowledgeDoc() ?? '');
+      }
+    });
+  }
+
+  onStartEdit(): void {
+    this.draft.set(this.knowledgeDoc() ?? '');
+    this.startEdit.emit();
+  }
+
+  onCancel(): void {
+    this.draft.set('');
+    this.cancelEdit.emit();
+  }
+
+  onSave(): void {
+    this.save.emit(this.draft());
+  }
+
+  onClear(): void {
+    this.clear.emit();
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, signal, effect } from '@angular/core';
+import { Component, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BroncoButtonComponent, TextareaComponent } from '../../shared/components/index.js';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
@@ -88,15 +88,6 @@ export class TicketDetailKnowledgeComponent {
   clear = output<void>();
 
   draft = signal('');
-
-  constructor() {
-    // Sync draft with knowledgeDoc when entering edit mode
-    effect(() => {
-      if (this.editing()) {
-        this.draft.set(this.knowledgeDoc() ?? '');
-      }
-    });
-  }
 
   onStartEdit(): void {
     this.draft.set(this.knowledgeDoc() ?? '');

--- a/services/control-panel/src/app/features/tickets/ticket-detail-log-digest.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-log-digest.component.ts
@@ -1,0 +1,143 @@
+import { Component, input, output } from '@angular/core';
+import { BroncoButtonComponent } from '../../shared/components/index.js';
+import { type LogSummary } from '../../core/services/log-summary.service';
+
+@Component({
+  selector: 'app-ticket-detail-log-digest',
+  standalone: true,
+  imports: [BroncoButtonComponent],
+  template: `
+    <div class="digest-toolbar">
+      <app-bronco-button
+        variant="secondary"
+        size="sm"
+        [disabled]="generating()"
+        (click)="generate.emit()"
+        ariaLabel="Summarize recent logs">
+        @if (generating()) {
+          <span class="spinner" aria-hidden="true"></span> Summarizing...
+        } @else {
+          <span aria-hidden="true">&#10024;</span> Summarize Recent Logs
+        }
+      </app-bronco-button>
+    </div>
+
+    @if (generating()) {
+      <div class="indeterminate-bar"><span class="indeterminate-track"></span></div>
+    }
+
+    @for (ls of summaries(); track ls.id) {
+      <div class="log-summary-entry">
+        <div class="log-summary-header">
+          <span class="log-summary-time">
+            {{ formatTime(ls.windowStart) }} — {{ formatTime(ls.windowEnd) }}
+          </span>
+          <span class="log-summary-count" [attr.title]="ls.logCount + ' log entries'">
+            {{ ls.logCount }} logs
+          </span>
+        </div>
+        <p class="log-summary-text">{{ ls.summary }}</p>
+        <div class="log-summary-services">
+          @for (svc of ls.services; track svc) {
+            <span class="service-chip">{{ svc }}</span>
+          }
+        </div>
+      </div>
+    } @empty {
+      <p class="empty">No log summaries yet. Click the button above to generate one.</p>
+    }
+  `,
+  styles: [`
+    :host {
+      display: block;
+      font-family: var(--font-primary);
+      color: var(--text-primary);
+    }
+    .digest-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .log-summary-entry {
+      padding: 12px 0;
+      border-bottom: 1px solid var(--border-light);
+    }
+    .log-summary-entry:last-child { border-bottom: none; }
+    .log-summary-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 4px;
+    }
+    .log-summary-time { font-size: 12px; color: var(--text-tertiary); }
+    .log-summary-count {
+      font-size: 11px;
+      color: var(--text-secondary);
+      background: var(--bg-muted);
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+    }
+    .log-summary-text {
+      margin: 4px 0 8px;
+      line-height: 1.5;
+      color: var(--text-primary);
+      font-size: 14px;
+    }
+    .log-summary-services { display: flex; gap: 4px; flex-wrap: wrap; }
+    .service-chip {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+      background: var(--color-info-subtle);
+      color: var(--color-info);
+    }
+    .empty {
+      color: var(--text-tertiary);
+      padding: 16px;
+      text-align: center;
+    }
+    .spinner {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border: 2px solid var(--border-medium);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .indeterminate-bar {
+      position: relative;
+      height: 3px;
+      background: var(--bg-muted);
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+      margin-bottom: 8px;
+    }
+    .indeterminate-track {
+      position: absolute;
+      left: -40%;
+      width: 40%;
+      height: 100%;
+      background: var(--accent);
+      animation: indeterminate 1.4s ease-in-out infinite;
+    }
+    @keyframes indeterminate {
+      0% { left: -40%; }
+      100% { left: 100%; }
+    }
+  `],
+})
+export class TicketDetailLogDigestComponent {
+  summaries = input.required<LogSummary[]>();
+  generating = input<boolean>(false);
+
+  generate = output<void>();
+
+  formatTime(dateStr: string): string {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
+      d.toLocaleTimeString(undefined, { hour12: true, hour: 'numeric', minute: '2-digit' });
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
@@ -1,0 +1,22 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-ticket-detail-resolution',
+  standalone: true,
+  template: `
+    <p class="summary-text">{{ summary() }}</p>
+  `,
+  styles: [`
+    .summary-text {
+      white-space: pre-wrap;
+      line-height: 1.6;
+      margin: 0;
+      color: var(--text-primary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+    }
+  `],
+})
+export class TicketDetailResolutionComponent {
+  summary = input.required<string>();
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-summary.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-summary.component.ts
@@ -1,0 +1,21 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-ticket-detail-summary',
+  standalone: true,
+  template: `
+    <p class="blurb-text">{{ emailBlurb() }}</p>
+  `,
+  styles: [`
+    .blurb-text {
+      line-height: 1.5;
+      margin: 0;
+      color: var(--text-primary);
+      font-family: var(--font-primary);
+      font-size: 14px;
+    }
+  `],
+})
+export class TicketDetailSummaryComponent {
+  emailBlurb = input.required<string>();
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.css
@@ -1,0 +1,348 @@
+:host {
+  display: block;
+  font-family: var(--font-primary);
+  color: var(--text-primary);
+}
+
+.timeline-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  gap: 12px;
+}
+.timeline-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.timeline-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+.timeline-controls app-form-field {
+  width: 180px;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.event-card {
+  border-left: 3px solid var(--border-light);
+}
+.event-type-ai_analysis      { border-left-color: var(--color-purple); }
+.event-type-ai_recommendation { border-left-color: var(--color-warning); }
+.event-type-system_note      { border-left-color: var(--border-medium); }
+.event-type-email_inbound,
+.event-type-email_outbound   { border-left-color: var(--color-success); }
+.event-type-code_change      { border-left-color: var(--color-error); }
+.event-type-status_change    { border-left-color: var(--color-warning); }
+
+.event-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.event-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+}
+.evt-icon { font-size: 12px; }
+.badge-ai_analysis      { background: var(--color-purple-subtle);  color: var(--color-purple); }
+.badge-ai_recommendation { background: var(--color-warning-subtle); color: var(--color-warning); }
+.badge-email_inbound    { background: var(--color-success-subtle); color: var(--color-success); }
+.badge-email_outbound   { background: var(--color-info-subtle);    color: var(--color-info); }
+.badge-status_change    { background: var(--color-warning-subtle); color: var(--color-warning); }
+.badge-code_change      { background: var(--color-error-subtle);   color: var(--color-error); }
+
+.event-actor {
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.event-date {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  margin-left: auto;
+  cursor: default;
+}
+
+.event-question {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: var(--color-info-subtle);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--color-info);
+}
+.question-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  font-weight: 700;
+}
+
+.event-content {
+  margin-top: 8px;
+  white-space: pre-wrap;
+  line-height: 1.5;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+.event-content.collapsed {
+  max-height: 100px;
+  overflow: hidden;
+}
+.ellipsis { color: var(--text-tertiary); }
+
+.probe-data-section { margin-top: 8px; }
+.probe-data-code {
+  background: var(--bg-code);
+  color: var(--text-code);
+  padding: 12px;
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  font-size: 12px;
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.probe-data {
+  font-size: 11px;
+  background: var(--bg-code);
+  color: var(--text-code);
+  padding: 10px;
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin: 6px 0;
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.recommendation-actions {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.rec-action-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--bg-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-light);
+}
+.rec-action-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.rec-resolved .rec-action-header { cursor: pointer; }
+.rec-expand-icon {
+  font-size: 14px;
+  color: var(--text-tertiary);
+}
+.rec-icon {
+  font-size: 14px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+.rec-action-detail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: baseline;
+  padding-left: 22px;
+}
+.rec-action-buttons {
+  display: flex;
+  gap: 6px;
+  padding-left: 22px;
+}
+.rec-action-type {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.rec-action-value {
+  font-size: 12px;
+  background: var(--color-info-subtle);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--color-info);
+}
+.rec-action-reason {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.rec-status-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+  margin-left: auto;
+}
+.rec-badge-auto_executed   { background: var(--color-success-subtle); color: var(--color-success); }
+.rec-badge-pending_approval { background: var(--color-warning-subtle); color: var(--color-warning); }
+.rec-badge-skipped         { background: var(--bg-muted); color: var(--text-tertiary); }
+.rec-badge-dismissed       { background: var(--color-error-subtle); color: var(--color-error); }
+.rec-badge-approved        { background: var(--color-success-subtle); color: var(--color-success); }
+
+.ai-triggered-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--color-warning-subtle);
+  color: var(--color-warning);
+  white-space: nowrap;
+}
+
+.markdown-content { white-space: normal; font-size: 13px; line-height: 1.5; }
+.markdown-content h1, .markdown-content h2, .markdown-content h3 { margin: 10px 0 4px; }
+.markdown-content h1 { font-size: 1.25em; }
+.markdown-content h2 { font-size: 1.1em; }
+.markdown-content p { margin: 4px 0; }
+.markdown-content ul, .markdown-content ol { margin: 4px 0; padding-left: 24px; }
+.markdown-content code {
+  background: var(--bg-muted);
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+}
+.markdown-content pre {
+  background: var(--bg-code);
+  color: var(--text-code);
+  padding: 10px;
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  margin: 6px 0;
+}
+.markdown-content pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+.markdown-content blockquote {
+  border-left: 3px solid var(--border-medium);
+  margin: 6px 0;
+  padding: 2px 12px;
+  color: var(--text-tertiary);
+}
+
+.event-ai-meta {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+.meta-chip {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+}
+.provider-chip {
+  font-weight: 600;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+}
+.provider-local  { background: var(--color-success-subtle); color: var(--color-success); }
+.provider-claude { background: var(--color-purple-subtle);  color: var(--color-purple); }
+.provider-openai { background: var(--color-info-subtle);    color: var(--color-info); }
+.provider-grok   { background: var(--color-warning-subtle); color: var(--color-warning); }
+.provider-google { background: var(--color-success-subtle); color: var(--color-success); }
+.model-chip      { background: var(--bg-muted); color: var(--text-primary); }
+.phase-chip      { background: var(--color-info-subtle); color: var(--color-info); }
+.task-chip       { background: var(--color-error-subtle); color: var(--color-error); }
+.token-chip      { background: var(--bg-muted); color: var(--text-tertiary); }
+.duration-chip   { background: var(--bg-muted); color: var(--text-tertiary); }
+
+.agentic-summary { margin-top: 8px; }
+.agentic-stats {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+.sufficiency-sufficient       { background: var(--color-success-subtle); color: var(--color-success); }
+.sufficiency-needs_user_input { background: var(--color-warning-subtle); color: var(--color-warning); }
+.sufficiency-insufficient     { background: var(--color-error-subtle);   color: var(--color-error); }
+.tool-calls-list {
+  padding: 4px 0 4px 12px;
+  border-left: 2px solid var(--border-light);
+  margin: 4px 0;
+}
+.tool-call-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 3px 0;
+  flex-wrap: wrap;
+}
+.tool-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.tool-result {
+  font-size: 11px;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  padding: 6px;
+  border-radius: var(--radius-sm);
+  margin: 2px 0;
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  width: 100%;
+}
+.sufficiency-detail {
+  font-size: 13px;
+  padding: 8px 12px;
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  margin: 4px 0;
+  color: var(--text-primary);
+}
+.sufficiency-detail p { margin: 2px 0; }
+.sufficiency-detail ul { margin: 4px 0; padding-left: 20px; }
+.cost-badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-success);
+  background: var(--color-success-subtle);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.empty {
+  color: var(--text-tertiary);
+  padding: 16px;
+  text-align: center;
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
@@ -1,0 +1,538 @@
+import { Component, computed, input, output, signal } from '@angular/core';
+import { CommonModule, DecimalPipe } from '@angular/common';
+import { CardComponent, BroncoButtonComponent, SelectComponent, FormFieldComponent } from '../../shared/components/index.js';
+import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import { type TicketEvent } from '../../core/services/ticket.service';
+
+@Component({
+  selector: 'app-ticket-detail-timeline',
+  standalone: true,
+  imports: [
+    CommonModule,
+    DecimalPipe,
+    CardComponent,
+    BroncoButtonComponent,
+    SelectComponent,
+    FormFieldComponent,
+    MarkdownPipe,
+    RelativeTimePipe,
+  ],
+  template: `
+    <div class="timeline-header">
+      <h3 class="timeline-title">Timeline</h3>
+      <div class="timeline-controls">
+        <app-form-field label="Filter">
+          <app-select
+            [value]="timelineFilter()"
+            [options]="filterOptions"
+            placeholder=""
+            (valueChange)="timelineFilter.set($event)" />
+        </app-form-field>
+        <app-bronco-button
+          variant="icon"
+          size="md"
+          [ariaLabel]="timelineSortAsc() ? 'Oldest first' : 'Newest first'"
+          (click)="toggleSort()">
+          <span aria-hidden="true">{{ timelineSortAsc() ? '\u2191' : '\u2193' }}</span>
+        </app-bronco-button>
+      </div>
+    </div>
+
+    <div class="timeline">
+      @for (event of filteredEvents(); track event.id) {
+        <app-card padding="md" class="event-card" [class]="'event-type-' + event.eventType.toLowerCase()">
+          <div class="event-header">
+            <span class="event-type-badge" [class]="'badge-' + event.eventType.toLowerCase()">
+              <span class="evt-icon" aria-hidden="true">{{ eventGlyph(event.eventType) }}</span>
+              <span>{{ formatEventType(event.eventType) }}</span>
+            </span>
+            @if (isAiTriggered(event)) {
+              <span class="ai-triggered-badge">AI Recommendation</span>
+            }
+            <span class="event-actor">{{ event.actor }}</span>
+            @if (isAgenticAnalysis(event)) {
+              @if (agenticMeta(event); as am) {
+                @if (am.totalCostUsd != null && am.totalCostUsd > 0) {
+                  <span class="cost-badge">\${{ am.totalCostUsd | number:'1.4-4' }}</span>
+                }
+              }
+            }
+            <span class="event-date" [attr.title]="event.createdAt">{{ event.createdAt | relativeTime }}</span>
+          </div>
+
+          <!-- Condensed Agentic Analysis card -->
+          @if (isAgenticAnalysis(event)) {
+            @if (agenticMeta(event); as am) {
+              <div class="agentic-summary">
+                <div class="agentic-stats">
+                  <span class="meta-chip task-chip">{{ am.taskType }}</span>
+                  <span class="meta-chip token-chip">{{ am.toolCallCount }} tool calls</span>
+                  <span class="meta-chip phase-chip">{{ am.iterationsRun }} iterations</span>
+                  @if (am.sufficiencyStatus) {
+                    <span class="meta-chip" [class]="'sufficiency-' + am.sufficiencyStatus.toLowerCase()">{{ am.sufficiencyStatus }}</span>
+                  }
+                  @if (am.sufficiencyConfidence) {
+                    <span class="meta-chip duration-chip">confidence: {{ am.sufficiencyConfidence }}</span>
+                  }
+                </div>
+
+                @if (am.toolCalls.length > 0) {
+                  <app-bronco-button variant="ghost" size="sm" (click)="toggleSection(event.id + ':tools')">
+                    <span aria-hidden="true">{{ expandedSections[event.id + ':tools'] ? '\u25B4' : '\u25BE' }}</span>
+                    Tool Calls ({{ am.toolCalls.length }})
+                  </app-bronco-button>
+                  @if (expandedSections[event.id + ':tools']) {
+                    <div class="tool-calls-list">
+                      @for (tc of am.toolCalls; track $index) {
+                        <div class="tool-call-row">
+                          <span class="tool-name">{{ tc.tool }}</span>
+                          @if (tc.system) { <span class="meta-chip provider-chip provider-local">{{ tc.system }}</span> }
+                          @if (tc.durationMs != null) { <span class="meta-chip duration-chip">{{ tc.durationMs }}ms</span> }
+                          @if (tc.output) {
+                            <app-bronco-button variant="ghost" size="sm" (click)="toggleSection(event.id + ':tc:' + $index)">
+                              {{ expandedSections[event.id + ':tc:' + $index] ? 'Hide' : 'Result' }}
+                            </app-bronco-button>
+                          }
+                          @if (expandedSections[event.id + ':tc:' + $index] && tc.output) {
+                            <pre class="tool-result">{{ tc.output }}</pre>
+                          }
+                        </div>
+                      }
+                    </div>
+                  }
+                }
+
+                @if (am.sufficiencyReason) {
+                  <app-bronco-button variant="ghost" size="sm" (click)="toggleSection(event.id + ':sufficiency')">
+                    <span aria-hidden="true">{{ expandedSections[event.id + ':sufficiency'] ? '\u25B4' : '\u25BE' }}</span>
+                    Sufficiency
+                  </app-bronco-button>
+                  @if (expandedSections[event.id + ':sufficiency']) {
+                    <div class="sufficiency-detail">
+                      <p><strong>Status:</strong> {{ am.sufficiencyStatus }} &middot; <strong>Confidence:</strong> {{ am.sufficiencyConfidence }}</p>
+                      <p>{{ am.sufficiencyReason }}</p>
+                      @if (am.sufficiencyQuestions && am.sufficiencyQuestions.length > 0) {
+                        <p><strong>Questions:</strong></p>
+                        <ul>@for (q of am.sufficiencyQuestions; track $index) { <li>{{ q }}</li> }</ul>
+                      }
+                    </div>
+                  }
+                }
+              </div>
+
+              @if (event.content) {
+                <app-bronco-button variant="ghost" size="sm" (click)="toggleSection(event.id + ':analysis')">
+                  <span aria-hidden="true">{{ expandedSections[event.id + ':analysis'] ? '\u25B4' : '\u25BE' }}</span>
+                  Analysis
+                </app-bronco-button>
+                @if (expandedSections[event.id + ':analysis']) {
+                  <div class="event-content markdown-content">
+                    <div [innerHTML]="event.content | markdown"></div>
+                  </div>
+                }
+              }
+            }
+          }
+
+          <!-- SYSTEM_NOTE with JSON probe data detection -->
+          @else if (event.eventType === 'SYSTEM_NOTE' && isJsonContent(event.content)) {
+            <app-bronco-button variant="ghost" size="sm" (click)="toggleEvent(event.id)">
+              <span aria-hidden="true">{{ expandedEvents[event.id] ? '\u25B4' : '\u25BE' }}</span>
+              Probe Data
+            </app-bronco-button>
+            @if (expandedEvents[event.id]) {
+              <pre class="probe-data">{{ formatJson(event.content!) }}</pre>
+            }
+          }
+
+          <!-- AI_RECOMMENDATION — render as action list -->
+          @else if (event.eventType === 'AI_RECOMMENDATION') {
+            @if (eventMeta(event); as meta) {
+              @if (meta.aiProvider || meta.aiModel) {
+                <div class="event-ai-meta">
+                  @if (meta.aiProvider) { <span class="meta-chip provider-chip provider-{{ meta.aiProvider.toLowerCase() }}">{{ meta.aiProvider }}</span> }
+                  @if (meta.aiModel) { <code class="meta-chip model-chip">{{ meta.aiModel }}</code> }
+                </div>
+              }
+            }
+          }
+
+          @if (event.content) {
+            @if (event.eventType === 'SYSTEM_NOTE' && isJsonContent(event.content)) {
+              <div class="probe-data-section">
+                <app-bronco-button variant="ghost" size="sm" (click)="toggleEvent(event.id)">
+                  <span aria-hidden="true">{{ expandedEvents[event.id] ? '\u25B4' : '\u25BE' }}</span>
+                  {{ expandedEvents[event.id] ? 'Hide Probe Data' : 'Show Probe Data' }}
+                </app-bronco-button>
+                @if (expandedEvents[event.id]) {
+                  <pre class="probe-data-code"><code>{{ formatJson(event.content) }}</code></pre>
+                }
+              </div>
+            } @else if (event.eventType === 'AI_RECOMMENDATION' && hasActionsMeta(event)) {
+              @if (recSummaryContent(event); as summary) {
+                <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && summary.length > 300">
+                  <div [innerHTML]="summary | markdown"></div>
+                </div>
+                @if (summary.length > 300) {
+                  <app-bronco-button variant="ghost" size="sm" (click)="toggleEvent(event.id + '-raw')">
+                    {{ expandedEvents[event.id + '-raw'] ? 'Hide details' : 'Show details' }}
+                  </app-bronco-button>
+                }
+              }
+              <div class="recommendation-actions">
+                @for (act of getEventActions(event); track $index) {
+                  <div class="rec-action-row" [class.rec-resolved]="getActionOutcome(act) !== 'pending_approval'">
+                    <div class="rec-action-header" (click)="getActionOutcome(act) !== 'pending_approval' ? toggleEvent(event.id + '-act-' + $index) : null">
+                      <span class="rec-icon" aria-hidden="true">{{ recActionGlyph(act.action) }}</span>
+                      <span class="rec-action-type">{{ formatRecActionType(act.action) }}</span>
+                      <span class="rec-status-badge" [class]="'rec-badge-' + getActionOutcome(act)">
+                        {{ getActionOutcomeLabel(act) }}
+                      </span>
+                      @if (getActionOutcome(act) !== 'pending_approval') {
+                        <span class="rec-expand-icon" aria-hidden="true">{{ expandedEvents[event.id + '-act-' + $index] ? '\u25B4' : '\u25BE' }}</span>
+                      }
+                    </div>
+                    @if (getActionOutcome(act) === 'pending_approval' || expandedEvents[event.id + '-act-' + $index]) {
+                      <div class="rec-action-detail">
+                        @if (act.value) {
+                          <span class="rec-action-value">{{ act.value }}</span>
+                        }
+                        <span class="rec-action-reason">{{ act.reason }}</span>
+                      </div>
+                    }
+                    @if (getActionOutcome(act) === 'pending_approval') {
+                      <div class="rec-action-buttons">
+                        <app-bronco-button variant="primary" size="sm" (click)="approveAction.emit(act.pendingActionId!)">Approve</app-bronco-button>
+                        <app-bronco-button variant="secondary" size="sm" (click)="dismissAction.emit(act.pendingActionId!)">Dismiss</app-bronco-button>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            } @else if (isMarkdownEvent(event.eventType)) {
+              <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
+                <div [innerHTML]="event.content | markdown"></div>
+              </div>
+              @if (event.content.length > 300) {
+                <app-bronco-button variant="ghost" size="sm" (click)="toggleEvent(event.id)">
+                  {{ expandedEvents[event.id] ? 'Show less' : 'Show more' }}
+                </app-bronco-button>
+              }
+            }
+          }
+
+          <!-- Default rendering for all other event types -->
+          @else {
+            @if (eventQuestion(event); as q) {
+              <div class="event-question">
+                <span class="question-icon" aria-hidden="true">?</span>
+                <span>{{ q }}</span>
+              </div>
+            }
+            @if (eventMeta(event); as meta) {
+              @if (meta.aiProvider || meta.aiModel) {
+                <div class="event-ai-meta">
+                  @if (meta.aiProvider) {
+                    <span class="meta-chip provider-chip provider-{{ meta.aiProvider.toLowerCase() }}">{{ meta.aiProvider }}</span>
+                  }
+                  @if (meta.aiModel) {
+                    <code class="meta-chip model-chip">{{ meta.aiModel }}</code>
+                  }
+                  @if (meta.phase) {
+                    <span class="meta-chip phase-chip">{{ meta.phase }}</span>
+                  }
+                  @if (meta.taskType) {
+                    <span class="meta-chip task-chip">{{ meta.taskType }}</span>
+                  }
+                  @if (meta.inputTokens != null) {
+                    <span class="meta-chip token-chip">{{ meta.inputTokens | number }}in / {{ meta.outputTokens | number }}out</span>
+                  }
+                  @if (meta.durationMs != null) {
+                    <span class="meta-chip duration-chip">{{ meta.durationMs }}ms</span>
+                  }
+                </div>
+              }
+            }
+            @if (event.content) {
+              @if (isMarkdownEvent(event.eventType)) {
+                <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
+                  <div [innerHTML]="event.content | markdown"></div>
+                </div>
+              } @else {
+                <p class="event-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
+                  {{ expandedEvents[event.id] ? event.content : event.content.slice(0, 300) }}
+                  @if (event.content.length > 300 && !expandedEvents[event.id]) {
+                    <span class="ellipsis">...</span>
+                  }
+                </p>
+              }
+              @if (event.content.length > 300) {
+                <app-bronco-button variant="ghost" size="sm" (click)="toggleEvent(event.id)">
+                  {{ expandedEvents[event.id] ? 'Show less' : 'Show more' }}
+                </app-bronco-button>
+              }
+            }
+          }
+        </app-card>
+      } @empty {
+        <p class="empty">No events match the current filter.</p>
+      }
+    </div>
+  `,
+  styleUrl: './ticket-detail-timeline.component.css',
+})
+export class TicketDetailTimelineComponent {
+  events = input.required<TicketEvent[]>();
+  pendingActionMap = input<Record<string, string>>({});
+
+  approveAction = output<string>();
+  dismissAction = output<string>();
+
+  timelineFilter = signal('');
+  timelineSortAsc = signal(true);
+
+  expandedEvents: Record<string, boolean> = {};
+  expandedSections: Record<string, boolean> = {};
+
+  filterOptions = [
+    { value: '', label: 'All Events' },
+    { value: 'COMMENT', label: 'Comments' },
+    { value: 'AI_ANALYSIS', label: 'AI Analysis' },
+    { value: 'STATUS_CHANGE', label: 'Status Changes' },
+    { value: 'EMAIL_INBOUND', label: 'Inbound Emails' },
+    { value: 'EMAIL_OUTBOUND', label: 'Outbound Emails' },
+    { value: 'CODE_CHANGE', label: 'Code Changes' },
+    { value: 'SYSTEM_NOTE', label: 'System Notes' },
+  ];
+
+  filteredEvents = computed(() => {
+    let evts = this.events();
+    if (this.timelineFilter()) {
+      evts = evts.filter(e => e.eventType === this.timelineFilter());
+    }
+    if (!this.timelineSortAsc()) {
+      evts = [...evts].reverse();
+    }
+    return evts;
+  });
+
+  toggleSort(): void {
+    this.timelineSortAsc.update(v => !v);
+  }
+
+  toggleEvent(key: string): void {
+    this.expandedEvents[key] = !this.expandedEvents[key];
+  }
+
+  toggleSection(key: string): void {
+    this.expandedSections[key] = !this.expandedSections[key];
+  }
+
+  isMarkdownEvent(eventType: string): boolean {
+    return eventType === 'AI_ANALYSIS' || eventType === 'AI_RECOMMENDATION' || eventType === 'COMMENT';
+  }
+
+  recSummaryContent(event: TicketEvent): string {
+    if (!event.content) return '';
+    const actionPrefixes = /^[-•]\s*(Auto-executed|Pending approval|Skipped):/i;
+    const headerPrefixes = /^\*\*(Auto-executed|Pending approval|Skipped):\*\*$/i;
+    return event.content
+      .split('\n')
+      .filter(line => !actionPrefixes.test(line.trim()) && !headerPrefixes.test(line.trim()))
+      .join('\n')
+      .trim();
+  }
+
+  formatEventType(type: string): string {
+    const labels: Record<string, string> = {
+      COMMENT: 'Comment',
+      STATUS_CHANGE: 'Status Change',
+      PRIORITY_CHANGE: 'Priority Change',
+      CATEGORY_CHANGE: 'Category Change',
+      AI_ANALYSIS: 'AI Analysis',
+      AI_RECOMMENDATION: 'AI Recommendation',
+      EMAIL_INBOUND: 'Email Received',
+      EMAIL_OUTBOUND: 'Email Sent',
+      CODE_CHANGE: 'Code Change',
+      SYSTEM_NOTE: 'System Note',
+    };
+    return labels[type] ?? type;
+  }
+
+  eventGlyph(type: string): string {
+    const glyphs: Record<string, string> = {
+      COMMENT: '\u{1F4AC}',
+      STATUS_CHANGE: '\u21C4',
+      PRIORITY_CHANGE: '\u26A0',
+      CATEGORY_CHANGE: '\u{1F3F7}',
+      AI_ANALYSIS: '\u26AC',
+      AI_RECOMMENDATION: '\u2731',
+      EMAIL_INBOUND: '\u2709',
+      EMAIL_OUTBOUND: '\u27A4',
+      CODE_CHANGE: '\u2329\u232A',
+      SYSTEM_NOTE: '\u2139',
+    };
+    return glyphs[type] ?? '\u25CF';
+  }
+
+  hasActionsMeta(event: TicketEvent): boolean {
+    const meta = event.metadata as Record<string, unknown> | null;
+    return Array.isArray(meta?.['actions']);
+  }
+
+  getEventActions(event: TicketEvent): Array<{ action: string; value?: string; reason: string; outcome?: string; pendingActionId?: string; recommendationType?: string }> {
+    const meta = event.metadata as Record<string, unknown> | null;
+    const actions = meta?.['actions'] as unknown[] | undefined;
+    if (!Array.isArray(actions)) return [];
+    return actions.map((a) => {
+      const obj = a as Record<string, unknown>;
+      return {
+        action: (obj['action'] as string) ?? '',
+        value: obj['value'] as string | undefined,
+        reason: (obj['reason'] as string) ?? '',
+        outcome: (obj['outcome'] as string) ?? (obj['applied'] === true ? 'auto_executed' : obj['applied'] === false ? 'skipped' : undefined),
+        pendingActionId: obj['pendingActionId'] as string | undefined,
+        recommendationType: obj['recommendationType'] as string | undefined,
+      };
+    });
+  }
+
+  getActionOutcome(act: { outcome?: string; applied?: boolean; pendingActionId?: string }): string {
+    if (act.pendingActionId) {
+      const liveStatus = this.pendingActionMap()[act.pendingActionId];
+      if (liveStatus === 'approved') return 'approved';
+      if (liveStatus === 'dismissed') return 'dismissed';
+      if (liveStatus === 'pending') return 'pending_approval';
+    }
+    if (act.outcome) return act.outcome;
+    if (act.applied === true) return 'auto_executed';
+    return 'skipped';
+  }
+
+  getActionOutcomeLabel(act: { outcome?: string; applied?: boolean }): string {
+    const outcome = this.getActionOutcome(act);
+    const labels: Record<string, string> = {
+      auto_executed: 'Auto-executed',
+      pending_approval: 'Pending Approval',
+      skipped: 'Skipped',
+      dismissed: 'Dismissed',
+      approved: 'Approved',
+    };
+    return labels[outcome] ?? outcome;
+  }
+
+  recActionGlyph(action: string): string {
+    const glyphs: Record<string, string> = {
+      set_status: '\u21C4',
+      set_priority: '\u26A0',
+      set_category: '\u{1F3F7}',
+      add_comment: '\u{1F4AC}',
+      trigger_code_fix: '\u2329\u232A',
+      send_followup_email: '\u2709',
+      escalate_deep_analysis: '\u26AC',
+      check_database_health: '\u2665',
+      assign_operator: '\u{1F464}',
+    };
+    return glyphs[action] ?? '\u2731';
+  }
+
+  formatRecActionType(action: string): string {
+    const labels: Record<string, string> = {
+      set_status: 'Change Status',
+      set_priority: 'Change Priority',
+      set_category: 'Change Category',
+      add_comment: 'Add Comment',
+      trigger_code_fix: 'Create Issue Job',
+      send_followup_email: 'Send Email',
+      escalate_deep_analysis: 'Escalate',
+      check_database_health: 'Check DB Health',
+      assign_operator: 'Assign Operator',
+    };
+    return labels[action] ?? action;
+  }
+
+  eventMeta(event: TicketEvent): {
+    aiProvider?: string;
+    aiModel?: string;
+    phase?: string;
+    taskType?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    durationMs?: number;
+  } | null {
+    const meta = event.metadata as Record<string, unknown> | null;
+    if (!meta) return null;
+    const aiProvider = meta['aiProvider'] as string | undefined;
+    const aiModel = meta['aiModel'] as string | undefined;
+    if (!aiProvider && !aiModel) return null;
+    const usage = meta['usage'] as { inputTokens?: number; outputTokens?: number } | undefined;
+    return {
+      aiProvider,
+      aiModel,
+      phase: meta['phase'] as string | undefined,
+      taskType: meta['taskType'] as string | undefined,
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      durationMs: meta['durationMs'] as number | undefined,
+    };
+  }
+
+  eventQuestion(event: TicketEvent): string | null {
+    const meta = event.metadata as Record<string, unknown> | null;
+    if (!meta || meta['phase'] !== 'ai_help') return null;
+    return (meta['question'] as string) ?? null;
+  }
+
+  isAiTriggered(event: TicketEvent): boolean {
+    const meta = event.metadata as Record<string, unknown> | null;
+    return meta?.['triggeredBy'] === 'ai_recommendation';
+  }
+
+  isAgenticAnalysis(event: TicketEvent): boolean {
+    const meta = event.metadata as Record<string, unknown> | null;
+    if (!meta || event.eventType !== 'AI_ANALYSIS') return false;
+    return meta['phase'] === 'agentic_analysis' || meta['phase'] === 'deep_analysis';
+  }
+
+  agenticMeta(event: TicketEvent): {
+    taskType: string;
+    iterationsRun: number;
+    toolCallCount: number;
+    toolCalls: Array<{ tool: string; system?: string; durationMs?: number; output?: string }>;
+    sufficiencyStatus: string | null;
+    sufficiencyConfidence: string | null;
+    sufficiencyReason: string | null;
+    sufficiencyQuestions: string[] | null;
+    totalCostUsd: number | null;
+  } | null {
+    const meta = event.metadata as Record<string, unknown> | null;
+    if (!meta) return null;
+    const toolCalls = (meta['toolCalls'] as Array<{ tool: string; system?: string; durationMs?: number; output?: string }>) ?? [];
+    return {
+      taskType: (meta['taskType'] as string) ?? 'DEEP_ANALYSIS',
+      iterationsRun: (meta['iterationsRun'] as number) ?? (meta['iterationCount'] as number) ?? 0,
+      toolCallCount: (meta['toolCallCount'] as number) ?? toolCalls.length,
+      toolCalls,
+      sufficiencyStatus: (meta['sufficiencyStatus'] as string) ?? null,
+      sufficiencyConfidence: (meta['sufficiencyConfidence'] as string) ?? null,
+      sufficiencyReason: (meta['sufficiencyReason'] as string) ?? null,
+      sufficiencyQuestions: (meta['sufficiencyQuestions'] as string[]) ?? null,
+      totalCostUsd: (meta['totalCostUsd'] as number) ?? null,
+    };
+  }
+
+  isJsonContent(content: string | null): boolean {
+    if (!content) return false;
+    const trimmed = content.trim();
+    return (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'));
+  }
+
+  formatJson(content: string): string {
+    try {
+      return JSON.stringify(JSON.parse(content), null, 2);
+    } catch {
+      return content;
+    }
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
@@ -41,9 +41,9 @@ import { type TicketEvent } from '../../core/services/ticket.service';
 
     <div class="timeline">
       @for (event of filteredEvents(); track event.id) {
-        <app-card padding="md" class="event-card" [class]="'event-type-' + event.eventType.toLowerCase()">
+        <app-card padding="md" class="event-card" [ngClass]="'event-type-' + event.eventType.toLowerCase()">
           <div class="event-header">
-            <span class="event-type-badge" [class]="'badge-' + event.eventType.toLowerCase()">
+            <span class="event-type-badge" [ngClass]="'badge-' + event.eventType.toLowerCase()">
               <span class="evt-icon" aria-hidden="true">{{ eventGlyph(event.eventType) }}</span>
               <span>{{ formatEventType(event.eventType) }}</span>
             </span>
@@ -70,7 +70,7 @@ import { type TicketEvent } from '../../core/services/ticket.service';
                   <span class="meta-chip token-chip">{{ am.toolCallCount }} tool calls</span>
                   <span class="meta-chip phase-chip">{{ am.iterationsRun }} iterations</span>
                   @if (am.sufficiencyStatus) {
-                    <span class="meta-chip" [class]="'sufficiency-' + am.sufficiencyStatus.toLowerCase()">{{ am.sufficiencyStatus }}</span>
+                    <span class="meta-chip" [ngClass]="'sufficiency-' + am.sufficiencyStatus.toLowerCase()">{{ am.sufficiencyStatus }}</span>
                   }
                   @if (am.sufficiencyConfidence) {
                     <span class="meta-chip duration-chip">confidence: {{ am.sufficiencyConfidence }}</span>
@@ -186,7 +186,7 @@ import { type TicketEvent } from '../../core/services/ticket.service';
                     <div class="rec-action-header" (click)="getActionOutcome(act) !== 'pending_approval' ? toggleEvent(event.id + '-act-' + $index) : null">
                       <span class="rec-icon" aria-hidden="true">{{ recActionGlyph(act.action) }}</span>
                       <span class="rec-action-type">{{ formatRecActionType(act.action) }}</span>
-                      <span class="rec-status-badge" [class]="'rec-badge-' + getActionOutcome(act)">
+                      <span class="rec-status-badge" [ngClass]="'rec-badge-' + getActionOutcome(act)">
                         {{ getActionOutcomeLabel(act) }}
                       </span>
                       @if (getActionOutcome(act) !== 'pending_approval') {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -1,318 +1,626 @@
-    .page-header { margin-bottom: 16px; }
-    .back-link { text-decoration: none; color: #666; }
-    .inline { display: inline; margin: 0 8px 0 4px; }
-    .ticket-number { color: #666; font-family: monospace; }
-    .ticket-meta { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; flex-wrap: wrap; }
-    .priority { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 4px; }
-    .priority-critical { background: #ffebee; color: #c62828; }
-    .priority-high { background: #fff3e0; color: #e65100; }
-    .priority-medium { background: #e3f2fd; color: #1565c0; }
-    .priority-low { background: #e8f5e9; color: #2e7d32; }
-    .source { color: #666; font-size: 13px; }
-    .date { color: #999; font-size: 13px; }
-    .status-select { width: 130px; font-size: 13px; }
-    .priority-select { width: 120px; font-size: 13px; }
-    .category-select { width: 160px; font-size: 13px; }
+:host {
+  display: block;
+  font-family: var(--font-primary);
+  color: var(--text-primary);
+}
 
-    /* Analysis status */
-    .analysis-badge { font-size: 11px; font-weight: 500; padding: 2px 10px; border-radius: 4px; display: inline-flex; align-items: center; gap: 4px; }
-    .analysis-pending { background: #f5f5f5; color: #666; }
-    .analysis-in_progress { background: #e3f2fd; color: #1565c0; }
-    .analysis-completed { background: #e8f5e9; color: #2e7d32; }
-    .analysis-failed { background: #ffebee; color: #c62828; }
-    .analysis-skipped { background: #f5f5f5; color: #999; }
-    .analysis-time { font-size: 10px; color: inherit; opacity: 0.8; margin-left: 4px; }
-    .spin-icon { font-size: 14px; width: 14px; height: 14px; animation: spin 1.5s linear infinite; }
-    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-    .retry-btn { font-size: 12px; }
-    .analysis-error { display: flex; align-items: flex-start; gap: 8px; background: #ffebee; color: #c62828; padding: 12px; border-radius: 8px; margin-bottom: 16px; font-size: 13px; line-height: 1.4; }
-    .analysis-error mat-icon { flex-shrink: 0; font-size: 20px; width: 20px; height: 20px; }
+.page-wrapper {
+  max-width: 1400px;
+  position: relative;
+}
 
-    /* Tab group */
-    .info-tabs { margin-bottom: 16px; }
-    .tab-content { padding: 16px 0; }
-    .knowledge-doc { font-size: 14px; line-height: 1.6; }
-    .knowledge-doc h3 { margin-top: 16px; margin-bottom: 8px; font-size: 16px; color: #333; border-bottom: 1px solid #e0e0e0; padding-bottom: 4px; }
-    .knowledge-doc h4 { margin-top: 12px; margin-bottom: 6px; font-size: 14px; color: #555; }
-    .knowledge-doc pre { background: #f5f5f5; padding: 8px 12px; border-radius: 4px; overflow-x: auto; font-size: 12px; }
-    .knowledge-doc code { background: #f5f5f5; padding: 1px 4px; border-radius: 3px; font-size: 12px; }
-    .tab-action-btn { margin-left: 4px; }
-    .tab-action-btn mat-icon { font-size: 16px; width: 16px; height: 16px; }
-    .blurb-text { line-height: 1.5; margin: 0; }
-    .summary-text { white-space: pre-wrap; line-height: 1.6; }
-    .description { white-space: pre-wrap; }
-    .show-more-btn { font-size: 12px; color: #3f51b5; padding: 0; min-width: auto; }
+.page-header {
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
 
-    /* Log digest */
-    .log-summary-entry { padding: 12px 0; border-bottom: 1px solid #eee; }
-    .log-summary-entry:last-child { border-bottom: none; }
-    .log-summary-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
-    .log-summary-time { font-size: 12px; color: #666; }
-    .log-summary-count { font-size: 11px; color: #666; background: #f0f0f0; padding: 2px 8px; border-radius: 12px; }
-    .log-summary-text { margin: 4px 0 8px; line-height: 1.5; color: #333; }
-    .log-summary-services { display: flex; gap: 4px; flex-wrap: wrap; }
-    .service-chip { font-size: 11px; padding: 2px 8px; border-radius: 12px; background: #e8eaf6; color: #3f51b5; }
+.header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 
-    /* Logs tab */
-    .tab-badge { font-size: 10px; background: #e0e0e0; color: #333; padding: 1px 6px; border-radius: 10px; margin-left: 6px; font-weight: 500; }
-    .logs-filter-bar { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
-    .logs-filter-field { width: 140px; font-size: 13px; }
-    .logs-ai-section { margin-bottom: 16px; }
-    .logs-section-title { display: flex; align-items: center; gap: 6px; font-size: 14px; font-weight: 500; margin: 0 0 8px; color: #333; }
-    .section-icon { font-size: 18px; width: 18px; height: 18px; color: #666; }
-    .ai-usage-list { display: flex; flex-direction: column; gap: 4px; }
-    .ai-usage-row { display: flex; align-items: center; gap: 6px; font-size: 12px; padding: 4px 8px; background: #fafafa; border-radius: 4px; flex-wrap: wrap; }
-    .ai-usage-time { color: #999; font-size: 11px; min-width: 100px; font-family: monospace; }
-    .ai-usage-cost { color: #2e7d32; font-weight: 500; font-family: monospace; font-size: 11px; margin-left: auto; }
-    .logs-list { display: flex; flex-direction: column; gap: 2px; }
-    .log-entry { padding: 6px 10px; border-radius: 4px; border-left: 3px solid transparent; }
-    .log-level-error { border-left-color: #c62828; background: #fff8f8; }
-    .log-level-warn { border-left-color: #e65100; background: #fffaf5; }
-    .log-level-info { border-left-color: #1565c0; background: #f8fbff; }
-    .log-level-debug { border-left-color: #999; background: #fafafa; }
-    .log-entry-header { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }
-    .log-time { color: #999; font-family: monospace; font-size: 11px; min-width: 100px; flex-shrink: 0; }
-    .log-level-badge { font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 3px; text-transform: uppercase; }
-    .log-badge-error { background: #ffebee; color: #c62828; }
-    .log-badge-warn { background: #fff3e0; color: #e65100; }
-    .log-badge-info { background: #e3f2fd; color: #1565c0; }
-    .log-badge-debug { background: #f5f5f5; color: #999; }
-    .log-service { color: #6a1b9a; font-weight: 500; font-size: 11px; }
-    .log-message { color: #333; flex: 1; word-break: break-word; }
-    .log-expand-btn { font-size: 11px; color: #666; padding: 0; min-width: auto; margin-top: 2px; }
-    .log-expand-btn mat-icon { font-size: 14px; width: 14px; height: 14px; }
-    .log-metadata { font-size: 11px; background: #f5f5f5; padding: 8px; border-radius: 4px; margin: 4px 0 0; overflow-x: auto; max-height: 300px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
-    .log-error-detail { font-size: 11px; color: #c62828; margin-top: 4px; white-space: pre-wrap; }
-    .logs-pagination { display: flex; align-items: center; gap: 12px; margin-top: 12px; padding-top: 12px; border-top: 1px solid #eee; }
-    .logs-showing { font-size: 12px; color: #666; }
+.back-link {
+  text-decoration: none;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.back-link:hover { color: var(--accent); }
 
-    /* Process flow */
-    .flow-card { margin-bottom: 16px; }
-    .flow-container { display: flex; align-items: flex-start; gap: 4px; flex-wrap: wrap; padding: 8px 0; overflow-x: auto; }
-    .flow-node { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border-radius: 16px; font-size: 11px; font-weight: 500; white-space: nowrap; }
-    .flow-start { background: #e3f2fd; color: #1565c0; }
-    .flow-action { background: #f3e5f5; color: #6a1b9a; }
-    .flow-ai { background: #fce4ec; color: #c62828; }
-    .flow-email { background: #e8f5e9; color: #2e7d32; }
-    .flow-status { background: #fff3e0; color: #e65100; }
-    .flow-end { background: #f5f5f5; color: #666; }
-    .flow-icon { font-size: 14px; width: 14px; height: 14px; }
-    .flow-arrow { color: #bbb; display: flex; align-items: center; }
-    .flow-arrow mat-icon { font-size: 18px; width: 18px; height: 18px; }
-    .flow-branch { display: flex; flex-direction: column; gap: 4px; margin-left: 8px; padding-left: 8px; border-left: 2px solid #ddd; }
-    .flow-branch-row { display: flex; align-items: center; gap: 4px; }
-    .flow-connector { width: 12px; height: 2px; background: #ddd; }
+.page-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.ticket-number {
+  color: var(--text-tertiary);
+  font-weight: 500;
+  margin-right: 6px;
+}
 
-    /* AI Cost */
-    .cost-card { margin-bottom: 16px; background: #e8f5e9; }
-    .cost-summary { display: flex; gap: 24px; flex-wrap: wrap; }
-    .cost-item { display: flex; flex-direction: column; }
-    .cost-label { font-size: 11px; text-transform: uppercase; color: #666; letter-spacing: 0.5px; }
-    .cost-value { font-size: 20px; font-weight: 600; font-family: monospace; color: #222; }
-    .show-details-btn { font-size: 12px; margin-top: 8px; color: #2e7d32; }
-    .cost-breakdown { margin-top: 12px; border-top: 1px solid rgba(0,0,0,0.1); padding-top: 12px; }
-    .breakdown-group { margin-bottom: 12px; }
-    .breakdown-header { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
-    .breakdown-stats { font-size: 12px; color: #666; margin-left: auto; font-family: monospace; }
-    .call-list { padding-left: 16px; }
-    .call-row { display: flex; gap: 12px; align-items: center; font-size: 12px; padding: 2px 0; font-family: monospace; color: #555; }
-    .call-task { font-weight: 500; color: #333; min-width: 140px; font-family: inherit; }
-    .call-tokens { color: #666; }
-    .call-cost { color: #2e7d32; font-weight: 500; }
-    .call-duration { color: #999; }
-    .call-time { color: #999; margin-left: auto; }
+.ticket-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+.ticket-meta app-select {
+  display: inline-block;
+  min-width: 140px;
+}
+.source {
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+.date {
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
 
-    /* Timeline header and controls */
-    .timeline-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
-    .timeline-header h3 { margin: 0; }
-    .timeline-controls { display: flex; align-items: center; gap: 8px; }
-    .timeline-filter-field { width: 160px; font-size: 13px; }
+/* Analysis status */
+.analysis-badge {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+}
+.analysis-pending     { background: var(--bg-muted); color: var(--text-secondary); }
+.analysis-in_progress { background: var(--color-info-subtle); color: var(--color-info); }
+.analysis-completed   { background: var(--color-success-subtle); color: var(--color-success); }
+.analysis-failed      { background: var(--color-error-subtle); color: var(--color-error); }
+.analysis-skipped     { background: var(--bg-muted); color: var(--text-tertiary); }
+.analysis-time {
+  font-size: 10px;
+  color: inherit;
+  opacity: 0.8;
+  margin-left: 4px;
+}
+.spin-icon {
+  display: inline-block;
+  font-size: 14px;
+  animation: spin 1.5s linear infinite;
+}
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
 
-    /* Timeline */
-    .timeline { display: flex; flex-direction: column; gap: 8px; margin-bottom: 24px; }
-    .event-header { display: flex; align-items: center; gap: 8px; }
-    .event-type-badge { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 4px; background: #f5f5f5; color: #555; }
-    .event-type-badge mat-icon { font-size: 15px; width: 15px; height: 15px; }
-    .badge-ai_analysis { background: #ede7f6; color: #5e35b1; }
-    .badge-ai_recommendation { background: #fff8e1; color: #f57f17; }
-    .badge-email_inbound { background: #e8f5e9; color: #2e7d32; }
-    .badge-email_outbound { background: #e3f2fd; color: #1565c0; }
-    .badge-status_change { background: #fff3e0; color: #e65100; }
-    .badge-code_change { background: #fce4ec; color: #c62828; }
-    .event-actor { color: #666; font-size: 13px; }
-    .event-date { color: #999; font-size: 13px; margin-left: auto; cursor: default; }
-    .event-question { display: flex; align-items: flex-start; gap: 4px; margin-top: 6px; padding: 6px 10px; background: #e3f2fd; border-radius: 6px; font-size: 13px; color: #1565c0; }
-    .question-icon { font-size: 16px; width: 16px; height: 16px; flex-shrink: 0; margin-top: 1px; }
-    .event-content { margin-top: 8px; white-space: pre-wrap; line-height: 1.5; }
-    .event-content.collapsed { max-height: 100px; overflow: hidden; }
-    .ellipsis { color: #999; }
-    .event-type-ai_analysis { border-left: 3px solid #7c4dff; }
-    .event-type-ai_recommendation { border-left: 3px solid #ffab00; }
-    .event-type-system_note { border-left: 3px solid #bdbdbd; }
-    .event-type-email_inbound, .event-type-email_outbound { border-left: 3px solid #4caf50; }
-    .event-type-code_change { border-left: 3px solid #e91e63; }
-    /* Probe data (JSON SYSTEM_NOTE) */
-    .probe-data-section { margin-top: 8px; }
-    .probe-data-code { background: #263238; color: #eeffff; padding: 12px; border-radius: 6px; overflow-x: auto; font-size: 12px; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
-    /* AI Recommendation action list */
-    .recommendation-actions { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
-    .rec-action-row { display: flex; flex-direction: column; gap: 4px; padding: 6px 10px; background: #fafafa; border-radius: 6px; border: 1px solid #eee; }
-    .rec-action-header { display: flex; align-items: center; gap: 8px; }
-    .rec-resolved .rec-action-header { cursor: pointer; }
-    .rec-expand-icon { font-size: 16px; width: 16px; height: 16px; color: #999; }
-    .rec-icon { font-size: 18px; width: 18px; height: 18px; color: #666; flex-shrink: 0; }
-    .rec-action-detail { display: flex; flex-wrap: wrap; gap: 4px; align-items: baseline; padding-left: 26px; }
-    .rec-action-buttons { display: flex; gap: 6px; padding-left: 26px; }
-    .rec-action-type { font-weight: 600; font-size: 13px; }
-    .rec-action-value { font-family: monospace; font-size: 12px; background: #e8eaf6; padding: 1px 6px; border-radius: 3px; color: #283593; }
-    .rec-action-reason { font-size: 12px; color: #666; }
-    .rec-status-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; margin-left: auto; }
-    .rec-badge-auto_executed { background: #e8f5e9; color: #2e7d32; }
-    .rec-badge-pending_approval { background: #fff3e0; color: #e65100; }
-    .rec-badge-skipped { background: #f5f5f5; color: #999; }
-    .rec-badge-dismissed { background: #fce4ec; color: #c62828; }
-    .rec-badge-approved { background: #e8f5e9; color: #2e7d32; }
-    .rec-approve-btn, .rec-dismiss-btn { font-size: 11px; min-height: 28px; line-height: 28px; padding: 0 10px; }
-    .ai-triggered-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #fff8e1; color: #f57f17; white-space: nowrap; }
-    .markdown-content { white-space: normal; }
-    .markdown-content h1, .markdown-content h2, .markdown-content h3 { margin: 10px 0 4px; }
-    .markdown-content h1 { font-size: 1.25em; }
-    .markdown-content h2 { font-size: 1.1em; }
-    .markdown-content p { margin: 4px 0; }
-    .markdown-content ul, .markdown-content ol { margin: 4px 0; padding-left: 24px; }
-    .markdown-content code { background: #f5f5f5; padding: 1px 4px; border-radius: 3px; font-size: 0.9em; }
-    .markdown-content pre { background: #263238; color: #eeffff; padding: 10px; border-radius: 6px; overflow-x: auto; margin: 6px 0; }
-    .markdown-content pre code { background: transparent; color: inherit; padding: 0; }
-    .markdown-content blockquote { border-left: 3px solid #ddd; margin: 6px 0; padding: 2px 12px; color: #666; }
-    .event-ai-meta { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
-    .meta-chip { font-size: 10px; padding: 1px 6px; border-radius: 4px; display: inline-block; }
-    .provider-chip { font-weight: 600; font-family: monospace; background: #f5f5f5; color: #333; }
-    .provider-local { background: #e8f5e9; color: #2e7d32; }
-    .provider-claude { background: #f3e5f5; color: #6a1b9a; }
-    .provider-openai { background: #e3f2fd; color: #1565c0; }
-    .provider-grok { background: #fff3e0; color: #e65100; }
-    .provider-google { background: #e8f5e9; color: #1b5e20; }
-    .model-chip { background: #f5f5f5; color: #333; font-size: 10px; }
-    .model-name { font-size: 12px; background: #f5f5f5; padding: 2px 6px; border-radius: 3px; }
-    .phase-chip { background: #e8eaf6; color: #3f51b5; }
-    .task-chip { background: #fce4ec; color: #c62828; }
-    .token-chip { background: #f5f5f5; color: #666; font-family: monospace; }
-    .duration-chip { background: #f5f5f5; color: #999; font-family: monospace; }
+.analysis-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: var(--color-error-subtle);
+  color: var(--color-error);
+  padding: 12px;
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.error-icon {
+  flex-shrink: 0;
+  font-size: 18px;
+}
 
-    /* Agentic analysis card */
-    .agentic-summary { margin-top: 8px; }
-    .agentic-stats { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 4px; }
-    .sufficiency-sufficient { background: #e8f5e9; color: #2e7d32; }
-    .sufficiency-needs_user_input { background: #fff3e0; color: #e65100; }
-    .sufficiency-insufficient { background: #ffebee; color: #c62828; }
-    .tool-calls-list { padding: 4px 0 4px 12px; border-left: 2px solid #e0e0e0; margin: 4px 0; }
-    .tool-call-row { display: flex; align-items: center; gap: 6px; font-size: 12px; padding: 3px 0; flex-wrap: wrap; }
-    .tool-name { font-weight: 600; font-family: monospace; color: #333; font-size: 12px; }
-    .tool-result { font-size: 11px; background: #f5f5f5; padding: 6px; border-radius: 4px; margin: 2px 0; overflow-x: auto; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; width: 100%; }
-    .sufficiency-detail { font-size: 13px; padding: 8px 12px; background: #fafafa; border-radius: 4px; margin: 4px 0; }
-    .sufficiency-detail p { margin: 2px 0; }
-    .sufficiency-detail ul { margin: 4px 0; padding-left: 20px; }
-    .cost-badge { font-size: 11px; font-weight: 600; font-family: monospace; color: #2e7d32; background: #e8f5e9; padding: 2px 8px; border-radius: 4px; }
+/* Tab group */
+.info-tabs { margin-bottom: 16px; }
 
-    /* Probe data */
-    .probe-data { font-size: 11px; background: #263238; color: #eeffff; padding: 10px; border-radius: 6px; overflow-x: auto; margin: 6px 0; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+/* Indeterminate progress bar */
+.indeterminate-bar {
+  position: relative;
+  height: 3px;
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+.indeterminate-track {
+  position: absolute;
+  left: -40%;
+  width: 40%;
+  height: 100%;
+  background: var(--accent);
+  animation: indeterminate 1.4s ease-in-out infinite;
+}
+@keyframes indeterminate {
+  0% { left: -40%; }
+  100% { left: 100%; }
+}
 
-    /* Recommendation actions */
-    .recommendation-actions { margin: 8px 0; }
-    .recommendation-row { display: flex; align-items: center; gap: 6px; font-size: 13px; padding: 3px 0; }
-    .recommendation-row.action-applied .action-status-icon { color: #2e7d32; }
-    .action-status-icon { font-size: 16px; width: 16px; height: 16px; color: #999; }
-    .action-label { font-weight: 500; }
-    .action-detail { color: #666; font-size: 12px; }
+/* Logs tab */
+.logs-filter-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.logs-filter-bar app-form-field {
+  width: 160px;
+}
+.search-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-card);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  font-family: var(--font-primary);
+  font-size: 14px;
+  color: var(--text-primary);
+  outline: none;
+}
+.search-input:focus {
+  border-color: var(--accent);
+}
 
-    /* Unified logs */
-    .unified-type-badge { font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 3px; text-transform: uppercase; letter-spacing: 0.3px; }
-    .ubadge-log { background: #e3f2fd; color: #1565c0; }
-    .ubadge-ai { background: #f3e5f5; color: #6a1b9a; }
-    .ubadge-tool { background: #e8f5e9; color: #2e7d32; }
-    .ubadge-step { background: #fff3e0; color: #e65100; }
-    .ubadge-error { background: #ffebee; color: #c62828; }
-    .log-seq { font-size: 10px; color: #bbb; font-family: monospace; min-width: 32px; flex-shrink: 0; }
-    .iteration-group-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px 4px; margin-top: 8px; border-top: 2px solid #e0e0e0; }
-    .iteration-group-header:first-child { margin-top: 0; border-top: none; }
-    .iteration-icon { font-size: 16px; width: 16px; height: 16px; color: #7c4dff; }
-    .iteration-label { font-size: 12px; font-weight: 600; color: #5e35b1; }
-    .iteration-grouped { border-left-width: 3px; margin-left: 8px; }
-    .unified-type-error { border-left-color: #c62828; background: #fff8f8; }
-    .unified-type-ai { border-left-color: #7c4dff; background: #faf8ff; }
-    .unified-type-tool { border-left-color: #2e7d32; background: #f8fff8; }
-    .unified-type-step { border-left-color: #e65100; background: #fffaf5; }
+.logs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 
-    /* AI detail sections in unified logs */
-    .ai-detail-sections { padding: 8px 0 4px; }
-    .ai-detail-label { font-size: 11px; font-weight: 600; color: #666; margin: 4px 0 2px; }
-    .ai-detail-block { margin-bottom: 8px; }
+.log-entry {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border-left: 3px solid transparent;
+}
+.log-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  flex-wrap: wrap;
+}
 
-    /* Logs cost summary */
-    .logs-cost-summary { background: #f8faf8; border: 1px solid #e0e8e0; border-radius: 8px; padding: 12px 16px; margin-bottom: 12px; }
-    .cost-summary-row { display: flex; gap: 24px; flex-wrap: wrap; }
-    .cost-summary-item { display: flex; flex-direction: column; }
-    .cost-summary-label { font-size: 10px; text-transform: uppercase; color: #666; letter-spacing: 0.5px; }
-    .cost-summary-value { font-size: 16px; font-weight: 600; font-family: monospace; color: #222; }
-    .cost-breakdown-inline { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; font-size: 12px; color: #555; }
-    .breakdown-chip { display: flex; align-items: center; gap: 4px; }
-    .model-name-sm { font-size: 10px; background: #f5f5f5; padding: 1px 4px; border-radius: 3px; }
+.log-time {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  min-width: 100px;
+  flex-shrink: 0;
+}
+.log-seq {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  min-width: 32px;
+  flex-shrink: 0;
+}
+.log-level-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+}
+.log-badge-error { background: var(--color-error-subtle);   color: var(--color-error); }
+.log-badge-warn  { background: var(--color-warning-subtle); color: var(--color-warning); }
+.log-badge-info  { background: var(--color-info-subtle);    color: var(--color-info); }
+.log-badge-debug { background: var(--bg-muted);             color: var(--text-tertiary); }
 
-    /* Knowledge doc editing */
-    .knowledge-editor { width: 100%; font-family: monospace; font-size: 13px; padding: 12px; border: 1px solid #ccc; border-radius: 6px; resize: vertical; box-sizing: border-box; }
-    .knowledge-actions { display: flex; gap: 8px; margin-bottom: 12px; }
+.log-service {
+  color: var(--color-purple);
+  font-weight: 500;
+  font-size: 11px;
+}
+.log-message {
+  color: var(--text-primary);
+  flex: 1;
+  word-break: break-word;
+}
+.log-expand-btn { font-size: 11px; }
+.log-metadata {
+  font-size: 11px;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  margin: 4px 0 0;
+  overflow-x: auto;
+  max-height: 300px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.log-error-detail {
+  font-size: 11px;
+  color: var(--color-error);
+  margin-top: 4px;
+  white-space: pre-wrap;
+}
+.logs-pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-light);
+}
+.logs-showing {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
 
-    .add-comment { margin-bottom: 24px; }
-    .full-width { width: 100%; }
-    .empty { color: #999; padding: 16px; text-align: center; }
+.unified-type-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.ubadge-log   { background: var(--color-info-subtle);    color: var(--color-info); }
+.ubadge-ai    { background: var(--color-purple-subtle);  color: var(--color-purple); }
+.ubadge-tool  { background: var(--color-success-subtle); color: var(--color-success); }
+.ubadge-step  { background: var(--color-warning-subtle); color: var(--color-warning); }
+.ubadge-error { background: var(--color-error-subtle);   color: var(--color-error); }
 
-    /* Re-run analysis bar */
-    .reanalyze-bar { margin-bottom: 16px; }
+.iteration-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 4px;
+  margin-top: 8px;
+  border-top: 2px solid var(--border-light);
+}
+.iteration-group-header:first-child {
+  margin-top: 0;
+  border-top: none;
+}
+.iteration-icon {
+  font-size: 14px;
+  color: var(--color-purple);
+}
+.iteration-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-purple);
+}
+.iteration-grouped {
+  border-left-width: 3px;
+  margin-left: 8px;
+}
+.unified-type-error { border-left-color: var(--color-error);   background: var(--color-error-subtle); }
+.unified-type-ai    { border-left-color: var(--color-purple);  background: var(--color-purple-subtle); }
+.unified-type-tool  { border-left-color: var(--color-success); background: var(--color-success-subtle); }
+.unified-type-step  { border-left-color: var(--color-warning); background: var(--color-warning-subtle); }
 
-    /* Floating AI help button */
-    .ai-fab { position: fixed; bottom: 24px; right: 24px; z-index: 100; }
+.ai-detail-sections { padding: 8px 0 4px; }
+.ai-detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  margin: 4px 0 2px;
+}
+.ai-detail-block { margin-bottom: 8px; }
 
-    /* Step grouping */
-    .step-group { margin-bottom: 8px; border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden; }
-    .step-group-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: #f5f5f5; cursor: pointer; user-select: none; flex-wrap: wrap; }
-    .step-group-header:hover { background: #eeeeee; }
-    .step-name { font-size: 13px; font-weight: 700; color: #333; letter-spacing: 0.3px; }
-    .step-status-icon { font-size: 18px; width: 18px; height: 18px; }
-    .status-completed { color: #2e7d32; }
-    .status-failed { color: #c62828; }
-    .status-running { color: #e65100; }
-    .step-meta-chip { font-size: 11px; padding: 1px 7px; border-radius: 10px; background: #e8eaf6; color: #3949ab; white-space: nowrap; }
-    .step-meta-chip.token-chip { background: #fff3e0; color: #e65100; }
-    .step-meta-chip.cost-chip { background: #e8f5e9; color: #2e7d32; font-weight: 600; }
-    .step-entry-count { font-size: 11px; color: #999; margin-left: auto; }
-    .step-chevron { font-size: 18px; width: 18px; height: 18px; color: #999; }
-    .step-group-entries { padding: 6px 8px; background: #fafafa; }
+.ai-usage-cost {
+  color: var(--color-success);
+  font-weight: 500;
+  font-size: 11px;
+  margin-left: auto;
+}
 
-    /* Conversation tab */
-    .conv-view { padding: 12px 0; }
-    .conv-step-section { margin-bottom: 20px; }
-    .conv-step-label { display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; color: #888; margin-bottom: 8px; border-bottom: 1px solid #eee; padding-bottom: 4px; }
-    .conv-step-icon { font-size: 14px; width: 14px; height: 14px; color: #aaa; }
-    .conv-ai-block { border-left: 3px solid #7c4dff; background: #fafafa; border-radius: 0 6px 6px 0; padding: 8px 12px; margin-bottom: 10px; }
-    .conv-subtask { margin-left: 20px; border-left: 2px solid #b39ddb; background: #f5f3ff; border-radius: 0 6px 6px 0; padding: 6px 10px; margin-top: 6px; }
-    .subtask-icon { font-size: 16px; width: 16px; height: 16px; color: #9575cd; }
-    .conv-ai-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 6px; }
-    .conv-task-type { font-size: 12px; font-weight: 700; background: #e8f5e9; color: #2e7d32; padding: 1px 7px; border-radius: 10px; }
-    .conv-model { font-size: 11px; color: #888; font-family: monospace; }
-    .conv-tokens { font-size: 11px; background: #fff3e0; color: #e65100; padding: 1px 7px; border-radius: 10px; }
-    .conv-cost { font-size: 11px; font-weight: 600; color: #2e7d32; }
-    .conv-turns { border-left: 2px solid #e0e0e0; margin-left: 8px; padding-left: 8px; margin-bottom: 6px; }
-    .conv-turn { display: flex; align-items: center; gap: 8px; padding: 2px 0; font-size: 12px; }
-    .conv-turn-user { color: #444; }
-    .conv-turn-assistant { color: #3949ab; }
-    .conv-turn-role { font-size: 14px; }
-    .conv-tool-call { background: #e8f5e9; color: #2e7d32; padding: 1px 7px; border-radius: 10px; font-size: 11px; font-family: monospace; }
-    .conv-token-count { font-size: 10px; color: #bbb; }
-    .conv-final-label { font-size: 10px; font-weight: 700; color: #999; text-transform: uppercase; letter-spacing: 0.5px; display: block; margin-bottom: 2px; }
-    .conv-final-response { margin-top: 6px; }
-    .conv-response-text { font-size: 12px; font-family: monospace; color: #333; margin: 0; white-space: pre-wrap; word-break: break-word; background: #f7f7f7; padding: 6px 8px; border-radius: 4px; border-left: 2px solid #7c4dff; }
-    .conv-prompt-block .conv-response-text { border-left-color: #ff9800; background: #fffdf5; }
-    .conv-response-text.clamped { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
-    .conv-empty { padding: 24px; text-align: center; color: #888; }
-    .inline-expand-btn { font-size: 11px; color: #666; padding: 0; min-width: auto; margin-top: 2px; }
-    .inline-expand-btn mat-icon { font-size: 14px; width: 14px; height: 14px; }
+/* Logs cost summary */
+.logs-cost-summary {
+  background: var(--color-success-subtle);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  margin-bottom: 12px;
+}
+.cost-summary-row {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.cost-summary-item {
+  display: flex;
+  flex-direction: column;
+}
+.cost-summary-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  letter-spacing: 0.5px;
+}
+.cost-summary-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.cost-breakdown-inline {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.breakdown-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.model-name-sm {
+  font-size: 10px;
+  background: var(--bg-muted);
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+}
+.meta-chip {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+}
+.provider-chip {
+  font-weight: 600;
+  background: var(--bg-muted);
+  color: var(--text-primary);
+}
+.provider-local  { background: var(--color-success-subtle); color: var(--color-success); }
+.provider-claude { background: var(--color-purple-subtle);  color: var(--color-purple); }
+.provider-openai { background: var(--color-info-subtle);    color: var(--color-info); }
+.provider-grok   { background: var(--color-warning-subtle); color: var(--color-warning); }
+.provider-google { background: var(--color-success-subtle); color: var(--color-success); }
+.model-chip      { background: var(--bg-muted); color: var(--text-primary); }
+.task-chip       { background: var(--color-error-subtle); color: var(--color-error); }
+.token-chip      { background: var(--bg-muted); color: var(--text-tertiary); }
+.duration-chip   { background: var(--bg-muted); color: var(--text-tertiary); }
+
+/* Step grouping */
+.step-group {
+  margin-bottom: 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.step-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--bg-muted);
+  cursor: pointer;
+  user-select: none;
+  flex-wrap: wrap;
+}
+.step-group-header:hover { background: var(--bg-hover); }
+.step-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.3px;
+}
+.step-status-icon {
+  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+.status-completed { color: var(--color-success); }
+.status-failed    { color: var(--color-error); }
+.status-running   { color: var(--color-warning); }
+.step-meta-chip {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  background: var(--color-info-subtle);
+  color: var(--color-info);
+  white-space: nowrap;
+}
+.step-meta-chip.token-chip { background: var(--color-warning-subtle); color: var(--color-warning); }
+.step-meta-chip.cost-chip  { background: var(--color-success-subtle); color: var(--color-success); font-weight: 600; }
+.step-entry-count {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+.step-chevron {
+  font-size: 14px;
+  color: var(--text-tertiary);
+}
+.step-group-entries {
+  padding: 6px 8px;
+  background: var(--bg-page);
+}
+
+/* Conversation tab */
+.conv-view { padding: 12px 0; }
+.conv-step-section { margin-bottom: 20px; }
+.conv-step-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-tertiary);
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border-light);
+  padding-bottom: 4px;
+}
+.conv-step-icon {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.conv-ai-block {
+  border-left: 3px solid var(--color-purple);
+  background: var(--color-purple-subtle);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: 8px 12px;
+  margin-bottom: 10px;
+}
+.conv-subtask {
+  margin-left: 20px;
+  border-left: 2px solid var(--color-purple);
+  background: var(--color-purple-subtle);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: 6px 10px;
+  margin-top: 6px;
+}
+.subtask-icon {
+  font-size: 14px;
+  color: var(--color-purple);
+}
+.conv-ai-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+.conv-task-type {
+  font-size: 12px;
+  font-weight: 700;
+  background: var(--color-success-subtle);
+  color: var(--color-success);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+.conv-model {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.conv-tokens {
+  font-size: 11px;
+  background: var(--color-warning-subtle);
+  color: var(--color-warning);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+.conv-cost {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-success);
+}
+.conv-turns {
+  border-left: 2px solid var(--border-light);
+  margin-left: 8px;
+  padding-left: 8px;
+  margin-bottom: 6px;
+}
+.conv-turn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: 12px;
+}
+.conv-turn-user      { color: var(--text-secondary); }
+.conv-turn-assistant { color: var(--color-info); }
+.conv-turn-role { font-size: 14px; }
+.conv-tool-call {
+  background: var(--color-success-subtle);
+  color: var(--color-success);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+}
+.conv-token-count {
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+.conv-final-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  display: block;
+  margin-bottom: 2px;
+}
+.conv-final-response { margin-top: 6px; }
+.conv-response-text {
+  font-size: 12px;
+  color: var(--text-primary);
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-card);
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid var(--color-purple);
+}
+.conv-prompt-block .conv-response-text {
+  border-left-color: var(--color-warning);
+  background: var(--color-warning-subtle);
+}
+.conv-response-text.clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.conv-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-tertiary);
+}
+.inline-expand-btn {
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+/* Empty state */
+.empty {
+  color: var(--text-tertiary);
+  padding: 16px;
+  text-align: center;
+}
+.loading {
+  color: var(--text-tertiary);
+  padding: 32px;
+  text-align: center;
+}
+
+/* Add comment card */
+.add-comment {
+  display: block;
+  margin-bottom: 24px;
+}
+.comment-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+/* Re-run analysis bar */
+.reanalyze-bar {
+  margin-bottom: 16px;
+}
+
+/* Floating AI help button */
+.ai-fab {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border: none;
+  cursor: pointer;
+  font-size: 22px;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 120ms ease;
+}
+.ai-fab:hover { opacity: 0.85; }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1,27 +1,32 @@
 import { Component, DestroyRef, inject, OnInit, signal, input, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { CommonModule, DatePipe, JsonPipe } from '@angular/common';
+import { CommonModule, DatePipe, DecimalPipe, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatTabsModule } from '@angular/material/tabs';
 import { firstValueFrom } from 'rxjs';
-import { TicketService, Ticket, TicketEvent, type TicketAppLog, type TicketAiUsageLog, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse } from '../../core/services/ticket.service';
+import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse } from '../../core/services/ticket.service';
 import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service';
 import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service';
 import { AiHelpDialogComponent } from '../../shared/components/ai-help-dialog.component';
-import { DialogComponent } from '../../shared/components/dialog.component';
+import {
+  CardComponent,
+  BroncoButtonComponent,
+  TabComponent,
+  TabGroupComponent,
+  SelectComponent,
+  FormFieldComponent,
+  TextareaComponent,
+  DialogComponent,
+} from '../../shared/components/index.js';
 import { AiLogEntryComponent } from './ai-log-entry.component';
-import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
-import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
+import { TicketDetailSummaryComponent } from './ticket-detail-summary.component.js';
+import { TicketDetailResolutionComponent } from './ticket-detail-resolution.component.js';
+import { TicketDetailDetailsComponent } from './ticket-detail-details.component.js';
+import { TicketDetailKnowledgeComponent } from './ticket-detail-knowledge.component.js';
+import { TicketDetailLogDigestComponent } from './ticket-detail-log-digest.component.js';
+import { TicketDetailFlowComponent, type FlowNode } from './ticket-detail-flow.component.js';
+import { TicketDetailCostComponent } from './ticket-detail-cost.component.js';
+import { TicketDetailTimelineComponent } from './ticket-detail-timeline.component.js';
 import { ToastService } from '../../core/services/toast.service';
 
 interface StepGroup {
@@ -35,135 +40,120 @@ interface StepGroup {
   expanded: boolean;
 }
 
-interface FlowNode {
-  label: string;
-  icon: string;
-  type: 'start' | 'action' | 'ai' | 'email' | 'status' | 'end';
-  children?: FlowNode[];
-}
-
 @Component({
   standalone: true,
-  imports: [CommonModule, RouterLink, DatePipe, JsonPipe, FormsModule, MatCardModule, MatButtonModule, MatIconModule, MatChipsModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatProgressBarModule, MatTooltipModule, MatTabsModule, MarkdownPipe, RelativeTimePipe, AiLogEntryComponent, DialogComponent, AiHelpDialogComponent],
+  imports: [
+    CommonModule,
+    RouterLink,
+    DatePipe,
+    DecimalPipe,
+    JsonPipe,
+    FormsModule,
+    CardComponent,
+    BroncoButtonComponent,
+    TabComponent,
+    TabGroupComponent,
+    SelectComponent,
+    FormFieldComponent,
+    TextareaComponent,
+    DialogComponent,
+    AiLogEntryComponent,
+    AiHelpDialogComponent,
+    TicketDetailSummaryComponent,
+    TicketDetailResolutionComponent,
+    TicketDetailDetailsComponent,
+    TicketDetailKnowledgeComponent,
+    TicketDetailLogDigestComponent,
+    TicketDetailFlowComponent,
+    TicketDetailCostComponent,
+    TicketDetailTimelineComponent,
+  ],
   template: `
     @if (ticket(); as t) {
-      <div class="page-header">
-        <div>
-          <a routerLink="/tickets" class="back-link">Tickets</a> /
-          <h1 class="inline">@if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> — }{{ t.subject }}</h1>
-        </div>
-      </div>
-
-      <div class="ticket-meta">
-        <mat-select [value]="t.priority" (selectionChange)="updateField('priority', $event.value)" class="priority-select" aria-label="Priority">
-          <mat-option value="LOW"><span class="priority priority-low">Low</span></mat-option>
-          <mat-option value="MEDIUM"><span class="priority priority-medium">Medium</span></mat-option>
-          <mat-option value="HIGH"><span class="priority priority-high">High</span></mat-option>
-          <mat-option value="CRITICAL"><span class="priority priority-critical">Critical</span></mat-option>
-        </mat-select>
-        <mat-select [value]="t.status" (selectionChange)="updateStatus($event.value)" class="status-select" aria-label="Status">
-          <mat-option value="OPEN">Open</mat-option>
-          <mat-option value="IN_PROGRESS">In Progress</mat-option>
-          <mat-option value="WAITING">Waiting</mat-option>
-          <mat-option value="RESOLVED">Resolved</mat-option>
-          <mat-option value="CLOSED">Closed</mat-option>
-        </mat-select>
-        <mat-select [value]="t.category ?? ''" (selectionChange)="updateField('category', $event.value || null)" class="category-select" aria-label="Category">
-          <mat-option value="">None</mat-option>
-          <mat-option value="DATABASE_PERF">Database Perf</mat-option>
-          <mat-option value="BUG_FIX">Bug Fix</mat-option>
-          <mat-option value="FEATURE_REQUEST">Feature Request</mat-option>
-          <mat-option value="SCHEMA_CHANGE">Schema Change</mat-option>
-          <mat-option value="CODE_REVIEW">Code Review</mat-option>
-          <mat-option value="ARCHITECTURE">Architecture</mat-option>
-          <mat-option value="GENERAL">General</mat-option>
-        </mat-select>
-        <span class="source">via {{ t.source }}</span>
-        <span class="date">{{ t.createdAt | date:'medium' }}</span>
-        <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
-          @if (t.analysisStatus === 'IN_PROGRESS') {
-            <mat-icon class="spin-icon">sync</mat-icon>
-          }
-          {{ formatAnalysisStatus(t.analysisStatus) }}
-          @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
-            <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
-          }
-        </span>
-        @if (t.analysisStatus === 'FAILED') {
-          <button mat-stroked-button color="warn" class="retry-btn" (click)="reanalyze()" [disabled]="reanalyzing()">
-            <mat-icon>replay</mat-icon> Retry Analysis
-          </button>
-        }
-      </div>
-
-      @if (t.analysisStatus === 'FAILED' && t.analysisError) {
-        <div class="analysis-error">
-          <mat-icon>error_outline</mat-icon>
-          <span>{{ t.analysisError }}</span>
-        </div>
-      }
-
-      <!-- Tab group: AI Summary, Resolution Summary, Details, Log Digest -->
-      <mat-tab-group class="info-tabs" animationDuration="0ms" (selectedTabChange)="onTabChange($event)">
-        @if (emailBlurb()) {
-          <mat-tab label="AI Summary">
-            <div class="tab-content">
-              <p class="blurb-text">{{ emailBlurb() }}</p>
-            </div>
-          </mat-tab>
-        }
-        @if (t.summary) {
-          <mat-tab label="Resolution Summary">
-            <div class="tab-content">
-              <p class="summary-text">{{ t.summary }}</p>
-            </div>
-          </mat-tab>
-        }
-        <mat-tab label="Details">
-          <div class="tab-content">
-            @if (t.description) {
-              <p class="description">{{ truncateDescription(t.description) }}</p>
-              @if (t.description.length > 300) {
-                <button mat-button class="show-more-btn" (click)="descExpanded = !descExpanded">
-                  {{ descExpanded ? 'Show less' : 'Show more' }}
-                </button>
-              }
-            }
-            @if (t.system) { <p><strong>System:</strong> {{ t.system.name }}</p> }
-            @if (t.client) { <p><strong>Client:</strong> {{ t.client.name }}</p> }
+      <div class="page-wrapper">
+        <div class="page-header">
+          <div class="header-left">
+            <a routerLink="/tickets" class="back-link">&larr; Tickets</a>
+            <h1 class="page-title">
+              @if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> }
+              {{ t.subject }}
+            </h1>
           </div>
-        </mat-tab>
-        @if (t.knowledgeDoc || editingKnowledgeDoc()) {
-          <mat-tab label="Knowledge">
-            <div class="tab-content knowledge-doc">
-              @if (editingKnowledgeDoc()) {
-                <textarea class="knowledge-editor" [(ngModel)]="knowledgeDocDraft" rows="20"></textarea>
-                <div class="knowledge-actions">
-                  <button mat-raised-button color="primary" (click)="saveKnowledgeDoc()">Save</button>
-                  <button mat-stroked-button (click)="cancelEditKnowledgeDoc()">Cancel</button>
-                </div>
-              } @else {
-                <div class="knowledge-actions">
-                  <button mat-stroked-button (click)="startEditKnowledgeDoc()">
-                    <mat-icon>edit</mat-icon> Edit
-                  </button>
-                  <button mat-stroked-button color="warn" (click)="clearKnowledgeDoc()">
-                    <mat-icon>delete</mat-icon> Clear
-                  </button>
-                </div>
-                <div [innerHTML]="t.knowledgeDoc | markdown"></div>
-              }
-            </div>
-          </mat-tab>
-        }
-        <mat-tab>
-          <ng-template mat-tab-label>
-            Logs
-            @if (unifiedLogsTotal() > 0) {
-              <span class="tab-badge">{{ unifiedLogsTotal() }}</span>
+        </div>
+
+        <div class="ticket-meta">
+          <app-select
+            [value]="t.priority"
+            [options]="priorityOptions"
+            placeholder=""
+            (valueChange)="updateField('priority', $event)" />
+          <app-select
+            [value]="t.status"
+            [options]="statusOptions"
+            placeholder=""
+            (valueChange)="updateStatus($event)" />
+          <app-select
+            [value]="t.category ?? ''"
+            [options]="categoryOptions"
+            placeholder=""
+            (valueChange)="updateField('category', $event || null)" />
+          <span class="source">via {{ t.source }}</span>
+          <span class="date">{{ t.createdAt | date:'medium' }}</span>
+          <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
+            @if (t.analysisStatus === 'IN_PROGRESS') {
+              <span class="spin-icon" aria-hidden="true">&#10227;</span>
             }
-          </ng-template>
-          <div class="tab-content">
+            {{ formatAnalysisStatus(t.analysisStatus) }}
+            @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
+              <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
+            }
+          </span>
+          @if (t.analysisStatus === 'FAILED') {
+            <app-bronco-button variant="destructive" size="sm" (click)="reanalyze()" [disabled]="reanalyzing()">
+              <span aria-hidden="true">&#x21bb;</span> Retry Analysis
+            </app-bronco-button>
+          }
+        </div>
+
+        @if (t.analysisStatus === 'FAILED' && t.analysisError) {
+          <div class="analysis-error">
+            <span class="error-icon" aria-hidden="true">&#9888;</span>
+            <span>{{ t.analysisError }}</span>
+          </div>
+        }
+
+        <app-tab-group
+          class="info-tabs"
+          [selectedIndex]="selectedTabIndex()"
+          (selectedIndexChange)="onTabIndexChange($event)">
+          @if (emailBlurb()) {
+            <app-tab label="AI Summary">
+              <app-ticket-detail-summary [emailBlurb]="emailBlurb()!" />
+            </app-tab>
+          }
+          @if (t.summary) {
+            <app-tab label="Resolution Summary">
+              <app-ticket-detail-resolution [summary]="t.summary" />
+            </app-tab>
+          }
+          <app-tab label="Details">
+            <app-ticket-detail-details
+              [description]="t.description"
+              [systemName]="t.system?.name ?? null"
+              [clientName]="t.client?.name ?? null" />
+          </app-tab>
+          @if (t.knowledgeDoc || editingKnowledgeDoc()) {
+            <app-tab label="Knowledge">
+              <app-ticket-detail-knowledge
+                [knowledgeDoc]="t.knowledgeDoc ?? null"
+                [editing]="editingKnowledgeDoc()"
+                (startEdit)="editingKnowledgeDoc.set(true)"
+                (cancelEdit)="editingKnowledgeDoc.set(false)"
+                (save)="saveKnowledgeDoc($event)"
+                (clear)="clearKnowledgeDoc()" />
+            </app-tab>
+          }
+          <app-tab [label]="logsTabLabel()">
             <!-- Cost summary card -->
             @if (costSummary(); as cs) {
               @if (cs.callCount > 0) {
@@ -203,41 +193,37 @@ interface FlowNode {
 
             <!-- Filter bar -->
             <div class="logs-filter-bar">
-              <mat-form-field class="logs-filter-field">
-                <mat-label>Type</mat-label>
-                <mat-select [ngModel]="unifiedTypeFilter()" (ngModelChange)="unifiedTypeFilter.set($event); loadUnifiedLogs()">
-                  <mat-option value="">All</mat-option>
-                  <mat-option value="ai">AI Calls</mat-option>
-                  <mat-option value="tool">Tool Calls</mat-option>
-                  <mat-option value="step">Steps</mat-option>
-                  <mat-option value="error">Errors</mat-option>
-                  <mat-option value="log">Logs</mat-option>
-                </mat-select>
-              </mat-form-field>
-              <mat-form-field class="logs-filter-field">
-                <mat-label>Level</mat-label>
-                <mat-select [ngModel]="logsLevelFilter()" (ngModelChange)="logsLevelFilter.set($event); loadUnifiedLogs()">
-                  <mat-option value="">All</mat-option>
-                  <mat-option value="ERROR">Error</mat-option>
-                  <mat-option value="WARN">Warn</mat-option>
-                  <mat-option value="INFO">Info</mat-option>
-                  <mat-option value="DEBUG">Debug</mat-option>
-                </mat-select>
-              </mat-form-field>
-              <mat-form-field class="logs-filter-field">
-                <mat-label>Search</mat-label>
-                <input matInput [ngModel]="logsSearchFilter()" (ngModelChange)="logsSearchFilter.set($event)" (keyup.enter)="loadUnifiedLogs()">
-              </mat-form-field>
-              <button mat-icon-button matTooltip="Search" (click)="loadUnifiedLogs()">
-                <mat-icon>search</mat-icon>
-              </button>
-              <button mat-icon-button matTooltip="Refresh" (click)="loadUnifiedLogs()">
-                <mat-icon>refresh</mat-icon>
-              </button>
+              <app-form-field label="Type">
+                <app-select
+                  [value]="unifiedTypeFilter()"
+                  [options]="typeFilterOptions"
+                  placeholder=""
+                  (valueChange)="unifiedTypeFilter.set($event); loadUnifiedLogs()" />
+              </app-form-field>
+              <app-form-field label="Level">
+                <app-select
+                  [value]="logsLevelFilter()"
+                  [options]="levelFilterOptions"
+                  placeholder=""
+                  (valueChange)="logsLevelFilter.set($event); loadUnifiedLogs()" />
+              </app-form-field>
+              <app-form-field label="Search">
+                <input
+                  type="text"
+                  class="search-input"
+                  [(ngModel)]="logsSearchInput"
+                  (keyup.enter)="onSearchEnter()" />
+              </app-form-field>
+              <app-bronco-button variant="icon" size="md" ariaLabel="Search" (click)="onSearchEnter()">
+                <span aria-hidden="true">&#x1F50D;</span>
+              </app-bronco-button>
+              <app-bronco-button variant="icon" size="md" ariaLabel="Refresh" (click)="loadUnifiedLogs()">
+                <span aria-hidden="true">&#x21bb;</span>
+              </app-bronco-button>
             </div>
 
             @if (unifiedLogsLoading()) {
-              <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+              <div class="indeterminate-bar"><span class="indeterminate-track"></span></div>
             }
 
             <!-- Unified log stream -->
@@ -246,28 +232,28 @@ interface FlowNode {
               @for (entry of ungroupedEntries(); track entry.id; let idx = $index) {
                 @if (isIterationHeader(entry)) {
                   <div class="iteration-group-header">
-                    <mat-icon class="iteration-icon">loop</mat-icon>
+                    <span class="iteration-icon" aria-hidden="true">&#x21bb;</span>
                     <span class="iteration-label">{{ extractIterationLabel(entry) }}</span>
                     <span class="log-seq">#{{ idx + 1 }}</span>
-                    <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
+                    <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
                   </div>
                 } @else if (entry.type === 'ai') {
                   <app-ai-log-entry [entry]="entry" [idx]="idx" [iterationGrouped]="isWithinIteration(entry)" />
                 } @else {
-                  <div class="log-entry" [ngClass]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
+                  <div class="log-entry" [class]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
                     <div class="log-entry-header">
                       <span class="log-seq">#{{ idx + 1 }}</span>
-                      <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
-                      <span class="unified-type-badge" [ngClass]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
+                      <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
+                      <span class="unified-type-badge" [class]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
                       @if (entry.level) { <span class="log-level-badge log-badge-{{ entry.level.toLowerCase() }}">{{ entry.level }}</span> }
                       @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                       <span class="log-message">{{ entry.message }}</span>
                     </div>
                     @if (entry.context && hasKeys(entry.context)) {
-                      <button mat-button class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
+                      <app-bronco-button variant="ghost" size="sm" class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
                         {{ expandedLogs[entry.id] ? 'Hide metadata' : 'Show metadata' }}
-                        <mat-icon>{{ expandedLogs[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                      </button>
+                        <span aria-hidden="true">{{ expandedLogs[entry.id] ? '\u25B4' : '\u25BE' }}</span>
+                      </app-bronco-button>
                       @if (expandedLogs[entry.id]) { <pre class="log-metadata">{{ entry.context | json }}</pre> }
                     }
                     @if (entry.error) { <div class="log-error-detail">{{ entry.error }}</div> }
@@ -279,9 +265,13 @@ interface FlowNode {
               @for (group of stepGroups(); track $index) {
                 <div class="step-group">
                   <div class="step-group-header" (click)="group.expanded = !group.expanded">
-                    <mat-icon class="step-status-icon" [class.status-completed]="group.status === 'completed'" [class.status-failed]="group.status === 'failed'" [class.status-running]="group.status === 'running'">
-                      {{ group.status === 'completed' ? 'check_circle' : group.status === 'failed' ? 'error' : 'pending' }}
-                    </mat-icon>
+                    <span class="step-status-icon"
+                          [class.status-completed]="group.status === 'completed'"
+                          [class.status-failed]="group.status === 'failed'"
+                          [class.status-running]="group.status === 'running'"
+                          aria-hidden="true">
+                      {{ group.status === 'completed' ? '\u2713' : group.status === 'failed' ? '\u2715' : '\u25CB' }}
+                    </span>
                     <span class="step-name">{{ group.stepName }}</span>
                     @if (group.aiCallCount > 0) {
                       <span class="step-meta-chip">{{ group.aiCallCount }} AI call{{ group.aiCallCount > 1 ? 's' : '' }}</span>
@@ -291,23 +281,23 @@ interface FlowNode {
                       }
                     }
                     <span class="step-entry-count">{{ group.entries.length }} entr{{ group.entries.length === 1 ? 'y' : 'ies' }}</span>
-                    <mat-icon class="step-chevron">{{ group.expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+                    <span class="step-chevron" aria-hidden="true">{{ group.expanded ? '\u25B4' : '\u25BE' }}</span>
                   </div>
                   @if (group.expanded) {
                     <div class="step-group-entries">
                       @for (entry of group.entries; track entry.id; let idx = $index) {
                         @if (isIterationHeader(entry)) {
                           <div class="iteration-group-header">
-                            <mat-icon class="iteration-icon">loop</mat-icon>
+                            <span class="iteration-icon" aria-hidden="true">&#x21bb;</span>
                             <span class="iteration-label">{{ extractIterationLabel(entry) }}</span>
-                            <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
+                            <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
                           </div>
                         } @else {
-                          <div class="log-entry" [ngClass]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
+                          <div class="log-entry" [class]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
                             <div class="log-entry-header">
                               <span class="log-seq">#{{ idx + 1 }}</span>
-                              <span class="log-time" [matTooltip]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
-                              <span class="unified-type-badge" [ngClass]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
+                              <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
+                              <span class="unified-type-badge" [class]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
                               @if (entry.type === 'ai') {
                                 <span class="meta-chip provider-chip provider-{{ (entry.provider ?? '').toLowerCase() }}">{{ entry.provider }}</span>
                                 <code class="meta-chip model-chip">{{ entry.model }}</code>
@@ -323,10 +313,10 @@ interface FlowNode {
                               }
                             </div>
                             @if (entry.type === 'ai') {
-                              <button mat-button class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
+                              <app-bronco-button variant="ghost" size="sm" class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
                                 {{ expandedLogs[entry.id] ? 'Hide details' : 'Show details' }}
-                                <mat-icon>{{ expandedLogs[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                              </button>
+                                <span aria-hidden="true">{{ expandedLogs[entry.id] ? '\u25B4' : '\u25BE' }}</span>
+                              </app-bronco-button>
                               @if (expandedLogs[entry.id]) {
                                 <div class="ai-detail-sections">
                                   @if (entry.promptKey) { <div class="ai-detail-label">Prompt Key: <code>{{ entry.promptKey }}</code></div> }
@@ -350,10 +340,10 @@ interface FlowNode {
                             }
                             @if (entry.type !== 'ai') {
                               @if (entry.context && hasKeys(entry.context)) {
-                                <button mat-button class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
+                                <app-bronco-button variant="ghost" size="sm" class="log-expand-btn" (click)="expandedLogs[entry.id] = !expandedLogs[entry.id]">
                                   {{ expandedLogs[entry.id] ? 'Hide metadata' : 'Show metadata' }}
-                                  <mat-icon>{{ expandedLogs[entry.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                                </button>
+                                  <span aria-hidden="true">{{ expandedLogs[entry.id] ? '\u25B4' : '\u25BE' }}</span>
+                                </app-bronco-button>
                                 @if (expandedLogs[entry.id]) { <pre class="log-metadata">{{ entry.context | json }}</pre> }
                               }
                               @if (entry.error) { <div class="log-error-detail">{{ entry.error }}</div> }
@@ -375,15 +365,13 @@ interface FlowNode {
             @if (unifiedLogsTotal() > unifiedLogs().length) {
               <div class="logs-pagination">
                 <span class="logs-showing">Showing {{ unifiedLogs().length }} of {{ unifiedLogsTotal() }}</span>
-                <button mat-stroked-button (click)="loadMoreUnifiedLogs()">Load more</button>
+                <app-bronco-button variant="secondary" size="sm" (click)="loadMoreUnifiedLogs()">Load more</app-bronco-button>
               </div>
             }
-          </div>
-        </mat-tab>
-        <mat-tab label="Conversation">
-          <div class="tab-content">
+          </app-tab>
+          <app-tab label="Conversation">
             @if (conversationLoading()) {
-              <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+              <div class="indeterminate-bar"><span class="indeterminate-track"></span></div>
             } @else if (!conversationLoaded()) {
               <div class="conv-empty">
                 <p>Activate this tab to load conversation.</p>
@@ -395,7 +383,7 @@ interface FlowNode {
                 @for (group of convStepGroups(); track $index) {
                   <div class="conv-step-section">
                     <div class="conv-step-label">
-                      <mat-icon class="conv-step-icon">{{ group.status === 'completed' ? 'check_circle' : group.status === 'failed' ? 'error' : 'pending' }}</mat-icon>
+                      <span class="conv-step-icon" aria-hidden="true">{{ group.status === 'completed' ? '\u2713' : group.status === 'failed' ? '\u2715' : '\u25CB' }}</span>
                       {{ group.stepName }}
                     </div>
                     @for (entry of group.entries; track entry.id) {
@@ -410,9 +398,9 @@ interface FlowNode {
                           @if (convMessages(entry).length > 0) {
                             <div class="conv-turns">
                               @for (turn of convMessages(entry); track $index) {
-                                <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
-                                  <span class="conv-turn-role">{{ turn.role === 'user' ? '👤' : '🤖' }}</span>
-                                  @if (turn.toolName) { <span class="conv-tool-call">🔧 {{ turn.toolName }}</span> }
+                                <div class="conv-turn" [class]="'conv-turn-' + turn.role">
+                                  <span class="conv-turn-role">{{ turn.role === 'user' ? '\u{1F464}' : '\u{1F916}' }}</span>
+                                  @if (turn.toolName) { <span class="conv-tool-call">\u{1F527} {{ turn.toolName }}</span> }
                                   @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
                                 </div>
                               }
@@ -423,10 +411,10 @@ interface FlowNode {
                               <span class="conv-final-label">Prompt</span>
                               <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[entry.id]">{{ convPromptText(entry) }}</pre>
                               @if (isMultilineConvPrompt(entry)) {
-                                <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
+                                <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
                                   {{ convPromptExpanded[entry.id] ? 'less' : 'more' }}
-                                  <mat-icon>{{ convPromptExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                                </button>
+                                  <span aria-hidden="true">{{ convPromptExpanded[entry.id] ? '\u23F6' : '\u23F7' }}</span>
+                                </app-bronco-button>
                               }
                             </div>
                           }
@@ -435,10 +423,10 @@ interface FlowNode {
                               <span class="conv-final-label">Response</span>
                               <pre class="conv-response-text" [class.clamped]="!convExpanded[entry.id]">{{ convResponseText(entry) }}</pre>
                               @if (isMultilineConv(entry)) {
-                                <button mat-button class="inline-expand-btn" (click)="convExpanded[entry.id] = !convExpanded[entry.id]">
+                                <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[entry.id] = !convExpanded[entry.id]">
                                   {{ convExpanded[entry.id] ? 'less' : 'more' }}
-                                  <mat-icon>{{ convExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                                </button>
+                                  <span aria-hidden="true">{{ convExpanded[entry.id] ? '\u23F6' : '\u23F7' }}</span>
+                                </app-bronco-button>
                               }
                             </div>
                           }
@@ -447,7 +435,7 @@ interface FlowNode {
                             @for (sub of getSubTasks(group.entries, orchestrationId); track sub.id) {
                               <div class="conv-subtask">
                                 <div class="conv-ai-header">
-                                  <mat-icon class="subtask-icon">subdirectory_arrow_right</mat-icon>
+                                  <span class="subtask-icon" aria-hidden="true">\u21B3</span>
                                   <span class="conv-task-type">{{ sub.taskType }}</span>
                                   <span class="conv-model">{{ sub.model }}</span>
                                   <span class="conv-tokens">{{ sub.inputTokens | number }}in / {{ sub.outputTokens | number }}out</span>
@@ -458,10 +446,10 @@ interface FlowNode {
                                     <span class="conv-final-label">Prompt</span>
                                     <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[sub.id]">{{ convPromptText(sub) }}</pre>
                                     @if (isMultilineConvPrompt(sub)) {
-                                      <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[sub.id] = !convPromptExpanded[sub.id]">
+                                      <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[sub.id] = !convPromptExpanded[sub.id]">
                                         {{ convPromptExpanded[sub.id] ? 'less' : 'more' }}
-                                        <mat-icon>{{ convPromptExpanded[sub.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                                      </button>
+                                        <span aria-hidden="true">{{ convPromptExpanded[sub.id] ? '\u23F6' : '\u23F7' }}</span>
+                                      </app-bronco-button>
                                     }
                                   </div>
                                 }
@@ -470,10 +458,10 @@ interface FlowNode {
                                     <span class="conv-final-label">Response</span>
                                     <pre class="conv-response-text" [class.clamped]="!convExpanded[sub.id]">{{ convResponseText(sub) }}</pre>
                                     @if (isMultilineConv(sub)) {
-                                      <button mat-button class="inline-expand-btn" (click)="convExpanded[sub.id] = !convExpanded[sub.id]">
+                                      <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[sub.id] = !convExpanded[sub.id]">
                                         {{ convExpanded[sub.id] ? 'less' : 'more' }}
-                                        <mat-icon>{{ convExpanded[sub.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                                      </button>
+                                        <span aria-hidden="true">{{ convExpanded[sub.id] ? '\u23F6' : '\u23F7' }}</span>
+                                      </app-bronco-button>
                                     }
                                   </div>
                                 }
@@ -497,9 +485,9 @@ interface FlowNode {
                       @if (convMessages(entry).length > 0) {
                         <div class="conv-turns">
                           @for (turn of convMessages(entry); track $index) {
-                            <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
-                              <span class="conv-turn-role">{{ turn.role === 'user' ? '👤' : '🤖' }}</span>
-                              @if (turn.toolName) { <span class="conv-tool-call">🔧 {{ turn.toolName }}</span> }
+                            <div class="conv-turn" [class]="'conv-turn-' + turn.role">
+                              <span class="conv-turn-role">{{ turn.role === 'user' ? '\u{1F464}' : '\u{1F916}' }}</span>
+                              @if (turn.toolName) { <span class="conv-tool-call">\u{1F527} {{ turn.toolName }}</span> }
                               @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
                             </div>
                           }
@@ -510,10 +498,10 @@ interface FlowNode {
                           <span class="conv-final-label">Prompt</span>
                           <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[entry.id]">{{ convPromptText(entry) }}</pre>
                           @if (isMultilineConvPrompt(entry)) {
-                            <button mat-button class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
+                            <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
                               {{ convPromptExpanded[entry.id] ? 'less' : 'more' }}
-                              <mat-icon>{{ convPromptExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                            </button>
+                              <span aria-hidden="true">{{ convPromptExpanded[entry.id] ? '\u23F6' : '\u23F7' }}</span>
+                            </app-bronco-button>
                           }
                         </div>
                       }
@@ -522,10 +510,10 @@ interface FlowNode {
                           <span class="conv-final-label">Response</span>
                           <pre class="conv-response-text" [class.clamped]="!convExpanded[entry.id]">{{ convResponseText(entry) }}</pre>
                           @if (isMultilineConv(entry)) {
-                            <button mat-button class="inline-expand-btn" (click)="convExpanded[entry.id] = !convExpanded[entry.id]">
+                            <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[entry.id] = !convExpanded[entry.id]">
                               {{ convExpanded[entry.id] ? 'less' : 'more' }}
-                              <mat-icon>{{ convExpanded[entry.id] ? 'keyboard_double_arrow_up' : 'keyboard_double_arrow_down' }}</mat-icon>
-                            </button>
+                              <span aria-hidden="true">{{ convExpanded[entry.id] ? '\u23F6' : '\u23F7' }}</span>
+                            </app-bronco-button>
                           }
                         </div>
                       }
@@ -534,460 +522,53 @@ interface FlowNode {
                 }
               </div>
             }
-          </div>
-        </mat-tab>
-        <mat-tab>
-          <ng-template mat-tab-label>
-            Log Digest
-            <button mat-icon-button class="tab-action-btn" (click)="generateLogSummary(); $event.stopPropagation()" [disabled]="generatingLogs()" [matTooltip]="'Summarize recent logs'">
-              <mat-icon>{{ generatingLogs() ? 'hourglass_empty' : 'auto_awesome' }}</mat-icon>
-            </button>
-          </ng-template>
-          <div class="tab-content">
-            @if (generatingLogs()) {
-              <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-            }
-            @for (ls of logSummaries(); track ls.id) {
-              <div class="log-summary-entry">
-                <div class="log-summary-header">
-                  <span class="log-summary-time">
-                    {{ formatTime(ls.windowStart) }} — {{ formatTime(ls.windowEnd) }}
-                  </span>
-                  <span class="log-summary-count" [matTooltip]="ls.logCount + ' log entries'">
-                    {{ ls.logCount }} logs
-                  </span>
-                </div>
-                <p class="log-summary-text">{{ ls.summary }}</p>
-                <div class="log-summary-services">
-                  @for (svc of ls.services; track svc) {
-                    <span class="service-chip">{{ svc }}</span>
-                  }
-                </div>
-              </div>
-            } @empty {
-              <p class="empty">No log summaries yet. Click the sparkle button to generate one.</p>
-            }
-          </div>
-        </mat-tab>
-      </mat-tab-group>
+          </app-tab>
+          <app-tab label="Log Digest">
+            <app-ticket-detail-log-digest
+              [summaries]="logSummaries()"
+              [generating]="generatingLogs()"
+              (generate)="generateLogSummary()" />
+          </app-tab>
+        </app-tab-group>
 
-      <!-- Process Flow -->
-      @if (flowNodes().length > 0) {
-        <mat-card class="flow-card">
-          <mat-card-header>
-            <mat-icon mat-card-avatar>account_tree</mat-icon>
-            <mat-card-title>Process Flow</mat-card-title>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="flow-container">
-              @for (node of flowNodes(); track node.type + ':' + node.label + ':' + $index; let i = $index) {
-                <div class="flow-node flow-{{ node.type }}">
-                  <mat-icon class="flow-icon">{{ node.icon }}</mat-icon>
-                  <span class="flow-label">{{ node.label }}</span>
-                </div>
-                @if (node.children && node.children.length > 0) {
-                  <div class="flow-branch">
-                    @for (child of node.children; track child.type + ':' + child.label + ':' + $index; let j = $index) {
-                      <div class="flow-branch-row">
-                        <div class="flow-connector"></div>
-                        <div class="flow-node flow-{{ child.type }}">
-                          <mat-icon class="flow-icon">{{ child.icon }}</mat-icon>
-                          <span class="flow-label">{{ child.label }}</span>
-                        </div>
-                        @if (child.children && child.children.length > 0) {
-                          @for (grandchild of child.children; track grandchild.type + ':' + grandchild.label + ':' + $index) {
-                            <div class="flow-connector"></div>
-                            <div class="flow-node flow-{{ grandchild.type }}">
-                              <mat-icon class="flow-icon">{{ grandchild.icon }}</mat-icon>
-                              <span class="flow-label">{{ grandchild.label }}</span>
-                            </div>
-                          }
-                        }
-                      </div>
-                    }
-                  </div>
-                }
-                @if (i < flowNodes().length - 1 && !node.children?.length) {
-                  <div class="flow-arrow">
-                    <mat-icon>arrow_forward</mat-icon>
-                  </div>
-                }
-              }
-            </div>
-          </mat-card-content>
-        </mat-card>
-      }
-
-      <!-- AI Cost with expandable breakdown -->
-      @if (ticketCost(); as cost) {
-        @if (cost.callCount > 0) {
-          <mat-card class="cost-card">
-            <mat-card-header>
-              <mat-icon mat-card-avatar>analytics</mat-icon>
-              <mat-card-title>AI Cost</mat-card-title>
-            </mat-card-header>
-            <mat-card-content>
-              <div class="cost-summary">
-                <div class="cost-item">
-                  <span class="cost-label">Total Cost</span>
-                  <span class="cost-value">\${{ cost.totalCostUsd | number:'1.4-4' }}</span>
-                </div>
-                <div class="cost-item">
-                  <span class="cost-label">AI Calls</span>
-                  <span class="cost-value">{{ cost.callCount | number }}</span>
-                </div>
-                <div class="cost-item">
-                  <span class="cost-label">Input Tokens</span>
-                  <span class="cost-value">{{ cost.totalInputTokens | number }}</span>
-                </div>
-                <div class="cost-item">
-                  <span class="cost-label">Output Tokens</span>
-                  <span class="cost-value">{{ cost.totalOutputTokens | number }}</span>
-                </div>
-              </div>
-
-              @if (cost.breakdown.length > 0) {
-                <button mat-button class="show-details-btn" (click)="costDetailsExpanded = !costDetailsExpanded">
-                  {{ costDetailsExpanded ? 'Hide details' : 'Show details' }}
-                  <mat-icon>{{ costDetailsExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
-                </button>
-              }
-
-              @if (costDetailsExpanded) {
-                <div class="cost-breakdown">
-                  @for (item of cost.breakdown; track item.provider + ':' + item.model) {
-                    <div class="breakdown-group">
-                      <div class="breakdown-header">
-                        <span class="provider-chip provider-{{ item.provider.toLowerCase() }}">{{ item.provider }}</span>
-                        <code class="model-name">{{ item.model }}</code>
-                        <span class="breakdown-stats">
-                          {{ item.callCount }} calls &middot;
-                          \${{ item.totalCostUsd | number:'1.4-4' }}
-                        </span>
-                      </div>
-                      @if (item.calls && item.calls.length > 0) {
-                        <div class="call-list">
-                          @for (call of item.calls; track call.id) {
-                            <div class="call-row">
-                              <span class="call-task">{{ call.taskType }}</span>
-                              <span class="call-tokens">{{ call.inputTokens | number }}in / {{ call.outputTokens | number }}out</span>
-                              @if (call.costUsd != null) {
-                                <span class="call-cost">\${{ call.costUsd | number:'1.4-4' }}</span>
-                              }
-                              @if (call.durationMs != null) {
-                                <span class="call-duration">{{ call.durationMs }}ms</span>
-                              }
-                              <span class="call-time">{{ call.createdAt | date:'shortTime' }}</span>
-                            </div>
-                          }
-                        </div>
-                      }
-                    </div>
-                  }
-                </div>
-              }
-            </mat-card-content>
-          </mat-card>
+        @if (flowNodes().length > 0) {
+          <app-ticket-detail-flow [nodes]="flowNodes()" />
         }
-      }
 
-      <!-- Timeline with filter and sort controls -->
-      <div class="timeline-header">
-        <h3>Timeline</h3>
-        <div class="timeline-controls">
-          <mat-form-field class="timeline-filter-field">
-            <mat-label>Filter</mat-label>
-            <mat-select [ngModel]="timelineFilter()" (ngModelChange)="timelineFilter.set($event)">
-              <mat-option value="">All Events</mat-option>
-              <mat-option value="COMMENT">Comments</mat-option>
-              <mat-option value="AI_ANALYSIS">AI Analysis</mat-option>
-              <mat-option value="STATUS_CHANGE">Status Changes</mat-option>
-              <mat-option value="EMAIL_INBOUND">Inbound Emails</mat-option>
-              <mat-option value="EMAIL_OUTBOUND">Outbound Emails</mat-option>
-              <mat-option value="CODE_CHANGE">Code Changes</mat-option>
-              <mat-option value="SYSTEM_NOTE">System Notes</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <button mat-icon-button [matTooltip]="timelineSortAsc() ? 'Oldest first' : 'Newest first'" (click)="toggleTimelineSort()">
-            <mat-icon>{{ timelineSortAsc() ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
-          </button>
+        <app-ticket-detail-cost [cost]="ticketCost()" />
+
+        <app-ticket-detail-timeline
+          [events]="events()"
+          [pendingActionMap]="pendingActionMap()"
+          (approveAction)="approvePendingAction($event)"
+          (dismissAction)="dismissPendingAction($event)" />
+
+        <app-card padding="md" class="add-comment">
+          <app-form-field label="Add comment">
+            <app-textarea
+              [value]="newComment"
+              [rows]="2"
+              (valueChange)="newComment = $event" />
+          </app-form-field>
+          <div class="comment-actions">
+            <app-bronco-button variant="primary" (click)="addComment()" [disabled]="!newComment">
+              <span aria-hidden="true">&#x27A4;</span> Add Comment
+            </app-bronco-button>
+          </div>
+        </app-card>
+
+        <div class="reanalyze-bar">
+          <app-bronco-button variant="secondary" (click)="reanalyze()" [disabled]="reanalyzing()">
+            <span aria-hidden="true">&#x21bb;</span> Re-run Analysis
+          </app-bronco-button>
         </div>
-      </div>
-      <div class="timeline">
-        @for (event of filteredEvents(); track event.id) {
-          <mat-card class="event-card" [ngClass]="'event-type-' + event.eventType.toLowerCase()">
-            <mat-card-content>
-              <div class="event-header">
-                <span class="event-type-badge" [ngClass]="'badge-' + event.eventType.toLowerCase()">
-                  <mat-icon>{{ eventIcon(event.eventType) }}</mat-icon>
-                  <span>{{ formatEventType(event.eventType) }}</span>
-                </span>
-                @if (isAiTriggered(event)) {
-                  <span class="ai-triggered-badge">AI Recommendation</span>
-                }
-                <span class="event-actor">{{ event.actor }}</span>
-                @if (isAgenticAnalysis(event)) {
-                  @if (agenticMeta(event); as am) {
-                    @if (am.totalCostUsd != null && am.totalCostUsd > 0) {
-                      <span class="cost-badge">\${{ am.totalCostUsd | number:'1.4-4' }}</span>
-                    }
-                  }
-                }
-                <span class="event-date" [matTooltip]="event.createdAt | date:'medium'">{{ event.createdAt | relativeTime }}</span>
-              </div>
 
-              <!-- Condensed Agentic Analysis card -->
-              @if (isAgenticAnalysis(event)) {
-                @if (agenticMeta(event); as am) {
-                  <div class="agentic-summary">
-                    <div class="agentic-stats">
-                      <span class="meta-chip task-chip">{{ am.taskType }}</span>
-                      <span class="meta-chip token-chip">{{ am.toolCallCount }} tool calls</span>
-                      <span class="meta-chip phase-chip">{{ am.iterationsRun }} iterations</span>
-                      @if (am.sufficiencyStatus) {
-                        <span class="meta-chip" [ngClass]="'sufficiency-' + am.sufficiencyStatus.toLowerCase()">{{ am.sufficiencyStatus }}</span>
-                      }
-                      @if (am.sufficiencyConfidence) {
-                        <span class="meta-chip duration-chip">confidence: {{ am.sufficiencyConfidence }}</span>
-                      }
-                    </div>
-
-                    <!-- Collapsible Tool Calls -->
-                    @if (am.toolCalls.length > 0) {
-                      <button mat-button class="show-more-btn" (click)="expandedSections[event.id + ':tools'] = !expandedSections[event.id + ':tools']">
-                        <mat-icon>{{ expandedSections[event.id + ':tools'] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                        Tool Calls ({{ am.toolCalls.length }})
-                      </button>
-                      @if (expandedSections[event.id + ':tools']) {
-                        <div class="tool-calls-list">
-                          @for (tc of am.toolCalls; track $index) {
-                            <div class="tool-call-row">
-                              <span class="tool-name">{{ tc.tool }}</span>
-                              @if (tc.system) { <span class="meta-chip provider-chip provider-local">{{ tc.system }}</span> }
-                              @if (tc.durationMs != null) { <span class="meta-chip duration-chip">{{ tc.durationMs }}ms</span> }
-                              @if (tc.output) {
-                                <button mat-button class="show-more-btn" (click)="expandedSections[event.id + ':tc:' + $index] = !expandedSections[event.id + ':tc:' + $index]">
-                                  {{ expandedSections[event.id + ':tc:' + $index] ? 'Hide' : 'Result' }}
-                                </button>
-                              }
-                              @if (expandedSections[event.id + ':tc:' + $index] && tc.output) {
-                                <pre class="tool-result">{{ tc.output }}</pre>
-                              }
-                            </div>
-                          }
-                        </div>
-                      }
-                    }
-
-                    <!-- Collapsible Sufficiency details -->
-                    @if (am.sufficiencyReason) {
-                      <button mat-button class="show-more-btn" (click)="expandedSections[event.id + ':sufficiency'] = !expandedSections[event.id + ':sufficiency']">
-                        <mat-icon>{{ expandedSections[event.id + ':sufficiency'] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                        Sufficiency
-                      </button>
-                      @if (expandedSections[event.id + ':sufficiency']) {
-                        <div class="sufficiency-detail">
-                          <p><strong>Status:</strong> {{ am.sufficiencyStatus }} &middot; <strong>Confidence:</strong> {{ am.sufficiencyConfidence }}</p>
-                          <p>{{ am.sufficiencyReason }}</p>
-                          @if (am.sufficiencyQuestions && am.sufficiencyQuestions.length > 0) {
-                            <p><strong>Questions:</strong></p>
-                            <ul>@for (q of am.sufficiencyQuestions; track $index) { <li>{{ q }}</li> }</ul>
-                          }
-                        </div>
-                      }
-                    }
-                  </div>
-
-                  <!-- Collapsible Analysis content -->
-                  @if (event.content) {
-                    <button mat-button class="show-more-btn" (click)="expandedSections[event.id + ':analysis'] = !expandedSections[event.id + ':analysis']">
-                      <mat-icon>{{ expandedSections[event.id + ':analysis'] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                      Analysis
-                    </button>
-                    @if (expandedSections[event.id + ':analysis']) {
-                      <div class="event-content markdown-content">
-                        <div [innerHTML]="event.content | markdown"></div>
-                      </div>
-                    }
-                  }
-                }
-              }
-
-              <!-- SYSTEM_NOTE with JSON probe data detection -->
-              @else if (event.eventType === 'SYSTEM_NOTE' && isJsonContent(event.content)) {
-                <button mat-button class="show-more-btn" (click)="expandedEvents[event.id] = !expandedEvents[event.id]">
-                  <mat-icon>{{ expandedEvents[event.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                  Probe Data
-                </button>
-                @if (expandedEvents[event.id]) {
-                  <pre class="probe-data">{{ formatJson(event.content!) }}</pre>
-                }
-              }
-
-              <!-- AI_RECOMMENDATION — render as action list -->
-              @else if (event.eventType === 'AI_RECOMMENDATION') {
-                @if (eventMeta(event); as meta) {
-                  @if (meta.aiProvider || meta.aiModel) {
-                    <div class="event-ai-meta">
-                      @if (meta.aiProvider) { <span class="meta-chip provider-chip provider-{{ meta.aiProvider.toLowerCase() }}">{{ meta.aiProvider }}</span> }
-                      @if (meta.aiModel) { <code class="meta-chip model-chip">{{ meta.aiModel }}</code> }
-                    </div>
-                  }
-                }
-              }
-              @if (event.content) {
-                @if (event.eventType === 'SYSTEM_NOTE' && isJsonContent(event.content)) {
-                  <!-- Probe data / JSON SYSTEM_NOTE — collapsible formatted code block -->
-                  <div class="probe-data-section">
-                    <button mat-button class="show-more-btn" (click)="expandedEvents[event.id] = !expandedEvents[event.id]">
-                      <mat-icon>{{ expandedEvents[event.id] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                      {{ expandedEvents[event.id] ? 'Hide Probe Data' : 'Show Probe Data' }}
-                    </button>
-                    @if (expandedEvents[event.id]) {
-                      <pre class="probe-data-code"><code>{{ formatJson(event.content) }}</code></pre>
-                    }
-                  </div>
-                } @else if (event.eventType === 'AI_RECOMMENDATION' && hasActionsMeta(event)) {
-                  <!-- AI Recommendation summary above action cards (action bullets stripped) -->
-                  @if (recSummaryContent(event); as summary) {
-                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id + '-raw'] && summary.length > 300">
-                      <div [innerHTML]="summary | markdown"></div>
-                    </div>
-                    @if (summary.length > 300) {
-                      <button mat-button class="show-more-btn" (click)="expandedEvents[event.id + '-raw'] = !expandedEvents[event.id + '-raw']">
-                        {{ expandedEvents[event.id + '-raw'] ? 'Hide details' : 'Show details' }}
-                      </button>
-                    }
-                  }
-                  <!-- AI Recommendation action cards -->
-                  <div class="recommendation-actions">
-                    @for (act of getEventActions(event); track $index) {
-                      <div class="rec-action-row" [class.rec-resolved]="getActionOutcome(act) !== 'pending_approval'">
-                        <div class="rec-action-header" (click)="getActionOutcome(act) !== 'pending_approval' ? expandedEvents[event.id + '-act-' + $index] = !expandedEvents[event.id + '-act-' + $index] : null">
-                          <mat-icon class="rec-icon">{{ recActionIcon(act.action) }}</mat-icon>
-                          <span class="rec-action-type">{{ formatRecActionType(act.action) }}</span>
-                          <span class="rec-status-badge" [class]="'rec-badge-' + getActionOutcome(act)">
-                            {{ getActionOutcomeLabel(act) }}
-                          </span>
-                          @if (getActionOutcome(act) !== 'pending_approval') {
-                            <mat-icon class="rec-expand-icon">{{ expandedEvents[event.id + '-act-' + $index] ? 'expand_less' : 'expand_more' }}</mat-icon>
-                          }
-                        </div>
-                        @if (getActionOutcome(act) === 'pending_approval' || expandedEvents[event.id + '-act-' + $index]) {
-                          <div class="rec-action-detail">
-                            @if (act.value) {
-                              <span class="rec-action-value">{{ act.value }}</span>
-                            }
-                            <span class="rec-action-reason">{{ act.reason }}</span>
-                          </div>
-                        }
-                        @if (getActionOutcome(act) === 'pending_approval') {
-                          <div class="rec-action-buttons">
-                            <button mat-stroked-button color="primary" class="rec-approve-btn" (click)="approvePendingAction(act.pendingActionId)">Approve</button>
-                            <button mat-stroked-button class="rec-dismiss-btn" (click)="dismissPendingAction(act.pendingActionId)">Dismiss</button>
-                          </div>
-                        }
-                      </div>
-                    }
-                  </div>
-                } @else if (isMarkdownEvent(event.eventType)) {
-                  <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
-                    <div [innerHTML]="event.content | markdown"></div>
-                  </div>
-                  @if (event.content.length > 300) {
-                    <button mat-button class="show-more-btn" (click)="expandedEvents[event.id] = !expandedEvents[event.id]">
-                      {{ expandedEvents[event.id] ? 'Show less' : 'Show more' }}
-                    </button>
-                  }
-                }
-              }
-
-              <!-- Default rendering for all other event types -->
-              @else {
-                <!-- AI help question (if present in metadata) -->
-                @if (eventQuestion(event); as q) {
-                  <div class="event-question">
-                    <mat-icon class="question-icon">help_outline</mat-icon>
-                    <span>{{ q }}</span>
-                  </div>
-                }
-                <!-- AI metadata chips -->
-                @if (eventMeta(event); as meta) {
-                  @if (meta.aiProvider || meta.aiModel) {
-                    <div class="event-ai-meta">
-                      @if (meta.aiProvider) {
-                        <span class="meta-chip provider-chip provider-{{ meta.aiProvider.toLowerCase() }}">{{ meta.aiProvider }}</span>
-                      }
-                      @if (meta.aiModel) {
-                        <code class="meta-chip model-chip">{{ meta.aiModel }}</code>
-                      }
-                      @if (meta.phase) {
-                        <span class="meta-chip phase-chip">{{ meta.phase }}</span>
-                      }
-                      @if (meta.taskType) {
-                        <span class="meta-chip task-chip">{{ meta.taskType }}</span>
-                      }
-                      @if (meta.inputTokens != null) {
-                        <span class="meta-chip token-chip">{{ meta.inputTokens | number }}in / {{ meta.outputTokens | number }}out</span>
-                      }
-                      @if (meta.durationMs != null) {
-                        <span class="meta-chip duration-chip">{{ meta.durationMs }}ms</span>
-                      }
-                    </div>
-                  }
-                }
-                @if (event.content) {
-                  @if (isMarkdownEvent(event.eventType)) {
-                    <div class="event-content markdown-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
-                      <div [innerHTML]="event.content | markdown"></div>
-                    </div>
-                  } @else {
-                    <p class="event-content" [class.collapsed]="!expandedEvents[event.id] && event.content.length > 300">
-                      {{ expandedEvents[event.id] ? event.content : event.content.slice(0, 300) }}
-                      @if (event.content.length > 300 && !expandedEvents[event.id]) {
-                        <span class="ellipsis">...</span>
-                      }
-                    </p>
-                  }
-                  @if (event.content.length > 300) {
-                    <button mat-button class="show-more-btn" (click)="expandedEvents[event.id] = !expandedEvents[event.id]">
-                      {{ expandedEvents[event.id] ? 'Show less' : 'Show more' }}
-                    </button>
-                  }
-                }
-              }
-            </mat-card-content>
-          </mat-card>
-        } @empty {
-          <p class="empty">No events match the current filter.</p>
-        }
-      </div>
-
-      <mat-card class="add-comment">
-        <mat-card-content>
-          <mat-form-field class="full-width">
-            <mat-label>Add comment</mat-label>
-            <textarea matInput [(ngModel)]="newComment" rows="2"></textarea>
-          </mat-form-field>
-          <button mat-raised-button color="primary" (click)="addComment()" [disabled]="!newComment">
-            <mat-icon>send</mat-icon> Add Comment
-          </button>
-        </mat-card-content>
-      </mat-card>
-
-      <!-- Re-run Analysis button -->
-      <div class="reanalyze-bar">
-        <button mat-stroked-button (click)="reanalyze()" [disabled]="reanalyzing()">
-          <mat-icon>replay</mat-icon> Re-run Analysis
+        <button class="ai-fab" type="button" aria-label="Ask AI for Help" (click)="openAiHelp()">
+          <span aria-hidden="true">&#x2728;</span>
         </button>
       </div>
-
-      <!-- Floating AI Help button -->
-      <button mat-fab class="ai-fab" color="accent" (click)="openAiHelp()" matTooltip="Ask AI for Help">
-        <mat-icon>psychology</mat-icon>
-      </button>
     } @else {
-      <p>Loading...</p>
+      <p class="loading">Loading...</p>
     }
 
     @if (showAiHelpDialog()) {
@@ -1026,12 +607,8 @@ export class TicketDetailComponent implements OnInit {
   generatingLogs = signal(false);
   reanalyzing = signal(false);
   editingKnowledgeDoc = signal(false);
-  knowledgeDocDraft = '';
   newComment = '';
-  descExpanded = false;
-  costDetailsExpanded = false;
-  expandedEvents: Record<string, boolean> = {};
-  expandedSections: Record<string, boolean> = {};
+  logsSearchInput = '';
 
   // Unified logs tab state
   unifiedLogs = signal<UnifiedLogEntry[]>([]);
@@ -1053,26 +630,67 @@ export class TicketDetailComponent implements OnInit {
   convExpanded: Record<string, boolean> = {};
   convPromptExpanded: Record<string, boolean> = {};
 
-  // Legacy — still used by loadTicketAiUsage for the existing AI Cost card
-  ticketLogs = signal<TicketAppLog[]>([]);
-  ticketLogsTotal = signal(0);
-  ticketLogsLoading = signal(false);
-  ticketAiUsageLogs = signal<TicketAiUsageLog[]>([]);
+  // Tab tracking
+  selectedTabIndex = signal(0);
 
-  // Timeline filter/sort
-  timelineFilter = signal('');
-  timelineSortAsc = signal(true); // true = oldest first (matches event order from API)
-
-  filteredEvents = computed(() => {
-    let evts = this.events();
-    if (this.timelineFilter()) {
-      evts = evts.filter(e => e.eventType === this.timelineFilter());
-    }
-    if (!this.timelineSortAsc()) {
-      evts = [...evts].reverse();
-    }
-    return evts;
+  /** Dynamic tab labels (depends on which conditional tabs are visible). */
+  tabsInOrder = computed<string[]>(() => {
+    const t = this.ticket();
+    const labels: string[] = [];
+    if (this.emailBlurb()) labels.push('AI Summary');
+    if (t?.summary) labels.push('Resolution Summary');
+    labels.push('Details');
+    if (t?.knowledgeDoc || this.editingKnowledgeDoc()) labels.push('Knowledge');
+    labels.push('Logs');
+    labels.push('Conversation');
+    labels.push('Log Digest');
+    return labels;
   });
+
+  logsTabLabel = computed(() => {
+    const total = this.unifiedLogsTotal();
+    return total > 0 ? `Logs (${total})` : 'Logs';
+  });
+
+  // Static select option lists
+  readonly priorityOptions = [
+    { value: 'LOW', label: 'Low' },
+    { value: 'MEDIUM', label: 'Medium' },
+    { value: 'HIGH', label: 'High' },
+    { value: 'CRITICAL', label: 'Critical' },
+  ];
+  readonly statusOptions = [
+    { value: 'OPEN', label: 'Open' },
+    { value: 'IN_PROGRESS', label: 'In Progress' },
+    { value: 'WAITING', label: 'Waiting' },
+    { value: 'RESOLVED', label: 'Resolved' },
+    { value: 'CLOSED', label: 'Closed' },
+  ];
+  readonly categoryOptions = [
+    { value: '', label: 'None' },
+    { value: 'DATABASE_PERF', label: 'Database Perf' },
+    { value: 'BUG_FIX', label: 'Bug Fix' },
+    { value: 'FEATURE_REQUEST', label: 'Feature Request' },
+    { value: 'SCHEMA_CHANGE', label: 'Schema Change' },
+    { value: 'CODE_REVIEW', label: 'Code Review' },
+    { value: 'ARCHITECTURE', label: 'Architecture' },
+    { value: 'GENERAL', label: 'General' },
+  ];
+  readonly typeFilterOptions = [
+    { value: '', label: 'All' },
+    { value: 'ai', label: 'AI Calls' },
+    { value: 'tool', label: 'Tool Calls' },
+    { value: 'step', label: 'Steps' },
+    { value: 'error', label: 'Errors' },
+    { value: 'log', label: 'Logs' },
+  ];
+  readonly levelFilterOptions = [
+    { value: '', label: 'All' },
+    { value: 'ERROR', label: 'Error' },
+    { value: 'WARN', label: 'Warn' },
+    { value: 'INFO', label: 'Info' },
+    { value: 'DEBUG', label: 'Debug' },
+  ];
 
   /** Extract a short email blurb from the first AI_ANALYSIS triage event. */
   emailBlurb = computed(() => {
@@ -1173,14 +791,13 @@ export class TicketDetailComponent implements OnInit {
     this.loadTicketCost();
     this.loadUnifiedLogs();
     this.loadCostSummary();
-    this.loadTicketAiUsage();
     this.loadPendingActions();
     this.destroyRef.onDestroy(() => this.stopPolling());
   }
 
   loadPendingActions(): void {
     this.ticketService.getPendingActions(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (actions) => {
+      next: (actions: PendingAction[]) => {
         const map: Record<string, string> = {};
         for (const a of actions) map[a.id] = a.status;
         this.pendingActionMap.set(map);
@@ -1241,19 +858,6 @@ export class TicketDetailComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(res => {
         this.logSummaries.set(res.summaries);
-      });
-  }
-
-  // Legacy loadTicketLogs — replaced by loadUnifiedLogs
-  loadTicketLogs(): void { /* no-op */ }
-
-  loadTicketAiUsage(): void {
-    this.ticketService
-      .getTicketAiUsage(this.id(), { limit: 100 })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (res) => this.ticketAiUsageLogs.set(res.logs),
-        error: () => {},
       });
   }
 
@@ -1352,8 +956,9 @@ export class TicketDetailComponent implements OnInit {
       });
   }
 
-  loadMoreLogs(): void {
-    // Legacy — kept for backward compatibility but loadMoreUnifiedLogs is primary
+  onSearchEnter(): void {
+    this.logsSearchFilter.set(this.logsSearchInput);
+    this.loadUnifiedLogs();
   }
 
   private buildGroups(entries: UnifiedLogEntry[]): { groups: StepGroup[]; ungrouped: UnifiedLogEntry[] } {
@@ -1432,8 +1037,10 @@ export class TicketDetailComponent implements OnInit {
       });
   }
 
-  onTabChange(event: { tab: { textLabel: string } }): void {
-    if (event.tab.textLabel === 'Conversation') {
+  onTabIndexChange(idx: number): void {
+    this.selectedTabIndex.set(idx);
+    const labels = this.tabsInOrder();
+    if (labels[idx] === 'Conversation') {
       this.loadConversationEntries();
     }
   }
@@ -1521,22 +1128,11 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  startEditKnowledgeDoc(): void {
-    this.knowledgeDocDraft = this.ticket()?.knowledgeDoc ?? '';
-    this.editingKnowledgeDoc.set(true);
-  }
-
-  cancelEditKnowledgeDoc(): void {
-    this.editingKnowledgeDoc.set(false);
-    this.knowledgeDocDraft = '';
-  }
-
-  saveKnowledgeDoc(): void {
-    const doc = this.knowledgeDocDraft.trim() || null;
+  saveKnowledgeDoc(draft: string): void {
+    const doc = draft.trim() || null;
     this.ticketService.updateKnowledgeDoc(this.id(), doc).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
         this.editingKnowledgeDoc.set(false);
-        this.knowledgeDocDraft = '';
         this.toast.success('Knowledge doc updated');
         this.load();
       },
@@ -1580,7 +1176,6 @@ export class TicketDetailComponent implements OnInit {
 
   onAiHelpClosed(): void {
     this.showAiHelpDialog.set(false);
-    // Reload timeline to show any new AI_ANALYSIS events
     this.load();
     this.loadTicketCost();
   }
@@ -1599,137 +1194,7 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  toggleTimelineSort(): void {
-    this.timelineSortAsc.update(v => !v);
-  }
-
-  isMarkdownEvent(eventType: string): boolean {
-    return eventType === 'AI_ANALYSIS' || eventType === 'AI_RECOMMENDATION' || eventType === 'COMMENT';
-  }
-
-  recSummaryContent(event: TicketEvent): string {
-    if (!event.content) return '';
-    const actionPrefixes = /^[-•]\s*(Auto-executed|Pending approval|Skipped):/i;
-    const headerPrefixes = /^\*\*(Auto-executed|Pending approval|Skipped):\*\*$/i;
-    return event.content
-      .split('\n')
-      .filter(line => !actionPrefixes.test(line.trim()) && !headerPrefixes.test(line.trim()))
-      .join('\n')
-      .trim();
-  }
-
-  formatEventType(type: string): string {
-    const labels: Record<string, string> = {
-      COMMENT: 'Comment',
-      STATUS_CHANGE: 'Status Change',
-      PRIORITY_CHANGE: 'Priority Change',
-      CATEGORY_CHANGE: 'Category Change',
-      AI_ANALYSIS: 'AI Analysis',
-      AI_RECOMMENDATION: 'AI Recommendation',
-      EMAIL_INBOUND: 'Email Received',
-      EMAIL_OUTBOUND: 'Email Sent',
-      CODE_CHANGE: 'Code Change',
-      SYSTEM_NOTE: 'System Note',
-    };
-    return labels[type] ?? type;
-  }
-
-  eventIcon(type: string): string {
-    const icons: Record<string, string> = {
-      COMMENT: 'comment',
-      STATUS_CHANGE: 'swap_horiz',
-      PRIORITY_CHANGE: 'priority_high',
-      CATEGORY_CHANGE: 'category',
-      AI_ANALYSIS: 'psychology',
-      AI_RECOMMENDATION: 'lightbulb',
-      EMAIL_INBOUND: 'email',
-      EMAIL_OUTBOUND: 'send',
-      CODE_CHANGE: 'code',
-      SYSTEM_NOTE: 'info',
-    };
-    return icons[type] ?? 'event';
-  }
-
-  // ─── AI Recommendation / Probe Data helpers ───
-
-  hasActionsMeta(event: TicketEvent): boolean {
-    const meta = event.metadata as Record<string, unknown> | null;
-    return Array.isArray(meta?.['actions']);
-  }
-
-  getEventActions(event: TicketEvent): Array<{ action: string; value?: string; reason: string; outcome?: string; pendingActionId?: string; recommendationType?: string }> {
-    const meta = event.metadata as Record<string, unknown> | null;
-    const actions = meta?.['actions'] as unknown[] | undefined;
-    if (!Array.isArray(actions)) return [];
-    return actions.map((a) => {
-      const obj = a as Record<string, unknown>;
-      return {
-        action: (obj['action'] as string) ?? '',
-        value: obj['value'] as string | undefined,
-        reason: (obj['reason'] as string) ?? '',
-        outcome: (obj['outcome'] as string) ?? (obj['applied'] === true ? 'auto_executed' : obj['applied'] === false ? 'skipped' : undefined),
-        pendingActionId: obj['pendingActionId'] as string | undefined,
-        recommendationType: obj['recommendationType'] as string | undefined,
-      };
-    });
-  }
-
-  getActionOutcome(act: { outcome?: string; applied?: boolean; pendingActionId?: string }): string {
-    // Check live pending action status first (reflects approve/dismiss without reload)
-    if (act.pendingActionId) {
-      const liveStatus = this.pendingActionMap()[act.pendingActionId];
-      if (liveStatus === 'approved') return 'approved';
-      if (liveStatus === 'dismissed') return 'dismissed';
-      if (liveStatus === 'pending') return 'pending_approval';
-    }
-    if (act.outcome) return act.outcome;
-    if (act.applied === true) return 'auto_executed';
-    return 'skipped';
-  }
-
-  getActionOutcomeLabel(act: { outcome?: string; applied?: boolean }): string {
-    const outcome = this.getActionOutcome(act);
-    const labels: Record<string, string> = {
-      auto_executed: 'Auto-executed',
-      pending_approval: 'Pending Approval',
-      skipped: 'Skipped',
-      dismissed: 'Dismissed',
-      approved: 'Approved',
-    };
-    return labels[outcome] ?? outcome;
-  }
-
-  recActionIcon(action: string): string {
-    const icons: Record<string, string> = {
-      set_status: 'swap_horiz',
-      set_priority: 'priority_high',
-      set_category: 'category',
-      add_comment: 'comment',
-      trigger_code_fix: 'code',
-      send_followup_email: 'email',
-      escalate_deep_analysis: 'psychology',
-      check_database_health: 'monitor_heart',
-      assign_operator: 'person',
-    };
-    return icons[action] ?? 'lightbulb';
-  }
-
-  formatRecActionType(action: string): string {
-    const labels: Record<string, string> = {
-      set_status: 'Change Status',
-      set_priority: 'Change Priority',
-      set_category: 'Change Category',
-      add_comment: 'Add Comment',
-      trigger_code_fix: 'Create Issue Job',
-      send_followup_email: 'Send Email',
-      escalate_deep_analysis: 'Escalate',
-      check_database_health: 'Check DB Health',
-      assign_operator: 'Assign Operator',
-    };
-    return labels[action] ?? action;
-  }
-
-  approvePendingAction(actionId?: string): void {
+  approvePendingAction(actionId: string): void {
     if (!actionId) return;
     const ticketId = this.ticket()?.id;
     if (!ticketId) return;
@@ -1743,7 +1208,7 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  dismissPendingAction(actionId?: string): void {
+  dismissPendingAction(actionId: string): void {
     if (!actionId) return;
     const ticketId = this.ticket()?.id;
     if (!ticketId) return;
@@ -1757,40 +1222,6 @@ export class TicketDetailComponent implements OnInit {
     });
   }
 
-  /** Extract AI-relevant metadata from an event for display. */
-  eventMeta(event: TicketEvent): {
-    aiProvider?: string;
-    aiModel?: string;
-    phase?: string;
-    taskType?: string;
-    inputTokens?: number;
-    outputTokens?: number;
-    durationMs?: number;
-  } | null {
-    const meta = event.metadata as Record<string, unknown> | null;
-    if (!meta) return null;
-    const aiProvider = meta['aiProvider'] as string | undefined;
-    const aiModel = meta['aiModel'] as string | undefined;
-    if (!aiProvider && !aiModel) return null;
-    const usage = meta['usage'] as { inputTokens?: number; outputTokens?: number } | undefined;
-    return {
-      aiProvider,
-      aiModel,
-      phase: meta['phase'] as string | undefined,
-      taskType: meta['taskType'] as string | undefined,
-      inputTokens: usage?.inputTokens,
-      outputTokens: usage?.outputTokens,
-      durationMs: meta['durationMs'] as number | undefined,
-    };
-  }
-
-  /** Extract question from AI_ANALYSIS ai_help event metadata. */
-  eventQuestion(event: TicketEvent): string | null {
-    const meta = event.metadata as Record<string, unknown> | null;
-    if (!meta || meta['phase'] !== 'ai_help') return null;
-    return (meta['question'] as string) ?? null;
-  }
-
   formatAnalysisStatus(status: string | undefined): string {
     const labels: Record<string, string> = {
       PENDING: 'Pending',
@@ -1800,11 +1231,6 @@ export class TicketDetailComponent implements OnInit {
       SKIPPED: 'Skipped',
     };
     return labels[status ?? ''] ?? status ?? '-';
-  }
-
-  truncateDescription(desc: string): string {
-    if (this.descExpanded || desc.length <= 300) return desc;
-    return desc.slice(0, 300) + '...';
   }
 
   formatTime(dateStr: string): string {
@@ -1819,85 +1245,18 @@ export class TicketDetailComponent implements OnInit {
     return `${(ms / 60_000).toFixed(1)}m`;
   }
 
-  /** Check if a timeline event was triggered by an AI recommendation auto-execution. */
-  isAiTriggered(event: TicketEvent): boolean {
-    const meta = event.metadata as Record<string, unknown> | null;
-    return meta?.['triggeredBy'] === 'ai_recommendation';
-  }
-
-  /** Check if an AI_ANALYSIS event is from the agentic analysis phase (has rich metadata). */
-  isAgenticAnalysis(event: TicketEvent): boolean {
-    const meta = event.metadata as Record<string, unknown> | null;
-    if (!meta || event.eventType !== 'AI_ANALYSIS') return false;
-    return meta['phase'] === 'agentic_analysis' || meta['phase'] === 'deep_analysis';
-  }
-
-  /** Extract structured metadata from agentic analysis events. */
-  agenticMeta(event: TicketEvent): {
-    taskType: string;
-    iterationsRun: number;
-    toolCallCount: number;
-    toolCalls: Array<{ tool: string; system?: string; durationMs?: number; output?: string }>;
-    sufficiencyStatus: string | null;
-    sufficiencyConfidence: string | null;
-    sufficiencyReason: string | null;
-    sufficiencyQuestions: string[] | null;
-    totalCostUsd: number | null;
-  } | null {
-    const meta = event.metadata as Record<string, unknown> | null;
-    if (!meta) return null;
-    const toolCalls = (meta['toolCalls'] as Array<{ tool: string; system?: string; durationMs?: number; output?: string }>) ?? [];
-    return {
-      taskType: (meta['taskType'] as string) ?? 'DEEP_ANALYSIS',
-      iterationsRun: (meta['iterationsRun'] as number) ?? (meta['iterationCount'] as number) ?? 0,
-      toolCallCount: (meta['toolCallCount'] as number) ?? toolCalls.length,
-      toolCalls,
-      sufficiencyStatus: (meta['sufficiencyStatus'] as string) ?? null,
-      sufficiencyConfidence: (meta['sufficiencyConfidence'] as string) ?? null,
-      sufficiencyReason: (meta['sufficiencyReason'] as string) ?? null,
-      sufficiencyQuestions: (meta['sufficiencyQuestions'] as string[]) ?? null,
-      totalCostUsd: (meta['totalCostUsd'] as number) ?? null,
-    };
-  }
-
-  /** Check if content looks like JSON (for SYSTEM_NOTE probe data detection). */
-  isJsonContent(content: string | null): boolean {
-    if (!content) return false;
-    const trimmed = content.trim();
-    return (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'));
-  }
-
-  formatJson(content: string): string {
-    try {
-      return JSON.stringify(JSON.parse(content), null, 2);
-    } catch {
-      return content;
-    }
-  }
-
-  /** Check if a log entry is an iteration header (matches "Agentic analysis iteration N/M"). */
   isIterationHeader(entry: UnifiedLogEntry): boolean {
     return !!(entry.message && /^Agentic analysis iteration \d+\/\d+/.test(entry.message));
   }
 
-  /** Extract a display label from an iteration header log entry. */
   extractIterationLabel(entry: UnifiedLogEntry): string {
     const match = entry.message?.match(/^Agentic analysis iteration (\d+)\/(\d+)/);
     if (match) return `Iteration ${match[1]} of ${match[2]}`;
     return 'Iteration';
   }
 
-  /** Check if a log entry falls within an agentic iteration (tool/reasoning entries). */
   isWithinIteration(entry: UnifiedLogEntry): boolean {
     if (!entry.message) return false;
     return /^Agentic (tool call|reasoning)/.test(entry.message);
-  }
-
-  /** Extract recommendation actions from AI_RECOMMENDATION metadata. */
-  recommendationActions(event: TicketEvent): Array<{ action: string; applied: boolean; detail?: string }> | null {
-    const meta = event.metadata as Record<string, unknown> | null;
-    if (!meta) return null;
-    const actions = meta['actions'] as Array<{ action: string; applied: boolean; detail?: string }> | undefined;
-    return actions && actions.length > 0 ? actions : null;
   }
 }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -83,16 +83,19 @@ interface StepGroup {
 
         <div class="ticket-meta">
           <app-select
+            ariaLabel="Priority"
             [value]="t.priority"
             [options]="priorityOptions"
             placeholder=""
             (valueChange)="updateField('priority', $event)" />
           <app-select
+            ariaLabel="Status"
             [value]="t.status"
             [options]="statusOptions"
             placeholder=""
             (valueChange)="updateStatus($event)" />
           <app-select
+            ariaLabel="Category"
             [value]="t.category ?? ''"
             [options]="categoryOptions"
             placeholder=""
@@ -240,11 +243,11 @@ interface StepGroup {
                 } @else if (entry.type === 'ai') {
                   <app-ai-log-entry [entry]="entry" [idx]="idx" [iterationGrouped]="isWithinIteration(entry)" />
                 } @else {
-                  <div class="log-entry" [class]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
+                  <div class="log-entry" [ngClass]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
                     <div class="log-entry-header">
                       <span class="log-seq">#{{ idx + 1 }}</span>
                       <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
-                      <span class="unified-type-badge" [class]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
+                      <span class="unified-type-badge" [ngClass]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
                       @if (entry.level) { <span class="log-level-badge log-badge-{{ entry.level.toLowerCase() }}">{{ entry.level }}</span> }
                       @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                       <span class="log-message">{{ entry.message }}</span>
@@ -293,11 +296,11 @@ interface StepGroup {
                             <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
                           </div>
                         } @else {
-                          <div class="log-entry" [class]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
+                          <div class="log-entry" [ngClass]="'unified-type-' + entry.type" [class.iteration-grouped]="isWithinIteration(entry)">
                             <div class="log-entry-header">
                               <span class="log-seq">#{{ idx + 1 }}</span>
                               <span class="log-time" [attr.title]="entry.timestamp">{{ formatTime(entry.timestamp) }}</span>
-                              <span class="unified-type-badge" [class]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
+                              <span class="unified-type-badge" [ngClass]="'ubadge-' + entry.type">{{ entry.type | uppercase }}</span>
                               @if (entry.type === 'ai') {
                                 <span class="meta-chip provider-chip provider-{{ (entry.provider ?? '').toLowerCase() }}">{{ entry.provider }}</span>
                                 <code class="meta-chip model-chip">{{ entry.model }}</code>
@@ -398,7 +401,7 @@ interface StepGroup {
                           @if (convMessages(entry).length > 0) {
                             <div class="conv-turns">
                               @for (turn of convMessages(entry); track $index) {
-                                <div class="conv-turn" [class]="'conv-turn-' + turn.role">
+                                <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
                                   <span class="conv-turn-role">{{ turn.role === 'user' ? '\u{1F464}' : '\u{1F916}' }}</span>
                                   @if (turn.toolName) { <span class="conv-tool-call">\u{1F527} {{ turn.toolName }}</span> }
                                   @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
@@ -485,7 +488,7 @@ interface StepGroup {
                       @if (convMessages(entry).length > 0) {
                         <div class="conv-turns">
                           @for (turn of convMessages(entry); track $index) {
-                            <div class="conv-turn" [class]="'conv-turn-' + turn.role">
+                            <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
                               <span class="conv-turn-role">{{ turn.role === 'user' ? '\u{1F464}' : '\u{1F916}' }}</span>
                               @if (turn.toolName) { <span class="conv-tool-call">\u{1F527} {{ turn.toolName }}</span> }
                               @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -8,6 +8,7 @@ import { Component, input, output } from '@angular/core';
       class="select-input"
       [value]="value()"
       [disabled]="disabled()"
+      [attr.aria-label]="ariaLabel() || null"
       (change)="onChange($event)">
       @if (placeholder()) {
         <option value="" disabled>{{ placeholder() }}</option>
@@ -54,6 +55,7 @@ export class SelectComponent {
   options = input.required<Array<{ value: string; label: string }>>();
   placeholder = input<string>('Select...');
   disabled = input<boolean>(false);
+  ariaLabel = input<string>('');
 
   valueChange = output<string>();
 


### PR DESCRIPTION
## Summary

- Rewrites the ticket detail page (`services/control-panel/src/app/features/tickets/ticket-detail.component.ts`) to drop all `@angular/material` usage in favor of the custom Bronco design system.
- Splits per-tab content into 8 focused sub-components (`summary`, `resolution`, `details`, `knowledge`, `log-digest`, `flow`, `cost`, `timeline`) — parent shrinks from 1903 to ~1100 lines.
- All hardcoded colors replaced with `theme.css` CSS custom properties so the page works in all 6 themes.
- Adopts the `page-wrapper` / `page-header` / `page-title` shell convention.
- **Conversation tab grouping/sorting and sub-task chaining preserved byte-for-byte** — the carefully tuned `flowNodes`, `buildGroups`, `buildStepGroups`, `buildConvGroups`, `loadConversationEntries`, `isSubTask`, `getOrchestrationId`, `getSubTasks`, `convMessages`, `convPromptText`, `convResponseText`, `isMultilineConvPrompt`, `isMultilineConv`, `loadUnifiedLogs`, `pollUnifiedLogs`, `loadMoreUnifiedLogs` methods and the `conversationEntries`/`conversationLoading`/`conversationLoaded`/`convStepGroups`/`convUngrouped`/`stepGroups`/`ungroupedEntries`/`convExpanded`/`convPromptExpanded` signals are unchanged.
- The Conversation and Logs tabs are inlined in the parent (Conversation per the preservation rules; Logs because it shares helpers with the conversation builder).
- Refs #131.

## Migration map

| Replaced | With |
|---|---|
| `mat-tab-group` / `mat-tab` | `app-tab-group` / `app-tab` |
| `mat-card` | `app-card` |
| `mat-button` / `mat-raised-button` / `mat-icon-button` | `app-bronco-button` (variants: `primary`, `secondary`, `ghost`, `destructive`, `icon`) |
| `mat-select` | `app-select` |
| `mat-form-field` + `matInput` | `app-form-field` + `app-text-input` / `app-textarea` |
| `mat-icon` (font) | Inline Unicode glyphs / SVG |
| `mat-progress-bar` (indeterminate) | CSS-only `.indeterminate-bar` |
| `mat-tooltip` | Native `[attr.title]` |
| Hardcoded hex / rgba | `var(--*)` tokens from `theme.css` |

## Verification

- `pnpm typecheck` ✅
- `pnpm build` ✅
- `git grep "@angular/material" services/control-panel/src/app/features/tickets/` returns nothing
- `git grep -nE '#[0-9a-fA-F]{3,6}|rgba\(' services/control-panel/src/app/features/tickets/ticket-detail*.{ts,css}` returns only HTML-entity false positives (`&#10227;`, `&#9888;`, etc.)

## Test plan

- [ ] Open any ticket detail page in dev
- [ ] Click through all tabs — render without errors
- [ ] **Conversation tab**: step group labels render, AI calls nested under steps, sub-tasks (`conversationMetadata.isSubTask = true`) appear nested INSIDE their parent AI block (NOT siblings at top level), expand/collapse on prompt + response works, token counts and costs render
- [ ] **Logs tab**: step groups expand/collapse, filter dropdowns work, search + refresh work, "Load more" pagination works
- [ ] **Details / AI Summary / Resolution Summary / Knowledge** tabs render
- [ ] **Knowledge tab**: edit / save / clear flow works
- [ ] **Log Digest tab**: "Summarize" button triggers generation
- [ ] **Process Flow** card renders nested branch nodes
- [ ] **AI Cost** card expand/collapse with breakdown
- [ ] **Timeline**: filter dropdown, sort toggle, agentic analysis expand sections, AI recommendation approve/dismiss buttons
- [ ] **Add comment**, **Re-run Analysis**, **AI Help FAB** all work
- [ ] Smoke-test in at least 2 themes (Apple light + one dark, e.g. Linear or Sentry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
