### PR TITLE
chore: remove @angular/material from control panel (refs #131)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,9 +254,6 @@ importers:
       '@angular/forms':
         specifier: ^20.0.0
         version: 20.3.18(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
-      '@angular/material':
-        specifier: ^20.0.0
-        version: 20.2.14(zs2a4chd7sxckx4soy3okdwste)
       '@angular/platform-browser':
         specifier: ^20.0.0
         version: 20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))

--- a/services/control-panel/package.json
+++ b/services/control-panel/package.json
@@ -18,7 +18,6 @@
     "@angular/compiler": "^20.0.0",
     "@angular/core": "^20.0.0",
     "@angular/forms": "^20.0.0",
-    "@angular/material": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/platform-browser-dynamic": "^20.0.0",
     "@angular/router": "^20.0.0",

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -1,5 +1,3 @@
-@use '@angular/material' as mat;
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -8,19 +6,6 @@ html, body {
   height: 100%;
   margin: 0;
   font-family: var(--font-primary, -apple-system, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif);
-}
-
-:root {
-  @include mat.all-component-themes(mat.define-theme((
-    color: (
-      theme-type: light,
-      primary: mat.$azure-palette,
-      tertiary: mat.$blue-palette,
-    ),
-    density: (
-      scale: -1,
-    ),
-  )));
 }
 
 .spacer {
@@ -50,17 +35,6 @@ app-dialog .dialog-body [dialogFooter] {
 
 
 @media (max-width: 767px) {
-  .mat-mdc-table {
-    display: block;
-    overflow-x: auto;
-  }
-  .mat-mdc-dialog-container {
-    max-width: 95vw !important;
-  }
-  .mat-mdc-card {
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-  }
   h1 { font-size: 1.5rem; }
   h2 { font-size: 1.25rem; }
 }


### PR DESCRIPTION
## Summary

Final cleanup PR for the control panel UX redesign (#131). After PRs #173, #174, and #175 merged, every TypeScript file in the control panel has zero `@angular/material` imports. This PR removes the last dead Material references from `styles.scss` and drops the `@angular/material` package dependency entirely.

## Changes

**`services/control-panel/src/styles.scss`**
- Drop `@use '@angular/material' as mat;`
- Drop the entire `:root { @include mat.all-component-themes(...); }` block (Material's default theme generation, no longer used)
- Drop the `.mat-mdc-table`, `.mat-mdc-dialog-container`, and `.mat-mdc-card` selectors inside the mobile media query (no DOM elements match anymore)
- Keep the `h1`/`h2` font-size adjustments inside the same media query

**`services/control-panel/package.json`**
- Remove `@angular/material` from `dependencies`
- `@angular/cdk` remains — still used for clipboard, overlay, drag-drop, and a11y primitives that the custom Bronco components depend on

**`pnpm-lock.yaml`**
- Regenerated via `pnpm install`
- Lockfile delta is only 3 lines — Material's transitive deps were already shared with `@angular/cdk` and Angular core, so almost nothing unique gets dropped

## Result

🎉 **Zero Angular Material references in the control panel.** The redesign goal of #131 (control panel scope) is complete.

```
$ git grep -nE "@angular/material|mat-mdc-|mat\." services/control-panel/src/ services/control-panel/package.json
(zero results)
```

## What's next (separate work)

- **Icon system** — the migration replaced `mat-icon` with a mix of Unicode glyphs and inline SVGs. This works but is visually inconsistent. A unified icon system (likely Font Awesome via `@fortawesome/angular-fontawesome` wrapped in an `<app-icon>` Bronco component) is planned as a follow-up.
- **Ticket portal redesign** — tracked separately in #177. The portal still uses Angular Material and needs to be brought to control panel parity.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @bronco/control-panel build` passes
- [x] `git grep "@angular/material" services/control-panel/src/` returns zero results
- [x] `@angular/cdk` confirmed still in dependencies
- [ ] Manual smoke test: navigate the control panel, verify no broken styling

Refs #131.
