### PR TITLE
fix: cleanup batch — select binding, maxTokens guard, dead code, system edit, category backfill (fixes #190, fixes #203, fixes #202, fixes #201, fixes #200, fixes #199)

### DIFF
--- a/packages/ai-provider/src/factory.ts
+++ b/packages/ai-provider/src/factory.ts
@@ -101,6 +101,11 @@ export interface AIRouterDb {
 export interface CreateAIRouterConfig {
   /** Encryption key for decrypting API keys stored in the DB. */
   encryptionKey: string;
+  /**
+   * Optional loader for the global default maxTokens (AnalysisStrategy.defaultMaxTokens).
+   * Used as the final fallback in the maxTokens resolution chain.
+   */
+  defaultMaxTokensLoader?: () => Promise<number | undefined>;
 }
 
 /**
@@ -324,6 +329,7 @@ export function createAIRouter(
     costLookup,
     byokCredentialResolver,
     clientAiModeResolver,
+    defaultMaxTokensLoader: config.defaultMaxTokensLoader,
   });
 
   return {

--- a/packages/ai-provider/src/router.ts
+++ b/packages/ai-provider/src/router.ts
@@ -165,7 +165,7 @@ export class AIRouter {
       }
     }
 
-    // Resolve model config for maxTokens fallback (DB config → prompt config → request)
+    // maxTokens resolution: request (highest priority, already applied) → DB per-task model config → global default loader
     if (!finalRequest.maxTokens && this.modelConfigResolver) {
       const modelConfig = await this.modelConfigResolver.resolve(finalRequest.taskType, clientId);
       if (modelConfig.maxTokens) {
@@ -310,7 +310,7 @@ export class AIRouter {
       }
     }
 
-    // Resolve model config for maxTokens fallback (DB config → prompt config → request)
+    // maxTokens resolution: request (highest priority, already applied) → DB per-task model config → global default loader
     if (!finalRequest.maxTokens && this.modelConfigResolver) {
       const modelConfig = await this.modelConfigResolver.resolve(finalRequest.taskType, clientId);
       if (modelConfig.maxTokens) {

--- a/packages/ai-provider/src/router.ts
+++ b/packages/ai-provider/src/router.ts
@@ -105,6 +105,7 @@ export class AIRouter {
   private costLookup: AiCostLookup | undefined;
   private byokCredentialResolver: ((clientId: string, provider: string) => Promise<string | null>) | undefined;
   private clientAiModeResolver: ((clientId: string) => Promise<string | null>) | undefined;
+  private defaultMaxTokensLoader: (() => Promise<number | undefined>) | undefined;
 
   /** Cache of provider instances keyed by provider, model, baseUrl, and a hash of the apiKey (see getOrCreateProvider()). */
   private providerCache = new Map<string, AIProviderClient>();
@@ -119,6 +120,7 @@ export class AIRouter {
     this.costLookup = config.costLookup;
     this.byokCredentialResolver = config.byokCredentialResolver;
     this.clientAiModeResolver = config.clientAiModeResolver;
+    this.defaultMaxTokensLoader = config.defaultMaxTokensLoader;
   }
 
   async generate(request: AIRequest): Promise<AIResponse> {
@@ -168,6 +170,14 @@ export class AIRouter {
       const modelConfig = await this.modelConfigResolver.resolve(finalRequest.taskType, clientId);
       if (modelConfig.maxTokens) {
         finalRequest = { ...finalRequest, maxTokens: modelConfig.maxTokens };
+      }
+    }
+
+    // Global default fallback (AnalysisStrategy.defaultMaxTokens)
+    if (!finalRequest.maxTokens && this.defaultMaxTokensLoader) {
+      const globalDefault = await this.defaultMaxTokensLoader();
+      if (globalDefault) {
+        finalRequest = { ...finalRequest, maxTokens: globalDefault };
       }
     }
 
@@ -297,6 +307,22 @@ export class AIRouter {
         finalRequest.systemPrompt = finalRequest.systemPrompt
           ? `${finalRequest.systemPrompt}\n\n${memory.content}`
           : memory.content;
+      }
+    }
+
+    // Resolve model config for maxTokens fallback (DB config → prompt config → request)
+    if (!finalRequest.maxTokens && this.modelConfigResolver) {
+      const modelConfig = await this.modelConfigResolver.resolve(finalRequest.taskType, clientId);
+      if (modelConfig.maxTokens) {
+        finalRequest.maxTokens = modelConfig.maxTokens;
+      }
+    }
+
+    // Global default fallback (AnalysisStrategy.defaultMaxTokens)
+    if (!finalRequest.maxTokens && this.defaultMaxTokensLoader) {
+      const globalDefault = await this.defaultMaxTokensLoader();
+      if (globalDefault) {
+        finalRequest.maxTokens = globalDefault;
       }
     }
 

--- a/packages/ai-provider/src/types.ts
+++ b/packages/ai-provider/src/types.ts
@@ -84,4 +84,10 @@ export interface AIRouterConfig {
   byokCredentialResolver?: (clientId: string, provider: string) => Promise<string | null>;
   /** Optional resolver that returns the client's aiMode ('platform' | 'byok'). */
   clientAiModeResolver?: (clientId: string) => Promise<string | null>;
+  /**
+   * Optional loader for the global default maxTokens (AnalysisStrategy.defaultMaxTokens).
+   * Used as the final fallback in the maxTokens resolution chain, after request,
+   * prompt-resolved, and per-task/client AiModelConfig values.
+   */
+  defaultMaxTokensLoader?: () => Promise<number | undefined>;
 }

--- a/packages/db/prisma/migrations/20260411010000_backfill_general_category/migration.sql
+++ b/packages/db/prisma/migrations/20260411010000_backfill_general_category/migration.sql
@@ -1,0 +1,3 @@
+-- Backfill NULL ticket categories with GENERAL so that every ticket has a
+-- category and statistics/group-bys don't silently drop uncategorized rows.
+UPDATE "tickets" SET "category" = 'GENERAL' WHERE "category" IS NULL;

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
@@ -30,7 +30,8 @@ import { SystemDialogComponent } from '../../../systems/system-dialog.component'
       <app-data-table
         [data]="systems()"
         [trackBy]="trackById"
-        [rowClickable]="false"
+        [rowClickable]="true"
+        (rowClick)="editSystem($event)"
         emptyMessage="No systems configured.">
         <app-data-column key="name" header="Name" [sortable]="false">
           <ng-template #cell let-s>{{ s.name }}</ng-template>
@@ -59,9 +60,10 @@ import { SystemDialogComponent } from '../../../systems/system-dialog.component'
     </div>
 
     @if (showDialog()) {
-      <app-dialog [open]="true" title="Add Database System" maxWidth="600px" (openChange)="showDialog.set(false)">
+      <app-dialog [open]="true" [title]="editingSystem() ? 'Edit Database System' : 'Add Database System'" maxWidth="600px" (openChange)="showDialog.set(false)">
         <app-system-dialog-content
           [clientId]="clientId()"
+          [system]="editingSystem()"
           (saved)="onSaved()"
           (cancelled)="showDialog.set(false)" />
       </app-dialog>
@@ -130,6 +132,7 @@ export class ClientSystemsTabComponent implements OnInit {
 
   systems = signal<System[]>([]);
   showDialog = signal(false);
+  editingSystem = signal<System | undefined>(undefined);
 
   trackById = (s: System): string => s.id;
 
@@ -144,6 +147,12 @@ export class ClientSystemsTabComponent implements OnInit {
   }
 
   openDialog(): void {
+    this.editingSystem.set(undefined);
+    this.showDialog.set(true);
+  }
+
+  editSystem(system: System): void {
+    this.editingSystem.set(system);
     this.showDialog.set(true);
   }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -407,7 +407,7 @@ interface ConvTreeNode {
               </div>
             } @else if (conversationEntries().length === 0) {
               <div class="conv-empty"><p>No AI calls recorded for this ticket.</p></div>
-            } @else if (hasLineageData()) {
+            } @else if (hasTreeData()) {
               <!-- Tree view — new data with parentLogId lineage -->
               <div class="conv-view">
                 @for (item of convTreeFlat(); track item.node.entry.id) {
@@ -477,79 +477,8 @@ interface ConvTreeNode {
                 }
               </div>
             } @else {
-              <!-- Legacy view: flat grouping by step + orchestrationId -->
+              <!-- Legacy flat view: step groups + orchestrationId fallback -->
               <div class="conv-view">
-                @if (hasTreeData()) {
-                <!-- Tree view: entries linked by parentLogId -->
-                @for (node of flattenTree(convTreeRoots()); track node.entry.id) {
-                  <div class="conv-tree-node" [style.padding-left.px]="node.depth * 20">
-                    @if (node.entry.type === 'ai') {
-                      <div class="conv-ai-block">
-                        <div class="conv-ai-header">
-                          @if (node.children.length > 0) {
-                            <button class="conv-collapse-btn" (click)="toggleCollapse(node.entry.id)" [attr.aria-expanded]="!isCollapsed(node.entry.id)">
-                              {{ isCollapsed(node.entry.id) ? '\u25B6' : '\u25BC' }}
-                            </button>
-                          }
-                          <span class="conv-task-type">{{ node.entry.taskType }}</span>
-                          <span class="conv-model">{{ node.entry.model }}</span>
-                          <span class="conv-tokens">{{ node.entry.inputTokens | number }}in / {{ node.entry.outputTokens | number }}out</span>
-                          @if (node.entry.costUsd != null) { <span class="conv-cost">\${{ node.entry.costUsd | number:'1.4-4' }}</span> }
-                          @if (node.children.length > 0) { <span class="conv-child-count">({{ node.children.length }})</span> }
-                        </div>
-                        @if (convMessages(node.entry).length > 0) {
-                          <div class="conv-turns">
-                            @for (turn of convMessages(node.entry); track $index) {
-                              <div class="conv-turn" [ngClass]="'conv-turn-' + turn.role">
-                                <span class="conv-turn-role">{{ turn.role === 'user' ? '\u{1F464}' : '\u{1F916}' }}</span>
-                                @if (turn.toolName) { <span class="conv-tool-call">\u{1F527} {{ turn.toolName }}</span> }
-                                @if (turn.tokenCount) { <span class="conv-token-count">{{ turn.tokenCount | number }} tokens</span> }
-                              </div>
-                            }
-                          </div>
-                        }
-                        @if (node.entry.archive?.fullPrompt || node.entry.promptText) {
-                          <div class="conv-final-response conv-prompt-block">
-                            <span class="conv-final-label">Prompt</span>
-                            <pre class="conv-response-text" [class.clamped]="!convPromptExpanded[node.entry.id]">{{ convPromptText(node.entry) }}</pre>
-                            @if (isMultilineConvPrompt(node.entry)) {
-                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convPromptExpanded[node.entry.id] = !convPromptExpanded[node.entry.id]">
-                                {{ convPromptExpanded[node.entry.id] ? 'less' : 'more' }}
-                                <span aria-hidden="true">{{ convPromptExpanded[node.entry.id] ? '\u23F6' : '\u23F7' }}</span>
-                              </app-bronco-button>
-                            }
-                          </div>
-                        }
-                        @if (node.entry.archive?.fullResponse || node.entry.responseText) {
-                          <div class="conv-final-response">
-                            <span class="conv-final-label">Response</span>
-                            <pre class="conv-response-text" [class.clamped]="!convExpanded[node.entry.id]">{{ convResponseText(node.entry) }}</pre>
-                            @if (isMultilineConv(node.entry)) {
-                              <app-bronco-button variant="ghost" size="sm" class="inline-expand-btn" (click)="convExpanded[node.entry.id] = !convExpanded[node.entry.id]">
-                                {{ convExpanded[node.entry.id] ? 'less' : 'more' }}
-                                <span aria-hidden="true">{{ convExpanded[node.entry.id] ? '\u23F6' : '\u23F7' }}</span>
-                              </app-bronco-button>
-                            }
-                          </div>
-                        }
-                      </div>
-                    } @else if (node.entry.type === 'tool') {
-                      <div class="conv-tool-entry">
-                        <span class="conv-tool-icon" aria-hidden="true">\u{1F527}</span>
-                        <span class="conv-tool-msg">{{ node.entry.message }}</span>
-                        @if (node.entry.context?.['artifactId']) {
-                          <a class="artifact-link" [href]="ticketService.getArtifactDownloadUrl('' + node.entry.context!['artifactId'])" download>&#x2B73; Full output</a>
-                        }
-                      </div>
-                    } @else {
-                      <div class="conv-log-entry conv-log-{{ node.entry.level?.toLowerCase() ?? 'info' }}">
-                        <span class="conv-log-msg">{{ node.entry.message }}</span>
-                      </div>
-                    }
-                  </div>
-                }
-                } @else {
-                <!-- Legacy flat view: step groups + orchestration fallback -->
                 @for (group of convStepGroups(); track $index) {
                   <div class="conv-step-section">
                     <div class="conv-step-label">
@@ -690,7 +619,6 @@ interface ConvTreeNode {
                     </div>
                   }
                 }
-                }
               </div>
             }
             }
@@ -821,7 +749,6 @@ export class TicketDetailComponent implements OnInit {
   convUngrouped = signal<UnifiedLogEntry[]>([]);
   convExpanded: Record<string, boolean> = {};
   convPromptExpanded: Record<string, boolean> = {};
-  convCollapsed: Record<string, boolean> = {};
   convTreeRoots = signal<ConvTreeNode[]>([]);
   convTreeFlat = computed<Array<{ node: ConvTreeNode; visible: boolean }>>(() => {
     const result: Array<{ node: ConvTreeNode; visible: boolean }> = [];
@@ -1268,32 +1195,6 @@ export class TicketDetailComponent implements OnInit {
 
   hasTreeData(): boolean {
     return this.conversationEntries().some(e => !!e.parentLogId);
-  }
-
-  hasLineageData(): boolean {
-    return this.hasTreeData();
-  }
-
-  toggleCollapse(id: string): void {
-    this.convCollapsed[id] = !this.convCollapsed[id];
-  }
-
-  isCollapsed(id: string): boolean {
-    return !!this.convCollapsed[id];
-  }
-
-  flattenTree(roots: ConvTreeNode[]): ConvTreeNode[] {
-    const result: ConvTreeNode[] = [];
-    const walk = (nodes: ConvTreeNode[]) => {
-      for (const node of nodes) {
-        result.push(node);
-        if (!this.isCollapsed(node.entry.id)) {
-          walk(node.children);
-        }
-      }
-    };
-    walk(roots);
-    return result;
   }
 
   loadConversationEntries(): void {

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -24,7 +24,7 @@ let standaloneSelectCounter = 0;
       [attr.aria-label]="ariaLabel() || null"
       (change)="onChange($event)">
       @for (opt of options(); track opt.value) {
-        <option [value]="opt.value" [attr.selected]="opt.value === value() ? '' : null">{{ opt.label }}</option>
+        <option [value]="opt.value" [selected]="opt.value === value()">{{ opt.label }}</option>
       }
     </select>
   `,

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -2125,7 +2125,7 @@ async function executeOrchestratedSubTask(
         systemPrompt: subTaskSystemPrompt,
         providerOverride: 'CLAUDE',
         modelOverride: model,
-        maxTokens: defaultMaxTokens,
+        maxTokens: defaultMaxTokens ?? 4096,
       });
 
       passInput += response.usage?.inputTokens ?? 0;
@@ -2201,7 +2201,7 @@ async function executeOrchestratedSubTask(
           systemPrompt: 'Summarize the tool results into a structured finding. Do not call additional tools.',
           providerOverride: 'CLAUDE',
           modelOverride: model,
-          maxTokens: defaultMaxTokens,
+          maxTokens: defaultMaxTokens ?? 4096,
         });
 
         passInput += summaryResponse.usage?.inputTokens ?? 0;
@@ -3045,7 +3045,7 @@ async function executeRoutePipeline(
               systemPrompt: ORCHESTRATED_SYSTEM_PROMPT,
               providerOverride: 'CLAUDE',
               modelOverride: 'claude-opus-4-6',
-              maxTokens: defaultMaxTokens,
+              maxTokens: defaultMaxTokens ?? 4096,
             });
 
             orchTotalInputTokens += strategistResponse.usage?.inputTokens ?? 0;
@@ -3258,7 +3258,7 @@ async function executeRoutePipeline(
               tools: agenticTools,
               messages,
               context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!(clientContext || environmentContext), logId: aiCallId, ...(previousAiCallId ? { parentLogId: previousAiCallId, parentLogType: 'ai' as const } : {}) },
-              maxTokens: defaultMaxTokens,
+              maxTokens: defaultMaxTokens ?? 4096,
             });
           } catch (error) {
             if (error instanceof Error && /tool/i.test(error.message) && /support/i.test(error.message)) {

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -15,11 +15,20 @@ const appLog = new AppLogger('ticket-analyzer');
 
 const ANALYSIS_STRATEGY_KEY = 'system-config-analysis-strategy';
 
+let maxTokensCache: { value: number | undefined; expiresAt: number } | null = null;
+const MAX_TOKENS_CACHE_TTL_MS = 60_000; // 1 minute
+
 async function loadDefaultMaxTokens(db: import('@bronco/db').PrismaClient): Promise<number | undefined> {
+  const now = Date.now();
+  if (maxTokensCache && now < maxTokensCache.expiresAt) {
+    return maxTokensCache.value;
+  }
   try {
     const row = await db.appSetting.findUnique({ where: { key: ANALYSIS_STRATEGY_KEY } });
     const val = (row?.value as Record<string, unknown> | null)?.['defaultMaxTokens'];
-    return typeof val === 'number' && val > 0 ? val : undefined;
+    const result = typeof val === 'number' && val > 0 ? val : undefined;
+    maxTokensCache = { value: result, expiresAt: now + MAX_TOKENS_CACHE_TTL_MS };
+    return result;
   } catch {
     return undefined;
   }

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -63,6 +63,7 @@ async function main(): Promise<void> {
   // --- AI router (DB-backed provider config) ---
   const { ai, clientMemoryResolver } = createAIRouter(db, {
     encryptionKey: config.ENCRYPTION_KEY,
+    defaultMaxTokensLoader: () => loadDefaultMaxTokens(db),
   });
 
   // --- Queues ---


### PR DESCRIPTION
- SelectComponent: [attr.selected] → [selected] property binding (#190)
- analyzer: restore maxTokens ?? 4096 fallback for sub-task calls (#203)
- ticket-detail: remove unreachable flattenTree path and duplicate collapse mechanism (#202)
- systems-tab: restore row click → edit system dialog flow (#201)
- AIRouter: thread defaultMaxTokens global fallback into generate() (#200)
- Prisma migration: backfill NULL category → GENERAL (#199)
- Verified #182 already fixed (fence stripping in parseAiResponse)