### PR TITLE
Post-release cleanup: dialog/select fixes, system editing, Copilot review, deploy-hugo fix

### DIFF
--- a/services/control-panel/Dockerfile
+++ b/services/control-panel/Dockerfile
@@ -5,8 +5,10 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy workspace config (including .npmrc — required so pnpm knows the
+# @awesome.me / @fortawesome scopes resolve to npm.fontawesome.com instead
+# of registry.npmjs.org).
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY services/control-panel/package.json services/control-panel/
 COPY packages/shared-ui/package.json packages/shared-ui/
 
@@ -28,8 +30,10 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 WORKDIR /app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy workspace config (including .npmrc — required so pnpm knows the
+# @awesome.me / @fortawesome scopes resolve to npm.fontawesome.com instead
+# of registry.npmjs.org).
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY services/ticket-portal/package.json services/ticket-portal/
 COPY packages/shared-ui/package.json packages/shared-ui/
 

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -55,6 +55,10 @@ export class DetailPanelService {
       this.entityType.set(type);
       this.entityId.set(params.detail);
       this.mode.set(mode);
+    } else {
+      // No detail param in URL → clear any in-memory panel state so the URL
+      // remains the source of truth (covers back/forward and direct nav).
+      this.dismiss();
     }
   }
 }

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
@@ -14,7 +14,7 @@ import {
 import { McpServerInfoComponent } from '../../../../shared/components/mcp-server-info.component';
 import { IntegrationDialogComponent } from '../../../integrations/integration-dialog.component';
 
-const SENSITIVE_KEYS = ['encryptedPassword', 'encryptedPat', 'password', 'pat', 'token', 'secret', 'apiKey'];
+const SENSITIVE_KEYS = ['encryptedpassword', 'encryptedpat', 'password', 'pat', 'token', 'secret', 'apikey'];
 
 @Component({
   selector: 'app-client-integrations-tab',
@@ -243,10 +243,30 @@ export class ClientIntegrationsTabComponent implements OnInit {
   }
 
   redactConfig(config: Record<string, unknown>): Record<string, unknown> {
-    const redacted: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(config)) {
-      redacted[key] = SENSITIVE_KEYS.includes(key) ? '********' : value;
+    return this.redactValue(config) as Record<string, unknown>;
+  }
+
+  /**
+   * Recursively walks an arbitrary value and redacts any field whose key
+   * (compared case-insensitively) appears in `SENSITIVE_KEYS`. Handles nested
+   * objects and arrays so secrets buried in nested integration configs aren't
+   * accidentally rendered in the JSON preview.
+   */
+  private redactValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map(v => this.redactValue(v));
     }
-    return redacted;
+    if (value !== null && typeof value === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+        if (SENSITIVE_KEYS.includes(key.toLowerCase())) {
+          out[key] = '********';
+        } else {
+          out[key] = this.redactValue(v);
+        }
+      }
+      return out;
+    }
+    return value;
   }
 }

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
@@ -30,7 +30,8 @@ import { SystemDialogComponent } from '../../../systems/system-dialog.component'
       <app-data-table
         [data]="systems()"
         [trackBy]="trackById"
-        [rowClickable]="false"
+        [rowClickable]="true"
+        (rowClick)="editSystem($event)"
         emptyMessage="No systems configured.">
         <app-data-column key="name" header="Name" [sortable]="false">
           <ng-template #cell let-s>{{ s.name }}</ng-template>
