### PR TITLE
feat: add parent/child lineage to ticket conversation events (refs #187)

### DIFF
--- a/packages/ai-provider/src/factory.ts
+++ b/packages/ai-provider/src/factory.ts
@@ -230,10 +230,13 @@ export function createAIRouter(
   const usageWriter = async (entry: AiUsageEntry): Promise<string | undefined> => {
     if (!dbReady) return undefined;
     // Prisma JSON fields need undefined (not null) for "no value" — strip null conversationMetadata
-    const { conversationMetadata, ...rest } = entry;
-    const data = conversationMetadata != null
-      ? { ...rest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
-      : rest;
+    const { conversationMetadata, logId, ...rest } = entry;
+    const data = {
+      ...(logId ? { id: logId } : {}),
+      ...(conversationMetadata != null
+        ? { ...rest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
+        : rest),
+    };
     const row = await db.aiUsageLog.create({ data: data as Record<string, unknown> });
     return row.id;
   };

--- a/packages/ai-provider/src/router.ts
+++ b/packages/ai-provider/src/router.ts
@@ -228,7 +228,7 @@ export class AIRouter {
       this.usageWriter({
         ...(request.context?.logId ? { logId: request.context.logId as string } : {}),
         ...(request.context?.parentLogId ? { parentLogId: request.context.parentLogId as string } : {}),
-        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as string } : {}),
+        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as 'ai' | 'app' } : {}),
         provider: response.provider,
         model: response.model,
         taskType: request.taskType,
@@ -389,7 +389,7 @@ export class AIRouter {
       this.usageWriter({
         ...(request.context?.logId ? { logId: request.context.logId as string } : {}),
         ...(request.context?.parentLogId ? { parentLogId: request.context.parentLogId as string } : {}),
-        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as string } : {}),
+        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as 'ai' | 'app' } : {}),
         provider: response.provider,
         model: response.model,
         taskType: request.taskType,

--- a/packages/ai-provider/src/router.ts
+++ b/packages/ai-provider/src/router.ts
@@ -226,6 +226,9 @@ export class AIRouter {
       const billingMode = !usedExplicitOverride && cachedAiMode === 'byok' ? 'byok' : 'platform';
       const archiveWriter = this.archiveWriter;
       this.usageWriter({
+        ...(request.context?.logId ? { logId: request.context.logId as string } : {}),
+        ...(request.context?.parentLogId ? { parentLogId: request.context.parentLogId as string } : {}),
+        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as string } : {}),
         provider: response.provider,
         model: response.model,
         taskType: request.taskType,
@@ -384,6 +387,9 @@ export class AIRouter {
       const toolPromptText = finalRequest.prompt ?? extractLastUserMessage(finalRequest.messages);
       const archiveWriter = this.archiveWriter;
       this.usageWriter({
+        ...(request.context?.logId ? { logId: request.context.logId as string } : {}),
+        ...(request.context?.parentLogId ? { parentLogId: request.context.parentLogId as string } : {}),
+        ...(request.context?.parentLogType ? { parentLogType: request.context.parentLogType as string } : {}),
         provider: response.provider,
         model: response.model,
         taskType: request.taskType,

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -13,6 +13,9 @@ export interface AIProviderClient {
 
 /** Entry written to persistent storage for every AI generation call. */
 export interface AiUsageEntry {
+  logId?: string;         // Pre-generated UUID for this entry's row ID
+  parentLogId?: string;   // FK to parent log entry
+  parentLogType?: string; // 'ai' | 'app'
   provider: string;
   model: string;
   taskType: string;

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -15,7 +15,7 @@ export interface AIProviderClient {
 export interface AiUsageEntry {
   logId?: string;         // Pre-generated UUID for this entry's row ID
   parentLogId?: string;   // FK to parent log entry
-  parentLogType?: string; // 'ai' | 'app'
+  parentLogType?: 'ai' | 'app';
   provider: string;
   model: string;
   taskType: string;

--- a/packages/db/prisma/migrations/20260409010000_add_parent_log_lineage/migration.sql
+++ b/packages/db/prisma/migrations/20260409010000_add_parent_log_lineage/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "app_logs" ADD COLUMN "parent_log_id" UUID,
+ADD COLUMN "parent_log_type" TEXT;
+
+-- AlterTable
+ALTER TABLE "ai_usage_logs" ADD COLUMN "parent_log_id" UUID,
+ADD COLUMN "parent_log_type" TEXT;
+
+-- CreateIndex
+CREATE INDEX "app_logs_parent_log_id_idx" ON "app_logs"("parent_log_id");
+
+-- CreateIndex
+CREATE INDEX "ai_usage_logs_parent_log_id_idx" ON "ai_usage_logs"("parent_log_id");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -640,20 +640,23 @@ model ClientIntegration {
 // --- Application Logs ---
 
 model AppLog {
-  id         String   @id @default(uuid()) @db.Uuid
-  level      LogLevel
-  service    String
-  message    String
-  context    Json?
-  entityId   String?  @map("entity_id") @db.Uuid
-  entityType String?  @map("entity_type") // e.g. "ticket" or "operational_task"
-  error      String?
-  createdAt  DateTime @default(now()) @map("created_at")
+  id            String   @id @default(uuid()) @db.Uuid
+  level         LogLevel
+  service       String
+  message       String
+  context       Json?
+  entityId      String?  @map("entity_id") @db.Uuid
+  entityType    String?  @map("entity_type") // e.g. "ticket" or "operational_task"
+  error         String?
+  parentLogId   String?  @map("parent_log_id") @db.Uuid
+  parentLogType String?  @map("parent_log_type")
+  createdAt     DateTime @default(now()) @map("created_at")
 
   @@index([service, createdAt])
   @@index([level, createdAt])
   @@index([entityId, entityType])
   @@index([createdAt])
+  @@index([parentLogId])
   @@map("app_logs")
 }
 
@@ -699,6 +702,8 @@ model AiUsageLog {
   systemPrompt          String?  @map("system_prompt") @db.Text
   responseText          String?  @map("response_text") @db.Text
   conversationMetadata  Json?    @map("conversation_metadata")
+  parentLogId   String?  @map("parent_log_id") @db.Uuid
+  parentLogType String?  @map("parent_log_type")
   createdAt    DateTime @default(now()) @map("created_at")
 
   archive AiPromptArchive?
@@ -708,6 +713,7 @@ model AiUsageLog {
   @@index([clientId])
   @@index([createdAt])
   @@index([taskType])
+  @@index([parentLogId])
   @@map("ai_usage_logs")
 }
 

--- a/packages/shared-utils/src/app-logger.ts
+++ b/packages/shared-utils/src/app-logger.ts
@@ -183,7 +183,7 @@ export class AppLogger {
 export function createPrismaLogWriter(db: any): AppLogWriter {
   return async (entry: AppLogEntry) => {
     const parentLogId = (entry.context?.parentLogId as string) ?? undefined;
-    const parentLogType = (entry.context?.parentLogType as string) ?? undefined;
+    const parentLogType = (entry.context?.parentLogType as 'ai' | 'app') ?? undefined;
     await db.appLog.create({
       data: {
         level: entry.level,

--- a/packages/shared-utils/src/app-logger.ts
+++ b/packages/shared-utils/src/app-logger.ts
@@ -182,6 +182,8 @@ export class AppLogger {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createPrismaLogWriter(db: any): AppLogWriter {
   return async (entry: AppLogEntry) => {
+    const parentLogId = (entry.context?.parentLogId as string) ?? undefined;
+    const parentLogType = (entry.context?.parentLogType as string) ?? undefined;
     await db.appLog.create({
       data: {
         level: entry.level,
@@ -191,6 +193,8 @@ export function createPrismaLogWriter(db: any): AppLogWriter {
         entityId: entry.entityId ?? undefined,
         entityType: entry.entityType ?? undefined,
         error: entry.error ?? undefined,
+        ...(parentLogId ? { parentLogId } : {}),
+        ...(parentLogType ? { parentLogType } : {}),
       },
     });
   };

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -139,6 +139,9 @@ export interface UnifiedLogEntry {
   systemPrompt?: string | null;
   responseText?: string | null;
   conversationMetadata?: Record<string, unknown> | null;
+  // lineage fields
+  parentLogId?: string | null;
+  parentLogType?: string | null;
   archive?: UnifiedLogArchive | null;
 }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -490,6 +490,11 @@
 .conv-collapse-btn:hover {
   color: var(--color-purple);
 }
+.conv-collapse-btn:focus-visible {
+  outline: 2px solid var(--color-purple);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 .conv-tool-node {
   display: flex;
   align-items: center;

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -479,24 +479,46 @@
 .conv-tree-node {
   transition: margin-left 0.15s ease;
 }
-.conv-tree-toggle {
+.conv-collapse-btn {
+  all: unset;
   cursor: pointer;
   color: var(--color-muted);
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
 }
-.conv-tree-toggle:hover {
+.conv-collapse-btn:hover {
   color: var(--color-purple);
 }
-.conv-tool-block {
+.conv-tool-node {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   border-left: 2px solid var(--color-muted);
   background: var(--color-surface-raised);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   padding: 4px 10px;
   margin-bottom: 6px;
-}
-.conv-tool-name {
   font-size: 12px;
-  color: var(--color-muted);
+  color: var(--text-secondary);
+}
+.conv-tool-node.conv-tool-error {
+  border-left-color: var(--color-error);
+}
+.conv-tool-icon {
+  flex-shrink: 0;
+}
+.conv-tool-msg {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.conv-tool-dur {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-size: 11px;
 }
 .conv-ai-header {
   display: flex;

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -476,6 +476,28 @@
   font-size: 14px;
   color: var(--color-purple);
 }
+.conv-tree-node {
+  transition: margin-left 0.15s ease;
+}
+.conv-tree-toggle {
+  cursor: pointer;
+  color: var(--color-muted);
+  flex-shrink: 0;
+}
+.conv-tree-toggle:hover {
+  color: var(--color-purple);
+}
+.conv-tool-block {
+  border-left: 2px solid var(--color-muted);
+  background: var(--color-surface-raised);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: 4px 10px;
+  margin-bottom: 6px;
+}
+.conv-tool-name {
+  font-size: 12px;
+  color: var(--color-muted);
+}
 .conv-ai-header {
   display: flex;
   align-items: center;

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -45,6 +45,7 @@ interface ConvTreeNode {
   entry: UnifiedLogEntry;
   children: ConvTreeNode[];
   depth: number;
+  collapsed: boolean;
 }
 
 @Component({
@@ -385,73 +386,72 @@ interface ConvTreeNode {
             } @else if (conversationEntries().length === 0) {
               <div class="conv-empty"><p>No AI calls recorded for this ticket.</p></div>
             } @else if (hasLineageData()) {
-              <!-- Tree view: entries with parentLogId lineage -->
+              <!-- Tree view — new data with parentLogId lineage -->
               <div class="conv-view">
-                @for (node of flattenTree(convTreeRoots()); track node.entry.id) {
-                  <div class="conv-tree-node" [style.margin-left.px]="node.depth * 24">
-                    @if (node.entry.type === 'ai') {
-                      <div class="conv-ai-block">
-                        <div class="conv-ai-header">
-                          @if (hasChildren(node.entry.id)) {
-                            <app-icon [name]="convCollapsed[node.entry.id] ? 'chevron-right' : 'chevron-down'" size="xs" class="conv-tree-toggle" (click)="toggleTreeCollapse(node.entry.id)" />
+                @for (item of convTreeFlat(); track item.node.entry.id) {
+                  @if (item.visible) {
+                    @let entry = item.node.entry;
+                    @let node = item.node;
+                    <div class="conv-tree-node" [style.margin-left.px]="node.depth * 24">
+                      @if (entry.type === 'ai') {
+                        <div class="conv-ai-block">
+                          <div class="conv-ai-header">
+                            @if (node.children.length > 0) {
+                              <button class="conv-collapse-btn" (click)="toggleConvNode(node)" [attr.title]="node.collapsed ? 'Expand' : 'Collapse'">
+                                <app-icon [name]="node.collapsed ? 'chevron-right' : 'chevron-down'" size="xs" />
+                              </button>
+                            }
+                            @if (node.depth > 0) { <app-icon name="subdirectory" size="xs" class="subtask-icon" /> }
+                            <span class="conv-task-type">{{ entry.taskType }}</span>
+                            <span class="conv-model">{{ entry.model }}</span>
+                            <span class="conv-tokens">{{ entry.inputTokens | number }}in / {{ entry.outputTokens | number }}out</span>
+                            @if (entry.costUsd != null) { <span class="conv-cost">\${{ entry.costUsd | number:'1.4-4' }}</span> }
+                          </div>
+                          @if (convMessages(entry).length > 0) {
+                            <div class="conv-turns">
+                              @for (turn of convMessages(entry); track $index) {
+                                <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
+                                  <app-icon [name]="turn.role === 'user' ? 'user' : 'robot'" size="xs" class="conv-turn-role" />
+                                  @if (turn.toolName) { <span class="conv-tool-call"><app-icon name="wrench" size="xs" /> {{ turn.toolName }}</span> }
+                                  @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
+                                </div>
+                              }
+                            </div>
                           }
-                          @if (node.depth > 0) { <app-icon name="subdirectory" size="xs" class="subtask-icon" /> }
-                          <span class="conv-task-type">{{ node.entry.taskType }}</span>
-                          <span class="conv-model">{{ node.entry.model }}</span>
-                          <span class="conv-tokens">{{ node.entry.inputTokens | number }}in / {{ node.entry.outputTokens | number }}out</span>
-                          @if (node.entry.costUsd != null) { <span class="conv-cost">\${{ node.entry.costUsd | number:'1.4-4' }}</span> }
+                          @if (entry.archive?.fullPrompt || entry.promptText) {
+                            <div class="conv-final-response conv-prompt-block">
+                              <span class="conv-final-label">Prompt</span>
+                              <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[entry.id]">{{ convPromptText(entry) }}</pre>
+                              @if (isMultilineConvPrompt(entry)) {
+                                <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[entry.id] = !convPromptExpanded[entry.id]">
+                                  {{ convPromptExpanded[entry.id] ? 'less' : 'more' }}
+                                  <app-icon [name]="convPromptExpanded[entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
+                                </app-bronco-button>
+                              }
+                            </div>
+                          }
+                          @if (entry.archive?.fullResponse || entry.responseText) {
+                            <div class="conv-final-response">
+                              <span class="conv-final-label">Response</span>
+                              <pre class="conv-response-text" [class.clamped]="!convExpanded[entry.id]">{{ convResponseText(entry) }}</pre>
+                              @if (isMultilineConv(entry)) {
+                                <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[entry.id] = !convExpanded[entry.id]">
+                                  {{ convExpanded[entry.id] ? 'less' : 'more' }}
+                                  <app-icon [name]="convExpanded[entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
+                                </app-bronco-button>
+                              }
+                            </div>
+                          }
                         </div>
-                        @if (convMessages(node.entry).length > 0) {
-                          <div class="conv-turns">
-                            @for (turn of convMessages(node.entry); track $index) {
-                              <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
-                                <app-icon [name]="turn.role === 'user' ? 'user' : 'robot'" size="xs" class="conv-turn-role" />
-                                @if (turn.toolName) { <span class="conv-tool-call"><app-icon name="wrench" size="xs" /> {{ turn.toolName }}</span> }
-                                @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
-                              </div>
-                            }
-                          </div>
-                        }
-                        @if (node.entry.archive?.fullPrompt || node.entry.promptText) {
-                          <div class="conv-final-response conv-prompt-block">
-                            <span class="conv-final-label">Prompt</span>
-                            <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[node.entry.id]">{{ convPromptText(node.entry) }}</pre>
-                            @if (isMultilineConvPrompt(node.entry)) {
-                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[node.entry.id] = !convPromptExpanded[node.entry.id]">
-                                {{ convPromptExpanded[node.entry.id] ? 'less' : 'more' }}
-                                <app-icon [name]="convPromptExpanded[node.entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
-                              </app-bronco-button>
-                            }
-                          </div>
-                        }
-                        @if (node.entry.archive?.fullResponse || node.entry.responseText) {
-                          <div class="conv-final-response">
-                            <span class="conv-final-label">Response</span>
-                            <pre class="conv-response-text" [class.clamped]="!convExpanded[node.entry.id]">{{ convResponseText(node.entry) }}</pre>
-                            @if (isMultilineConv(node.entry)) {
-                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[node.entry.id] = !convExpanded[node.entry.id]">
-                                {{ convExpanded[node.entry.id] ? 'less' : 'more' }}
-                                <app-icon [name]="convExpanded[node.entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
-                              </app-bronco-button>
-                            }
-                          </div>
-                        }
-                      </div>
-                    } @else if (node.entry.type === 'tool') {
-                      <div class="conv-tool-block">
-                        <div class="conv-ai-header">
-                          @if (node.depth > 0) { <app-icon name="subdirectory" size="xs" class="subtask-icon" /> }
-                          <app-icon name="wrench" size="xs" />
-                          <span class="conv-tool-name">{{ node.entry.message }}</span>
+                      } @else if (entry.type === 'tool' || entry.type === 'log' || entry.type === 'step' || entry.type === 'error') {
+                        <div class="conv-tool-node" [class.conv-tool-error]="entry.type === 'error'">
+                          <app-icon [name]="entry.type === 'error' ? 'close' : entry.type === 'step' ? 'pending' : 'wrench'" size="xs" class="conv-tool-icon" />
+                          <span class="conv-tool-msg">{{ entry.message }}</span>
+                          @if (entry.durationMs != null) { <span class="conv-tool-dur">{{ entry.durationMs }}ms</span> }
                         </div>
-                      </div>
-                    } @else if (node.entry.type === 'step') {
-                      <div class="conv-step-label">
-                        <app-icon [name]="node.entry.message?.toLowerCase()?.includes('completed') ? 'check' : node.entry.message?.toLowerCase()?.includes('failed') ? 'close' : 'pending'" size="xs" class="conv-step-icon" />
-                        {{ node.entry.message }}
-                      </div>
-                    }
-                  </div>
+                      }
+                    </div>
+                  }
                 }
               </div>
             } @else {
@@ -706,9 +706,23 @@ export class TicketDetailComponent implements OnInit {
   convUngrouped = signal<UnifiedLogEntry[]>([]);
   convExpanded: Record<string, boolean> = {};
   convPromptExpanded: Record<string, boolean> = {};
-  convCollapsed: Record<string, boolean> = {};
-  convTreeRoots = signal<ConvTreeNode[]>([]);
+  convTree = signal<ConvTreeNode[]>([]);
   hasLineageData = signal(false);
+
+  /** Pre-flattened tree with visibility tracking — cached via computed signal. */
+  convTreeFlat = computed<Array<{ node: ConvTreeNode; visible: boolean }>>(() => {
+    const result: Array<{ node: ConvTreeNode; visible: boolean }> = [];
+    const flatten = (nodes: ConvTreeNode[], parentVisible: boolean) => {
+      for (const node of nodes) {
+        result.push({ node, visible: parentVisible });
+        if (node.children.length > 0) {
+          flatten(node.children, parentVisible && !node.collapsed);
+        }
+      }
+    };
+    flatten(this.convTree(), true);
+    return result;
+  });
 
   // Tab tracking
   selectedTabIndex = signal(0);
@@ -1099,7 +1113,7 @@ export class TicketDetailComponent implements OnInit {
     const hasLineage = entries.some(e => !!e.parentLogId);
     this.hasLineageData.set(hasLineage);
     if (hasLineage) {
-      this.convTreeRoots.set(this.buildConvTree(entries));
+      this.convTree.set(this.buildConvTree(entries));
     }
   }
 
@@ -1153,7 +1167,7 @@ export class TicketDetailComponent implements OnInit {
 
     // Create nodes
     for (const entry of entries) {
-      nodeMap.set(entry.id, { entry, children: [], depth: 0 });
+      nodeMap.set(entry.id, { entry, children: [], depth: 0, collapsed: false });
     }
 
     // Link parents
@@ -1180,36 +1194,9 @@ export class TicketDetailComponent implements OnInit {
     return roots;
   }
 
-  /** Flatten a tree into a list with depth info for template rendering. */
-  flattenTree(nodes: ConvTreeNode[]): ConvTreeNode[] {
-    const result: ConvTreeNode[] = [];
-    const walk = (list: ConvTreeNode[]): void => {
-      for (const node of list) {
-        result.push(node);
-        if (!this.convCollapsed[node.entry.id] && node.children.length > 0) {
-          walk(node.children);
-        }
-      }
-    };
-    walk(nodes);
-    return result;
-  }
-
-  toggleTreeCollapse(entryId: string): void {
-    this.convCollapsed[entryId] = !this.convCollapsed[entryId];
-  }
-
-  hasChildren(entryId: string): boolean {
-    const findNode = (nodes: ConvTreeNode[]): ConvTreeNode | undefined => {
-      for (const n of nodes) {
-        if (n.entry.id === entryId) return n;
-        const found = findNode(n.children);
-        if (found) return found;
-      }
-      return undefined;
-    };
-    const node = findNode(this.convTreeRoots());
-    return !!node && node.children.length > 0;
+  toggleConvNode(node: ConvTreeNode): void {
+    node.collapsed = !node.collapsed;
+    this.convTree.set([...this.convTree()]);
   }
 
   convMessages(entry: UnifiedLogEntry): Array<{ role: string; tokenCount?: number; toolName?: string }> {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -41,6 +41,12 @@ interface StepGroup {
   expanded: boolean;
 }
 
+interface ConvTreeNode {
+  entry: UnifiedLogEntry;
+  children: ConvTreeNode[];
+  depth: number;
+}
+
 @Component({
   standalone: true,
   imports: [
@@ -378,7 +384,78 @@ interface StepGroup {
               </div>
             } @else if (conversationEntries().length === 0) {
               <div class="conv-empty"><p>No AI calls recorded for this ticket.</p></div>
+            } @else if (hasLineageData()) {
+              <!-- Tree view: entries with parentLogId lineage -->
+              <div class="conv-view">
+                @for (node of flattenTree(convTreeRoots()); track node.entry.id) {
+                  <div class="conv-tree-node" [style.margin-left.px]="node.depth * 24">
+                    @if (node.entry.type === 'ai') {
+                      <div class="conv-ai-block">
+                        <div class="conv-ai-header">
+                          @if (hasChildren(node.entry.id)) {
+                            <app-icon [name]="convCollapsed[node.entry.id] ? 'chevron-right' : 'chevron-down'" size="xs" class="conv-tree-toggle" (click)="toggleTreeCollapse(node.entry.id)" />
+                          }
+                          @if (node.depth > 0) { <app-icon name="subdirectory" size="xs" class="subtask-icon" /> }
+                          <span class="conv-task-type">{{ node.entry.taskType }}</span>
+                          <span class="conv-model">{{ node.entry.model }}</span>
+                          <span class="conv-tokens">{{ node.entry.inputTokens | number }}in / {{ node.entry.outputTokens | number }}out</span>
+                          @if (node.entry.costUsd != null) { <span class="conv-cost">\${{ node.entry.costUsd | number:'1.4-4' }}</span> }
+                        </div>
+                        @if (convMessages(node.entry).length > 0) {
+                          <div class="conv-turns">
+                            @for (turn of convMessages(node.entry); track $index) {
+                              <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
+                                <app-icon [name]="turn.role === 'user' ? 'user' : 'robot'" size="xs" class="conv-turn-role" />
+                                @if (turn.toolName) { <span class="conv-tool-call"><app-icon name="wrench" size="xs" /> {{ turn.toolName }}</span> }
+                                @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
+                              </div>
+                            }
+                          </div>
+                        }
+                        @if (node.entry.archive?.fullPrompt || node.entry.promptText) {
+                          <div class="conv-final-response conv-prompt-block">
+                            <span class="conv-final-label">Prompt</span>
+                            <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[node.entry.id]">{{ convPromptText(node.entry) }}</pre>
+                            @if (isMultilineConvPrompt(node.entry)) {
+                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[node.entry.id] = !convPromptExpanded[node.entry.id]">
+                                {{ convPromptExpanded[node.entry.id] ? 'less' : 'more' }}
+                                <app-icon [name]="convPromptExpanded[node.entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
+                              </app-bronco-button>
+                            }
+                          </div>
+                        }
+                        @if (node.entry.archive?.fullResponse || node.entry.responseText) {
+                          <div class="conv-final-response">
+                            <span class="conv-final-label">Response</span>
+                            <pre class="conv-response-text" [class.clamped]="!convExpanded[node.entry.id]">{{ convResponseText(node.entry) }}</pre>
+                            @if (isMultilineConv(node.entry)) {
+                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[node.entry.id] = !convExpanded[node.entry.id]">
+                                {{ convExpanded[node.entry.id] ? 'less' : 'more' }}
+                                <app-icon [name]="convExpanded[node.entry.id] ? 'chevron-up' : 'chevron-down'" size="xs" />
+                              </app-bronco-button>
+                            }
+                          </div>
+                        }
+                      </div>
+                    } @else if (node.entry.type === 'tool') {
+                      <div class="conv-tool-block">
+                        <div class="conv-ai-header">
+                          @if (node.depth > 0) { <app-icon name="subdirectory" size="xs" class="subtask-icon" /> }
+                          <app-icon name="wrench" size="xs" />
+                          <span class="conv-tool-name">{{ node.entry.message }}</span>
+                        </div>
+                      </div>
+                    } @else if (node.entry.type === 'step') {
+                      <div class="conv-step-label">
+                        <app-icon [name]="node.entry.message?.toLowerCase()?.includes('completed') ? 'check' : node.entry.message?.toLowerCase()?.includes('failed') ? 'close' : 'pending'" size="xs" class="conv-step-icon" />
+                        {{ node.entry.message }}
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
             } @else {
+              <!-- Legacy view: flat grouping by step + orchestrationId -->
               <div class="conv-view">
                 @for (group of convStepGroups(); track $index) {
                   <div class="conv-step-section">
@@ -629,6 +706,9 @@ export class TicketDetailComponent implements OnInit {
   convUngrouped = signal<UnifiedLogEntry[]>([]);
   convExpanded: Record<string, boolean> = {};
   convPromptExpanded: Record<string, boolean> = {};
+  convCollapsed: Record<string, boolean> = {};
+  convTreeRoots = signal<ConvTreeNode[]>([]);
+  hasLineageData = signal(false);
 
   // Tab tracking
   selectedTabIndex = signal(0);
@@ -1014,6 +1094,13 @@ export class TicketDetailComponent implements OnInit {
     const { groups, ungrouped } = this.buildGroups(entries);
     this.convStepGroups.set(groups);
     this.convUngrouped.set(ungrouped);
+
+    // Build lineage tree if any entry has parentLogId
+    const hasLineage = entries.some(e => !!e.parentLogId);
+    this.hasLineageData.set(hasLineage);
+    if (hasLineage) {
+      this.convTreeRoots.set(this.buildConvTree(entries));
+    }
   }
 
   loadConversationEntries(): void {
@@ -1057,6 +1144,72 @@ export class TicketDetailComponent implements OnInit {
     return entries.filter(e =>
       e.type === 'ai' && this.isSubTask(e) && this.getOrchestrationId(e) === orchestrationId
     );
+  }
+
+  /** Build a tree from parentLogId relationships. Returns root nodes. */
+  private buildConvTree(entries: UnifiedLogEntry[]): ConvTreeNode[] {
+    const nodeMap = new Map<string, ConvTreeNode>();
+    const roots: ConvTreeNode[] = [];
+
+    // Create nodes
+    for (const entry of entries) {
+      nodeMap.set(entry.id, { entry, children: [], depth: 0 });
+    }
+
+    // Link parents
+    for (const entry of entries) {
+      const node = nodeMap.get(entry.id)!;
+      if (entry.parentLogId && nodeMap.has(entry.parentLogId)) {
+        const parent = nodeMap.get(entry.parentLogId)!;
+        parent.children.push(node);
+        node.depth = parent.depth + 1;
+      } else {
+        roots.push(node);
+      }
+    }
+
+    // Propagate depths (parents may have been processed after children)
+    const setDepths = (node: ConvTreeNode, depth: number): void => {
+      node.depth = depth;
+      for (const child of node.children) {
+        setDepths(child, depth + 1);
+      }
+    };
+    for (const root of roots) setDepths(root, 0);
+
+    return roots;
+  }
+
+  /** Flatten a tree into a list with depth info for template rendering. */
+  flattenTree(nodes: ConvTreeNode[]): ConvTreeNode[] {
+    const result: ConvTreeNode[] = [];
+    const walk = (list: ConvTreeNode[]): void => {
+      for (const node of list) {
+        result.push(node);
+        if (!this.convCollapsed[node.entry.id] && node.children.length > 0) {
+          walk(node.children);
+        }
+      }
+    };
+    walk(nodes);
+    return result;
+  }
+
+  toggleTreeCollapse(entryId: string): void {
+    this.convCollapsed[entryId] = !this.convCollapsed[entryId];
+  }
+
+  hasChildren(entryId: string): boolean {
+    const findNode = (nodes: ConvTreeNode[]): ConvTreeNode | undefined => {
+      for (const n of nodes) {
+        if (n.entry.id === entryId) return n;
+        const found = findNode(n.children);
+        if (found) return found;
+      }
+      return undefined;
+    };
+    const node = findNode(this.convTreeRoots());
+    return !!node && node.children.length > 0;
   }
 
   convMessages(entry: UnifiedLogEntry): Array<{ role: string; tokenCount?: number; toolName?: string }> {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -397,7 +397,7 @@ interface ConvTreeNode {
                         <div class="conv-ai-block">
                           <div class="conv-ai-header">
                             @if (node.children.length > 0) {
-                              <button class="conv-collapse-btn" (click)="toggleConvNode(node)" [attr.title]="node.collapsed ? 'Expand' : 'Collapse'">
+                              <button type="button" class="conv-collapse-btn" (click)="toggleConvNode(node)" [attr.aria-label]="node.collapsed ? 'Expand' : 'Collapse'" [attr.aria-expanded]="!node.collapsed">
                                 <app-icon [name]="node.collapsed ? 'chevron-right' : 'chevron-down'" size="xs" />
                               </button>
                             }

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -690,6 +690,8 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       systemPrompt?: string | null;
       responseText?: string | null;
       conversationMetadata?: unknown;
+      parentLogId?: string | null;
+      parentLogType?: string | null;
       archive?: {
         fullPrompt: string;
         fullResponse: string;
@@ -724,6 +726,8 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         message: log.message,
         context: log.context,
         error: log.error,
+        parentLogId: log.parentLogId ?? null,
+        parentLogType: log.parentLogType ?? null,
       });
     }
 
@@ -744,6 +748,8 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         systemPrompt: ai.systemPrompt,
         responseText: ai.responseText,
         conversationMetadata: ai.conversationMetadata,
+        parentLogId: ai.parentLogId ?? null,
+        parentLogType: ai.parentLogType ?? null,
         archive: (ai as unknown as { archive?: UnifiedEntry['archive'] }).archive ?? null,
       });
     }

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -2040,7 +2040,7 @@ async function executeOrchestratedSubTask(
   agenticTools: AIToolDefinition[],
   mcpIntegrations: Map<string, McpIntegrationInfo>,
   repoIdByPrefix: Map<string, string>,
-  orchestration?: { id: string; iteration: number },
+  orchestration?: { id: string; iteration: number; parentLogId?: string },
   modelMap?: Record<string, string>,
 ): Promise<SubTaskResult> {
   const { ai } = deps;
@@ -2105,7 +2105,10 @@ async function executeOrchestratedSubTask(
     let hasToolError = false;
 
     if (tools.length > 0) {
-      const orchCtx = orchestration ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true } : {};
+      const subTaskLogId = randomUUID();
+      const orchCtx = orchestration
+        ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true, logId: subTaskLogId, ...(orchestration.parentLogId ? { parentLogId: orchestration.parentLogId, parentLogType: 'ai' } : {}) }
+        : { logId: subTaskLogId };
       const response = await ai.generateWithTools({
         taskType: TaskType.DEEP_ANALYSIS,
         context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
@@ -2154,11 +2157,32 @@ async function executeOrchestratedSubTask(
             });
           }
           if (result.isError) hasToolError = true;
+
+          // Write AppLog so tool calls appear in the conversation tree
+          appLog.info(
+            `Orchestrated tool call: ${toolUse.name} (${elapsed}ms)`,
+            {
+              ticketId,
+              tool: toolUse.name,
+              durationMs: elapsed,
+              params: toolUse.input ? JSON.stringify(toolUse.input).slice(0, 1000) : null,
+              resultPreview: result.result?.slice(0, 500) ?? null,
+              isError: result.isError ?? false,
+              parentLogId: subTaskLogId,
+              parentLogType: 'ai',
+            },
+            ticketId,
+            'ticket',
+          );
         }
 
+        const summaryLogId = randomUUID();
+        const summaryOrchCtx = orchestration
+          ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true, logId: summaryLogId, parentLogId: subTaskLogId, parentLogType: 'ai' }
+          : { logId: summaryLogId, parentLogId: subTaskLogId, parentLogType: 'ai' };
         const summaryResponse = await ai.generateWithTools({
           taskType: TaskType.DEEP_ANALYSIS,
-          context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
+          context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...summaryOrchCtx },
           messages: [
             { role: 'user', content: task.prompt },
             { role: 'assistant', content: response.contentBlocks },
@@ -2204,7 +2228,10 @@ async function executeOrchestratedSubTask(
     }
 
     // No tools — pure analysis
-    const orchCtx = orchestration ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true } : {};
+    const pureLogId = randomUUID();
+    const orchCtx = orchestration
+      ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true, logId: pureLogId, ...(orchestration.parentLogId ? { parentLogId: orchestration.parentLogId, parentLogType: 'ai' } : {}) }
+      : { logId: pureLogId };
     const response = await ai.generate({
       taskType: TaskType.DEEP_ANALYSIS,
       context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, ...orchCtx },
@@ -2998,9 +3025,10 @@ async function executeRoutePipeline(
               strategistPrompt = `Continue the investigation. Here is the knowledge document so far:\n\n${currentRunContent}\n\n## Next Investigation Step\n${orchNextPrompt}`;
             }
 
+            const strategistLogId = randomUUID();
             const strategistResponse = await ai.generate({
               taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
-              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1 },
+              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1, logId: strategistLogId },
               prompt: strategistPrompt,
               systemPrompt: ORCHESTRATED_SYSTEM_PROMPT,
               providerOverride: 'CLAUDE',
@@ -3034,7 +3062,7 @@ async function executeRoutePipeline(
             const taskBatches = chunkArray(plan.tasks, maxParallelTasks);
             for (const batch of taskBatches) {
               const results = await Promise.allSettled(
-                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1 }, orchModelMap)),
+                batch.map(task => executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId }, orchModelMap)),
               );
 
               for (let j = 0; j < results.length; j++) {
@@ -3048,7 +3076,7 @@ async function executeRoutePipeline(
                 } else {
                   // Retry once on failure
                   try {
-                    const retryResult = await executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix);
+                    const retryResult = await executeOrchestratedSubTask(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId }, orchModelMap);
                     knowledgeDoc += `\n\n#### ${task.prompt} (retry)\n${retryResult.content}`;
                     orchTotalInputTokens += retryResult.inputTokens;
                     orchTotalOutputTokens += retryResult.outputTokens;
@@ -3196,8 +3224,10 @@ async function executeRoutePipeline(
 
         let finalAnalysis = '';
         let iterationsRun = 0;
+        let previousAiCallId: string | undefined;
         for (let i = 0; i < maxIterations; i++) {
           iterationsRun = i + 1;
+          const aiCallId = randomUUID();
           appLog.info(`Agentic analysis iteration ${i + 1}/${maxIterations}`, { ticketId, iteration: i + 1 }, ticketId, 'ticket');
 
           let response: AIToolResponse;
@@ -3207,7 +3237,7 @@ async function executeRoutePipeline(
               systemPrompt: agenticSystemPrompt,
               tools: agenticTools,
               messages,
-              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!(clientContext || environmentContext) },
+              context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!(clientContext || environmentContext), logId: aiCallId, ...(previousAiCallId ? { parentLogId: previousAiCallId, parentLogType: 'ai' } : {}) },
               maxTokens: 4096,
             });
           } catch (error) {
@@ -3303,6 +3333,8 @@ async function executeRoutePipeline(
                 params: toolUse.input ? JSON.stringify(toolUse.input).slice(0, 1000) : null,
                 resultPreview: result.result?.slice(0, 2000) ?? null,
                 isError: result.isError ?? false,
+                parentLogId: aiCallId,
+                parentLogType: 'ai',
               },
               ticketId,
               'ticket',
@@ -3311,6 +3343,7 @@ async function executeRoutePipeline(
 
           // Append tool results as user message
           messages.push({ role: 'user', content: toolResults as AIToolResultBlock[] });
+          previousAiCallId = aiCallId;
         }
 
         if (!finalAnalysis) {


### PR DESCRIPTION
## Summary

Adds parent/child lineage tracking to ticket conversation events so the conversation tab renders a proper tree instead of a flat chronological list.

- Add `parentLogId` / `parentLogType` columns to both `AiUsageLog` and `AppLog` tables with indexes
- Thread pre-generated `logId` UUIDs through the AI router so callers can reference log entries as parents without awaiting the fire-and-forget writer
- Full-context agentic loop: each tool call AppLog is parented to the AI call that requested it, each AI iteration chains to the previous
- Orchestrated analysis: sub-task AI calls parent to the strategist, tool calls now write AppLog entries (previously invisible in the conversation view)
- Fix retry bug: orchestration context + model map now passed on sub-task retry (was missing both)
- Unified-logs API returns `parentLogId` / `parentLogType` on every entry
- Frontend conversation tab builds a collapsible tree from lineage data, with cached computed signal for flattening (best of Sonnet perf approach + Opus correctness)
- Old data without `parentLogId` renders using legacy flat grouping

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] Run Prisma migration on Hugo: `npx prisma migrate deploy`
- [ ] Trigger a fresh agentic analysis on a test ticket
- [ ] Verify conversation tab renders tree with nested tool calls under AI calls
- [ ] Verify collapse/expand works on tree nodes
- [ ] Verify old tickets (no lineage data) still render with legacy flat view

Refs #187.

Generated with [Claude Code](https://claude.com/claude-code)
