### PR TITLE
feat: RBAC with scoped control panel and notification routing (fixes #196, fixes #206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,11 +295,13 @@ This applies to both automated reviewers (Copilot) and human reviewers. The goal
 
 ## Build and Test
 
+**Build order matters.** On a fresh checkout (or after `pnpm clean`), you MUST run `pnpm build` BEFORE `pnpm typecheck`. Workspace packages like `ai-provider`, `shared-utils`, and the services depend on the compiled `.d.ts` outputs of `shared-types` and `shared-utils`. Running `pnpm typecheck` first will fail with errors like `Cannot find module '@bronco/shared-types' or its corresponding type declarations` because those declarations only exist after `pnpm build` produces them in each package's `dist/` folder. The same rule applies after pulling changes that touch `packages/shared-types/`, `packages/shared-utils/`, or `packages/db/` — rebuild before typechecking.
+
 ```bash
 pnpm install              # Install all dependencies
-pnpm build                # Build all packages
-pnpm typecheck            # Type check all packages
-pnpm clean                # Remove all dist/ folders
+pnpm build                # Build all packages (REQUIRED before typecheck on a fresh checkout)
+pnpm typecheck            # Type check all packages (run AFTER pnpm build)
+pnpm clean                # Remove all dist/ folders (after this, re-run pnpm build before typecheck)
 
 pnpm db:generate          # Regenerate Prisma client
 pnpm db:migrate           # Run Prisma migrations

--- a/packages/db/prisma/migrations/20260412010000_add_rbac_and_notification_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260412010000_add_rbac_and_notification_mode/migration.sql
@@ -1,0 +1,39 @@
+-- AlterEnum: add OPERATOR to ClientUserType
+ALTER TYPE "client_user_type" ADD VALUE 'OPERATOR' BEFORE 'USER';
+
+-- AlterTable: operators — add is_admin
+ALTER TABLE "operators" ADD COLUMN "is_admin" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: people — add has_ops_access
+ALTER TABLE "people" ADD COLUMN "has_ops_access" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable: clients — add notification_mode
+ALTER TABLE "clients" ADD COLUMN "notification_mode" TEXT NOT NULL DEFAULT 'client';
+
+-- CreateTable: operator_clients junction
+CREATE TABLE "operator_clients" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "operator_id" UUID NOT NULL,
+    "client_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "operator_clients_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "operator_clients_operator_id_client_id_key" ON "operator_clients"("operator_id", "client_id");
+
+-- CreateIndex
+CREATE INDEX "operator_clients_operator_id_idx" ON "operator_clients"("operator_id");
+
+-- CreateIndex
+CREATE INDEX "operator_clients_client_id_idx" ON "operator_clients"("client_id");
+
+-- AddForeignKey
+ALTER TABLE "operator_clients" ADD CONSTRAINT "operator_clients_operator_id_fkey" FOREIGN KEY ("operator_id") REFERENCES "operators"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "operator_clients" ADD CONSTRAINT "operator_clients_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Data backfill: set existing operators as platform admins
+UPDATE "operators" SET "is_admin" = true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -76,6 +76,7 @@ model Person {
   passwordHash    String?   @map("password_hash")
   userType        ClientUserType? @map("user_type")
   hasPortalAccess Boolean   @default(false) @map("has_portal_access")
+  hasOpsAccess    Boolean   @default(false) @map("has_ops_access")
   lastLoginAt     DateTime? @map("last_login_at")
   isActive        Boolean   @default(true) @map("is_active")
   createdAt       DateTime  @default(now()) @map("created_at")
@@ -111,6 +112,7 @@ model Operator {
   email        String   @unique
   name         String
   isActive     Boolean  @default(true) @map("is_active")
+  isAdmin      Boolean  @default(false) @map("is_admin")
   notifyEmail  Boolean  @default(true) @map("notify_email")
   notifySlack  Boolean  @default(false) @map("notify_slack")
   slackUserId  String?  @map("slack_user_id")
@@ -120,8 +122,24 @@ model Operator {
   assignedTickets    Ticket[]
   approvedJobs       IssueJob[] @relation("ApprovedByOperator")
   slackConversations SlackConversationLog[]
+  assignedClients    OperatorClient[]
 
   @@map("operators")
+}
+
+model OperatorClient {
+  id         String   @id @default(uuid()) @db.Uuid
+  operatorId String   @map("operator_id") @db.Uuid
+  clientId   String   @map("client_id") @db.Uuid
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  operator Operator @relation(fields: [operatorId], references: [id], onDelete: Cascade)
+  client   Client   @relation(fields: [clientId], references: [id], onDelete: Cascade)
+
+  @@unique([operatorId, clientId])
+  @@index([operatorId])
+  @@index([clientId])
+  @@map("operator_clients")
 }
 
 // --- Core entities ---
@@ -133,6 +151,7 @@ model Client {
   isActive              Boolean  @default(true) @map("is_active")
   autoRouteTickets      Boolean  @default(true) @map("auto_route_tickets")
   allowSelfRegistration Boolean  @default(false) @map("allow_self_registration")
+  notificationMode      String   @default("client") @map("notification_mode") // 'operator' | 'client'
   aiMode                String   @default("platform") @map("ai_mode")
   notes                String?
   companyProfile       String?  @map("company_profile")
@@ -165,6 +184,7 @@ model Client {
   ingestionRuns       IngestionRun[]
   emailProcessingLogs EmailProcessingLog[]
   slackConversations  SlackConversationLog[]
+  operatorAssignments OperatorClient[]
 
   @@map("clients")
 }
@@ -1079,6 +1099,7 @@ enum UserRole {
 
 enum ClientUserType {
   ADMIN
+  OPERATOR
   USER
 
   @@map("client_user_type")

--- a/packages/shared-types/src/client-user.ts
+++ b/packages/shared-types/src/client-user.ts
@@ -1,5 +1,6 @@
 export const ClientUserType = {
   ADMIN: 'ADMIN',
+  OPERATOR: 'OPERATOR',
   USER: 'USER',
 } as const;
 export type ClientUserType = (typeof ClientUserType)[keyof typeof ClientUserType];

--- a/packages/shared-types/src/client.ts
+++ b/packages/shared-types/src/client.ts
@@ -20,6 +20,12 @@ export const BillingPeriod = {
 } as const;
 export type BillingPeriod = (typeof BillingPeriod)[keyof typeof BillingPeriod];
 
+export const NotificationMode = {
+  CLIENT: 'client',
+  OPERATOR: 'operator',
+} as const;
+export type NotificationMode = (typeof NotificationMode)[keyof typeof NotificationMode];
+
 export interface Client {
   id: string;
   name: string;
@@ -27,6 +33,7 @@ export interface Client {
   isActive: boolean;
   autoRouteTickets: boolean;
   allowSelfRegistration: boolean;
+  notificationMode: NotificationMode;
   aiMode: AiMode;
   notes: string | null;
   companyProfile: string | null;

--- a/packages/shared-types/src/operator.ts
+++ b/packages/shared-types/src/operator.ts
@@ -3,6 +3,7 @@ export interface Operator {
   email: string;
   name: string;
   isActive: boolean;
+  isAdmin: boolean;
   notifyEmail: boolean;
   notifySlack: boolean;
   slackUserId: string | null;

--- a/packages/shared-types/src/person.ts
+++ b/packages/shared-types/src/person.ts
@@ -10,6 +10,7 @@ export interface Person {
   slackUserId: string | null;
   isPrimary: boolean;
   hasPortalAccess: boolean;
+  hasOpsAccess: boolean;
   userType: ClientUserType | null;
   isActive: boolean;
   lastLoginAt: Date | null;

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -13,8 +13,16 @@ export { buildUtcCron } from './cron-tz.js';
 export type { BuildUtcCronOpts } from './cron-tz.js';
 export { Mailer } from './mailer.js';
 export type { SmtpConfig, ReplyOptions } from './mailer.js';
-export { notifyOperators } from './notify-operators.js';
-export type { OperatorRecord, NotifyOperatorsOpts, NotifyOperatorsResult, SlackSender, NotificationPreference } from './notify-operators.js';
+export { notifyOperators, notifyClientOperators } from './notify-operators.js';
+export type {
+  OperatorRecord,
+  NotifyOperatorsOpts,
+  NotifyOperatorsResult,
+  SlackSender,
+  NotificationPreference,
+  ClientOperatorRecord,
+  NotifyClientOperatorsOpts,
+} from './notify-operators.js';
 export { loadSmtpFromDb } from './smtp-loader.js';
 export { loadImapFromDb } from './imap-loader.js';
 export type { ImapDbConfig } from './imap-loader.js';

--- a/packages/shared-utils/src/notify-operators.ts
+++ b/packages/shared-utils/src/notify-operators.ts
@@ -283,6 +283,77 @@ async function dispatchWithPreference(
   return emailRecipients;
 }
 
+/**
+ * A client-side person who can receive notifications routed to a client (used
+ * when `client.notificationMode === 'operator'`). These are people on the
+ * client team with `userType` of OPERATOR or ADMIN.
+ */
+export interface ClientOperatorRecord {
+  id: string;
+  email: string;
+  name: string;
+  userType: string;
+  slackUserId: string | null;
+}
+
+export interface NotifyClientOperatorsOpts {
+  subject: string;
+  body: string;
+  clientId: string;
+  slack?: SlackSender;
+  /** Optional Slack channel for the client (sends a channel message in addition to DMs). */
+  slackChannelId?: string;
+}
+
+/**
+ * Notify client operators (people on the client team with userType ADMIN/OPERATOR
+ * and hasOpsAccess). Used by the NOTIFY_OPERATOR step when a client has
+ * `notificationMode === 'operator'` and wants resolution notifications routed to
+ * its own ops team instead of (or in addition to) the platform operators.
+ *
+ * Returns the list of email addresses that received the notification.
+ */
+export async function notifyClientOperators(
+  mailer: Mailer,
+  getClientOperators: (clientId: string) => Promise<ClientOperatorRecord[]>,
+  opts: NotifyClientOperatorsOpts,
+): Promise<string[]> {
+  const operators = await getClientOperators(opts.clientId);
+  const recipients: string[] = [];
+
+  if (operators.length === 0) {
+    logger.warn({ clientId: opts.clientId }, 'No client operators to notify');
+  }
+
+  for (const op of operators) {
+    try {
+      await mailer.send({ to: op.email, subject: opts.subject, body: opts.body });
+      recipients.push(op.email);
+      logger.info({ to: op.email, clientId: opts.clientId }, 'Client operator notification sent');
+    } catch (err) {
+      logger.error({ err, to: op.email }, 'Failed to send client operator notification');
+    }
+
+    if (op.slackUserId && opts.slack?.isConnected()) {
+      try {
+        await opts.slack.sendDM(op.slackUserId, `*${opts.subject}*\n${opts.body}`);
+      } catch (err) {
+        logger.warn({ err, slackUserId: op.slackUserId }, 'Failed to send client operator Slack DM');
+      }
+    }
+  }
+
+  if (opts.slackChannelId && opts.slack?.isConnected()) {
+    try {
+      await opts.slack.sendMessage(opts.slackChannelId, `*${opts.subject}*\n${opts.body}`);
+    } catch (err) {
+      logger.warn({ err, channelId: opts.slackChannelId }, 'Failed to send client Slack channel notification');
+    }
+  }
+
+  return recipients;
+}
+
 function resolveEmailRecipients(
   operators: OperatorRecord[],
   emailTarget: string,

--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -1,5 +1,21 @@
-import { Routes } from '@angular/router';
+import { Routes, RedirectFunction } from '@angular/router';
+import { inject } from '@angular/core';
 import { authGuard } from './core/guards/auth.guard';
+import { scopedOpsGuard } from './core/guards/scoped-ops.guard';
+import { AuthService } from './core/services/auth.service';
+
+/**
+ * Default redirect for the `/` path. Operators go to /dashboard; scoped ops
+ * users go straight to their own client detail page.
+ */
+const defaultRedirect: RedirectFunction = () => {
+  const auth = inject(AuthService);
+  const user = auth.currentUser();
+  if (user?.isPortalOpsUser && user.clientId) {
+    return `/clients/${user.clientId}`;
+  }
+  return '/dashboard';
+};
 
 export const routes: Routes = [
   {
@@ -10,13 +26,15 @@ export const routes: Routes = [
     path: '',
     canActivate: [authGuard],
     children: [
-      { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+      { path: '', pathMatch: 'full', redirectTo: defaultRedirect },
       {
         path: 'dashboard',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/dashboard/dashboard.component').then(m => m.DashboardComponent),
       },
       {
         path: 'clients',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/clients/client-list.component').then(m => m.ClientListComponent),
       },
       {
@@ -33,34 +51,42 @@ export const routes: Routes = [
       },
       {
         path: 'prompts',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/prompts/prompt-list.component').then(m => m.PromptListComponent),
       },
       {
         path: 'prompts/:key',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/prompts/prompt-detail.component').then(m => m.PromptDetailComponent),
       },
       {
         path: 'logs',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/logs/log-viewer.component').then(m => m.LogViewerComponent),
       },
       {
         path: 'email-logs',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/email-logs/email-log.component').then(m => m.EmailLogComponent),
       },
       {
         path: 'slack-conversations',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/slack-conversations/slack-conversations.component').then(m => m.SlackConversationsComponent),
       },
       {
         path: 'ai-usage',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/ai-usage/ai-usage.component').then(m => m.AiUsageComponent),
       },
       {
         path: 'ai-providers',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/ai-providers/ai-providers.component').then(m => m.AiProvidersComponent),
       },
       {
         path: 'activity',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/activity-feed/activity-feed.component').then(m => m.ActivityFeedComponent),
       },
       {
@@ -69,22 +95,27 @@ export const routes: Routes = [
       },
       {
         path: 'system-status',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/system-status/system-status.component').then(m => m.SystemStatusComponent),
       },
       {
         path: 'failed-jobs',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/failed-jobs/failed-job-list.component').then(m => m.FailedJobListComponent),
       },
       {
         path: 'system-issues',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/system-issues/system-issues.component').then(m => m.SystemIssuesComponent),
       },
       {
         path: 'system-analysis',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/system-analysis/system-analysis.component').then(m => m.SystemAnalysisComponent),
       },
       {
         path: 'notification-preferences',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/notification-preferences/notification-preferences.component').then(m => m.NotificationPreferencesComponent),
       },
       {
@@ -94,30 +125,37 @@ export const routes: Routes = [
       },
       {
         path: 'settings',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/settings/settings.component').then(m => m.SettingsComponent),
       },
       {
         path: 'release-notes',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/release-notes/release-notes.component').then(m => m.ReleaseNotesComponent),
       },
       {
         path: 'ticket-routes',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/ticket-routes/ticket-route-list.component').then(m => m.TicketRouteListComponent),
       },
       {
         path: 'ingestion-jobs',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/ingestion-jobs/ingestion-job-list.component').then(m => m.IngestionJobListComponent),
       },
       {
         path: 'scheduled-probes',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/scheduled-probes/probe-list.component').then(m => m.ProbeListComponent),
       },
       {
         path: 'scheduled-probes/:id/runs',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/scheduled-probes/probe-runs.component').then(m => m.ProbeRunsComponent),
       },
       {
         path: 'users',
+        canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/users/user-list.component').then(m => m.UserListComponent),
       },
     ],

--- a/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
@@ -1,0 +1,41 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Routes a scoped ops user (client-side Person with hasOpsAccess) is allowed
+ * to visit directly. Anything else is redirected to their own client detail
+ * page. This guard is a no-op for operators.
+ */
+const SCOPED_ALLOWED_PREFIXES = [
+  '/dashboard',   // dashboard is rewritten to client detail in the default redirect
+  '/tickets',     // list + detail
+  '/profile',
+  '/login',
+];
+
+function isAllowedPath(url: string): boolean {
+  // /clients/:id is allowed, but /clients (the list) is not
+  if (url === '/clients' || url.startsWith('/clients?')) return false;
+  if (url.startsWith('/clients/')) return true;
+  return SCOPED_ALLOWED_PREFIXES.some(prefix => url === prefix || url.startsWith(`${prefix}/`) || url.startsWith(`${prefix}?`));
+}
+
+export const scopedOpsGuard: CanActivateFn = (_route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  const user = auth.currentUser();
+  if (!user || user.isPortalOpsUser !== true) {
+    // Not a scoped user — no restrictions.
+    return true;
+  }
+
+  const clientId = user.clientId;
+  const fallback = clientId ? router.parseUrl(`/clients/${clientId}`) : router.parseUrl('/profile');
+
+  if (isAllowedPath(state.url)) {
+    return true;
+  }
+  return fallback;
+};

--- a/services/control-panel/src/app/core/services/auth.service.ts
+++ b/services/control-panel/src/app/core/services/auth.service.ts
@@ -1,8 +1,10 @@
-import { Injectable, inject, signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, of, tap, map, catchError, shareReplay, finalize, switchMap, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
+
+export type PortalUserType = 'ADMIN' | 'OPERATOR' | 'USER';
 
 export interface AuthUser {
   id: string;
@@ -10,12 +12,32 @@ export interface AuthUser {
   name: string;
   role: string;
   themePreference?: string;
+  /** True when the principal is a client-side Person using a portal JWT with hasOpsAccess. */
+  isPortalOpsUser?: boolean;
+  /** Set when isPortalOpsUser is true — the Person's client. */
+  clientId?: string | null;
+  /** Portal user type when isPortalOpsUser is true. */
+  portalUserType?: PortalUserType | null;
 }
 
-interface LoginResponse {
+interface OperatorLoginResponse {
   accessToken: string;
   refreshToken: string;
   user: AuthUser;
+}
+
+interface PortalLoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    clientId: string;
+    userType: PortalUserType;
+    hasOpsAccess: boolean;
+    client?: { name: string; shortCode: string } | null;
+  };
 }
 
 interface RefreshResponse {
@@ -34,6 +56,31 @@ interface MeResponse {
   themePreference?: string;
 }
 
+interface PortalMeResponse {
+  id: string;
+  email: string;
+  name: string;
+  clientId: string;
+  userType: PortalUserType | null;
+  hasPortalAccess: boolean;
+  hasOpsAccess: boolean;
+  isActive: boolean;
+  lastLoginAt: string | null;
+  createdAt: string;
+  client?: { name: string; shortCode: string } | null;
+}
+
+interface DecodedJwtPayload {
+  exp?: number;
+  type?: string;
+  sub?: string;
+  email?: string;
+  clientId?: string;
+  userType?: PortalUserType;
+  hasOpsAccess?: boolean;
+  [key: string]: unknown;
+}
+
 const ACCESS_TOKEN_KEY = 'rc_access_token';
 const REFRESH_TOKEN_KEY = 'rc_refresh_token';
 
@@ -47,18 +94,29 @@ export class AuthService {
 
   currentUser = signal<AuthUser | null>(null);
 
+  /** True when the logged-in principal is a client-side Person with ops access. */
+  readonly isScopedOpsUser = computed(() => this.currentUser()?.isPortalOpsUser === true);
+
   get accessToken(): string | null {
     return localStorage.getItem(ACCESS_TOKEN_KEY);
   }
 
-  login(email: string, password: string): Observable<LoginResponse> {
-    return this.http.post<LoginResponse>(`${this.baseUrl}/auth/login`, { email, password }).pipe(
-      tap(res => {
-        localStorage.setItem(ACCESS_TOKEN_KEY, res.accessToken);
-        localStorage.setItem(REFRESH_TOKEN_KEY, res.refreshToken);
-        this.currentUser.set(res.user);
-        this.scheduleProactiveRefresh(res.accessToken);
-        this.router.navigateByUrl('/dashboard');
+  /**
+   * Login: tries operator login first. If the backend returns 401 (invalid
+   * credentials for an operator account), falls back to portal login so that
+   * a client-side Person with hasOpsAccess can sign in with the same form.
+   */
+  login(email: string, password: string): Observable<OperatorLoginResponse | PortalLoginResponse> {
+    return this.http.post<OperatorLoginResponse>(`${this.baseUrl}/auth/login`, { email, password }).pipe(
+      tap(res => this.applyOperatorLogin(res)),
+      catchError((err: HttpErrorResponse) => {
+        if (err.status !== 401 && err.status !== 403) {
+          return throwError(() => err);
+        }
+        // Operator login failed — try portal login
+        return this.http.post<PortalLoginResponse>(`${this.baseUrl}/portal/auth/login`, { email, password }).pipe(
+          tap(res => this.applyPortalLogin(res)),
+        );
       }),
     );
   }
@@ -84,7 +142,11 @@ export class AuthService {
       return this.refreshInFlight$;
     }
 
-    this.refreshInFlight$ = this.http.post<RefreshResponse>(`${this.baseUrl}/auth/refresh`, { refreshToken }).pipe(
+    // Pick refresh endpoint based on stored access token shape
+    const isPortal = this.isPortalToken(this.accessToken);
+    const refreshUrl = isPortal ? `${this.baseUrl}/portal/auth/refresh` : `${this.baseUrl}/auth/refresh`;
+
+    this.refreshInFlight$ = this.http.post<RefreshResponse>(refreshUrl, { refreshToken }).pipe(
       tap(res => {
         localStorage.setItem(ACCESS_TOKEN_KEY, res.accessToken);
         localStorage.setItem(REFRESH_TOKEN_KEY, res.refreshToken);
@@ -110,35 +172,85 @@ export class AuthService {
     }
 
     return this.refreshTokens().pipe(
-      switchMap(() => this.http.get<MeResponse>(`${this.baseUrl}/auth/me`)),
-      tap(user => {
-        this.currentUser.set({
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          role: user.role,
-          themePreference: user.themePreference,
-        });
-      }),
+      switchMap(() => this.fetchMe()),
       map(() => true),
       catchError(() => of(false)),
     );
   }
 
   updateProfile(data: { name?: string; email?: string }): Observable<AuthUser> {
-    return this.http.patch<AuthUser>(`${this.baseUrl}/auth/profile`, data).pipe(
-      tap(user => this.currentUser.set(user)),
+    const isPortal = this.currentUser()?.isPortalOpsUser === true;
+    const url = isPortal ? `${this.baseUrl}/portal/auth/profile` : `${this.baseUrl}/auth/profile`;
+    const method$ = isPortal
+      ? this.http.patch<Partial<AuthUser>>(url, data)
+      : this.http.patch<AuthUser>(url, data);
+    return method$.pipe(
+      tap(user => {
+        const existing = this.currentUser();
+        if (existing) {
+          this.currentUser.set({ ...existing, ...user } as AuthUser);
+        }
+      }),
+      map(user => {
+        const existing = this.currentUser();
+        return (existing ?? (user as AuthUser)) as AuthUser;
+      }),
     );
   }
 
   changePassword(currentPassword: string, newPassword: string): Observable<{ message: string }> {
-    return this.http.post<{ message: string }>(`${this.baseUrl}/auth/change-password`, { currentPassword, newPassword });
+    const isPortal = this.currentUser()?.isPortalOpsUser === true;
+    const url = isPortal
+      ? `${this.baseUrl}/portal/auth/change-password`
+      : `${this.baseUrl}/auth/change-password`;
+    return this.http.post<{ message: string }>(url, { currentPassword, newPassword });
   }
 
   initialize(): Observable<void> {
     const token = localStorage.getItem(ACCESS_TOKEN_KEY);
     if (!token) return of(undefined);
 
+    return this.fetchMe().pipe(
+      tap(() => this.scheduleProactiveRefresh(token)),
+      map(() => undefined),
+      catchError(() => {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+        return of(undefined);
+      }),
+    );
+  }
+
+  /**
+   * Fetches the current user via the appropriate /me endpoint based on the
+   * stored access token shape. Used on app init and after refresh.
+   */
+  private fetchMe(): Observable<AuthUser> {
+    const token = this.accessToken;
+    if (token && this.isPortalToken(token)) {
+      return this.http.get<PortalMeResponse>(`${this.baseUrl}/portal/auth/me`).pipe(
+        tap(me => {
+          this.currentUser.set({
+            id: me.id,
+            email: me.email,
+            name: me.name,
+            role: 'CLIENT',
+            isPortalOpsUser: me.hasOpsAccess === true,
+            clientId: me.clientId,
+            portalUserType: (me.userType ?? null) as PortalUserType | null,
+          });
+        }),
+        map(me => this.currentUser() ?? {
+          id: me.id,
+          email: me.email,
+          name: me.name,
+          role: 'CLIENT',
+          isPortalOpsUser: me.hasOpsAccess === true,
+          clientId: me.clientId,
+          portalUserType: (me.userType ?? null) as PortalUserType | null,
+        }),
+      );
+    }
     return this.http.get<MeResponse>(`${this.baseUrl}/auth/me`).pipe(
       tap(user => {
         this.currentUser.set({
@@ -147,16 +259,61 @@ export class AuthService {
           name: user.name,
           role: user.role,
           themePreference: user.themePreference,
+          isPortalOpsUser: false,
+          clientId: null,
+          portalUserType: null,
         });
-        this.scheduleProactiveRefresh(token);
       }),
-      map(() => undefined),
-      catchError(() => {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
-        localStorage.removeItem(REFRESH_TOKEN_KEY);
-        return of(undefined);
-      }),
+      map(user => ({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        themePreference: user.themePreference,
+        isPortalOpsUser: false,
+        clientId: null,
+        portalUserType: null,
+      })),
     );
+  }
+
+  private applyOperatorLogin(res: OperatorLoginResponse): void {
+    localStorage.setItem(ACCESS_TOKEN_KEY, res.accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, res.refreshToken);
+    this.currentUser.set({
+      ...res.user,
+      isPortalOpsUser: false,
+      clientId: null,
+      portalUserType: null,
+    });
+    this.scheduleProactiveRefresh(res.accessToken);
+    this.router.navigateByUrl('/dashboard');
+  }
+
+  private applyPortalLogin(res: PortalLoginResponse): void {
+    // Reject portal logins without ops access — the control panel is only
+    // accessible to ops-access people.
+    if (!res.user.hasOpsAccess) {
+      throw new HttpErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        error: { error: 'This account does not have control panel access' },
+      });
+    }
+    localStorage.setItem(ACCESS_TOKEN_KEY, res.accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, res.refreshToken);
+    this.currentUser.set({
+      id: res.user.id,
+      email: res.user.email,
+      name: res.user.name,
+      role: 'CLIENT',
+      isPortalOpsUser: true,
+      clientId: res.user.clientId,
+      portalUserType: res.user.userType,
+    });
+    this.scheduleProactiveRefresh(res.accessToken);
+    // Route scoped users to their own client detail page
+    this.router.navigateByUrl(`/clients/${res.user.clientId}`);
   }
 
   private scheduleProactiveRefresh(accessToken: string): void {
@@ -181,7 +338,13 @@ export class AuthService {
     }
   }
 
-  private decodeJwtPayload(token: string): { exp?: number; [key: string]: unknown } | null {
+  private isPortalToken(token: string | null): boolean {
+    if (!token) return false;
+    const payload = this.decodeJwtPayload(token);
+    return payload?.type === 'portal_access';
+  }
+
+  private decodeJwtPayload(token: string): DecodedJwtPayload | null {
     try {
       const parts = token.split('.');
       if (parts.length !== 3) return null;
@@ -190,7 +353,7 @@ export class AuthService {
       // Pad to multiple of 4
       const padLen = (4 - (base64.length % 4)) % 4;
       base64 += '='.repeat(padLen);
-      return JSON.parse(atob(base64));
+      return JSON.parse(atob(base64)) as DecodedJwtPayload;
     } catch {
       return null;
     }

--- a/services/control-panel/src/app/core/services/client.service.ts
+++ b/services/control-panel/src/app/core/services/client.service.ts
@@ -10,6 +10,7 @@ export interface Client {
   isActive: boolean;
   autoRouteTickets: boolean;
   allowSelfRegistration: boolean;
+  notificationMode: 'client' | 'operator';
   aiMode: string;
   notes: string | null;
   companyProfile: string | null;

--- a/services/control-panel/src/app/core/services/person.service.ts
+++ b/services/control-panel/src/app/core/services/person.service.ts
@@ -12,7 +12,8 @@ export interface Person {
   slackUserId: string | null;
   isPrimary: boolean;
   hasPortalAccess: boolean;
-  userType: 'ADMIN' | 'USER' | null;
+  hasOpsAccess: boolean;
+  userType: 'ADMIN' | 'OPERATOR' | 'USER' | null;
   isActive: boolean;
   lastLoginAt: string | null;
   createdAt: string;

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -41,7 +41,7 @@ type ClientDetailTabSlug = (typeof CLIENT_DETAIL_TAB_SLUGS)[number];
   ],
   template: `
     @if (client(); as c) {
-      <app-client-header [client]="c" />
+      <app-client-header [client]="c" (clientChange)="onClientUpdated($event)" />
 
       <app-tab-group [selectedIndex]="selectedTab()" (selectedIndexChange)="onTabChange($event)">
         <app-tab label="Systems">

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -9,16 +9,6 @@ import {
   ToggleSwitchComponent,
 } from '../../../shared/components/index.js';
 
-// Duck-typed surface for scoped-ops detection. Workstream A is adding either
-// `isScopedOpsUser()` to AuthService or an `isPortalOpsUser` flag on the user
-// signal. We read defensively so this file compiles before that lands.
-type AuthWithScopedCheck = AuthService & {
-  isScopedOpsUser?: () => boolean;
-};
-type UserWithPortalFlag = {
-  isPortalOpsUser?: boolean;
-};
-
 @Component({
   selector: 'app-client-header',
   standalone: true,
@@ -125,27 +115,11 @@ export class ClientHeaderComponent {
   clientChange = output<Client>();
 
   private clientService = inject(ClientService);
-  private auth = inject(AuthService) as AuthWithScopedCheck;
+  private auth = inject(AuthService);
   private toast = inject(ToastService);
   private destroyRef = inject(DestroyRef);
 
-  isScoped = computed(() => {
-    // Prefer the dedicated helper once workstream A ships it.
-    if (typeof this.auth.isScopedOpsUser === 'function') {
-      try {
-        return this.auth.isScopedOpsUser();
-      } catch {
-        // Fall through to the user-flag fallback below.
-      }
-    }
-    // Fallback: check for the flag workstream A is adding to the user payload.
-    const user = this.auth.currentUser() as (UserWithPortalFlag | null);
-    if (user && typeof user.isPortalOpsUser === 'boolean') {
-      return user.isPortalOpsUser;
-    }
-    // Neither surface exists yet — default to showing the toggle.
-    return false;
-  });
+  isScoped = computed(() => this.auth.isScopedOpsUser());
 
   onNotificationModeChange(operatorMode: boolean): void {
     const c = this.client();

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -1,9 +1,23 @@
-import { Component, input } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { Client } from '../../../core/services/client.service';
+import { Client, ClientService } from '../../../core/services/client.service';
+import { AuthService } from '../../../core/services/auth.service';
+import { ToastService } from '../../../core/services/toast.service';
 import {
   BroncoButtonComponent,
+  ToggleSwitchComponent,
 } from '../../../shared/components/index.js';
+
+// Duck-typed surface for scoped-ops detection. Workstream A is adding either
+// `isScopedOpsUser()` to AuthService or an `isPortalOpsUser` flag on the user
+// signal. We read defensively so this file compiles before that lands.
+type AuthWithScopedCheck = AuthService & {
+  isScopedOpsUser?: () => boolean;
+};
+type UserWithPortalFlag = {
+  isPortalOpsUser?: boolean;
+};
 
 @Component({
   selector: 'app-client-header',
@@ -11,6 +25,7 @@ import {
   imports: [
     RouterLink,
     BroncoButtonComponent,
+    ToggleSwitchComponent,
   ],
   template: `
     @let c = client();
@@ -25,6 +40,20 @@ import {
           }
         </div>
       </div>
+      @if (!isScoped()) {
+        <div class="header-right">
+          <div class="notif-mode">
+            <app-toggle-switch
+              [checked]="c.notificationMode === 'operator'"
+              label="Operator notification mode"
+              (checkedChange)="onNotificationModeChange($event)" />
+            <p class="notif-hint">
+              Operator mode sends resolution notifications to client staff with ops access.
+              Client mode routes them to platform operators.
+            </p>
+          </div>
+        </div>
+      }
     </div>
   `,
   styles: [`
@@ -38,6 +67,12 @@ import {
       gap: 16px;
     }
     .header-left { display: flex; flex-direction: column; gap: 4px; }
+    .header-right {
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-end;
+      padding-top: 6px;
+    }
     .title-row { display: flex; align-items: center; gap: 10px; }
     .page-title {
       margin: 6px 0 0;
@@ -68,8 +103,67 @@ import {
       background: var(--bg-muted);
       color: var(--text-tertiary);
     }
+    .notif-mode {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 4px;
+      max-width: 320px;
+    }
+    .notif-hint {
+      margin: 0;
+      font-family: var(--font-primary);
+      font-size: 11px;
+      color: var(--text-tertiary);
+      line-height: 1.4;
+      text-align: right;
+    }
   `],
 })
 export class ClientHeaderComponent {
   client = input.required<Client>();
+  clientChange = output<Client>();
+
+  private clientService = inject(ClientService);
+  private auth = inject(AuthService) as AuthWithScopedCheck;
+  private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
+
+  isScoped = computed(() => {
+    // Prefer the dedicated helper once workstream A ships it.
+    if (typeof this.auth.isScopedOpsUser === 'function') {
+      try {
+        return this.auth.isScopedOpsUser();
+      } catch {
+        // Fall through to the user-flag fallback below.
+      }
+    }
+    // Fallback: check for the flag workstream A is adding to the user payload.
+    const user = this.auth.currentUser() as (UserWithPortalFlag | null);
+    if (user && typeof user.isPortalOpsUser === 'boolean') {
+      return user.isPortalOpsUser;
+    }
+    // Neither surface exists yet — default to showing the toggle.
+    return false;
+  });
+
+  onNotificationModeChange(operatorMode: boolean): void {
+    const c = this.client();
+    const next: 'client' | 'operator' = operatorMode ? 'operator' : 'client';
+    if (c.notificationMode === next) return;
+    this.clientService
+      .updateClient(c.id, { notificationMode: next })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.clientChange.emit({ ...c, ...updated });
+          this.toast.success(
+            next === 'operator'
+              ? 'Notifications now routed to client ops users'
+              : 'Notifications now routed to platform operators',
+          );
+        },
+        error: () => this.toast.error('Failed to update notification mode'),
+      });
+  }
 }

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
@@ -46,9 +46,9 @@ import { PersonDialogComponent } from '../../../people/person-dialog.component';
         <app-data-column key="role" header="Role" [sortable]="false">
           <ng-template #cell let-p>{{ p.role ?? '-' }}</ng-template>
         </app-data-column>
-        <app-data-column key="access" header="Access" [sortable]="false" width="120px">
+        <app-data-column key="access" header="Access" [sortable]="false" width="130px">
           <ng-template #cell let-p>
-            <span class="chip" [class.chip-admin]="accessLabel(p) === 'Ops Admin' || accessLabel(p) === 'Portal Admin'" [class.chip-operator]="accessLabel(p) === 'Ops Operator'" [class.chip-user]="accessLabel(p) === 'Portal User' || accessLabel(p) === 'Contact'">
+            <span class="chip" [class.chip-admin]="accessLabel(p) === 'Ops Admin' || accessLabel(p) === 'Portal Admin'" [class.chip-operator]="accessLabel(p) === 'Ops Operator' || accessLabel(p) === 'Portal Operator'" [class.chip-user]="accessLabel(p) === 'Portal User' || accessLabel(p) === 'Contact'">
               {{ accessLabel(p) }}
             </span>
           </ng-template>
@@ -168,16 +168,17 @@ export class ClientPeopleTabComponent implements OnInit {
 
   trackById = (p: Person): string => p.id;
 
-  accessLabel(p: Person): 'Ops Admin' | 'Ops Operator' | 'Portal Admin' | 'Portal User' | 'Contact' {
+  accessLabel(p: Person): 'Ops Admin' | 'Ops Operator' | 'Portal Admin' | 'Portal Operator' | 'Portal User' | 'Contact' {
     // Ops access takes precedence. ADMIN → Ops Admin; anything else (OPERATOR, USER, null)
     // defensively falls through to Ops Operator as the lowest ops tier.
     if (p.hasOpsAccess) {
       return p.userType === 'ADMIN' ? 'Ops Admin' : 'Ops Operator';
     }
-    // Portal access without ops access: ADMIN or OPERATOR are treated as Portal Admin
-    // (OPERATOR rank >= USER); USER/null → Portal User.
+    // Portal access without ops access: ADMIN → Portal Admin, OPERATOR → Portal Operator, USER/null → Portal User.
     if (p.hasPortalAccess) {
-      return p.userType === 'ADMIN' || p.userType === 'OPERATOR' ? 'Portal Admin' : 'Portal User';
+      if (p.userType === 'ADMIN') return 'Portal Admin';
+      if (p.userType === 'OPERATOR') return 'Portal Operator';
+      return 'Portal User';
     }
     return 'Contact';
   }

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
@@ -46,15 +46,11 @@ import { PersonDialogComponent } from '../../../people/person-dialog.component';
         <app-data-column key="role" header="Role" [sortable]="false">
           <ng-template #cell let-p>{{ p.role ?? '-' }}</ng-template>
         </app-data-column>
-        <app-data-column key="portal" header="Portal" [sortable]="false" width="100px">
+        <app-data-column key="access" header="Access" [sortable]="false" width="120px">
           <ng-template #cell let-p>
-            @if (p.hasPortalAccess) {
-              <span class="chip" [class.chip-admin]="p.userType === 'ADMIN'" [class.chip-user]="p.userType !== 'ADMIN'">
-                {{ p.userType === 'ADMIN' ? 'Admin' : 'User' }}
-              </span>
-            } @else {
-              <span class="muted">-</span>
-            }
+            <span class="chip" [class.chip-admin]="accessLabel(p) === 'Ops Admin' || accessLabel(p) === 'Portal Admin'" [class.chip-operator]="accessLabel(p) === 'Ops Operator'" [class.chip-user]="accessLabel(p) === 'Portal User' || accessLabel(p) === 'Contact'">
+              {{ accessLabel(p) }}
+            </span>
           </ng-template>
         </app-data-column>
         <app-data-column key="status" header="Status" [sortable]="false" width="110px">
@@ -134,6 +130,10 @@ import { PersonDialogComponent } from '../../../people/person-dialog.component';
       background: var(--color-info-subtle);
       color: var(--color-info);
     }
+    .chip-operator {
+      background: var(--color-warning-subtle, var(--bg-muted));
+      color: var(--color-warning, var(--text-secondary));
+    }
     .chip-user {
       background: var(--bg-muted);
       color: var(--text-secondary);
@@ -167,6 +167,20 @@ export class ClientPeopleTabComponent implements OnInit {
   editing = signal<Person | null>(null);
 
   trackById = (p: Person): string => p.id;
+
+  accessLabel(p: Person): 'Ops Admin' | 'Ops Operator' | 'Portal Admin' | 'Portal User' | 'Contact' {
+    // Ops access takes precedence. ADMIN → Ops Admin; anything else (OPERATOR, USER, null)
+    // defensively falls through to Ops Operator as the lowest ops tier.
+    if (p.hasOpsAccess) {
+      return p.userType === 'ADMIN' ? 'Ops Admin' : 'Ops Operator';
+    }
+    // Portal access without ops access: ADMIN or OPERATOR are treated as Portal Admin
+    // (OPERATOR rank >= USER); USER/null → Portal User.
+    if (p.hasPortalAccess) {
+      return p.userType === 'ADMIN' || p.userType === 'OPERATOR' ? 'Portal Admin' : 'Portal User';
+    }
+    return 'Contact';
+  }
 
   ngOnInit(): void {
     this.load();

--- a/services/control-panel/src/app/features/people/person-dialog.component.ts
+++ b/services/control-panel/src/app/features/people/person-dialog.component.ts
@@ -51,8 +51,15 @@ import {
             (checkedChange)="onPortalAccessChange($event)" />
         </div>
 
-        @if (form.hasPortalAccess) {
-          @if (!isEdit || form.enablingPortalAccess) {
+        <div class="toggle-row">
+          <app-toggle-switch
+            [checked]="form.hasOpsAccess"
+            label="Ops access (control panel for this client)"
+            (checkedChange)="onOpsAccessChange($event)" />
+        </div>
+
+        @if (form.hasPortalAccess || form.hasOpsAccess) {
+          @if (form.hasPortalAccess && (!isEdit || form.enablingPortalAccess)) {
             <app-form-field
               [label]="isEdit ? 'Password (required to enable portal access)' : 'Password'"
               hint="Minimum 8 characters">
@@ -68,6 +75,9 @@ import {
               [options]="userTypeOptions"
               (valueChange)="onUserTypeChange($event)" />
           </app-form-field>
+          @if (form.hasOpsAccess && form.userType === 'USER') {
+            <p class="hint-warning">Ops access requires user type Operator or Admin.</p>
+          }
           @if (isEdit) {
             <div class="toggle-row">
               <app-toggle-switch
@@ -98,6 +108,7 @@ import {
       border-top: 1px solid var(--border-subtle);
     }
     .toggle-row { display: flex; align-items: center; }
+    .hint-warning { font-size: 12px; color: var(--color-warning, #b07d00); margin: 0; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
@@ -114,6 +125,7 @@ export class PersonDialogComponent implements OnInit {
 
   userTypeOptions = [
     { value: 'USER', label: 'User' },
+    { value: 'OPERATOR', label: 'Operator' },
     { value: 'ADMIN', label: 'Admin' },
   ];
 
@@ -125,10 +137,11 @@ export class PersonDialogComponent implements OnInit {
     slackUserId: '',
     isPrimary: false,
     hasPortalAccess: false,
+    hasOpsAccess: false,
     /** True when editing an existing person who did NOT previously have portal access. */
     enablingPortalAccess: false,
     password: '',
-    userType: 'USER' as 'USER' | 'ADMIN',
+    userType: 'USER' as 'USER' | 'OPERATOR' | 'ADMIN',
     isActive: true,
   };
 
@@ -148,9 +161,10 @@ export class PersonDialogComponent implements OnInit {
         slackUserId: p.slackUserId ?? '',
         isPrimary: p.isPrimary,
         hasPortalAccess: p.hasPortalAccess,
+        hasOpsAccess: p.hasOpsAccess ?? false,
         enablingPortalAccess: false,
         password: '',
-        userType: (p.userType ?? 'USER') as 'USER' | 'ADMIN',
+        userType: (p.userType ?? 'USER') as 'USER' | 'OPERATOR' | 'ADMIN',
         isActive: p.isActive,
       };
     }
@@ -162,14 +176,24 @@ export class PersonDialogComponent implements OnInit {
     this.form.enablingPortalAccess = this.isEdit && !this.originalHasPortalAccess && value;
   }
 
+  onOpsAccessChange(value: boolean): void {
+    this.form.hasOpsAccess = value;
+    // Ops access requires OPERATOR or ADMIN — bump USER to OPERATOR.
+    if (value && this.form.userType === 'USER') {
+      this.form.userType = 'OPERATOR';
+    }
+  }
+
   onUserTypeChange(value: string): void {
-    this.form.userType = value === 'ADMIN' ? 'ADMIN' : 'USER';
+    this.form.userType = (value === 'ADMIN' || value === 'OPERATOR' ? value : 'USER') as 'USER' | 'OPERATOR' | 'ADMIN';
   }
 
   canSave(): boolean {
     if (!this.form.name || !this.form.email) return false;
     // Password required when creating with portal access, or when enabling portal access on an existing person.
     if (this.form.hasPortalAccess && (this.form.enablingPortalAccess || !this.isEdit) && this.form.password.length < 8) return false;
+    // Ops access requires non-USER user type
+    if (this.form.hasOpsAccess && this.form.userType === 'USER') return false;
     return true;
   }
 
@@ -184,8 +208,9 @@ export class PersonDialogComponent implements OnInit {
         slackUserId: this.form.slackUserId === '' ? null : this.form.slackUserId,
         isPrimary: this.form.isPrimary,
         hasPortalAccess: this.form.hasPortalAccess,
+        hasOpsAccess: this.form.hasOpsAccess,
       };
-      if (this.form.hasPortalAccess) {
+      if (this.form.hasPortalAccess || this.form.hasOpsAccess) {
         update.userType = this.form.userType;
         update.isActive = this.form.isActive;
       }
@@ -210,9 +235,12 @@ export class PersonDialogComponent implements OnInit {
         slackUserId: this.form.slackUserId || undefined,
         isPrimary: this.form.isPrimary,
         hasPortalAccess: this.form.hasPortalAccess,
+        hasOpsAccess: this.form.hasOpsAccess,
       };
       if (this.form.hasPortalAccess) {
         create.password = this.form.password;
+      }
+      if (this.form.hasPortalAccess || this.form.hasOpsAccess) {
         create.userType = this.form.userType;
       }
       this.personService.createPerson(create).subscribe({

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, OnInit, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AuthService } from '../core/services/auth.service';
@@ -22,51 +22,68 @@ import { FailedJobsService } from '../core/services/failed-jobs.service';
       </div>
 
       <div class="nav-sections">
-        <div class="nav-section">
-          <span class="section-label">Main</span>
-          <a routerLink="/dashboard" routerLinkActive="nav-active" class="nav-item">Dashboard</a>
-          <a routerLink="/tickets" routerLinkActive="nav-active" class="nav-item">Tickets @if (ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }</a>
-          <a routerLink="/activity" routerLinkActive="nav-active" class="nav-item">Activity Feed</a>
-          <a routerLink="/clients" routerLinkActive="nav-active" class="nav-item">Clients</a>
-        </div>
+        @if (isScoped()) {
+          <div class="nav-section">
+            <span class="section-label">Main</span>
+            <a routerLink="/tickets" routerLinkActive="nav-active" class="nav-item">Tickets @if (ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }</a>
+          </div>
+          @if (scopedClientLink(); as clientLink) {
+            <div class="nav-section">
+              <span class="section-label">Client</span>
+              <a [routerLink]="clientLink" routerLinkActive="nav-active" class="nav-item">Client Details</a>
+            </div>
+          }
+          <div class="nav-section">
+            <span class="section-label">Account</span>
+            <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
+          </div>
+        } @else {
+          <div class="nav-section">
+            <span class="section-label">Main</span>
+            <a routerLink="/dashboard" routerLinkActive="nav-active" class="nav-item">Dashboard</a>
+            <a routerLink="/tickets" routerLinkActive="nav-active" class="nav-item">Tickets @if (ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }</a>
+            <a routerLink="/activity" routerLinkActive="nav-active" class="nav-item">Activity Feed</a>
+            <a routerLink="/clients" routerLinkActive="nav-active" class="nav-item">Clients</a>
+          </div>
 
-        <div class="nav-section">
-          <span class="section-label">Operations</span>
-          <a routerLink="/scheduled-probes" routerLinkActive="nav-active" class="nav-item">Scheduled Probes</a>
-          <a routerLink="/ingestion-jobs" routerLinkActive="nav-active" class="nav-item">Ingestion Jobs</a>
-          <a routerLink="/failed-jobs" routerLinkActive="nav-active" class="nav-item">Failed Jobs @if (failedJobsBadge() > 0) { <span class="badge">{{ failedJobsBadge() }}</span> }</a>
-          <a routerLink="/logs" routerLinkActive="nav-active" class="nav-item">Logs</a>
-          <a routerLink="/email-logs" routerLinkActive="nav-active" class="nav-item">Email Log</a>
-        </div>
+          <div class="nav-section">
+            <span class="section-label">Operations</span>
+            <a routerLink="/scheduled-probes" routerLinkActive="nav-active" class="nav-item">Scheduled Probes</a>
+            <a routerLink="/ingestion-jobs" routerLinkActive="nav-active" class="nav-item">Ingestion Jobs</a>
+            <a routerLink="/failed-jobs" routerLinkActive="nav-active" class="nav-item">Failed Jobs @if (failedJobsBadge() > 0) { <span class="badge">{{ failedJobsBadge() }}</span> }</a>
+            <a routerLink="/logs" routerLinkActive="nav-active" class="nav-item">Logs</a>
+            <a routerLink="/email-logs" routerLinkActive="nav-active" class="nav-item">Email Log</a>
+          </div>
 
-        <div class="nav-section">
-          <span class="section-label">AI</span>
-          <a routerLink="/prompts" routerLinkActive="nav-active" class="nav-item">AI Prompts</a>
-          <a routerLink="/ai-providers" routerLinkActive="nav-active" class="nav-item">AI Providers</a>
-          <a routerLink="/ai-usage" routerLinkActive="nav-active" class="nav-item">AI Usage</a>
-          <a routerLink="/ticket-routes" routerLinkActive="nav-active" class="nav-item">Ticket Routes</a>
-          <a routerLink="/system-analysis" routerLinkActive="nav-active" class="nav-item">System Analysis</a>
-          <a routerLink="/system-issues" routerLinkActive="nav-active" class="nav-item">System Issues</a>
-        </div>
+          <div class="nav-section">
+            <span class="section-label">AI</span>
+            <a routerLink="/prompts" routerLinkActive="nav-active" class="nav-item">AI Prompts</a>
+            <a routerLink="/ai-providers" routerLinkActive="nav-active" class="nav-item">AI Providers</a>
+            <a routerLink="/ai-usage" routerLinkActive="nav-active" class="nav-item">AI Usage</a>
+            <a routerLink="/ticket-routes" routerLinkActive="nav-active" class="nav-item">Ticket Routes</a>
+            <a routerLink="/system-analysis" routerLinkActive="nav-active" class="nav-item">System Analysis</a>
+            <a routerLink="/system-issues" routerLinkActive="nav-active" class="nav-item">System Issues</a>
+          </div>
 
-        <div class="nav-section">
-          <span class="section-label">Integrations</span>
-          <a routerLink="/slack-conversations" routerLinkActive="nav-active" class="nav-item">Slack Conversations</a>
-          <a routerLink="/release-notes" routerLinkActive="nav-active" class="nav-item">Release Notes</a>
-        </div>
+          <div class="nav-section">
+            <span class="section-label">Integrations</span>
+            <a routerLink="/slack-conversations" routerLinkActive="nav-active" class="nav-item">Slack Conversations</a>
+            <a routerLink="/release-notes" routerLinkActive="nav-active" class="nav-item">Release Notes</a>
+          </div>
 
-        <div class="nav-section">
-          <span class="section-label">System</span>
-          <a routerLink="/system-status" routerLinkActive="nav-active" class="nav-item">Status</a>
-          <a routerLink="/settings" routerLinkActive="nav-active" class="nav-item">Settings</a>
-          <a routerLink="/users" routerLinkActive="nav-active" class="nav-item">User Maint</a>
-        </div>
+          <div class="nav-section">
+            <span class="section-label">System</span>
+            <a routerLink="/system-status" routerLinkActive="nav-active" class="nav-item">Status</a>
+            <a routerLink="/settings" routerLinkActive="nav-active" class="nav-item">Settings</a>
+            <a routerLink="/users" routerLinkActive="nav-active" class="nav-item">User Maint</a>
+          </div>
 
-        <div class="nav-section">
-          <span class="section-label">Account</span>
-          <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
-          <a routerLink="/notification-preferences" routerLinkActive="nav-active" class="nav-item">Notifications</a>
-        </div>
+          <div class="nav-section">
+            <span class="section-label">Account</span>
+            <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
+            <a routerLink="/notification-preferences" routerLinkActive="nav-active" class="nav-item">Notifications</a>
+          </div>
+        }
       </div>
 
       <div class="sidebar-footer">
@@ -221,7 +238,28 @@ export class SidebarComponent implements OnInit {
   readonly ticketBadge = signal(0);
   readonly failedJobsBadge = signal(0);
 
+  /** True when the signed-in principal is a scoped client-side ops user. */
+  readonly isScoped = computed(() => this.authService.isScopedOpsUser());
+
+  /**
+   * Deep link to the scoped user's client detail page. Returns null when the
+   * clientId isn't available (shouldn't happen for a valid scoped session, but
+   * we guard against it so the template can just @if on it).
+   */
+  readonly scopedClientLink = computed(() => {
+    const user = this.authService.currentUser();
+    if (!user?.isPortalOpsUser || !user.clientId) return null;
+    return ['/clients', user.clientId];
+  });
+
   ngOnInit(): void {
+    // Scoped ops users don't have permission to fetch global ticket stats or
+    // the failed-jobs queue, so skip those calls entirely — they would just
+    // 403 and noise up the console.
+    if (this.isScoped()) {
+      return;
+    }
+
     const activeStatuses = ACTIVE_STATUS_FILTER.split(',');
 
     this.ticketService.getStats()

--- a/services/copilot-api/src/plugins/auth.ts
+++ b/services/copilot-api/src/plugins/auth.ts
@@ -14,6 +14,7 @@ export interface PortalJwtPayload {
   email: string;
   clientId: string;
   userType: ClientUserType;
+  hasOpsAccess: boolean;
   type: 'portal_access';
 }
 
@@ -28,6 +29,7 @@ export interface PortalUser {
   email: string;
   clientId: string;
   userType: ClientUserType;
+  hasOpsAccess: boolean;
 }
 
 declare module 'fastify' {
@@ -80,6 +82,7 @@ export const authPlugin = fp(async (fastify, opts: AuthPluginOpts) => {
             email: payload.email,
             clientId: payload.clientId,
             userType: payload.userType,
+            hasOpsAccess: payload.hasOpsAccess ?? false,
           };
           return;
         } catch {
@@ -88,7 +91,25 @@ export const authPlugin = fp(async (fastify, opts: AuthPluginOpts) => {
         }
       }
 
-      // Control panel / other routes use main JWT secret
+      // Control panel / other routes:
+      // Try portal JWT first — Persons with hasOpsAccess can use the control panel.
+      try {
+        const payload = jwt.verify(token, opts.portalJwtSecret) as PortalJwtPayload;
+        if (payload.type === 'portal_access' && payload.hasOpsAccess) {
+          request.portalUser = {
+            id: payload.sub,
+            email: payload.email,
+            clientId: payload.clientId,
+            userType: payload.userType,
+            hasOpsAccess: true,
+          };
+          return;
+        }
+      } catch {
+        // Not a portal token — fall through to main JWT
+      }
+
+      // Main JWT secret (Operator)
       try {
         const payload = jwt.verify(token, opts.jwtSecret) as JwtPayload;
         if (payload.type !== 'access') {
@@ -113,19 +134,63 @@ export const authPlugin = fp(async (fastify, opts: AuthPluginOpts) => {
 
 /**
  * Route-level preHandler hook that requires the caller to be an authenticated
- * user with one of the specified roles. API-key callers (no user on request)
- * are allowed through since they are trusted service-to-service calls.
+ * operator (main JWT) with one of the specified roles. API-key callers (no
+ * user AND no portalUser on the request) are allowed through since they are
+ * trusted service-to-service calls.
+ *
+ * Portal users authenticated via a portal JWT are REJECTED — they must use
+ * routes guarded by `requireOpsAccess()` instead.
  */
 export function requireRole(...roles: UserRole[]) {
   return async function (
-    request: { user?: AuthUser },
+    request: { user?: AuthUser; portalUser?: PortalUser },
     reply: { code(c: number): { send(o: unknown): void } },
   ) {
+    // Portal user on a non-portal route — block even if hasOpsAccess.
+    // They must use routes that explicitly opt in via requireOpsAccess().
+    if (!request.user && request.portalUser) {
+      reply.code(403).send({ error: 'Forbidden: this route requires operator authentication' });
+      return;
+    }
+
     // API-key authenticated requests have no user — allow through
     if (!request.user) return;
 
     if (!roles.includes(request.user.role)) {
       reply.code(403).send({ error: 'Forbidden: insufficient role' });
     }
+  };
+}
+
+/**
+ * Route-level preHandler hook that allows either:
+ *  1. An authenticated operator (main JWT) with one of the specified roles, OR
+ *  2. A portal user with `hasOpsAccess === true`.
+ *
+ * Use this on routes that should be accessible to client-side ops people
+ * (e.g. clients, tickets, people) in addition to platform operators.
+ * Routes that should NOT be accessible to ops-access people (settings,
+ * system-status, operators, etc.) should use `requireRole()` instead.
+ */
+export function requireOpsAccess(...operatorRoles: UserRole[]) {
+  return async function (
+    request: { user?: AuthUser; portalUser?: PortalUser },
+    reply: { code(c: number): { send(o: unknown): void } },
+  ) {
+    // Operator with an acceptable role — allow
+    if (request.user) {
+      if (operatorRoles.length === 0 || operatorRoles.includes(request.user.role)) return;
+      reply.code(403).send({ error: 'Forbidden: insufficient role' });
+      return;
+    }
+
+    // Portal user with ops access — allow
+    if (request.portalUser?.hasOpsAccess) return;
+
+    // API-key (service-to-service) — allow
+    if (!request.portalUser) return;
+
+    // Portal user without ops access — reject
+    reply.code(403).send({ error: 'Forbidden: ops access required' });
   };
 }

--- a/services/copilot-api/src/plugins/client-scope.ts
+++ b/services/copilot-api/src/plugins/client-scope.ts
@@ -1,0 +1,53 @@
+import type { FastifyRequest } from 'fastify';
+
+export type ClientScope =
+  | { type: 'all' }
+  | { type: 'assigned'; clientIds: string[] }
+  | { type: 'single'; clientId: string };
+
+/**
+ * Resolve which clients the current caller can access.
+ *
+ * - Platform admin (User with role === 'ADMIN') → all clients
+ * - Scoped operator (User with role === 'OPERATOR') → assigned clients via OperatorClient
+ * - Person with hasOpsAccess or portal user → their own client
+ *
+ * The optional `getOperatorClientIds` resolver looks up assigned clients for a
+ * scoped operator. If omitted, scoped operators fall back to "all clients" so
+ * routes that don't yet support scoping continue to work.
+ */
+export async function resolveClientScope(
+  request: FastifyRequest,
+  getOperatorClientIds?: (operatorId: string) => Promise<string[]>,
+): Promise<ClientScope> {
+  // Operator (control panel user)
+  if (request.user) {
+    if (request.user.role === 'ADMIN') return { type: 'all' };
+
+    // Scoped operator — look up assigned clients
+    if (getOperatorClientIds) {
+      const clientIds = await getOperatorClientIds(request.user.id);
+      return { type: 'assigned', clientIds };
+    }
+    // No resolver provided — fall back to full access
+    return { type: 'all' };
+  }
+
+  // Person with ops access OR portal user — single-client scope
+  if (request.portalUser) {
+    return { type: 'single', clientId: request.portalUser.clientId };
+  }
+
+  // API-key authenticated requests have neither user nor portalUser.
+  // They are trusted service-to-service callers with full access.
+  return { type: 'all' };
+}
+
+/**
+ * Convert a ClientScope to a Prisma where clause fragment for clientId filtering.
+ */
+export function scopeToWhere(scope: ClientScope): { clientId?: string | { in: string[] } } {
+  if (scope.type === 'all') return {};
+  if (scope.type === 'assigned') return { clientId: { in: scope.clientIds } };
+  return { clientId: scope.clientId };
+}

--- a/services/copilot-api/src/plugins/client-scope.ts
+++ b/services/copilot-api/src/plugins/client-scope.ts
@@ -1,4 +1,17 @@
 import type { FastifyRequest } from 'fastify';
+import type { PrismaClient } from '@bronco/db';
+
+/**
+ * Look up the list of client IDs assigned to a scoped operator. Centralised
+ * here so it isn't duplicated across every route file that calls resolveClientScope.
+ */
+export async function getOperatorClientIds(db: PrismaClient, operatorId: string): Promise<string[]> {
+  const rows = await db.operatorClient.findMany({
+    where: { operatorId },
+    select: { clientId: true },
+  });
+  return rows.map((r) => r.clientId);
+}
 
 export type ClientScope =
   | { type: 'all' }

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -1,14 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { AiMode } from '@bronco/shared-types';
-import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
-
-async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
-  const rows = await fastify.db.operatorClient.findMany({
-    where: { operatorId },
-    select: { clientId: true },
-  });
-  return rows.map((r) => r.clientId);
-}
+import { resolveClientScope, scopeToWhere, getOperatorClientIds } from '../plugins/client-scope.js';
 
 const VALID_AI_MODES = new Set<string>(Object.values(AiMode));
 
@@ -28,17 +20,12 @@ function validateDomainMappings(domains: string[] | undefined): string[] | undef
 export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/api/clients', async (request) => {
     const scope = await resolveClientScope(request, (operatorId) =>
-      getOperatorClientIds(fastify, operatorId),
+      getOperatorClientIds(fastify.db, operatorId),
     );
 
-    // Apply scope filter (clientId field) translated to client.id for client list queries
+    // Apply scope filter — translate clientId to client.id for direct client queries
     const scopeWhere = scopeToWhere(scope);
-    const idFilter =
-      scopeWhere.clientId === undefined
-        ? {}
-        : typeof scopeWhere.clientId === 'string'
-          ? { id: scopeWhere.clientId }
-          : { id: scopeWhere.clientId };
+    const idFilter = scopeWhere.clientId !== undefined ? { id: scopeWhere.clientId } : {};
 
     return fastify.db.client.findMany({
       where: { isInternal: false, ...idFilter },

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -1,5 +1,14 @@
 import type { FastifyInstance } from 'fastify';
 import { AiMode } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
+
+async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
+  const rows = await fastify.db.operatorClient.findMany({
+    where: { operatorId },
+    select: { clientId: true },
+  });
+  return rows.map((r) => r.clientId);
+}
 
 const VALID_AI_MODES = new Set<string>(Object.values(AiMode));
 
@@ -17,9 +26,22 @@ function validateDomainMappings(domains: string[] | undefined): string[] | undef
 }
 
 export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
-  fastify.get('/api/clients', async () => {
+  fastify.get('/api/clients', async (request) => {
+    const scope = await resolveClientScope(request, (operatorId) =>
+      getOperatorClientIds(fastify, operatorId),
+    );
+
+    // Apply scope filter (clientId field) translated to client.id for client list queries
+    const scopeWhere = scopeToWhere(scope);
+    const idFilter =
+      scopeWhere.clientId === undefined
+        ? {}
+        : typeof scopeWhere.clientId === 'string'
+          ? { id: scopeWhere.clientId }
+          : { id: scopeWhere.clientId };
+
     return fastify.db.client.findMany({
-      where: { isInternal: false },
+      where: { isInternal: false, ...idFilter },
       include: { _count: { select: { tickets: true, systems: true } } },
       orderBy: { name: 'asc' },
     });
@@ -71,10 +93,10 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     },
   );
 
-  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null } }>(
+  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
     '/api/clients/:id',
     async (request, reply) => {
-      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, ...rest } = request.body;
+      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, ...rest } = request.body;
       if (aiMode !== undefined && !VALID_AI_MODES.has(aiMode)) {
         return reply.code(400).send({ error: `Invalid aiMode "${aiMode}". Valid: ${[...VALID_AI_MODES].join(', ')}` });
       }
@@ -90,6 +112,15 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
           throw Object.assign(new Error('billingMarkupPercent must be a finite number between 1.0 and 10.0'), { statusCode: 400 });
         }
       }
+      if (notificationMode !== undefined) {
+        if (notificationMode !== 'client' && notificationMode !== 'operator') {
+          return reply.code(400).send({ error: "notificationMode must be 'client' or 'operator'" });
+        }
+        // Only platform admins/operators may flip notification mode. Portal ops users are read-only on this field.
+        if (!request.user) {
+          return reply.code(403).send({ error: 'Only platform operators may change notificationMode' });
+        }
+      }
       const domainMappings = validateDomainMappings(rest.domainMappings);
       return fastify.db.client.update({
         where: { id: request.params.id },
@@ -100,6 +131,7 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
           ...(billingPeriod !== undefined && { billingPeriod }),
           ...(billingAnchorDay !== undefined && { billingAnchorDay }),
           ...(billingMarkupPercent !== undefined && { billingMarkupPercent }),
+          ...(notificationMode !== undefined && { notificationMode }),
         },
       });
     },

--- a/services/copilot-api/src/routes/index.ts
+++ b/services/copilot-api/src/routes/index.ts
@@ -4,7 +4,7 @@ import type { AIRouter, ClientMemoryResolver, ModelConfigResolver, ProviderConfi
 import type { TicketCreatedJob, IngestionJob } from '@bronco/shared-types';
 import { UserRole } from '@bronco/shared-types';
 import type { Config } from '../config.js';
-import { requireRole } from '../plugins/auth.js';
+import { requireRole, requireOpsAccess } from '../plugins/auth.js';
 import { healthRoutes } from './health.js';
 import { clientRoutes } from './clients.js';
 import { peopleRoutes } from './people.js';
@@ -77,19 +77,30 @@ export async function registerRoutes(fastify: FastifyInstance, opts: RouteOpts):
   await fastify.register(portalTicketRoutes, { config: opts.config, ticketCreatedQueue: opts.ticketCreatedQueue, ingestQueue: opts.ingestQueue });
   await fastify.register(portalUserRoutes);
 
-  // Control panel routes — require ADMIN or OPERATOR role.
-  // API-key callers (service-to-service) pass through; only JWT-authenticated
-  // CLIENT users are blocked.
+  // Client-scoped control panel routes — accessible to operators AND portal
+  // users with hasOpsAccess (client-scoped ops people).
+  const opsAccessGuard = requireOpsAccess(UserRole.ADMIN, UserRole.OPERATOR);
+
+  await fastify.register(async (scoped) => {
+    scoped.addHook('preHandler', opsAccessGuard);
+
+    await scoped.register(clientRoutes);
+    await scoped.register(peopleRoutes);
+    await scoped.register(ticketRoutes, { logSummarizeQueue: opts.logSummarizeQueue, systemAnalysisQueue: opts.systemAnalysisQueue, clientLearningQueue: opts.clientLearningQueue, ticketCreatedQueue: opts.ticketCreatedQueue, ingestQueue: opts.ingestQueue, ai: opts.ai });
+    await scoped.register(artifactRoutes, { config: opts.config });
+    await scoped.register(aiUsageRoutes, { ai: opts.ai });
+    await scoped.register(ticketFilterPresetRoutes);
+    await scoped.register(pendingActionRoutes);
+  });
+
+  // Admin-only control panel routes — require ADMIN or OPERATOR JWT.
+  // Portal users (even with hasOpsAccess) cannot access these.
   const controlPanelGuard = requireRole(UserRole.ADMIN, UserRole.OPERATOR);
 
   await fastify.register(async (scoped) => {
     scoped.addHook('preHandler', controlPanelGuard);
 
-    await scoped.register(clientRoutes);
-    await scoped.register(peopleRoutes);
     await scoped.register(systemRoutes);
-    await scoped.register(ticketRoutes, { logSummarizeQueue: opts.logSummarizeQueue, systemAnalysisQueue: opts.systemAnalysisQueue, clientLearningQueue: opts.clientLearningQueue, ticketCreatedQueue: opts.ticketCreatedQueue, ingestQueue: opts.ingestQueue, ai: opts.ai });
-    await scoped.register(artifactRoutes, { config: opts.config });
     await scoped.register(repoRoutes);
     await scoped.register(issueJobRoutes, { issueResolveQueue: opts.issueResolveQueue });
     await scoped.register(integrationRoutes, { encryptionKey: opts.config.ENCRYPTION_KEY, mcpDiscoveryQueue: opts.mcpDiscoveryQueue, onSlackIntegrationChange: opts.onSlackIntegrationChange });
@@ -101,7 +112,6 @@ export async function registerRoutes(fastify: FastifyInstance, opts: RouteOpts):
     await scoped.register(aiConfigRoutes, { modelConfigResolver: opts.modelConfigResolver, ai: opts.ai });
     await scoped.register(aiProviderRoutes, { providerConfigResolver: opts.providerConfigResolver, encryptionKey: opts.config.ENCRYPTION_KEY });
     await scoped.register(systemStatusRoutes, { config: opts.config });
-    await scoped.register(aiUsageRoutes, { ai: opts.ai });
     await scoped.register(systemAnalysisRoutes, { systemAnalysisQueue: opts.systemAnalysisQueue });
     await scoped.register(systemIssuesRoutes, { redisUrl: opts.config.REDIS_URL });
     await scoped.register(notificationChannelRoutes, { encryptionKey: opts.config.ENCRYPTION_KEY });
@@ -114,14 +124,12 @@ export async function registerRoutes(fastify: FastifyInstance, opts: RouteOpts):
     await scoped.register(clientAiCredentialRoutes, { encryptionKey: opts.config.ENCRYPTION_KEY });
     await scoped.register(userRoutes);
     await scoped.register(scheduledProbeRoutes, { probeQueue: opts.probeQueue });
-    await scoped.register(ticketFilterPresetRoutes);
     await scoped.register(ingestRoutes, { ingestQueue: opts.ingestQueue });
     await scoped.register(invoiceRoutes, { invoiceStoragePath: opts.config.INVOICE_STORAGE_PATH });
     await scoped.register(failedJobRoutes, { queueMap: opts.queueMap });
     await scoped.register(emailLogRoutes);
     await scoped.register(operatorRoutes);
     await scoped.register(notificationPreferenceRoutes);
-    await scoped.register(pendingActionRoutes);
     await scoped.register(slackConversationRoutes);
   });
 }

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -1,11 +1,58 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
+import { resolveClientScope } from '../plugins/client-scope.js';
 
 const emailSchema = z.string().email('Invalid email format');
 
+const ALLOWED_USER_TYPES = new Set(['ADMIN', 'OPERATOR', 'USER']);
+const OPS_USER_TYPES = new Set(['ADMIN', 'OPERATOR']);
+
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
+}
+
+async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
+  const rows = await fastify.db.operatorClient.findMany({
+    where: { operatorId },
+    select: { clientId: true },
+  });
+  return rows.map((r) => r.clientId);
+}
+
+/**
+ * Determine whether the caller is allowed to access people for the given client.
+ * Resolves the caller's client scope and checks whether `clientId` is within it.
+ * Returns `{ allowed: true }` when access is permitted, `{ allowed: false }` otherwise.
+ */
+async function checkClientAccess(
+  fastify: FastifyInstance,
+  request: FastifyRequest,
+  clientId: string | undefined,
+): Promise<{ allowed: boolean }> {
+  const scope = await resolveClientScope(request, (operatorId) =>
+    getOperatorClientIds(fastify, operatorId),
+  );
+  if (scope.type === 'all') return { allowed: true };
+  if (scope.type === 'assigned') {
+    if (!clientId) return { allowed: false };
+    return { allowed: scope.clientIds.includes(clientId) };
+  }
+  // single
+  if (!clientId) return { allowed: false };
+  return { allowed: clientId === scope.clientId };
+}
+
+/**
+ * Check whether the caller is allowed to mutate people for the given client.
+ * Client OPERATOR people are read-only — only ADMIN people (and Operators) can manage.
+ */
+function canManagePeople(request: FastifyRequest): boolean {
+  if (request.user) return true; // Any operator (platform admin or scoped) can manage
+  if (request.portalUser) {
+    return request.portalUser.hasOpsAccess && request.portalUser.userType === 'ADMIN';
+  }
+  return false;
 }
 
 export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
@@ -15,11 +62,36 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
    */
   fastify.get<{ Querystring: { clientId?: string } }>(
     '/api/people',
-    async (request) => {
+    async (request, reply) => {
       const { clientId } = request.query;
+
+      // Resolve scope and apply filtering
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify, operatorId),
+      );
+      let scopedClientIdFilter: string | { in: string[] } | undefined;
+      if (scope.type === 'assigned') {
+        if (scope.clientIds.length === 0) return [];
+        if (clientId) {
+          if (!scope.clientIds.includes(clientId)) {
+            return reply.code(403).send({ error: 'Forbidden: client not in scope' });
+          }
+          scopedClientIdFilter = clientId;
+        } else {
+          scopedClientIdFilter = { in: scope.clientIds };
+        }
+      } else if (scope.type === 'single') {
+        if (clientId && clientId !== scope.clientId) {
+          return reply.code(403).send({ error: 'Forbidden: client not in scope' });
+        }
+        scopedClientIdFilter = scope.clientId;
+      } else if (clientId) {
+        scopedClientIdFilter = clientId;
+      }
+
       return fastify.db.person.findMany({
         where: {
-          ...(clientId && { clientId }),
+          ...(scopedClientIdFilter !== undefined && { clientId: scopedClientIdFilter }),
         },
         select: {
           id: true,
@@ -31,6 +103,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
           slackUserId: true,
           isPrimary: true,
           hasPortalAccess: true,
+          hasOpsAccess: true,
           userType: true,
           isActive: true,
           lastLoginAt: true,
@@ -46,7 +119,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
   /**
    * GET /api/people/:id
    */
-  fastify.get<{ Params: { id: string } }>('/api/people/:id', async (request) => {
+  fastify.get<{ Params: { id: string } }>('/api/people/:id', async (request, reply) => {
     const person = await fastify.db.person.findUnique({
       where: { id: request.params.id },
       select: {
@@ -59,6 +132,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
         slackUserId: true,
         isPrimary: true,
         hasPortalAccess: true,
+        hasOpsAccess: true,
         userType: true,
         isActive: true,
         lastLoginAt: true,
@@ -68,6 +142,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       },
     });
     if (!person) return fastify.httpErrors.notFound('Person not found');
+    const access = await checkClientAccess(fastify, request, person.clientId);
+    if (!access.allowed) {
+      return reply.code(403).send({ error: 'Forbidden: client not in scope' });
+    }
     return person;
   });
 
@@ -85,14 +163,24 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       slackUserId?: string;
       isPrimary?: boolean;
       hasPortalAccess?: boolean;
+      hasOpsAccess?: boolean;
       password?: string;
       userType?: string;
     };
   }>('/api/people', async (request, reply) => {
-    const { clientId, name, email: rawEmail, phone, role, slackUserId, isPrimary, hasPortalAccess, password, userType } = request.body;
+    const { clientId, name, email: rawEmail, phone, role, slackUserId, isPrimary, hasPortalAccess, hasOpsAccess, password, userType } = request.body;
 
     if (!clientId || !name || !rawEmail) {
       return reply.code(400).send({ error: 'clientId, name, and email are required' });
+    }
+
+    if (!canManagePeople(request)) {
+      return reply.code(403).send({ error: 'Forbidden: insufficient role to manage people' });
+    }
+
+    const access = await checkClientAccess(fastify, request, clientId);
+    if (!access.allowed) {
+      return reply.code(403).send({ error: 'Forbidden: client not in scope' });
     }
 
     const parsed = emailSchema.safeParse(rawEmail);
@@ -101,6 +189,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
     }
     const email = rawEmail.trim().toLowerCase();
 
+    if (userType && !ALLOWED_USER_TYPES.has(userType)) {
+      return reply.code(400).send({ error: 'Invalid userType. Must be ADMIN, OPERATOR, or USER' });
+    }
+
     if (hasPortalAccess) {
       if (!password) {
         return reply.code(400).send({ error: 'password is required when hasPortalAccess is true' });
@@ -108,8 +200,19 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       if (password.length < 8) {
         return reply.code(400).send({ error: 'Password must be at least 8 characters' });
       }
-      if (userType && userType !== 'ADMIN' && userType !== 'USER') {
-        return reply.code(400).send({ error: 'Invalid userType. Must be ADMIN or USER' });
+    }
+
+    // Ops access requires portal access (so the person can log in) and an
+    // ADMIN or OPERATOR userType.
+    if (hasOpsAccess) {
+      if (!hasPortalAccess) {
+        return reply.code(400).send({ error: 'hasOpsAccess requires hasPortalAccess to be true' });
+      }
+      if (!password) {
+        return reply.code(400).send({ error: 'password is required when hasOpsAccess is true' });
+      }
+      if (!userType || !OPS_USER_TYPES.has(userType)) {
+        return reply.code(400).send({ error: 'hasOpsAccess requires userType to be ADMIN or OPERATOR' });
       }
     }
 
@@ -120,6 +223,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
     }
 
     const passwordHash = hasPortalAccess && password ? await bcrypt.hash(password, 10) : null;
+    const resolvedUserType =
+      hasPortalAccess || hasOpsAccess
+        ? ((userType ?? (hasOpsAccess ? 'OPERATOR' : 'USER')) as 'ADMIN' | 'OPERATOR' | 'USER')
+        : undefined;
 
     try {
       const person = await fastify.db.person.create({
@@ -132,8 +239,9 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
           slackUserId: slackUserId ?? null,
           isPrimary: isPrimary ?? false,
           hasPortalAccess: hasPortalAccess ?? false,
+          hasOpsAccess: hasOpsAccess ?? false,
           ...(passwordHash ? { passwordHash } : {}),
-          ...(hasPortalAccess ? { userType: (userType === 'ADMIN' ? 'ADMIN' : 'USER') as 'ADMIN' | 'USER' } : {}),
+          ...(resolvedUserType !== undefined ? { userType: resolvedUserType } : {}),
         },
         select: {
           id: true,
@@ -145,6 +253,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
           slackUserId: true,
           isPrimary: true,
           hasPortalAccess: true,
+          hasOpsAccess: true,
           userType: true,
           isActive: true,
           lastLoginAt: true,
@@ -176,16 +285,21 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       slackUserId?: string | null;
       isPrimary?: boolean;
       hasPortalAccess?: boolean;
+      hasOpsAccess?: boolean;
       password?: string;
       userType?: string;
       isActive?: boolean;
     };
   }>('/api/people/:id', async (request, reply) => {
     const { id } = request.params;
-    const { name, email: rawEmail, phone, role, slackUserId, isPrimary, hasPortalAccess, password, userType, isActive } = request.body;
+    const { name, email: rawEmail, phone, role, slackUserId, isPrimary, hasPortalAccess, hasOpsAccess, password, userType, isActive } = request.body;
 
-    if (userType && userType !== 'ADMIN' && userType !== 'USER') {
-      return reply.code(400).send({ error: 'Invalid userType. Must be ADMIN or USER' });
+    if (!canManagePeople(request)) {
+      return reply.code(403).send({ error: 'Forbidden: insufficient role to manage people' });
+    }
+
+    if (userType && !ALLOWED_USER_TYPES.has(userType)) {
+      return reply.code(400).send({ error: 'Invalid userType. Must be ADMIN, OPERATOR, or USER' });
     }
 
     const target = await fastify.db.person.findUnique({ where: { id } });
@@ -193,11 +307,32 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.code(404).send({ error: 'Person not found' });
     }
 
+    const access = await checkClientAccess(fastify, request, target.clientId);
+    if (!access.allowed) {
+      return reply.code(403).send({ error: 'Forbidden: client not in scope' });
+    }
+
     // Enabling portal access requires a password to be set — otherwise the person cannot log in.
     // To set/change a password on an existing portal user, use POST /api/people/:id/reset-password.
     if (hasPortalAccess === true && !target.hasPortalAccess) {
       if (!password || password.length < 8) {
         return reply.code(400).send({ error: 'password (minimum 8 characters) is required when enabling portal access' });
+      }
+    }
+
+    // Enabling ops access requires portal access (so the person can log in) and
+    // an ADMIN or OPERATOR userType.
+    if (hasOpsAccess === true) {
+      const effectiveHasPortal = hasPortalAccess ?? target.hasPortalAccess;
+      if (!effectiveHasPortal) {
+        return reply.code(400).send({ error: 'hasOpsAccess requires hasPortalAccess to be true' });
+      }
+      if (!target.passwordHash && !password) {
+        return reply.code(400).send({ error: 'hasOpsAccess requires the person to have a password — set one via password field or POST /api/people/:id/reset-password' });
+      }
+      const effectiveUserType = userType ?? target.userType ?? null;
+      if (!effectiveUserType || !OPS_USER_TYPES.has(effectiveUserType)) {
+        return reply.code(400).send({ error: 'hasOpsAccess requires userType to be ADMIN or OPERATOR' });
       }
     }
 
@@ -229,8 +364,9 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
           ...(slackUserId !== undefined && { slackUserId }),
           ...(isPrimary !== undefined && { isPrimary }),
           ...(hasPortalAccess !== undefined && { hasPortalAccess }),
+          ...(hasOpsAccess !== undefined && { hasOpsAccess }),
           ...(newPasswordHash && { passwordHash: newPasswordHash }),
-          ...(userType !== undefined && { userType: userType as 'ADMIN' | 'USER' }),
+          ...(userType !== undefined && { userType: userType as 'ADMIN' | 'OPERATOR' | 'USER' }),
           ...(isActive !== undefined && { isActive }),
         },
         select: {
@@ -243,6 +379,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
           slackUserId: true,
           isPrimary: true,
           hasPortalAccess: true,
+          hasOpsAccess: true,
           userType: true,
           isActive: true,
           lastLoginAt: true,
@@ -263,9 +400,16 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
    * Deactivate portal users; hard-delete contact-only people.
    */
   fastify.delete<{ Params: { id: string } }>('/api/people/:id', async (request, reply) => {
+    if (!canManagePeople(request)) {
+      return reply.code(403).send({ error: 'Forbidden: insufficient role to manage people' });
+    }
     const target = await fastify.db.person.findUnique({ where: { id: request.params.id } });
     if (!target) {
       return reply.code(404).send({ error: 'Person not found' });
+    }
+    const access = await checkClientAccess(fastify, request, target.clientId);
+    if (!access.allowed) {
+      return reply.code(403).send({ error: 'Forbidden: client not in scope' });
     }
 
     // Soft delete: portal users get deactivated so they retain historical ticket links
@@ -305,6 +449,9 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       const { id } = request.params;
       const { password } = request.body;
 
+      if (!canManagePeople(request)) {
+        return reply.code(403).send({ error: 'Forbidden: insufficient role to manage people' });
+      }
       if (!password || password.length < 8) {
         return reply.code(400).send({ error: 'Password must be at least 8 characters' });
       }
@@ -312,6 +459,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       const target = await fastify.db.person.findUnique({ where: { id } });
       if (!target) {
         return reply.code(404).send({ error: 'Person not found' });
+      }
+      const access = await checkClientAccess(fastify, request, target.clientId);
+      if (!access.allowed) {
+        return reply.code(403).send({ error: 'Forbidden: client not in scope' });
       }
       if (!target.hasPortalAccess) {
         return reply.code(400).send({ error: 'Person does not have portal access' });

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
-import { resolveClientScope } from '../plugins/client-scope.js';
+import { resolveClientScope, getOperatorClientIds } from '../plugins/client-scope.js';
 
 const emailSchema = z.string().email('Invalid email format');
 
@@ -10,14 +10,6 @@ const OPS_USER_TYPES = new Set(['ADMIN', 'OPERATOR']);
 
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
-}
-
-async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
-  const rows = await fastify.db.operatorClient.findMany({
-    where: { operatorId },
-    select: { clientId: true },
-  });
-  return rows.map((r) => r.clientId);
 }
 
 /**
@@ -31,7 +23,7 @@ async function checkClientAccess(
   clientId: string | undefined,
 ): Promise<{ allowed: boolean }> {
   const scope = await resolveClientScope(request, (operatorId) =>
-    getOperatorClientIds(fastify, operatorId),
+    getOperatorClientIds(fastify.db, operatorId),
   );
   if (scope.type === 'all') return { allowed: true };
   if (scope.type === 'assigned') {
@@ -67,7 +59,7 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
 
       // Resolve scope and apply filtering
       const scope = await resolveClientScope(request, (operatorId) =>
-        getOperatorClientIds(fastify, operatorId),
+        getOperatorClientIds(fastify.db, operatorId),
       );
       let scopedClientIdFilter: string | { in: string[] } | undefined;
       if (scope.type === 'assigned') {

--- a/services/copilot-api/src/routes/portal-auth.ts
+++ b/services/copilot-api/src/routes/portal-auth.ts
@@ -11,10 +11,17 @@ const REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 function signPortalAccessToken(
   secret: string,
-  user: { id: string; email: string; clientId: string; userType: ClientUserType },
+  user: { id: string; email: string; clientId: string; userType: ClientUserType; hasOpsAccess: boolean },
 ): string {
   return jwt.sign(
-    { sub: user.id, email: user.email, clientId: user.clientId, userType: user.userType, type: 'portal_access' },
+    {
+      sub: user.id,
+      email: user.email,
+      clientId: user.clientId,
+      userType: user.userType,
+      hasOpsAccess: user.hasOpsAccess,
+      type: 'portal_access',
+    },
     secret,
     { expiresIn: ACCESS_TOKEN_EXPIRY },
   );
@@ -81,6 +88,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
         email: user.email,
         clientId: user.clientId,
         userType,
+        hasOpsAccess: user.hasOpsAccess,
       });
       const refreshToken = await issueRefreshToken(user.id);
 
@@ -93,6 +101,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
           name: user.name,
           clientId: user.clientId,
           userType,
+          hasOpsAccess: user.hasOpsAccess,
           client: user.client,
         },
       };
@@ -145,6 +154,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
         email: user.email,
         clientId: user.clientId,
         userType,
+        hasOpsAccess: user.hasOpsAccess,
       });
       const newRefreshToken = await issueRefreshToken(user.id);
 
@@ -236,6 +246,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
         email: user.email,
         clientId: user.clientId,
         userType,
+        hasOpsAccess: user.hasOpsAccess,
       });
       const refreshToken = await issueRefreshToken(user.id);
 
@@ -248,6 +259,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
           name: user.name,
           clientId: user.clientId,
           userType,
+          hasOpsAccess: user.hasOpsAccess,
           client,
         },
       };
@@ -272,6 +284,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
         clientId: true,
         userType: true,
         hasPortalAccess: true,
+        hasOpsAccess: true,
         isActive: true,
         lastLoginAt: true,
         createdAt: true,

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -5,6 +5,15 @@ import { ensureClientUser, Prisma } from '@bronco/db';
 import { TicketStatus, TicketCategory, TicketEventType, Priority, TicketSource, TaskType, isClosedStatus, AnalysisStatus, SufficiencyStatus, LogLevel } from '@bronco/shared-types';
 import { getSelfAnalysisConfig } from '@bronco/shared-utils';
 import type { TicketCreatedJob, IngestionJob } from '@bronco/shared-types';
+import { resolveClientScope } from '../plugins/client-scope.js';
+
+async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
+  const rows = await fastify.db.operatorClient.findMany({
+    where: { operatorId },
+    select: { clientId: true },
+  });
+  return rows.map((r) => r.clientId);
+}
 
 interface TicketRouteOpts {
   logSummarizeQueue?: Queue;
@@ -92,9 +101,31 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         return fastify.httpErrors.badRequest('assignedOperatorId must be a valid UUID or "unassigned"');
       }
 
+      // Resolve caller's client scope (platform admin → all, scoped operator → assigned, person → single)
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify, operatorId),
+      );
+      let scopedClientIdFilter: string | { in: string[] } | undefined;
+      if (scope.type === 'assigned') {
+        // No assigned clients → empty result set
+        if (scope.clientIds.length === 0) return [];
+        // If caller passed an explicit clientId filter, intersect with assigned clients
+        if (clientId) {
+          if (!scope.clientIds.includes(clientId)) return [];
+          scopedClientIdFilter = clientId;
+        } else {
+          scopedClientIdFilter = { in: scope.clientIds };
+        }
+      } else if (scope.type === 'single') {
+        if (clientId && clientId !== scope.clientId) return [];
+        scopedClientIdFilter = scope.clientId;
+      } else if (clientId) {
+        scopedClientIdFilter = clientId;
+      }
+
       return fastify.db.ticket.findMany({
         where: {
-          ...(clientId && { clientId }),
+          ...(scopedClientIdFilter !== undefined && { clientId: scopedClientIdFilter }),
           ...(statusFilter && { status: statusFilter }),
           ...(category && { category: category as TicketCategory }),
           ...(priorityFilter && { priority: priorityFilter }),

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -5,15 +5,7 @@ import { ensureClientUser, Prisma } from '@bronco/db';
 import { TicketStatus, TicketCategory, TicketEventType, Priority, TicketSource, TaskType, isClosedStatus, AnalysisStatus, SufficiencyStatus, LogLevel } from '@bronco/shared-types';
 import { getSelfAnalysisConfig } from '@bronco/shared-utils';
 import type { TicketCreatedJob, IngestionJob } from '@bronco/shared-types';
-import { resolveClientScope } from '../plugins/client-scope.js';
-
-async function getOperatorClientIds(fastify: FastifyInstance, operatorId: string): Promise<string[]> {
-  const rows = await fastify.db.operatorClient.findMany({
-    where: { operatorId },
-    select: { clientId: true },
-  });
-  return rows.map((r) => r.clientId);
-}
+import { resolveClientScope, getOperatorClientIds } from '../plugins/client-scope.js';
 
 interface TicketRouteOpts {
   logSummarizeQueue?: Queue;
@@ -103,7 +95,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
 
       // Resolve caller's client scope (platform admin → all, scoped operator → assigned, person → single)
       const scope = await resolveClientScope(request, (operatorId) =>
-        getOperatorClientIds(fastify, operatorId),
+        getOperatorClientIds(fastify.db, operatorId),
       );
       let scopedClientIdFilter: string | { in: string[] } | undefined;
       if (scope.type === 'assigned') {

--- a/services/issue-resolver/src/notify.ts
+++ b/services/issue-resolver/src/notify.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from '@bronco/db';
+import { NotificationMode } from '@bronco/shared-types';
 import type { ResolutionPlan } from '@bronco/shared-types';
-import { Mailer, SlackClient, createLogger, decrypt, looksEncrypted, notifyOperators } from '@bronco/shared-utils';
+import { Mailer, SlackClient, createLogger, decrypt, looksEncrypted, notifyOperators, notifyClientOperators } from '@bronco/shared-utils';
 import type { SlackMessageResult, SlackSender } from '@bronco/shared-utils';
 
 const logger = createLogger('issue-resolver:notify');
@@ -296,6 +297,56 @@ export async function notifyPlanGenerated(opts: {
         );
 
         logger.info({ issueJobId }, 'Plan email notification dispatched via notifyOperators');
+
+        // If the client is configured for operator-mode notifications, also notify
+        // its own ops people (userType ADMIN/OPERATOR with hasOpsAccess).
+        try {
+          const job = await db.issueJob.findUnique({
+            where: { id: issueJobId },
+            select: {
+              ticket: {
+                select: {
+                  clientId: true,
+                  client: { select: { notificationMode: true, slackChannelId: true } },
+                },
+              },
+            },
+          });
+          const clientId = job?.ticket?.clientId;
+          const client = job?.ticket?.client;
+          if (clientId && client && client.notificationMode === NotificationMode.OPERATOR) {
+            await notifyClientOperators(
+              mailer,
+              async (cid) => {
+                const rows = await db.person.findMany({
+                  where: {
+                    clientId: cid,
+                    userType: { in: ['OPERATOR', 'ADMIN'] },
+                    isActive: true,
+                    hasOpsAccess: true,
+                  },
+                  select: { id: true, email: true, name: true, userType: true, slackUserId: true },
+                });
+                return rows.map((r) => ({
+                  id: r.id,
+                  email: r.email,
+                  name: r.name,
+                  userType: r.userType ?? 'USER',
+                  slackUserId: r.slackUserId,
+                }));
+              },
+              {
+                subject,
+                body,
+                clientId,
+                slackChannelId: client.slackChannelId ?? undefined,
+              },
+            );
+            logger.info({ issueJobId, clientId }, 'Plan email also routed to client operators');
+          }
+        } catch (err) {
+          logger.warn({ issueJobId, err }, 'Failed to route plan notification to client operators');
+        }
       } finally {
         await mailer.close();
       }

--- a/services/issue-resolver/src/notify.ts
+++ b/services/issue-resolver/src/notify.ts
@@ -339,6 +339,7 @@ export async function notifyPlanGenerated(opts: {
                 subject,
                 body,
                 clientId,
+                slack: opts.slack,
                 slackChannelId: client.slackChannelId ?? undefined,
               },
             );

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -4184,7 +4184,7 @@ async function executeRoutePipeline(
             try {
               const client = await db.client.findUnique({
                 where: { id: ctx.clientId },
-                select: { notificationMode: true, slackChannelId: true },
+                select: { notificationMode: true },
               });
               if (client && client.notificationMode === NotificationMode.OPERATOR) {
                 const sent = await notifyClientOperatorsFn(
@@ -4211,7 +4211,6 @@ async function executeRoutePipeline(
                     subject: notifySubject,
                     body: notifyBody,
                     clientId: ctx.clientId,
-                    slackChannelId: client.slackChannelId ?? undefined,
                   },
                 );
                 clientNotified.push(...sent);

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -7,8 +7,8 @@ import { Prisma } from '@bronco/db';
 import type { PrismaClient } from '@bronco/db';
 import type { TicketCategory, Priority, TicketStatus, TicketSource, AnalysisJob } from '@bronco/shared-types';
 import { AIRouter } from '@bronco/ai-provider';
-import { TaskType, RouteStepType, isClosedStatus, AnalysisStatus, SufficiencyStatus, SufficiencyConfidence } from '@bronco/shared-types';
-import { createLogger, AppLogger, createPrismaLogWriter, decrypt, looksEncrypted, MCP_TOOL_TIMEOUT_MS, mcpUrl, callMcpToolViaSdk, notifyOperators as notifyOperatorsFn, getSelfAnalysisConfig } from '@bronco/shared-utils';
+import { TaskType, RouteStepType, isClosedStatus, AnalysisStatus, SufficiencyStatus, SufficiencyConfidence, NotificationMode } from '@bronco/shared-types';
+import { createLogger, AppLogger, createPrismaLogWriter, decrypt, looksEncrypted, MCP_TOOL_TIMEOUT_MS, mcpUrl, callMcpToolViaSdk, notifyOperators as notifyOperatorsFn, notifyClientOperators as notifyClientOperatorsFn, getSelfAnalysisConfig } from '@bronco/shared-utils';
 import type { AIToolDefinition, AIMessage, AIToolUseBlock, AITextBlock, AIToolResponse, AIToolResultBlock } from '@bronco/shared-types';
 import type { Mailer, ReplyOptions } from '@bronco/shared-utils';
 import { executeRecommendations } from './recommendation-executor.js';
@@ -4178,18 +4178,62 @@ async function executeRoutePipeline(
                 getPreference: (evt) => db.notificationPreference.findUnique({ where: { event: evt } }),
               },
             );
-            if (notified.length > 0) {
+
+            // Also notify client operators if the client has notificationMode='operator'
+            const clientNotified: string[] = [];
+            try {
+              const client = await db.client.findUnique({
+                where: { id: ctx.clientId },
+                select: { notificationMode: true, slackChannelId: true },
+              });
+              if (client && client.notificationMode === NotificationMode.OPERATOR) {
+                const sent = await notifyClientOperatorsFn(
+                  mailer,
+                  async (clientId) => {
+                    const rows = await db.person.findMany({
+                      where: {
+                        clientId,
+                        userType: { in: ['OPERATOR', 'ADMIN'] },
+                        isActive: true,
+                        hasOpsAccess: true,
+                      },
+                      select: { id: true, email: true, name: true, userType: true, slackUserId: true },
+                    });
+                    return rows.map((r) => ({
+                      id: r.id,
+                      email: r.email,
+                      name: r.name,
+                      userType: r.userType ?? 'USER',
+                      slackUserId: r.slackUserId,
+                    }));
+                  },
+                  {
+                    subject: notifySubject,
+                    body: notifyBody,
+                    clientId: ctx.clientId,
+                    slackChannelId: client.slackChannelId ?? undefined,
+                  },
+                );
+                clientNotified.push(...sent);
+              }
+            } catch (err) {
+              const errMsg = err instanceof Error ? err.message : String(err);
+              appLog.warn(`NOTIFY_OPERATOR client routing failed: ${errMsg}`, { err, ticketId }, ticketId, 'ticket');
+            }
+
+            const allNotified = [...notified, ...clientNotified];
+            if (allNotified.length > 0) {
               await db.ticketEvent.create({
                 data: {
                   ticketId,
                   eventType: 'EMAIL_OUTBOUND',
                   content: notifyBody,
-                  metadata: { type: 'operator_notification', to: notified, subject: notifySubject },
+                  metadata: { type: 'operator_notification', to: allNotified, subject: notifySubject },
                   actor: 'system:analyzer',
                 },
               });
               const stepDuration = Date.now() - stepStart;
-              appLog.info(`Operator notifications sent to ${notified.join(', ')} (${(stepDuration / 1000).toFixed(1)}s)`, { ticketId, to: notified, durationMs: stepDuration }, ticketId, 'ticket');
+              appLog.info(`Operator notifications sent to ${allNotified.join(', ')} (${(stepDuration / 1000).toFixed(1)}s)`, { ticketId, to: allNotified, durationMs: stepDuration }, ticketId, 'ticket');
               stepsSucceeded++;
             } else {
               appLog.warn('NOTIFY_OPERATOR skipped — no operators configured for email notifications', { ticketId, stepId: step.id }, ticketId, 'ticket');


### PR DESCRIPTION
Fixes #196, fixes #206.

## Summary

Adds a 5-tier RBAC model (platform admin, scoped operator, client admin, client operator, client user), lets client-side ops people use the control panel via the portal JWT, and routes resolution notifications to client staff when the client is in operator mode.

## Schema

- `Operator.isAdmin` (backfilled true for existing operators)
- `OperatorClient` junction for scoped operators → assigned clients
- `Person.hasOpsAccess`
- `ClientUserType.OPERATOR` (between `ADMIN` and `USER`)
- `Client.notificationMode` (`'client'` default, `'operator'`)

Migration: `packages/db/prisma/migrations/20260412010000_add_rbac_and_notification_mode/`.

## Backend

- **Auth plugin** — control-panel routes try the portal JWT first and accept it when `hasOpsAccess === true`, else fall back to the main operator JWT. `request.portalUser` carries `clientId`, `userType`, `hasOpsAccess`.
- **Client scoping** — new `services/copilot-api/src/plugins/client-scope.ts` (`resolveClientScope` + `scopeToWhere`) wired into `/api/clients`, `/api/tickets`, `/api/people`. Platform admins see everything, scoped operators see assigned clients, portal ops people see only their own client. Explicit out-of-scope `clientId` query params return empty / 403.
- **People route** — supports `hasOpsAccess` + `OPERATOR` userType on create/update; validates `hasOpsAccess` requires `ADMIN`/`OPERATOR`. Platform/scoped operators can manage; ADMIN portal users with ops access can manage; OPERATOR portal users are read-only.
- **Client PATCH** — `notificationMode` field added with `'client' | 'operator'` validation, gated to platform operators (portal users get 403 if they try to change it).
- **`notifyClientOperators`** (new in `@bronco/shared-utils`) — sends resolution emails + optional Slack DMs/channel to the client's OPERATOR/ADMIN people with ops access. Wired into the `NOTIFY_OPERATOR` analyzer step and `issue-resolver/src/notify.ts`; triggered only when `client.notificationMode === 'operator'`.

## Frontend

- **Auth service** — extended `AuthUser` with `isPortalOpsUser` / `clientId` / `portalUserType`. `login()` tries operator login first; on 401/403 falls back to `/portal/auth/login` and rejects portal logins without ops access. `fetchMe()` picks `/portal/auth/me` vs `/auth/me` based on decoded JWT `type`. Refresh/change-password/update-profile route to the portal endpoints when scoped.
- **Route guard** — new `scopedOpsGuard` applied via `canActivate` on every global-only route. Scoped users are allowed `/dashboard` (rewritten), `/tickets*`, `/profile`, `/clients/:id`; everything else redirects to `/clients/<their-clientId>`. Default `/` redirect is a function that routes scoped users straight to their client detail.
- **Sidebar** — conditionally renders a minimal nav (Tickets, Client Details, Profile) for scoped users; badge fetches short-circuit so scoped users don't hit operator-only endpoints.
- **Client detail header** — notification mode toggle (hidden for scoped users) calls `PATCH /api/clients/:id` with a success/error toast and emits a `clientChange` event so the parent re-renders.
- **People tab** — access tier column returns one of `Ops Admin | Ops Operator | Portal Admin | Portal User | Contact` with chip styling, handling edge cases like `hasOpsAccess` with `userType: null`.
- **Person dialog** — `hasOpsAccess` toggle, `OPERATOR` user type option, validation preventing `hasOpsAccess` + `USER` combos.

## Docs

- `CLAUDE.md` Build and Test section now documents that `pnpm build` must run before `pnpm typecheck` on a fresh checkout (or after `pnpm clean`), because `ai-provider`, `shared-utils`, and the services depend on the compiled `.d.ts` outputs of `shared-types` / `shared-utils`.

## Test plan

- [ ] `pnpm build && pnpm typecheck` green (verified locally)
- [ ] Run the migration against a dev DB and confirm existing operators are backfilled `is_admin = true`
- [ ] Create a client Person with `hasOpsAccess = true, userType = 'OPERATOR'` and log in to the control panel with their credentials; confirm the sidebar is scoped and `/clients` redirects to their own client detail
- [ ] Confirm a platform admin still sees the full nav and can toggle `notificationMode` on any client
- [ ] Confirm a portal ops user gets 403 when trying to PATCH `notificationMode`
- [ ] Trigger a resolution plan on a client where `notificationMode = 'operator'` and confirm `notifyClientOperators` fires (email + Slack DMs to ops people)
- [ ] Confirm a resolution plan on a `notificationMode = 'client'` client still routes only to platform operators
- [ ] Confirm the People tab shows the correct tier chips across all five combinations