### PR TITLE
feat: Font Awesome Pro icon system foundation with kit-based install (refs #131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
 
       - name: Generate Prisma client
         run: pnpm db:generate

--- a/.github/workflows/deploy-hugo.yml
+++ b/.github/workflows/deploy-hugo.yml
@@ -235,6 +235,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          secrets: |
+            fontawesome_npm_auth_token=${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
           build-args: |
             BUILD_VERSION=${{ github.ref_name }}
           tags: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
 shamefully-hoist=false
 strict-peer-dependencies=false
 auto-install-peers=true
+
+@awesome.me:registry=https://npm.fontawesome.com/
+@fortawesome:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,18 @@ importers:
       '@angular/router':
         specifier: ^20.0.0
         version: 20.3.18(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
+      '@awesome.me/kit-9a8becfc3a':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@bronco/shared-ui':
         specifier: workspace:*
         version: link:../../packages/shared-ui
+      '@fortawesome/angular-fontawesome':
+        specifier: ^3.0.0
+        version: 3.0.0(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^7.2.0
+        version: 7.2.0
       marked:
         specifier: ^17.0.5
         version: 17.0.5
@@ -952,6 +961,10 @@ packages:
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
+  '@awesome.me/kit-9a8becfc3a@1.0.2':
+    resolution: {integrity: sha512-R8+u/lqLkdtqhLa97CCtk53hciZ6OEPvGoDqmxZq++EiKqzGRScb3TuI3n90Gzhgq6yulEVOEKYQXGWGCWoXhw==}
+    engines: {node: '>=16'}
+
   '@azure-rest/core-client@2.5.1':
     resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
     engines: {node: '>=20.0.0'}
@@ -1445,6 +1458,19 @@ packages:
 
   '@fastify/sensible@6.0.4':
     resolution: {integrity: sha512-1vxcCUlPMew6WroK8fq+LVOwbsLtX+lmuRuqpcp6eYqu6vmkLwbKTdBWAZwbeaSgCfW4tzUpTIHLLvTiQQ1BwQ==}
+
+  '@fortawesome/angular-fontawesome@3.0.0':
+    resolution: {integrity: sha512-+8Dd6DoJnqArfrZ5NvjHyRL64IIkTigXclbOOcFdYQ8/WFERQUDaEU6SAV8Q0JBpJhMS1McED7YCOCAE6SIVyA==}
+    peerDependencies:
+      '@angular/core': ^20.0.0
+
+  '@fortawesome/fontawesome-common-types@7.2.0':
+    resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
+    engines: {node: '>=6'}
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -5149,6 +5175,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@awesome.me/kit-9a8becfc3a@1.0.2':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
+
   '@azure-rest/core-client@2.5.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -5612,6 +5642,18 @@ snapshots:
       http-errors: 2.0.1
       type-is: 2.0.1
       vary: 1.1.2
+
+  '@fortawesome/angular-fontawesome@3.0.0(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))':
+    dependencies:
+      '@angular/core': 20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)
+      '@fortawesome/fontawesome-svg-core': 7.2.0
+      tslib: 2.8.1
+
+  '@fortawesome/fontawesome-common-types@7.2.0': {}
+
+  '@fortawesome/fontawesome-svg-core@7.2.0':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 7.2.0
 
   '@gar/promise-retry@1.0.3': {}
 

--- a/services/control-panel/Dockerfile
+++ b/services/control-panel/Dockerfile
@@ -11,7 +11,8 @@ COPY services/control-panel/package.json services/control-panel/
 COPY packages/shared-ui/package.json packages/shared-ui/
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=secret,id=fontawesome_npm_auth_token,env=FONTAWESOME_NPM_AUTH_TOKEN \
+    pnpm install --frozen-lockfile
 
 # Copy source
 COPY packages/shared-ui/ packages/shared-ui/
@@ -33,7 +34,8 @@ COPY services/ticket-portal/package.json services/ticket-portal/
 COPY packages/shared-ui/package.json packages/shared-ui/
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=secret,id=fontawesome_npm_auth_token,env=FONTAWESOME_NPM_AUTH_TOKEN \
+    pnpm install --frozen-lockfile
 
 # Copy source
 COPY packages/shared-ui/ packages/shared-ui/

--- a/services/control-panel/package.json
+++ b/services/control-panel/package.json
@@ -21,7 +21,10 @@
     "@angular/platform-browser": "^20.0.0",
     "@angular/platform-browser-dynamic": "^20.0.0",
     "@angular/router": "^20.0.0",
+    "@awesome.me/kit-9a8becfc3a": "^1.0.2",
     "@bronco/shared-ui": "workspace:*",
+    "@fortawesome/angular-fontawesome": "^3.0.0",
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "marked": "^17.0.5",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
@@ -31,9 +34,9 @@
     "@angular/build": "^20.0.0",
     "@angular/cli": "^20.0.0",
     "@angular/compiler-cli": "^20.0.0",
-    "tailwindcss": "^3.4.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.5.0",
+    "tailwindcss": "^3.4.0",
     "typescript": "~5.8.0"
   }
 }

--- a/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
@@ -12,6 +12,7 @@ import {
   DropdownMenuComponent,
   DropdownItemComponent,
   DialogComponent,
+  IconComponent,
 } from '../../shared/components/index.js';
 
 @Component({
@@ -25,6 +26,7 @@ import {
     DropdownItemComponent,
     DialogComponent,
     NotificationChannelDialogComponent,
+    IconComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -42,12 +44,8 @@ import {
       @if (channels().length === 0 && !loading()) {
         <app-card padding="md" class="empty-card">
           <div class="empty-content">
-            <span class="empty-icon" aria-hidden="true">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
-                <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
-                <line x1="1" y1="1" x2="23" y2="23"/>
-              </svg>
+            <span class="empty-icon">
+              <app-icon name="bell-off" size="xl" />
             </span>
             <div>
               <div class="empty-title">No notification channels configured</div>
@@ -62,17 +60,11 @@ import {
           <app-card padding="md" class="channel-card">
             <div class="channel-header">
               <div class="channel-name">
-                <span class="type-icon" aria-hidden="true">
+                <span class="type-icon">
                   @if (ch.type === 'EMAIL') {
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
-                      <polyline points="22,6 12,13 2,6"/>
-                    </svg>
+                    <app-icon name="email" size="sm" />
                   } @else {
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="5" y="2" width="14" height="20" rx="2" ry="2"/>
-                      <line x1="12" y1="18" x2="12.01" y2="18"/>
-                    </svg>
+                    <app-icon name="bell" size="sm" />
                   }
                 </span>
                 {{ ch.name }}

--- a/services/control-panel/src/app/shared/components/icon-registry.ts
+++ b/services/control-panel/src/app/shared/components/icon-registry.ts
@@ -1,0 +1,186 @@
+// Kit import path discovered from @awesome.me/kit-9a8becfc3a/package.json exports map.
+// The kit contains Pro Sharp Light icons at './icons/sharp/light'.
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  // Editing
+  faPencil,
+  faTrash,
+  faTrashCan,
+  faCopy,
+  faClipboard,
+  // Navigation
+  faChevronUp,
+  faChevronDown,
+  faChevronLeft,
+  faChevronRight,
+  faArrowUp,
+  faArrowDown,
+  faArrowLeft,
+  faArrowRight,
+  faArrowUpRightFromSquare,
+  faHouse,
+  faTurnDownRight,
+  // Status
+  faCheck,
+  faCircleCheck,
+  faXmark,
+  faCircleXmark,
+  faTriangleExclamation,
+  faCircleInfo,
+  faCircleQuestion,
+  faCircle,
+  faCircleDot,
+  // Actions
+  faArrowsRotate,
+  faRotate,
+  faMagnifyingGlass,
+  faFilter,
+  faSort,
+  faPlus,
+  faMinus,
+  faEllipsis,
+  faEllipsisVertical,
+  faSpinner,
+  faPlay,
+  faPause,
+  faStop,
+  // Communication
+  faEnvelope,
+  faComment,
+  faComments,
+  faBell,
+  faBellSlash,
+  // Entities
+  faUser,
+  faRobot,
+  faWrench,
+  faGear,
+  faCloud,
+  faServer,
+  faDatabase,
+  faBook,
+  faFileLines,
+  faFolder,
+  faFolderOpen,
+  // UI affordances
+  faSquareCheck,
+  faSquare,
+  faStar,
+  faSparkles,
+  faBolt,
+  faFlag,
+  faTag,
+  faTags,
+  faLink,
+  faLinkSlash,
+  faLock,
+  faLockOpen,
+  faEye,
+  faEyeSlash,
+  faClock,
+  faCalendar,
+} from '@awesome.me/kit-9a8becfc3a/icons/sharp/light';
+
+/**
+ * Bronco icon registry.
+ *
+ * Import path: @awesome.me/kit-9a8becfc3a/icons/sharp/light
+ * Discovered in Step 3 of the icon system foundation PR (refs #131). The kit
+ * package @awesome.me/kit-9a8becfc3a contains the Pro Sharp Light icons
+ * selected when the kit was created on fontawesome.com.
+ *
+ * Maps semantic Bronco names → FA icon definitions. Consumers reference
+ * icons by semantic name via <app-icon name="edit" />, NEVER by importing
+ * FA icons directly. This isolates the third-party library behind a single
+ * file so swapping libraries later is a one-file change.
+ *
+ * To add a new icon:
+ *   1. Import the fa* symbol from '@awesome.me/kit-9a8becfc3a/icons/sharp/light' above
+ *   2. Add a key to ICON_REGISTRY with a semantic name (kebab-case)
+ *   3. The IconName type updates automatically
+ *
+ * Naming guideline: use semantic intent, not the FA name. faPencil → "edit"
+ * not "pencil". faTrash → "delete" not "trash".
+ */
+export const ICON_REGISTRY = {
+  // Editing
+  edit: faPencil,
+  delete: faTrash,
+  'delete-can': faTrashCan,
+  copy: faCopy,
+  clipboard: faClipboard,
+  // Navigation
+  'chevron-up': faChevronUp,
+  'chevron-down': faChevronDown,
+  'chevron-left': faChevronLeft,
+  'chevron-right': faChevronRight,
+  'arrow-up': faArrowUp,
+  'arrow-down': faArrowDown,
+  'arrow-left': faArrowLeft,
+  'arrow-right': faArrowRight,
+  'external-link': faArrowUpRightFromSquare,
+  back: faArrowLeft,
+  home: faHouse,
+  subdirectory: faTurnDownRight,
+  // Status
+  check: faCheck,
+  'check-circle': faCircleCheck,
+  close: faXmark,
+  'close-circle': faCircleXmark,
+  warning: faTriangleExclamation,
+  info: faCircleInfo,
+  question: faCircleQuestion,
+  pending: faCircle,
+  active: faCircleDot,
+  // Actions
+  refresh: faArrowsRotate,
+  rotate: faRotate,
+  search: faMagnifyingGlass,
+  filter: faFilter,
+  sort: faSort,
+  add: faPlus,
+  remove: faMinus,
+  more: faEllipsis,
+  'more-vertical': faEllipsisVertical,
+  spinner: faSpinner,
+  play: faPlay,
+  pause: faPause,
+  stop: faStop,
+  // Communication
+  email: faEnvelope,
+  comment: faComment,
+  comments: faComments,
+  bell: faBell,
+  'bell-off': faBellSlash,
+  // Entities
+  user: faUser,
+  robot: faRobot,
+  wrench: faWrench,
+  gear: faGear,
+  cloud: faCloud,
+  server: faServer,
+  database: faDatabase,
+  book: faBook,
+  file: faFileLines,
+  folder: faFolder,
+  'folder-open': faFolderOpen,
+  // UI affordances
+  'square-check': faSquareCheck,
+  square: faSquare,
+  star: faStar,
+  sparkles: faSparkles,
+  bolt: faBolt,
+  flag: faFlag,
+  tag: faTag,
+  tags: faTags,
+  link: faLink,
+  'link-broken': faLinkSlash,
+  lock: faLock,
+  unlock: faLockOpen,
+  visible: faEye,
+  hidden: faEyeSlash,
+  clock: faClock,
+  calendar: faCalendar,
+} as const satisfies Record<string, IconDefinition>;
+
+export type IconName = keyof typeof ICON_REGISTRY;

--- a/services/control-panel/src/app/shared/components/icon.component.ts
+++ b/services/control-panel/src/app/shared/components/icon.component.ts
@@ -1,0 +1,63 @@
+import { Component, computed, input } from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ICON_REGISTRY, type IconName } from './icon-registry.js';
+
+export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * Bronco icon component.
+ *
+ * Wraps Font Awesome's <fa-icon> behind a stable, semantic-name API. The
+ * actual icon library (currently FA Pro Sharp Light via @awesome.me kit)
+ * is hidden from consumers — they reference icons by Bronco semantic name
+ * via <app-icon name="edit" />.
+ *
+ * Sizes map to fixed pixel values rather than FA's relative scale, so
+ * icons render consistently regardless of surrounding font size.
+ *
+ * Usage:
+ *   <app-icon name="edit" />
+ *   <app-icon name="chevron-down" size="sm" />
+ *   <app-icon name="warning" size="lg" ariaLabel="Critical alert" />
+ */
+@Component({
+  selector: 'app-icon',
+  standalone: true,
+  imports: [FaIconComponent],
+  template: `
+    <fa-icon
+      class="bronco-icon"
+      [class]="'icon-' + size()"
+      [icon]="iconRef()"
+      [fixedWidth]="fixedWidth()"
+      [attr.aria-hidden]="ariaLabel() ? null : true"
+      [attr.aria-label]="ariaLabel() || null"
+      [attr.role]="ariaLabel() ? 'img' : null" />
+  `,
+  styles: [`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .bronco-icon {
+      color: currentColor;
+      line-height: 1;
+    }
+
+    .icon-xs :is(svg) { width: 10px; height: 10px; }
+    .icon-sm :is(svg) { width: 12px; height: 12px; }
+    .icon-md :is(svg) { width: 16px; height: 16px; }
+    .icon-lg :is(svg) { width: 20px; height: 20px; }
+    .icon-xl :is(svg) { width: 24px; height: 24px; }
+  `],
+})
+export class IconComponent {
+  name = input.required<IconName>();
+  size = input<IconSize>('md');
+  fixedWidth = input<boolean>(false);
+  ariaLabel = input<string>('');
+
+  iconRef = computed(() => ICON_REGISTRY[this.name()]);
+}

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -23,3 +23,5 @@ export {
   DropdownDividerComponent,
   DropdownLabelComponent,
 } from './dropdown-menu.component';
+export { IconComponent, type IconSize } from './icon.component';
+export { ICON_REGISTRY, type IconName } from './icon-registry';

--- a/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
+++ b/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
@@ -1,12 +1,13 @@
 import { Component, input, output, inject } from '@angular/core';
 import { BroncoButtonComponent } from './bronco-button.component.js';
+import { IconComponent } from './index.js';
 import { IntegrationService, type McpDiscoveryMetadata } from '../../core/services/integration.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
   selector: 'app-mcp-server-info',
   standalone: true,
-  imports: [BroncoButtonComponent],
+  imports: [BroncoButtonComponent, IconComponent],
   template: `
     <div class="mcp-info">
       <!-- Server identity -->
@@ -33,11 +34,8 @@ import { ToastService } from '../../core/services/toast.service';
       <!-- Endpoint -->
       @if (endpoint()) {
         <div class="endpoint-row" [attr.title]="endpoint()!" [attr.aria-label]="'Endpoint: ' + endpoint()!">
-          <span class="small-icon" aria-hidden="true">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
-              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
-            </svg>
+          <span class="small-icon">
+            <app-icon name="link" size="sm" />
           </span>
           <code>{{ truncate(endpoint()!, 50) }}</code>
         </div>
@@ -94,7 +92,7 @@ import { ToastService } from '../../core/services/toast.service';
             @if (verifying) {
               <span class="spinner" aria-hidden="true"></span>
             } @else {
-              <span aria-hidden="true">&#x21BB;</span>
+              <app-icon name="refresh" size="sm" />
             }
             Verify
           </app-bronco-button>


### PR DESCRIPTION
## Summary

Lays the foundation for a unified icon system in the Bronco control panel using Font Awesome Pro Sharp Light, delivered via a Pro Kit npm package and wrapped behind a custom `<app-icon>` Bronco component.

This is **Phase 1 of 2**:
- Phase 1 (this PR): install + wrapper + registry + 2 pilot conversions to validate the system
- Phase 2 (separate PR): mechanical sweep across the remaining ~29 files containing ad-hoc Unicode glyphs and inline SVGs

## Why

The control panel's UX redesign migrated off Material's `mat-icon` and replaced icons with a mix of HTML entity glyphs (`&#x270E;`), Unicode escapes (`\u23F6`), and inline SVGs. The result works but is visually inconsistent — different stroke weights, alignment, and styles depending on the file. This PR establishes the canonical pattern for fixing it.

## Changes

### Foundation
- Add `.npmrc` at the repo root with FA Pro registry config (both `@awesome.me` and `@fortawesome` scopes mapped to `npm.fontawesome.com`, with the auth token sourced from `${FONTAWESOME_NPM_AUTH_TOKEN}`)
- Install `@fortawesome/angular-fontawesome`, `@fortawesome/fontawesome-svg-core`, and `@awesome.me/kit-9a8becfc3a` (the bronco Pro Kit, contains Sharp Light icons)
- Create `IconComponent` (`<app-icon name="..." size="..." />`) — wraps `fa-icon` and hides Font Awesome from consumers, so swapping the icon library later is a single-file change
- Create `ICON_REGISTRY` (`icon-registry.ts`) — maps ~80 semantic Bronco icon names to FA `IconDefinition` references, imported from `@awesome.me/kit-9a8becfc3a/icons/sharp/light` (the kit's discovered export path)
- Five fixed pixel sizes (xs/sm/md/lg/xl) for visual consistency
- Inherits color via `currentColor` for theme compatibility across all 6 themes
- A11y: decorative by default (`aria-hidden`), opt-in `role="img"` via `ariaLabel`

### Pilot conversions
- `services/control-panel/src/app/shared/components/mcp-server-info.component.ts` — replaces 2 inline SVGs (link, refresh) with `<app-icon>`
- `services/control-panel/src/app/features/notification-channels/notification-channels.component.ts` — replaces 3 inline SVGs (bell-off for empty state, email and bell for channel types)

### CI/Docker plumbing
- `.github/workflows/ci.yml` — pass `FONTAWESOME_NPM_AUTH_TOKEN` env var on the install step so the GitHub Actions runner can fetch FA Pro packages
- `services/control-panel/Dockerfile` — mount the secret into both `pnpm install` RUN steps via BuildKit secret mounts (`--mount=type=secret,id=fontawesome_npm_auth_token,env=...`) so the token is available at install time but never lands in an image layer
- `.github/workflows/deploy-hugo.yml` — pass the secret to `docker/build-push-action` so BuildKit can forward it into the Dockerfile mount

The repo secret `FONTAWESOME_NPM_AUTH_TOKEN` is already configured in GitHub Actions.

## Why kit-based instead of standard `@fortawesome/sharp-light-svg-icons`

- Tree-shakable to only the icons selected when the kit was created on fontawesome.com (smaller bundle)
- Single package to update when adding/removing icons (regenerate the kit)
- Font Awesome's recommended pattern for AI-agent-driven projects per docs.fontawesome.com/web/use-with/ai-agent-tools

## Operational notes for future Claude Code sessions

Two things tripped us up during foundation development that are now documented in user-global CLAUDE.md and project memory:

1. **`npm.fontawesome.com` redirects to `dl.fontawesome.com`** for actual package downloads. If you only allowlist `npm.fontawesome.com` in the Claude Code cloud sandbox network policy, the redirect target gets blocked and you see a misleading 403 that looks like a token problem. Allowlist BOTH hosts.
2. **The Package Token is distinct from the API Token** in the Font Awesome account UI. They're both UUIDs but have different scopes — the API Token will 403 against `npm.fontawesome.com`. Use the one labeled "Package Token" under the Tokens tab.

## Test plan

- [x] `pnpm install` succeeds with the FA token in the env (verified locally and in remote session)
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @bronco/control-panel build` passes
- [x] `git grep "@angular/material" services/control-panel/src/` still returns zero (foundation didn't reintroduce any)
- [ ] Manual: open a ticket with the dev server, scroll to the MCP server info component, verify the link/refresh icons render correctly
- [ ] Manual: open the Notification Channels page, verify the email/bell icons render in the channel cards
- [ ] Manual: test in 2 themes (Apple light + a dark theme like Linear) to confirm `currentColor` inheritance works

## Follow-up

The Phase 2 sweep PR will replace ad-hoc glyphs across the remaining ~29 files using the same `ICON_REGISTRY` pattern. Prompt is already drafted and queued.

Refs #131.