@@ -59,11 +60,16 @@ import { SystemDialogComponent } from '../../../systems/system-dialog.component'
     </div>
 
     @if (showDialog()) {
-      <app-dialog [open]="true" title="Add Database System" maxWidth="600px" (openChange)="showDialog.set(false)">
+      <app-dialog
+        [open]="true"
+        [title]="editingSystem() ? 'Edit Database System' : 'Add Database System'"
+        maxWidth="600px"
+        (openChange)="closeDialog()">
         <app-system-dialog-content
           [clientId]="clientId()"
+          [system]="editingSystem() ?? undefined"
           (saved)="onSaved()"
-          (cancelled)="showDialog.set(false)" />
+          (cancelled)="closeDialog()" />
       </app-dialog>
     }
   `,
@@ -130,6 +136,7 @@ export class ClientSystemsTabComponent implements OnInit {
 
   systems = signal<System[]>([]);
   showDialog = signal(false);
+  editingSystem = signal<System | null>(null);
 
   trackById = (s: System): string => s.id;
 
@@ -144,11 +151,22 @@ export class ClientSystemsTabComponent implements OnInit {
   }
 
   openDialog(): void {
+    this.editingSystem.set(null);
     this.showDialog.set(true);
   }
 
-  onSaved(): void {
+  editSystem(system: System): void {
+    this.editingSystem.set(system);
+    this.showDialog.set(true);
+  }
+
+  closeDialog(): void {
     this.showDialog.set(false);
+    this.editingSystem.set(null);
+  }
+
+  onSaved(): void {
+    this.closeDialog();
     this.load();
   }
 }

--- a/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/mcp-tool-visibility-dialog.component.ts
@@ -71,9 +71,15 @@ export class McpToolVisibilityDialogComponent implements OnInit {
   }
 
   enabledToolOptions(): Array<{ value: string; label: string }> {
-    return this.tools()
-      .filter(t => !this.disabledTools.has(t.name))
-      .map(t => ({ value: t.name, label: t.description ? `${t.name} — ${t.description}` : t.name }));
+    // Prepend an empty placeholder so the select reads as "nothing chosen"
+    // when toolToDisable is ''. Without this, the native <select> falls back
+    // to displaying the first option visually even though no option matches.
+    return [
+      { value: '', label: '— Select a tool —' },
+      ...this.tools()
+        .filter(t => !this.disabledTools.has(t.name))
+        .map(t => ({ value: t.name, label: t.description ? `${t.name} — ${t.description}` : t.name })),
+    ];
   }
 
   enable(name: string): void {
@@ -89,6 +95,8 @@ export class McpToolVisibilityDialogComponent implements OnInit {
   }
 
   apply(): void {
-    this.applied.emit(this.disabledTools);
+    // Emit a defensive copy so the receiver can't accidentally mutate this
+    // dialog's internal Set after the event handler runs.
+    this.applied.emit(new Set(this.disabledTools));
   }
 }

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RepoService, type CodeRepo } from '../../core/services/repo.service';
-import { ToastService } from '../../core/services/toast.service';
+import { RepoService, type CodeRepo } from '../../core/services/repo.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/systems/system-dialog.component.ts
+++ b/services/control-panel/src/app/features/systems/system-dialog.component.ts
@@ -1,6 +1,7 @@
-import { Component, inject, input, output } from '@angular/core';
+import { Component, inject, input, OnInit, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SystemService } from '../../core/services/system.service';
+import { System } from '../../core/services/client.service';
 import { ToastService } from '../../core/services/toast.service';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
@@ -74,7 +75,9 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
 
     <div class="dialog-actions" dialogFooter>
       <app-bronco-button variant="ghost" (click)="cancelled.emit()">Cancel</app-bronco-button>
-      <app-bronco-button variant="primary" [disabled]="!form.name || !form.host || form.port < 1 || form.port > 65535" (click)="save()">Create</app-bronco-button>
+      <app-bronco-button variant="primary" [disabled]="!form.name || !form.host || form.port < 1 || form.port > 65535" (click)="save()">
+        {{ editing ? 'Save' : 'Create' }}
+      </app-bronco-button>
     </div>
   `,
   styles: [`
@@ -84,14 +87,17 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class SystemDialogComponent {
+export class SystemDialogComponent implements OnInit {
   private systemService = inject(SystemService);
   private toast = inject(ToastService);
 
   clientId = input.required<string>();
+  system = input<System | undefined>(undefined);
 
   saved = output<boolean>();
   cancelled = output<void>();
+
+  editing = false;
 
   engineOptions = [
     { value: 'MSSQL', label: 'MSSQL' },
@@ -125,9 +131,26 @@ export class SystemDialogComponent {
     notes: '',
   };
 
+  ngOnInit(): void {
+    const sys = this.system();
+    if (sys) {
+      this.editing = true;
+      this.form = {
+        name: sys.name,
+        dbEngine: sys.dbEngine,
+        host: sys.host,
+        port: sys.port,
+        username: sys.username ?? '',
+        defaultDatabase: sys.defaultDatabase ?? '',
+        environment: sys.environment,
+        authMethod: sys.authMethod,
+        notes: sys.notes ?? '',
+      };
+    }
+  }
+
   save(): void {
-    this.systemService.createSystem({
-      clientId: this.clientId(),
+    const payload = {
       name: this.form.name,
       host: this.form.host,
       port: this.form.port,
@@ -137,12 +160,28 @@ export class SystemDialogComponent {
       environment: this.form.environment,
       authMethod: this.form.authMethod,
       notes: this.form.notes || undefined,
-    } as never).subscribe({
-      next: () => {
-        this.toast.success('System created');
-        this.saved.emit(true);
-      },
-      error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
-    });
+    };
+
+    const sys = this.system();
+    if (this.editing && sys) {
+      this.systemService.updateSystem(sys.id, payload as never).subscribe({
+        next: () => {
+          this.toast.success('System updated');
+          this.saved.emit(true);
+        },
+        error: (err) => this.toast.error(err.error?.error ?? 'Update failed'),
+      });
+    } else {
+      this.systemService.createSystem({
+        clientId: this.clientId(),
+        ...payload,
+      } as never).subscribe({
+        next: () => {
+          this.toast.success('System created');
+          this.saved.emit(true);
+        },
+        error: (err) => this.toast.error(err.error?.error ?? 'Failed'),
+      });
+    }
   }
 }

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -44,6 +44,9 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
       border-radius: var(--radius-lg);
       box-shadow: var(--shadow-card);
       width: 100%;
+      max-height: calc(100vh - 48px);
+      display: flex;
+      flex-direction: column;
       overflow: hidden;
       animation: scaleIn 150ms ease;
     }
@@ -54,6 +57,7 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
       justify-content: space-between;
       padding: 16px 20px;
       border-bottom: 1px solid var(--border-light);
+      flex-shrink: 0;
     }
 
     .dialog-title {
@@ -86,6 +90,9 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
 
     .dialog-body {
       padding: 20px;
+      overflow-y: auto;
+      flex: 1 1 auto;
+      min-height: 0;
     }
 
     @keyframes fadeIn {

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -20,12 +20,11 @@ let standaloneSelectCounter = 0;
     <select
       class="select-input"
       [id]="resolvedId()"
-      [value]="value()"
       [disabled]="disabled()"
       [attr.aria-label]="ariaLabel() || null"
       (change)="onChange($event)">
       @for (opt of options(); track opt.value) {
-        <option [value]="opt.value">{{ opt.label }}</option>
+        <option [value]="opt.value" [attr.selected]="opt.value === value() ? '' : null">{{ opt.label }}</option>
       }
     </select>
   `,


### PR DESCRIPTION
## Summary

Post-release cleanup batch off `staging`. Bundles four logical fixes:

1. **Misc dialog/select polish.** `app-dialog` is now scrollable for
   tall content (was clipping at viewport height). `app-select` binds
   value via `[attr.selected]` on each `<option>` instead of `[value]`
   on the parent `<select>` — the old binding evaluated before child
   `<option>`s rendered, so the integration edit dialog displayed
   "IMAP (Email)" and "Authorization: Bearer" regardless of the
   persisted value. The MCP tool visibility dialog now has an explicit
   empty placeholder option (so the picker reads as empty rather than
   showing the first tool) and emits a defensive copy of `disabledTools`.

2. **Edit existing database systems.** The new client-detail Systems
   tab had no edit affordance — only "+ Add System". Make rows
   clickable, add a `system` input + edit mode to `system-dialog`, and
   wire `updateSystem` through.

3. **Three of six Copilot review items from #183.** `.js` import
   extensions in `repo-dialog`, `restoreFromUrl` clears panel state when
   the URL has no `detail` param, recursive case-insensitive secret
   redaction in the integration config preview. Three remaining items
   are intentionally not addressed — see thread replies for the
   single-operator-private-project rationale.

4. **Fix the deploy-hugo failure that fired on the v0.1.0 tag push.**
   The control-panel Dockerfile was missing `COPY .npmrc` so pnpm
   inside the build couldn't resolve the `@awesome.me` Font Awesome
   scope and 404'd against npmjs.org. Add it to both build stages.

## Test plan

- [ ] Open the integration edit dialog for an MCP_DATABASE integration
      and confirm Type, Auth Header, and the Manage Tools "Disable a
      tool" picker all show the correct (or empty) value
- [ ] Open a tall dialog and verify the body scrolls
- [ ] Click a row in the client Systems tab and edit a system
- [ ] After merge to staging, push a fresh tag and verify deploy-hugo
      succeeds (or watch the next master release auto-deploy cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
