### PR TITLE
feat: mobile responsive control panel — phases 1 and 2

### DIFF
--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -158,6 +158,15 @@ export const routes: Routes = [
         canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/users/user-list.component').then(m => m.UserListComponent),
       },
+      {
+        // Mobile-only routed full-screen detail view. Desktop never navigates
+        // here — DetailPanelService.open() routes here only when
+        // viewport.isMobile() is true. The route is valid on desktop too (for
+        // direct deep links); the shell's detail-view wrapper just renders
+        // the same panel full-width.
+        path: 'detail/:type/:id',
+        loadComponent: () => import('./shell/detail-view.component').then(m => m.DetailViewComponent),
+      },
     ],
   },
 ];

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { Location } from '@angular/common';
 import { ViewportService } from './viewport.service.js';
 
 export type DetailEntityType = 'ticket' | 'client' | 'probe' | 'system' | 'analysis' | 'job';
@@ -14,8 +13,22 @@ const VALID_MODES: ReadonlySet<string> = new Set<DetailPanelMode>(['full', 'comp
 @Injectable({ providedIn: 'root' })
 export class DetailPanelService {
   private readonly router = inject(Router);
-  private readonly location = inject(Location);
   private readonly viewport = inject(ViewportService);
+
+  /**
+   * Parent list path per entity type. Used when closing the mobile routed
+   * detail view (so deep-link arrivals don't exit the app), and when flipping
+   * back to desktop from a routed view (to navigate to the parent list and
+   * restore the inline side pane via query params).
+   */
+  static readonly PARENT_LIST: Record<DetailEntityType, string> = {
+    ticket: '/dashboard',
+    client: '/clients',
+    probe: '/scheduled-probes',
+    system: '/system-status',
+    analysis: '/system-analysis',
+    job: '/failed-jobs',
+  };
 
   readonly entityType = signal<DetailEntityType | null>(null);
   readonly entityId = signal<string | null>(null);
@@ -50,13 +63,18 @@ export class DetailPanelService {
   }
 
   close(): void {
+    // Capture entity type BEFORE dismiss() clears it — we need it to pick
+    // the right parent list for the routed-view case.
+    const type = this.entityType();
+    const wasRouted = this.router.url.startsWith('/detail/');
     this.dismiss();
-    // On the routed detail view (`/detail/:type/:id`) the route itself is the
-    // state — use history to return to wherever the user came from. This
-    // covers both the mobile primary flow and the mobile→desktop resize
-    // edge case. On desktop list pages we just clear the query params.
-    if (this.router.url.startsWith('/detail/')) {
-      this.location.back();
+    if (wasRouted) {
+      // Mobile routed detail view. Navigate to the entity's parent list
+      // rather than `location.back()` — back is unreliable: deep-link
+      // arrivals (shared URL, bookmark) have no intra-app history and
+      // would exit the app entirely.
+      const parent = (type && DetailPanelService.PARENT_LIST[type]) || '/dashboard';
+      this.router.navigate([parent]);
       return;
     }
     this.router.navigate([], {
@@ -68,10 +86,26 @@ export class DetailPanelService {
 
   /** Reset panel state without navigating — use when another navigation is already in progress. */
   dismiss(): void {
+    if (this._suppressNextDismiss) {
+      this._suppressNextDismiss = false;
+      return;
+    }
     this.entityType.set(null);
     this.entityId.set(null);
     this.mode.set('full');
   }
+
+  /**
+   * Tell the NEXT dismiss() call to skip clearing signals. Used by the shell
+   * when a viewport-flip from mobile → desktop causes navigation away from
+   * `/detail/:type/:id` — DetailViewComponent's onDestroy would otherwise
+   * wipe the signals before the inline side pane could pick up the state.
+   */
+  suppressNextDismiss(): void {
+    this._suppressNextDismiss = true;
+  }
+
+  private _suppressNextDismiss = false;
 
   /**
    * Hydrate panel state from route params (used by the mobile routed

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationCancel, NavigationEnd, NavigationError, NavigationSkipped, Router } from '@angular/router';
+import { filter, first } from 'rxjs';
 import { ViewportService } from './viewport.service.js';
 
 export type DetailEntityType = 'ticket' | 'client' | 'probe' | 'system' | 'analysis' | 'job';
@@ -49,9 +50,13 @@ export class DetailPanelService {
   open(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
     this.setState(type, id, mode);
     if (this.viewport.isMobile()) {
+      // No `queryParamsHandling: 'merge'` — we're changing path into
+      // /detail/:type/:id, so we don't want list-page query params (e.g.
+      // `?clientId=…` on /tickets, `?tab=…` on settings-style pages, or
+      // stale desktop `?detail=…&type=…` from a pre-flip URL) to leak into
+      // the routed URL. Only `mode` when non-default is preserved.
       this.router.navigate(['/detail', type, id], {
-        queryParams: { mode: mode === 'full' ? null : mode },
-        queryParamsHandling: 'merge',
+        queryParams: mode === 'full' ? undefined : { mode },
       });
     } else {
       this.router.navigate([], {
@@ -100,17 +105,35 @@ export class DetailPanelService {
    * when a viewport-flip from mobile → desktop causes navigation away from
    * `/detail/:type/:id` — DetailViewComponent's onDestroy would otherwise
    * wipe the signals before the inline side pane could pick up the state.
+   *
+   * The flag is auto-cleared when the current navigation settles (end, cancel,
+   * error, or skipped) so a cancelled navigation can't leave it armed to
+   * silently swallow a later unrelated dismiss(). Any dismiss() during the
+   * navigation consumes the flag first; this subscription then becomes a
+   * no-op reset.
    */
   suppressNextDismiss(): void {
     this._suppressNextDismiss = true;
+    this.router.events
+      .pipe(
+        filter(e =>
+          e instanceof NavigationEnd ||
+          e instanceof NavigationCancel ||
+          e instanceof NavigationError ||
+          e instanceof NavigationSkipped,
+        ),
+        first(),
+      )
+      .subscribe(() => { this._suppressNextDismiss = false; });
   }
 
   private _suppressNextDismiss = false;
 
   /**
-   * Hydrate panel state from route params (used by the mobile routed
-   * DetailViewComponent). Validates entity type and mode the same way as
-   * `restoreFromUrl` — an unknown type falls back to `ticket`.
+   * Set panel state signals directly, without navigating or validating.
+   * Callers are responsible for validating `type`/`mode` — see
+   * `hydrateFromParams` (route-param entry point) and `restoreFromUrl`
+   * (query-param entry point) for the validating wrappers.
    */
   setState(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
     this.mode.set(mode);

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { ViewportService } from './viewport.service.js';
 
 export type DetailEntityType = 'ticket' | 'client' | 'probe' | 'system' | 'analysis' | 'job';
 export type DetailPanelMode = 'full' | 'compact';
@@ -12,27 +14,51 @@ const VALID_MODES: ReadonlySet<string> = new Set<DetailPanelMode>(['full', 'comp
 @Injectable({ providedIn: 'root' })
 export class DetailPanelService {
   private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  private readonly viewport = inject(ViewportService);
 
   readonly entityType = signal<DetailEntityType | null>(null);
   readonly entityId = signal<string | null>(null);
   readonly mode = signal<DetailPanelMode>('full');
   readonly isOpen = computed(() => this.entityId() !== null);
 
+  /**
+   * Open a detail view for the given entity. Behavior depends on viewport:
+   *
+   * - Desktop (`>= 768px`): set signals and merge `detail`/`type`/`mode` into
+   *   the current URL's query params. The inline side pane renders.
+   * - Mobile (`< 768px`): set signals AND navigate to `/detail/:type/:id`.
+   *   The routed `DetailViewComponent` renders the same panel full-screen.
+   *
+   * Signals are always set so components observing the panel state work
+   * identically across both code paths.
+   */
   open(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
-    this.mode.set(mode);
-    this.entityType.set(type);
-    this.entityId.set(id);
-    this.router.navigate([], {
-      queryParams: { detail: id, type, mode },
-      queryParamsHandling: 'merge',
-      replaceUrl: true,
-    });
+    this.setState(type, id, mode);
+    if (this.viewport.isMobile()) {
+      this.router.navigate(['/detail', type, id], {
+        queryParams: { mode: mode === 'full' ? null : mode },
+        queryParamsHandling: 'merge',
+      });
+    } else {
+      this.router.navigate([], {
+        queryParams: { detail: id, type, mode },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    }
   }
 
   close(): void {
-    this.entityType.set(null);
-    this.entityId.set(null);
-    this.mode.set('full');
+    this.dismiss();
+    // On the routed detail view (`/detail/:type/:id`) the route itself is the
+    // state — use history to return to wherever the user came from. This
+    // covers both the mobile primary flow and the mobile→desktop resize
+    // edge case. On desktop list pages we just clear the query params.
+    if (this.router.url.startsWith('/detail/')) {
+      this.location.back();
+      return;
+    }
     this.router.navigate([], {
       queryParams: { detail: null, type: null, mode: null },
       queryParamsHandling: 'merge',
@@ -45,6 +71,31 @@ export class DetailPanelService {
     this.entityType.set(null);
     this.entityId.set(null);
     this.mode.set('full');
+  }
+
+  /**
+   * Hydrate panel state from route params (used by the mobile routed
+   * DetailViewComponent). Validates entity type and mode the same way as
+   * `restoreFromUrl` — an unknown type falls back to `ticket`.
+   */
+  setState(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
+    this.mode.set(mode);
+    this.entityType.set(type);
+    this.entityId.set(id);
+  }
+
+  /**
+   * Parse raw route params and hydrate panel state, or dismiss if params
+   * describe no valid entity. Used by DetailViewComponent.
+   */
+  hydrateFromParams(params: { type?: string | null; id?: string | null; mode?: string | null }): void {
+    if (params.id && VALID_ENTITY_TYPES.has(params.type ?? '')) {
+      const type = params.type as DetailEntityType;
+      const mode = VALID_MODES.has(params.mode ?? '') ? (params.mode as DetailPanelMode) : 'full';
+      this.setState(type, params.id, mode);
+    } else {
+      this.dismiss();
+    }
   }
 
   /** Call from shell on init to restore panel from query param */

--- a/services/control-panel/src/app/core/services/sidebar.service.ts
+++ b/services/control-panel/src/app/core/services/sidebar.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, signal, inject, DestroyRef } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router, NavigationEnd, NavigationSkipped } from '@angular/router';
 import { filter } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -20,11 +20,14 @@ export class SidebarService {
   readonly isOpen = signal(false);
 
   constructor() {
-    // Any completed navigation closes the drawer. This covers nav-link taps,
-    // programmatic navigations from within the drawer, and browser history.
+    // Any completed navigation closes the drawer. Also listen for
+    // NavigationSkipped — Angular's default `onSameUrlNavigation: 'ignore'`
+    // suppresses NavigationEnd when a user taps a link for the already-active
+    // route (e.g. already on /dashboard and tapping "Dashboard" in the
+    // drawer), which would otherwise leave the drawer stuck open.
     this.router.events
       .pipe(
-        filter(e => e instanceof NavigationEnd),
+        filter(e => e instanceof NavigationEnd || e instanceof NavigationSkipped),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.close());

--- a/services/control-panel/src/app/core/services/sidebar.service.ts
+++ b/services/control-panel/src/app/core/services/sidebar.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, signal, inject, DestroyRef } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+/**
+ * Mobile sidebar drawer state.
+ *
+ * On desktop (`>= 768px`) the sidebar is rendered inline in the shell flex
+ * layout and this service is unused. On mobile the sidebar is rendered via a
+ * CDK Overlay drawer and the shell subscribes to `isOpen` to attach/detach
+ * the overlay. The drawer auto-closes on any successful route navigation so
+ * tapping a nav link both navigates and dismisses the drawer.
+ */
+@Injectable({ providedIn: 'root' })
+export class SidebarService {
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly isOpen = signal(false);
+
+  constructor() {
+    // Any completed navigation closes the drawer. This covers nav-link taps,
+    // programmatic navigations from within the drawer, and browser history.
+    this.router.events
+      .pipe(
+        filter(e => e instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.close());
+  }
+
+  open(): void { this.isOpen.set(true); }
+  close(): void { this.isOpen.set(false); }
+  toggle(): void { this.isOpen.update(v => !v); }
+}

--- a/services/control-panel/src/app/core/services/viewport.service.ts
+++ b/services/control-panel/src/app/core/services/viewport.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, inject } from '@angular/core';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+/**
+ * Responsive viewport service.
+ *
+ * Exposes `isMobile` as a signal backed by CDK BreakpointObserver. The single
+ * shell breakpoint — `(max-width: 767.98px)` — must be kept in sync with the
+ * media queries used in component CSS (sidebar, header, shell content, etc.)
+ * so the CSS branches and the template branches agree.
+ */
+@Injectable({ providedIn: 'root' })
+export class ViewportService {
+  private readonly bp = inject(BreakpointObserver);
+
+  /** True when viewport is below the shell mobile breakpoint. */
+  readonly isMobile = toSignal(
+    this.bp.observe('(max-width: 767.98px)').pipe(map(r => r.matches)),
+    { initialValue: false },
+  );
+}

--- a/services/control-panel/src/app/features/clients/client-list.component.ts
+++ b/services/control-panel/src/app/features/clients/client-list.component.ts
@@ -20,13 +20,13 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, Di
         (rowClick)="onClientClick($event)"
         emptyMessage="No clients yet">
 
-        <app-data-column key="name" header="Name" [sortable]="false">
+        <app-data-column key="name" header="Name" [sortable]="false" mobilePriority="primary">
           <ng-template #cell let-row>
             <span style="font-weight: 500; color: var(--text-primary);">{{ row.name }}</span>
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="shortCode" header="Code" width="100px" [sortable]="false">
+        <app-data-column key="shortCode" header="Code" width="100px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <span style="font-size: 12px; padding: 2px 8px; background: var(--bg-active); border-radius: var(--radius-sm); color: var(--accent); font-family: ui-monospace, monospace;">
               {{ row.shortCode }}
@@ -34,19 +34,19 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, Di
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="systems" header="Systems" width="90px" [sortable]="false">
+        <app-data-column key="systems" header="Systems" width="90px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             {{ row._count?.systems ?? 0 }}
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="tickets" header="Tickets" width="90px" [sortable]="false">
+        <app-data-column key="tickets" header="Tickets" width="90px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             {{ row._count?.tickets ?? 0 }}
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="status" header="Status" width="100px" [sortable]="false">
+        <app-data-column key="status" header="Status" width="100px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             @if (row.isActive) {
               <span style="font-size: 12px; font-weight: 500; color: var(--color-success);">Active</span>

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -61,13 +61,13 @@ const ACTION_LABELS: Record<string, string> = {
         (rowClick)="onProbeClick($event)"
         emptyMessage="No scheduled probes found">
 
-        <app-data-column key="name" header="Name" [sortable]="false">
+        <app-data-column key="name" header="Name" [sortable]="false" mobilePriority="primary">
           <ng-template #cell let-row>
             <span style="font-weight: 500; color: var(--text-primary);">{{ row.name }}</span>
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="client" header="Client" width="100px" [sortable]="false">
+        <app-data-column key="client" header="Client" width="100px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <span style="font-size: 12px; padding: 2px 8px; background: var(--bg-active); border-radius: var(--radius-sm); color: var(--accent); font-family: ui-monospace, monospace;">
               {{ row.client?.shortCode ?? '—' }}
@@ -75,7 +75,7 @@ const ACTION_LABELS: Record<string, string> = {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="tool" header="Tool" width="160px" [sortable]="false">
+        <app-data-column key="tool" header="Tool" width="160px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             @if (isBuiltinTool(row.toolName)) {
               <span style="font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: var(--radius-sm); background: rgba(0,113,227,0.08); color: var(--accent);">Built-in</span>
@@ -86,7 +86,7 @@ const ACTION_LABELS: Record<string, string> = {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="schedule" header="Schedule" width="180px" [sortable]="false">
+        <app-data-column key="schedule" header="Schedule" width="180px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <span style="font-size: 13px; color: var(--text-secondary);" [title]="row.cronExpression">
               {{ humanReadableSchedule(row) }}
@@ -94,13 +94,13 @@ const ACTION_LABELS: Record<string, string> = {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="action" header="Action" width="110px" [sortable]="false">
+        <app-data-column key="action" header="Action" width="110px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <span class="action-badge" [ngClass]="'action-' + row.action">{{ formatAction(row.action) }}</span>
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="lastRun" header="Last Run" width="140px" [sortable]="false">
+        <app-data-column key="lastRun" header="Last Run" width="140px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             @if (row.lastRunAt) {
               <div style="font-size: 12px; color: var(--text-secondary);">{{ formatDate(row.lastRunAt) }}</div>
@@ -111,7 +111,7 @@ const ACTION_LABELS: Record<string, string> = {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="active" header="Active" width="70px" [sortable]="false">
+        <app-data-column key="active" header="Active" width="70px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <app-toggle-switch
               [checked]="row.isActive"
@@ -120,7 +120,7 @@ const ACTION_LABELS: Record<string, string> = {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="actions" header="" width="120px" [sortable]="false">
+        <app-data-column key="actions" header="" width="120px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             <div style="display: flex; gap: 2px;" (click)="$event.stopPropagation()">
               <app-bronco-button variant="icon" size="sm" aria-label="Run history" [routerLink]="['/scheduled-probes', row.id, 'runs']" title="Run history"><app-icon name="clipboard" size="sm" /></app-bronco-button>

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -141,19 +141,19 @@ interface ActiveFilterChip {
         (rowClick)="navigateToTicket($event)"
         emptyMessage="No tickets match the current filters.">
 
-        <app-data-column key="priority" header="Priority" width="90px" [sortable]="false">
+        <app-data-column key="priority" header="Priority" width="90px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <app-priority-pill [priority]="row.priority" />
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="ticketNumber" header="#" width="70px" [sortable]="false">
+        <app-data-column key="ticketNumber" header="#" width="70px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             <span class="ticket-number">{{ row.ticketNumber ? '#' + row.ticketNumber : '' }}</span>
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="subject" header="Subject" [sortable]="false">
+        <app-data-column key="subject" header="Subject" [sortable]="false" mobilePriority="primary">
           <ng-template #cell let-row>
             <a [routerLink]="['/tickets', row.id]" class="subject-link" (click)="$event.stopPropagation()">{{ row.subject }}</a>
             @if (row.summary) {
@@ -162,19 +162,19 @@ interface ActiveFilterChip {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="client" header="Client" width="90px" [sortable]="false">
+        <app-data-column key="client" header="Client" width="90px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <span class="code-chip">{{ row.client?.shortCode }}</span>
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="status" header="Status" width="110px" [sortable]="false">
+        <app-data-column key="status" header="Status" width="110px" [sortable]="false" mobilePriority="secondary">
           <ng-template #cell let-row>
             <app-status-badge [status]="row.status" />
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="analysisStatus" header="Analysis" width="110px" [sortable]="false">
+        <app-data-column key="analysisStatus" header="Analysis" width="110px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             <span class="analysis-chip" [class]="'analysis-' + (row.analysisStatus?.toLowerCase() ?? 'none')">
               {{ formatAnalysisStatus(row.analysisStatus) }}
@@ -182,25 +182,25 @@ interface ActiveFilterChip {
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="category" header="Category" width="120px" [sortable]="false">
+        <app-data-column key="category" header="Category" width="120px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             {{ row.category ?? '-' }}
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="source" header="Source" width="100px" [sortable]="false">
+        <app-data-column key="source" header="Source" width="100px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             {{ row.source }}
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="created" header="Created" width="100px" [sortable]="false">
+        <app-data-column key="created" header="Created" width="100px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             {{ formatDate(row.createdAt) }}
           </ng-template>
         </app-data-column>
 
-        <app-data-column key="actions" header="" width="48px" [sortable]="false">
+        <app-data-column key="actions" header="" width="48px" [sortable]="false" mobilePriority="hidden">
           <ng-template #cell let-row>
             <app-bronco-button variant="icon" size="sm" (click)="openQuickActions(row); $event.stopPropagation()" title="Quick actions">
               <app-icon name="more-vertical" size="sm" />

--- a/services/control-panel/src/app/shared/components/data-table-column.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table-column.component.ts
@@ -1,5 +1,22 @@
 import { Component, contentChild, input, TemplateRef } from '@angular/core';
 
+/**
+ * Mobile card-layout priority for a `<app-data-column>`.
+ *
+ * Used by `DataTableComponent` when `viewport.isMobile()` to render rows as
+ * cards instead of a table:
+ * - `'primary'`   — column's cell template renders as the card's heading
+ *                   (no label prefix). Use for the entity's identifying field
+ *                   (e.g. ticket subject, client name).
+ * - `'secondary'` — column's cell template renders as a label/value row
+ *                   under the heading. This is the default and works for
+ *                   most fields without per-page tuning.
+ * - `'hidden'`    — column is omitted on mobile. Use for low-signal columns
+ *                   like timestamps, source codes, action buttons that don't
+ *                   make sense in a card.
+ */
+export type DataTableMobilePriority = 'primary' | 'secondary' | 'hidden';
+
 @Component({
   selector: 'app-data-column',
   standalone: true,
@@ -10,6 +27,7 @@ export class DataTableColumnComponent<T = unknown> {
   header = input.required<string>();
   sortable = input<boolean>(true);
   width = input<string>('');
+  mobilePriority = input<DataTableMobilePriority>('secondary');
   headerTpl = contentChild<TemplateRef<unknown>>('header');
   cellTpl = contentChild.required<TemplateRef<{ $implicit: T }>>('cell');
 }

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -19,6 +19,7 @@ import { ViewportService } from '../../core/services/viewport.service';
               class="card"
               [class.clickable]="rowClickable()"
               [class.expanded]="expandedRow() === row"
+              [attr.role]="rowClickable() ? 'button' : null"
               [attr.tabindex]="rowClickable() ? 0 : null"
               (click)="rowClickable() ? rowClick.emit(row) : null"
               (keydown.enter)="rowClickable() ? rowClick.emit(row) : null"

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -1,16 +1,58 @@
-import { Component, contentChild, contentChildren, input, output, TemplateRef } from '@angular/core';
+import { Component, computed, contentChild, contentChildren, inject, input, output, TemplateRef } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { DataTableColumnComponent } from './data-table-column.component';
 import { IconComponent } from './icon.component';
+import { ViewportService } from '../../core/services/viewport.service';
 
 @Component({
   selector: 'app-data-table',
   standalone: true,
   imports: [NgTemplateOutlet, IconComponent],
   template: `
-    <div class="table-container">
+    <div class="table-container" [class.card-mode]="viewport.isMobile()">
       @if (data().length === 0) {
         <div class="table-empty">{{ emptyMessage() }}</div>
+      } @else if (viewport.isMobile()) {
+        <div class="card-list">
+          @for (row of data(); track trackBy()(row)) {
+            <div
+              class="card"
+              [class.clickable]="rowClickable()"
+              [class.expanded]="expandedRow() === row"
+              [attr.tabindex]="rowClickable() ? 0 : null"
+              (click)="rowClickable() ? rowClick.emit(row) : null"
+              (keydown.enter)="rowClickable() ? rowClick.emit(row) : null"
+              (keydown.space)="rowClickable() ? onRowSpace($event, row) : null">
+              @for (col of primaryCols(); track col.key()) {
+                <div class="card-primary">
+                  <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
+                </div>
+              }
+              @if (subtitleTpl()) {
+                <div class="card-subtitle">
+                  <ng-container [ngTemplateOutlet]="subtitleTpl()!" [ngTemplateOutletContext]="{ $implicit: row }" />
+                </div>
+              }
+              @if (secondaryCols().length > 0) {
+                <div class="card-rows">
+                  @for (col of secondaryCols(); track col.key()) {
+                    <div class="card-row">
+                      <span class="card-label">{{ col.header() }}</span>
+                      <span class="card-value">
+                        <ng-container [ngTemplateOutlet]="col.cellTpl()" [ngTemplateOutletContext]="{ $implicit: row }" />
+                      </span>
+                    </div>
+                  }
+                </div>
+              }
+              @if (expandedRow() === row && expandedTpl()) {
+                <div class="card-expanded">
+                  <ng-container [ngTemplateOutlet]="expandedTpl()!" [ngTemplateOutletContext]="{ $implicit: row }" />
+                </div>
+              }
+            </div>
+          }
+        </div>
       } @else {
         <table>
           <thead>
@@ -177,9 +219,109 @@ import { IconComponent } from './icon.component';
       font-size: 14px;
       color: var(--text-tertiary);
     }
+
+    /*
+     * Mobile card variant.
+     *
+     * When viewport.isMobile() is true, rows are rendered as stacked cards
+     * (.card-list / .card). The entire styling for that path lives below
+     * — the desktop table styles above are untouched. The .card-mode
+     * container also drops the outer card chrome (background, shadow,
+     * border-radius) so each row-card carries its own elevation, matching
+     * platform-native list patterns.
+     */
+    .table-container.card-mode {
+      background: transparent;
+      box-shadow: none;
+      border-radius: 0;
+      overflow: visible;
+    }
+
+    .card-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border-light);
+      border-radius: var(--radius-lg);
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      box-shadow: var(--shadow-card);
+      font-family: var(--font-primary);
+      transition: background 120ms ease;
+    }
+
+    .card.clickable {
+      cursor: pointer;
+      min-height: 44px;
+    }
+
+    .card.clickable:hover,
+    .card.clickable:focus-visible {
+      background: var(--bg-hover);
+      outline: none;
+    }
+
+    .card.clickable:focus-visible {
+      box-shadow: 0 0 0 2px var(--focus-ring);
+    }
+
+    .card-primary {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text-primary);
+      line-height: 1.3;
+      word-break: break-word;
+    }
+
+    .card-subtitle {
+      font-size: 12px;
+      color: var(--text-tertiary);
+      line-height: 1.4;
+    }
+
+    .card-rows {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .card-row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .card-label {
+      color: var(--text-tertiary);
+      font-size: 12px;
+      flex-shrink: 0;
+    }
+
+    .card-value {
+      text-align: right;
+      min-width: 0;
+      word-break: break-word;
+    }
+
+    .card-expanded {
+      margin-top: 4px;
+      padding-top: 8px;
+      border-top: 1px solid var(--border-light);
+    }
   `],
 })
 export class DataTableComponent<T = unknown> {
+  readonly viewport = inject(ViewportService);
+
   data = input.required<T[]>();
   trackBy = input.required<(item: T) => string>();
   sortColumn = input<string>('');
@@ -194,6 +336,13 @@ export class DataTableComponent<T = unknown> {
   columns = contentChildren(DataTableColumnComponent);
   expandedTpl = contentChild<TemplateRef<{ $implicit: T }>>('expandedRow');
   subtitleTpl = contentChild<TemplateRef<unknown>>('subtitle');
+
+  readonly primaryCols = computed(() =>
+    this.columns().filter(c => c.mobilePriority() === 'primary'),
+  );
+  readonly secondaryCols = computed(() =>
+    this.columns().filter(c => c.mobilePriority() === 'secondary'),
+  );
 
   onSort(key: string): void {
     const direction = this.sortColumn() === key && this.sortDirection() === 'asc' ? 'desc' : 'asc';

--- a/services/control-panel/src/app/shared/components/icon-registry.ts
+++ b/services/control-panel/src/app/shared/components/icon-registry.ts
@@ -22,6 +22,7 @@ import {
   faAnglesRight,
   faHouse,
   faTurnDownRight,
+  faBars,
   // Status
   faCheck,
   faCircleCheck,
@@ -130,6 +131,7 @@ export const ICON_REGISTRY = {
   back: faArrowLeft,
   home: faHouse,
   subdirectory: faTurnDownRight,
+  menu: faBars,
   // Status
   check: faCheck,
   'check-circle': faCircleCheck,

--- a/services/control-panel/src/app/shared/components/paginator.component.ts
+++ b/services/control-panel/src/app/shared/components/paginator.component.ts
@@ -141,6 +141,46 @@ export interface PaginatorPageEvent {
     .paginator-summary {
       justify-content: flex-end;
     }
+
+    /*
+     * Mobile compact mode.
+     *
+     * Stack the three sections vertically (size, nav, summary), bump the
+     * nav buttons up to 44x44 tap targets, and let the page-size <select>
+     * stretch — much easier to thumb than the desktop 24x24 affordances.
+     * Desktop layout is byte-identical above 768px.
+     */
+    @media (max-width: 767.98px) {
+      .paginator {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 8px;
+        padding: 8px 0;
+      }
+      .paginator-section {
+        justify-content: center;
+      }
+      .paginator-nav {
+        gap: 6px;
+      }
+      .nav-btn {
+        width: 44px;
+        height: 44px;
+        font-size: 16px;
+      }
+      .page-size-select {
+        font-size: 14px;
+        padding: 8px 28px 8px 12px;
+        min-height: 44px;
+      }
+      .page-indicator,
+      .paginator-label {
+        font-size: 13px;
+      }
+      .paginator-summary {
+        justify-content: center;
+      }
+    }
   `],
 })
 export class PaginatorComponent {

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -12,6 +12,9 @@ import { DetailPanelService } from '../core/services/detail-panel.service';
 import { ThemeService } from '../core/services/theme.service';
 import { ViewportService } from '../core/services/viewport.service';
 import { SidebarService } from '../core/services/sidebar.service';
+import { AuthService } from '../core/services/auth.service';
+import { TicketService } from '../core/services/ticket.service';
+import { FailedJobsService } from '../core/services/failed-jobs.service';
 import { ToastContainerComponent } from '../shared/components/toast-container.component';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
@@ -95,6 +98,9 @@ export class AppShellComponent implements OnInit {
   readonly viewport = inject(ViewportService);
   private readonly sidebar = inject(SidebarService);
   private readonly theme = inject(ThemeService);
+  private readonly auth = inject(AuthService);
+  private readonly ticketService = inject(TicketService);
+  private readonly failedJobsService = inject(FailedJobsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly overlay = inject(Overlay);
@@ -144,6 +150,21 @@ export class AppShellComponent implements OnInit {
     this.router.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(event => {
       if (event instanceof NavigationEnd) this.updateTitle();
     });
+
+    // Seed sidebar badges here (not in SidebarComponent). The shell always
+    // mounts at app boot; the sidebar only mounts inline on desktop and
+    // lazily-inside-the-drawer on mobile, so scoping the fetch to the
+    // sidebar would miss the mobile boot case and leave badges at 0 until
+    // the user opens the drawer. Scoped ops users lack permission for both
+    // global stats and the failed-jobs queue — they would 403.
+    if (!this.auth.isScopedOpsUser()) {
+      this.ticketService.getStats()
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe();
+      this.failedJobsService.list({ limit: 1 })
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe();
+    }
   }
 
   private updateTitle(): void {

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -1,9 +1,8 @@
-import { Component, DestroyRef, effect, inject, OnInit, signal, untracked } from '@angular/core';
+import { Component, DestroyRef, effect, HostListener, inject, OnInit, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { RouterOutlet, ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { ESCAPE } from '@angular/cdk/keycodes';
 import { SidebarComponent } from './sidebar.component';
 import { SidebarDrawerComponent } from './sidebar-drawer.component';
 import { HeaderBarComponent } from './header-bar.component';
@@ -101,7 +100,6 @@ export class AppShellComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly ticketService = inject(TicketService);
   private readonly failedJobsService = inject(FailedJobsService);
-  private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly overlay = inject(Overlay);
   private readonly destroyRef = inject(DestroyRef);
@@ -109,6 +107,28 @@ export class AppShellComponent implements OnInit {
   readonly onDetailRoute = signal(false);
 
   private drawerRef: OverlayRef | null = null;
+
+  /**
+   * Global Escape handler for the sidebar drawer.
+   *
+   * We use @HostListener (document-level keydown via Angular's EventManager)
+   * rather than `drawerRef.keydownEvents()` because the overlay stream only
+   * fires when focus is inside the overlay. Document-level is robust across
+   * focus-loss scenarios.
+   */
+  @HostListener('document:keydown.escape', ['$event'])
+  private onDocumentEscape(e: KeyboardEvent): void {
+    // Precedence: drawer → side pane → no-op. Close whatever's "on top".
+    if (this.drawerRef) {
+      e.preventDefault();
+      this.sidebar.close();
+      return;
+    }
+    if (this.detailPanel.isOpen()) {
+      e.preventDefault();
+      this.detailPanel.close();
+    }
+  }
 
   constructor() {
     // Drawer open/close ↔ CDK Overlay attach/detach.
@@ -124,15 +144,43 @@ export class AppShellComponent implements OnInit {
       });
     });
 
-    // Desktop → mobile flip with a side pane open: clear state so the URL
-    // doesn't keep stale ?detail= query params and the hidden pane state
-    // doesn't reappear on resize back to desktop mid-session. Mobile →
-    // desktop is intentionally unhandled (the routed /detail view remains).
+    // Viewport flip: keep the pane visible across the 768px boundary by
+    // swapping presentations, not by destroying state.
+    //   Desktop → mobile: side pane open on /dashboard?detail=… →
+    //     navigate to /detail/:type/:id (routed full-screen view).
+    //   Mobile → desktop: routed view at /detail/:type/:id →
+    //     navigate to parent list with ?detail=…&type=…&mode=… query
+    //     params so the inline side pane renders.
+    // For the mobile→desktop direction, DetailViewComponent.ngOnDestroy
+    // would otherwise dismiss the signals mid-transition and blank the
+    // pane; we suppress that one dismiss so the inline pane picks up
+    // the existing state.
     effect(() => {
       const mobile = this.viewport.isMobile();
       untracked(() => {
-        if (mobile && this.detailPanel.isOpen() && !this.router.url.startsWith('/detail/')) {
-          this.detailPanel.close();
+        const onDetailRoute = this.router.url.startsWith('/detail/');
+        const type = this.detailPanel.entityType();
+        const id = this.detailPanel.entityId();
+        const mode = this.detailPanel.mode();
+
+        if (mobile && this.detailPanel.isOpen() && !onDetailRoute) {
+          // Desktop → mobile with side pane active.
+          if (!type || !id) return;
+          this.router.navigate(['/detail', type, id], {
+            queryParams: mode === 'full' ? undefined : { mode },
+          });
+          return;
+        }
+
+        if (!mobile && onDetailRoute) {
+          // Mobile → desktop on routed view: restore parent list + pane.
+          if (!type || !id) return;
+          const parent = DetailPanelService.PARENT_LIST[type] ?? '/dashboard';
+          this.detailPanel.suppressNextDismiss();
+          this.router.navigate([parent], {
+            queryParams: { detail: id, type, mode },
+            queryParamsHandling: 'merge',
+          });
         }
       });
     });
@@ -140,15 +188,43 @@ export class AppShellComponent implements OnInit {
 
   ngOnInit(): void {
     this.theme.init();
-    const params = this.route.snapshot.queryParams;
+    // Read query params directly from window.location, not the router.
+    // AppShellComponent is mounted via app.component.ts's
+    // `@if (currentUser())` conditional, which flips true as soon as
+    // auth init completes. At that moment Angular's router hasn't yet
+    // finished processing the initial URL, so `router.url` is still '/'
+    // and `ActivatedRoute.snapshot.queryParams` is empty even though the
+    // browser URL (`window.location`) holds the real query string. Parse
+    // window.location directly to restore pane state reliably — this is
+    // the source of truth.
+    const urlParams = new URLSearchParams(window.location.search);
     this.detailPanel.restoreFromUrl({
-      detail: params['detail'],
-      type: params['type'],
-      mode: params['mode'],
+      detail: urlParams.get('detail') ?? undefined,
+      type: urlParams.get('type') ?? undefined,
+      mode: urlParams.get('mode') ?? undefined,
     });
     this.updateTitle();
     this.router.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(event => {
-      if (event instanceof NavigationEnd) this.updateTitle();
+      if (!(event instanceof NavigationEnd)) return;
+      this.updateTitle();
+      // Re-sync pane state from the URL on every navigation. Without this,
+      // the signals persist across routerLink navigations (routerLink drops
+      // query params by default), so clicking a sidebar link while a pane
+      // is open would leave the pane stuck on the new page. Anchor the
+      // pane to the URL so it cleanly appears/disappears with nav.
+      //
+      // Skip when landing on a /detail/:type/:id route — DetailViewComponent
+      // owns signal hydration there via hydrateFromParams, and we don't
+      // want to race with it.
+      const url = event.urlAfterRedirects;
+      if (url.startsWith('/detail/')) return;
+      const search = url.split('?')[1] ?? '';
+      const urlParams = new URLSearchParams(search);
+      this.detailPanel.restoreFromUrl({
+        detail: urlParams.get('detail') ?? undefined,
+        type: urlParams.get('type') ?? undefined,
+        mode: urlParams.get('mode') ?? undefined,
+      });
     });
 
     // Seed sidebar badges here (not in SidebarComponent). The shell always
@@ -188,12 +264,6 @@ export class AppShellComponent implements OnInit {
       scrollStrategy: this.overlay.scrollStrategies.block(),
     });
     this.drawerRef.backdropClick().subscribe(() => this.sidebar.close());
-    this.drawerRef.keydownEvents().subscribe(e => {
-      if (e.keyCode === ESCAPE) {
-        e.preventDefault();
-        this.sidebar.close();
-      }
-    });
     this.drawerRef.attach(new ComponentPortal(SidebarDrawerComponent));
   }
 

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -218,12 +218,14 @@ export class AppShellComponent implements OnInit {
       // want to race with it.
       const url = event.urlAfterRedirects;
       if (url.startsWith('/detail/')) return;
-      const search = url.split('?')[1] ?? '';
-      const urlParams = new URLSearchParams(search);
+      // Use the router's own parser so query extraction is fragment-safe
+      // (a naive `url.split('?')[1]` would absorb a trailing `#fragment`
+      // into the last query value).
+      const tree = this.router.parseUrl(url);
       this.detailPanel.restoreFromUrl({
-        detail: urlParams.get('detail') ?? undefined,
-        type: urlParams.get('type') ?? undefined,
-        mode: urlParams.get('mode') ?? undefined,
+        detail: tree.queryParamMap.get('detail') ?? undefined,
+        type: tree.queryParamMap.get('type') ?? undefined,
+        mode: tree.queryParamMap.get('mode') ?? undefined,
       });
     });
 

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -1,11 +1,17 @@
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, effect, inject, OnInit, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterOutlet, ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { ESCAPE } from '@angular/cdk/keycodes';
 import { SidebarComponent } from './sidebar.component';
+import { SidebarDrawerComponent } from './sidebar-drawer.component';
 import { HeaderBarComponent } from './header-bar.component';
 import { DetailPanelComponent } from './detail-panel.component';
 import { DetailPanelService } from '../core/services/detail-panel.service';
 import { ThemeService } from '../core/services/theme.service';
+import { ViewportService } from '../core/services/viewport.service';
+import { SidebarService } from '../core/services/sidebar.service';
 import { ToastContainerComponent } from '../shared/components/toast-container.component';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
@@ -32,6 +38,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
   'ingestion-jobs': 'Ingestion Jobs',
   'scheduled-probes': 'Scheduled Probes',
   users: 'Users',
+  detail: 'Details',
 };
 
 @Component({
@@ -40,14 +47,16 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
   imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent, ToastContainerComponent],
   template: `
     <div class="shell">
-      <app-sidebar />
+      @if (!viewport.isMobile()) {
+        <app-sidebar />
+      }
       <div class="shell-main">
         <app-header-bar [title]="pageTitle()" />
         <main class="shell-content">
           <router-outlet />
         </main>
       </div>
-      @if (detailPanel.isOpen()) {
+      @if (!viewport.isMobile() && detailPanel.isOpen() && !onDetailRoute()) {
         <app-detail-panel />
       }
     </div>
@@ -74,15 +83,54 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
       overflow-y: auto;
       padding: 24px;
     }
+    @media (max-width: 767.98px) {
+      .shell-content {
+        padding: 12px;
+      }
+    }
   `],
 })
 export class AppShellComponent implements OnInit {
   readonly detailPanel = inject(DetailPanelService);
+  readonly viewport = inject(ViewportService);
+  private readonly sidebar = inject(SidebarService);
   private readonly theme = inject(ThemeService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly overlay = inject(Overlay);
   private readonly destroyRef = inject(DestroyRef);
   readonly pageTitle = signal('Dashboard');
+  readonly onDetailRoute = signal(false);
+
+  private drawerRef: OverlayRef | null = null;
+
+  constructor() {
+    // Drawer open/close ↔ CDK Overlay attach/detach.
+    effect(() => {
+      const open = this.sidebar.isOpen();
+      const mobile = this.viewport.isMobile();
+      untracked(() => {
+        if (open && mobile) {
+          this.openDrawer();
+        } else {
+          this.closeDrawer();
+        }
+      });
+    });
+
+    // Desktop → mobile flip with a side pane open: clear state so the URL
+    // doesn't keep stale ?detail= query params and the hidden pane state
+    // doesn't reappear on resize back to desktop mid-session. Mobile →
+    // desktop is intentionally unhandled (the routed /detail view remains).
+    effect(() => {
+      const mobile = this.viewport.isMobile();
+      untracked(() => {
+        if (mobile && this.detailPanel.isOpen() && !this.router.url.startsWith('/detail/')) {
+          this.detailPanel.close();
+        }
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.theme.init();
@@ -101,5 +149,36 @@ export class AppShellComponent implements OnInit {
   private updateTitle(): void {
     const segment = this.router.url.split('/').filter(Boolean)[0]?.split('?')[0] ?? 'dashboard';
     this.pageTitle.set(ROUTE_TITLE_MAP[segment] ?? 'Dashboard');
+    this.onDetailRoute.set(this.router.url.startsWith('/detail/'));
+  }
+
+  private openDrawer(): void {
+    if (this.drawerRef) return;
+    this.drawerRef = this.overlay.create({
+      hasBackdrop: true,
+      backdropClass: 'sidebar-drawer-backdrop',
+      panelClass: 'sidebar-drawer-pane',
+      positionStrategy: this.overlay.position()
+        .global()
+        .left('0')
+        .top('0'),
+      height: '100%',
+      disposeOnNavigation: false,
+      scrollStrategy: this.overlay.scrollStrategies.block(),
+    });
+    this.drawerRef.backdropClick().subscribe(() => this.sidebar.close());
+    this.drawerRef.keydownEvents().subscribe(e => {
+      if (e.keyCode === ESCAPE) {
+        e.preventDefault();
+        this.sidebar.close();
+      }
+    });
+    this.drawerRef.attach(new ComponentPortal(SidebarDrawerComponent));
+  }
+
+  private closeDrawer(): void {
+    if (!this.drawerRef) return;
+    this.drawerRef.dispose();
+    this.drawerRef = null;
   }
 }

--- a/services/control-panel/src/app/shell/detail-view.component.ts
+++ b/services/control-panel/src/app/shell/detail-view.component.ts
@@ -1,6 +1,7 @@
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest } from 'rxjs';
 import { DetailPanelComponent } from './detail-panel.component.js';
 import { DetailPanelService } from '../core/services/detail-panel.service.js';
 
@@ -37,14 +38,17 @@ export class DetailViewComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    // Hydrate on every param change (e.g. if user swaps entity via deep link).
-    this.route.paramMap
+    // Hydrate on every param change — including `mode`, which lives in the
+    // query map, not the route params. Using a snapshot read for `mode`
+    // (the prior approach) would miss updates when the user swaps `?mode=`
+    // while staying on the same `/detail/:type/:id` path.
+    combineLatest([this.route.paramMap, this.route.queryParamMap])
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(pm => {
+      .subscribe(([pm, qpm]) => {
         this.detailPanel.hydrateFromParams({
           type: pm.get('type'),
           id: pm.get('id'),
-          mode: this.route.snapshot.queryParamMap.get('mode'),
+          mode: qpm.get('mode'),
         });
       });
 

--- a/services/control-panel/src/app/shell/detail-view.component.ts
+++ b/services/control-panel/src/app/shell/detail-view.component.ts
@@ -1,0 +1,55 @@
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DetailPanelComponent } from './detail-panel.component.js';
+import { DetailPanelService } from '../core/services/detail-panel.service.js';
+
+/**
+ * Mobile-only routed wrapper for the detail panel.
+ *
+ * Reads `:type` and `:id` from the route, hydrates `DetailPanelService` state,
+ * then renders the same `DetailPanelComponent` used in desktop's side pane.
+ * The panel's full-screen styling on this route is applied via a global CSS
+ * selector (`.detail-route-page app-detail-panel`) in styles.scss so the
+ * DetailPanelComponent itself remains unchanged.
+ */
+@Component({
+  selector: 'app-detail-view',
+  standalone: true,
+  imports: [DetailPanelComponent],
+  template: `
+    <div class="detail-route-page">
+      <app-detail-panel />
+    </div>
+  `,
+  styles: [`
+    :host { display: block; height: 100%; }
+    .detail-route-page {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+  `],
+})
+export class DetailViewComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly detailPanel = inject(DetailPanelService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    // Hydrate on every param change (e.g. if user swaps entity via deep link).
+    this.route.paramMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(pm => {
+        this.detailPanel.hydrateFromParams({
+          type: pm.get('type'),
+          id: pm.get('id'),
+          mode: this.route.snapshot.queryParamMap.get('mode'),
+        });
+      });
+
+    // Leaving the route clears state so the inline pane doesn't re-appear on
+    // a subsequent desktop resize with stale signals.
+    this.destroyRef.onDestroy(() => this.detailPanel.dismiss());
+  }
+}

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -4,7 +4,6 @@ import { ViewportService } from '../core/services/viewport.service';
 import { SidebarService } from '../core/services/sidebar.service';
 
 const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
-const isMobileUA = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
 @Component({
   selector: 'app-header-bar',
@@ -28,7 +27,7 @@ const isMobileUA = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
       <button class="search-trigger" type="button" aria-label="Search">
         <app-icon class="search-icon" name="search" size="sm" />
         <span class="search-text">Search...</span>
-        @if (!isMobileUA) {
+        @if (!viewport.isMobile()) {
           <kbd class="search-kbd">{{ shortcutHint }}</kbd>
         }
       </button>
@@ -138,6 +137,5 @@ export class HeaderBarComponent {
   readonly viewport = inject(ViewportService);
   readonly sidebar = inject(SidebarService);
   title = input<string>('Dashboard');
-  readonly isMobileUA = isMobileUA;
   readonly shortcutHint = isMac ? '⌘K' : 'Ctrl+K';
 }

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -1,17 +1,34 @@
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
+import { IconComponent } from '../shared/components/icon.component';
+import { ViewportService } from '../core/services/viewport.service';
+import { SidebarService } from '../core/services/sidebar.service';
 
 const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
-const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+const isMobileUA = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 
 @Component({
   selector: 'app-header-bar',
   standalone: true,
+  imports: [IconComponent],
   template: `
     <header class="header-bar">
-      <span class="page-title">{{ title() }}</span>
+      <div class="header-left">
+        @if (viewport.isMobile()) {
+          <button
+            class="hamburger-btn"
+            type="button"
+            aria-label="Open navigation menu"
+            (click)="sidebar.toggle()"
+          >
+            <app-icon name="menu" size="md" />
+          </button>
+        }
+        <span class="page-title">{{ title() }}</span>
+      </div>
       <button class="search-trigger" type="button" aria-label="Search">
+        <app-icon class="search-icon" name="search" size="sm" />
         <span class="search-text">Search...</span>
-        @if (!isMobile) {
+        @if (!isMobileUA) {
           <kbd class="search-kbd">{{ shortcutHint }}</kbd>
         }
       </button>
@@ -29,12 +46,39 @@ const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
       align-items: center;
       justify-content: space-between;
       padding: 0 24px;
+      gap: 12px;
       font-family: var(--font-primary);
     }
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      flex: 1;
+    }
+    .hamburger-btn {
+      width: 44px;
+      height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      color: var(--text-primary);
+      flex-shrink: 0;
+      transition: background 120ms ease;
+    }
+    .hamburger-btn:hover { background: var(--bg-hover); }
     .page-title {
       font-size: 16px;
       font-weight: 600;
       color: var(--text-primary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
     }
     .search-trigger {
       display: flex;
@@ -46,11 +90,14 @@ const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
       border-radius: var(--radius-pill);
       cursor: pointer;
       font-family: var(--font-primary);
+      flex-shrink: 0;
       transition: background 120ms ease;
     }
     .search-trigger:hover {
       background: var(--bg-hover);
     }
+    /* Desktop: search icon is visual-only (text carries the affordance). */
+    .search-icon { display: none; color: var(--text-tertiary); }
     .search-text {
       font-size: 13px;
       color: var(--text-tertiary);
@@ -64,10 +111,33 @@ const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
       border-radius: 4px;
       padding: 1px 5px;
     }
+
+    /*
+     * Mobile compact mode: reduce horizontal padding, collapse the search
+     * trigger to an icon-only 44x44 hit area, and hide the "Search..." text
+     * and kbd hint. The hamburger already satisfies the 44px tap target on
+     * the left. The title stretches to fill the middle and truncates with
+     * ellipsis when it doesn't fit.
+     */
+    @media (max-width: 767.98px) {
+      .header-bar { padding: 0 12px; }
+      .search-trigger {
+        width: 44px;
+        height: 44px;
+        padding: 0;
+        justify-content: center;
+        background: none;
+      }
+      .search-trigger:hover { background: var(--bg-hover); }
+      .search-icon { display: inline-flex; }
+      .search-text { display: none; }
+    }
   `],
 })
 export class HeaderBarComponent {
+  readonly viewport = inject(ViewportService);
+  readonly sidebar = inject(SidebarService);
   title = input<string>('Dashboard');
-  readonly isMobile = isMobile;
+  readonly isMobileUA = isMobileUA;
   readonly shortcutHint = isMac ? '⌘K' : 'Ctrl+K';
 }

--- a/services/control-panel/src/app/shell/sidebar-drawer.component.ts
+++ b/services/control-panel/src/app/shell/sidebar-drawer.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { A11yModule } from '@angular/cdk/a11y';
+import { SidebarComponent } from './sidebar.component.js';
+
+/**
+ * Mobile drawer wrapper around `SidebarComponent`.
+ *
+ * Attached to a CDK Overlay by `AppShellComponent` when `viewport.isMobile()`
+ * is true and the drawer is open. Applies a focus trap so keyboard Tab stays
+ * within the drawer while open. The drawer chrome (width, slide animation,
+ * tap-target overrides) is styled globally via `.sidebar-drawer-pane` in
+ * styles.scss — `SidebarComponent` itself stays untouched.
+ */
+@Component({
+  selector: 'app-sidebar-drawer',
+  standalone: true,
+  imports: [SidebarComponent, A11yModule],
+  template: `
+    <div class="sidebar-drawer-host" cdkTrapFocus [cdkTrapFocusAutoCapture]="true">
+      <app-sidebar />
+    </div>
+  `,
+  styles: [`
+    :host { display: block; height: 100%; }
+    .sidebar-drawer-host { height: 100%; }
+  `],
+})
+export class SidebarDrawerComponent {}

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -224,6 +224,36 @@ import { FailedJobsService } from '../core/services/failed-jobs.service';
       min-width: 18px;
       text-align: center;
     }
+
+    /*
+     * Mobile shell chrome tap targets.
+     *
+     * Under 768px the sidebar is rendered inside a CDK Overlay drawer. Nav
+     * items, the logout button, the theme-indicator link, and the version
+     * label all get >= 44px hit areas so they're reliably tappable. This is
+     * scoped to the media query so desktop layout is byte-identical to the
+     * current mobile-design/staging.
+     */
+    @media (max-width: 767.98px) {
+      .nav-item {
+        padding: 12px 16px;
+        font-size: 14px;
+        min-height: 44px;
+      }
+      .logout-btn {
+        padding: 12px 16px;
+        font-size: 14px;
+        min-height: 44px;
+      }
+      .theme-indicator {
+        padding: 12px 16px;
+        font-size: 13px;
+        min-height: 44px;
+      }
+      .version-label {
+        padding: 8px 16px 12px;
+      }
+    }
   `],
 })
 export class SidebarComponent implements OnInit {

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -1,6 +1,6 @@
-import { Component, DestroyRef, computed, inject, OnInit } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { AuthService } from '../core/services/auth.service';
 import { ThemeService } from '../core/services/theme.service';
 import { VersionService } from '../core/services/version.service';
@@ -256,13 +256,12 @@ import { FailedJobsService } from '../core/services/failed-jobs.service';
     }
   `],
 })
-export class SidebarComponent implements OnInit {
+export class SidebarComponent {
   readonly authService = inject(AuthService);
   readonly themeService = inject(ThemeService);
   private readonly versionService = inject(VersionService);
   private readonly ticketService = inject(TicketService);
   private readonly failedJobsService = inject(FailedJobsService);
-  private readonly destroyRef = inject(DestroyRef);
 
   readonly version = toSignal(this.versionService.getVersion(), { initialValue: '' });
   readonly ticketBadge = this.ticketService.activeCount;
@@ -282,22 +281,4 @@ export class SidebarComponent implements OnInit {
     return ['/clients', user.clientId];
   });
 
-  ngOnInit(): void {
-    // Scoped ops users don't have permission to fetch global ticket stats or
-    // the failed-jobs queue, so skip those calls entirely — they would just
-    // 403 and noise up the console.
-    if (this.isScoped()) {
-      return;
-    }
-
-    // Seed both badges — subsequent getStats()/list() calls from their
-    // respective pages automatically update the shared signals.
-    this.ticketService.getStats()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-
-    this.failedJobsService.list({ limit: 1 })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
-  }
 }

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -38,3 +38,71 @@ app-dialog .dialog-body [dialogFooter] {
   h1 { font-size: 1.5rem; }
   h2 { font-size: 1.25rem; }
 }
+
+/*
+ * Mobile sidebar drawer.
+ *
+ * The sidebar renders inline on desktop (>= 768px) and via CDK Overlay on
+ * mobile (< 768px). The overlay panel is appended to the cdk-overlay-container
+ * in document.body, so these styles must be global to reach the overlay
+ * children. View-encapsulated component styles would not apply.
+ *
+ * Width is 280px (per Phase 1 spec — wider than the 240px inline sidebar so
+ * thumbs can comfortably hit nav items). A slide-in transform animation and
+ * backdrop fade match platform-native drawer UX.
+ */
+.cdk-overlay-pane.sidebar-drawer-pane {
+  width: 280px;
+  max-width: 80vw;
+  height: 100%;
+  pointer-events: auto;
+  animation: bronco-sidebar-drawer-slide-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.cdk-overlay-pane.sidebar-drawer-pane app-sidebar-drawer,
+.cdk-overlay-pane.sidebar-drawer-pane .sidebar-drawer-host,
+.cdk-overlay-pane.sidebar-drawer-pane app-sidebar,
+.cdk-overlay-pane.sidebar-drawer-pane .sidebar {
+  width: 280px;
+  min-width: 280px;
+  max-width: 100%;
+  height: 100%;
+}
+
+.cdk-overlay-pane.sidebar-drawer-pane .sidebar {
+  /* The inline sidebar relies on the shell's flex height; in the overlay it
+     needs an explicit box-shadow to read as elevated over the backdrop. */
+  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.18);
+}
+
+.cdk-overlay-backdrop.sidebar-drawer-backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+@keyframes bronco-sidebar-drawer-slide-in {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(0); }
+}
+
+/*
+ * Mobile-only: routed detail view renders the panel full-screen. The inline
+ * desktop pane uses a fixed 380px width; on the routed page we override that
+ * so the panel fills the shell content area.
+ */
+@media (max-width: 767.98px) {
+  .detail-route-page {
+    height: 100%;
+  }
+  .detail-route-page app-detail-panel {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+  }
+  .detail-route-page .detail-panel {
+    width: 100%;
+    min-width: 0;
+    height: 100%;
+    border-left: none;
+    animation: none;
+  }
+}

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -85,24 +85,25 @@ app-dialog .dialog-body [dialogFooter] {
 }
 
 /*
- * Mobile-only: routed detail view renders the panel full-screen. The inline
- * desktop pane uses a fixed 380px width; on the routed page we override that
- * so the panel fills the shell content area.
+ * Routed detail view renders the panel full-screen. The inline desktop pane
+ * uses a fixed 380px width; on the routed page (both mobile flow and desktop
+ * deep-link) we override that so the panel fills the shell content area.
+ * Not scoped to the mobile media query because /detail/:type/:id is advertised
+ * as a valid desktop deep-link too — without this override, desktop direct
+ * nav would render a narrow 380px pane inside `shell-content`.
  */
-@media (max-width: 767.98px) {
-  .detail-route-page {
-    height: 100%;
-  }
-  .detail-route-page app-detail-panel {
-    display: flex;
-    flex: 1;
-    min-height: 0;
-  }
-  .detail-route-page .detail-panel {
-    width: 100%;
-    min-width: 0;
-    height: 100%;
-    border-left: none;
-    animation: none;
-  }
+.detail-route-page {
+  height: 100%;
+}
+.detail-route-page app-detail-panel {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+.detail-route-page .detail-panel {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  border-left: none;
+  animation: none;
 }


### PR DESCRIPTION
## Summary

First two phases of the mobile-responsive control panel initiative (umbrella #224). All changes target the control panel; no backend code, no package.json changes. Desktop (≥768px) rendering is unchanged throughout.

- **Phase 1 — Responsive shell (closes #225):** `ViewportService` w/ CDK `BreakpointObserver` · sidebar renders as a CDK Overlay drawer under 768px (inline flex on desktop) · detail panel navigates to `/detail/:type/:id` on mobile, stays as a side pane on desktop · compact header (hamburger, icon-only search, truncated title) · 12px content padding · ≥44px tap targets on shell chrome · Escape closes drawer → side pane → no-op · viewport-flip preserves pane state in both directions.
- **Phase 2 — DataTable mobile cards (closes #226):** `DataTableComponent` renders rows as stacked cards under 768px; desktop `<table>` path untouched. `DataTableColumnComponent` gains `mobilePriority` (`primary` | `secondary` | `hidden`, default `secondary`). Annotated tickets, clients, probes explicitly; all other DataTable consumers get functional cards via the default. Paginator gets responsive stacking + 44px tap targets.
- **Baseline fixes surfaced during testing:** sidebar badges now seed from `AppShellComponent` (so they populate on mobile without needing the drawer to mount) · desktop pane restore reads from `window.location.search` (router URL is `/` when shell mounts via `app.component`'s auth-gated conditional) · pane state is URL-anchored across navigation (routerLink navigations cleanly dismiss; browser back restores) · mobile close button navigates to entity parent list rather than `location.back()` which exited the app on deep-link arrivals.

Targets `mobile-design/staging`. Phase 2.5 (#230), Phase 3 (#227), Phase 4 (#228), Phase 5 (#229) still to come.

## Test plan

**Desktop (≥768px — must be byte-identical to prior state):**
- [ ] `/dashboard` → click ticket row → side pane at 380px; visual parity with staging
- [ ] Side pane URL survives page refresh (`?detail=…&type=…&mode=…` restores the pane)
- [ ] Side pane URL survives new-window / deep link
- [ ] Click a sidebar link while pane is open → pane dismisses; browser back restores it
- [ ] `/clients` card click → side pane for client
- [ ] `/scheduled-probes` row click → side pane for probe
- [ ] `/tickets` subject click → full-page nav to `/tickets/:id` (unchanged)
- [ ] Pane close clears `?detail=…` query params
- [ ] All 6 themes (Linear, Apple, Nvidia, Sentry, Supabase, Vercel) — no contrast/variable regressions on shell chrome
- [ ] Table rendering on every list page visually identical to staging

**Mobile (390px in DevTools device toolbar):**
- [ ] Hamburger visible in header; sidebar hidden
- [ ] Tap hamburger → drawer slides in with dim backdrop
- [ ] Drawer dismisses on: backdrop tap, Escape (physical keyboard), nav-link tap
- [ ] Tickets badge populates in drawer (seeded by shell at app boot)
- [ ] Tap a ticket row on `/dashboard` → navigates to `/detail/ticket/:id` full-screen
- [ ] In-pane close button → returns to entity parent list (dashboard for tickets, /clients for clients, etc.)
- [ ] Browser back from `/detail/:type/:id` → returns to list
- [ ] `/tickets`, `/clients`, `/scheduled-probes` render as stacked cards with sensible primary/secondary/hidden priority
- [ ] Pagination controls stacked and tappable (≥44px)
- [ ] No horizontal scroll on shell chrome

**Viewport flip:**
- [ ] 1200 → 390 with side pane open → navigates to `/detail/:type/:id`, pane content stays visible
- [ ] 390 → 1200 on `/detail/:type/:id` → navigates back to parent list with query params, inline side pane reappears

**Build:**
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
