### PR TITLE
fix: frontend cleanup — config tab re-sync, person delete confirm (#212, #214)

### DIFF
--- a/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
@@ -140,12 +140,10 @@ export class ClientConfigTabComponent {
   slackValue = signal('');
   domainsValue = signal('');
   notesValue = signal('');
-  private initialized = false;
 
   ngOnChanges(): void {
     const c = this.client();
-    if (c && !this.initialized) {
-      this.initialized = true;
+    if (c) {
       this.slackValue.set(c.slackChannelId ?? '');
       this.domainsValue.set((c.domainMappings).join(', '));
       this.notesValue.set(c.notes ?? '');

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
@@ -68,7 +68,7 @@ import { PersonDialogComponent } from '../../../people/person-dialog.component';
           <ng-template #cell let-p>
             <div class="row-actions">
               <app-bronco-button variant="icon" size="sm" ariaLabel="Edit person" (click)="openEditDialog(p)">&#x270E;</app-bronco-button>
-              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete person" (click)="deletePerson(p.id)">&#x1F5D1;</app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete person" (click)="deletePerson(p)">&#x1F5D1;</app-bronco-button>
             </div>
           </ng-template>
         </app-data-column>
@@ -208,8 +208,12 @@ export class ClientPeopleTabComponent implements OnInit {
     this.load();
   }
 
-  deletePerson(id: string): void {
-    this.personService.deletePerson(id)
+  deletePerson(person: Person): void {
+    const message = person.hasPortalAccess
+      ? `Deactivate ${person.name}? They will lose portal access.`
+      : `Delete ${person.name}? This cannot be undone. If they are a follower on tickets, deletion will fail.`;
+    if (!confirm(message)) return;
+    this.personService.deletePerson(person.id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {


### PR DESCRIPTION
## Summary

- **#212** — Remove one-shot `initialized` guard in `config-tab.component.ts` so form signals (`slackValue`, `domainsValue`, `notesValue`) re-sync whenever the `client` input changes after first render, not just on the first change
- **#214** — Add a `confirm()` gate before hard-deleting a person in `people-tab.component.ts`, with context-aware message: portal users get a deactivation warning; plain contacts get a hard-delete warning mentioning ticket follower risk

> Notes: Issues #190, #201, and #202 listed in this task were already resolved in PR #207. This PR addresses the remaining two issues.

## Test plan

- [ ] Open a client detail, switch to the Config tab — verify form fields are populated
- [ ] Navigate to a different client and back — verify form fields update to the new client's values (previously they'd stay stale)
- [ ] On the People tab, click the delete icon for a plain contact — verify confirm dialog appears with hard-delete warning
- [ ] Click delete for a person with portal access — verify confirm dialog mentions deactivation/portal access loss
- [ ] Cancel the confirm — verify no deletion occurs

https://claude.ai/code/session_012nCfMzWjaRVetAL7yTYGsk