### PR TITLE
feat: mobile phase 2.5 — migrate 5 list pages to DataTable

### DIFF
--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -3,7 +3,14 @@ import { ActivatedRoute } from '@angular/router';
 import type { Subscription } from 'rxjs';
 import { FailedJobsService, FailedJob } from '../../core/services/failed-jobs.service';
 import { SystemStatusService, QueueStats } from '../../core/services/system-status.service';
-import { BroncoButtonComponent, ToolbarComponent, SelectComponent, CardComponent } from '../../shared/components/index.js';
+import {
+  BroncoButtonComponent,
+  ToolbarComponent,
+  SelectComponent,
+  CardComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+} from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
 const ALL_QUEUES = [
@@ -19,6 +26,8 @@ const ALL_QUEUES = [
     ToolbarComponent,
     SelectComponent,
     CardComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
   ],
   template: `
     <div class="page-header">
@@ -81,50 +90,78 @@ const ALL_QUEUES = [
     }
 
     @if (jobs().length > 0) {
-      <div class="job-list">
-        @for (job of jobs(); track job.id + job.queue) {
-          <div class="job-card" [class.expanded]="expandedJob() === job.id + ':' + job.queue">
-            <div class="job-header" (click)="toggleExpand(job)">
-              <div class="job-main">
-                <span class="job-queue-badge">{{ job.queue }}</span>
-                <span class="job-name">{{ job.name }}</span>
-                <span class="job-id">{{ job.id }}</span>
-              </div>
-              <div class="job-meta">
-                <span class="job-attempts">{{ job.attemptsMade }}/{{ job.maxAttempts || '?' }} attempts</span>
-                <span class="job-time">{{ formatTime(job.finishedOn || job.timestamp) }}</span>
-              </div>
-              <div class="job-actions" (click)="$event.stopPropagation()">
-                <app-bronco-button variant="icon" aria-label="Retry" (click)="retry(job)" [disabled]="acting()">
-                  ↻
-                </app-bronco-button>
-                <app-bronco-button variant="icon" aria-label="Discard" (click)="discard(job)" [disabled]="acting()">
-                  ✕
-                </app-bronco-button>
-              </div>
+      <app-data-table
+        [data]="jobs()"
+        [trackBy]="trackByJob"
+        [expandedRow]="expandedRowItem()"
+        (rowClick)="toggleExpand($event)">
+
+        <app-data-column key="queue" header="Queue" width="160px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            <span class="job-queue-badge">{{ row.queue }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="name" header="Name" [sortable]="false" mobilePriority="primary">
+          <ng-template #cell let-row>
+            <span class="job-name">{{ row.name }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="id" header="Job ID" width="120px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            <span class="job-id">{{ row.id }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="attempts" header="Attempts" width="110px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            <span class="job-attempts">{{ row.attemptsMade }}/{{ row.maxAttempts || '?' }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="time" header="Time" width="180px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            <span class="job-time">{{ formatTime(row.finishedOn || row.timestamp) }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="actions" header="" width="80px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            <div class="job-actions" (click)="$event.stopPropagation()">
+              <app-bronco-button variant="icon" aria-label="Retry" (click)="retry(row)" [disabled]="acting()">
+                ↻
+              </app-bronco-button>
+              <app-bronco-button variant="icon" aria-label="Discard" (click)="discard(row)" [disabled]="acting()">
+                ✕
+              </app-bronco-button>
             </div>
+          </ng-template>
+        </app-data-column>
 
-            <div class="job-reason">{{ truncate(job.failedReason, 200) }}</div>
+        <ng-template #subtitle let-row>
+          @if (row.failedReason) {
+            <span class="job-reason">{{ truncate(row.failedReason, 200) }}</span>
+          }
+        </ng-template>
 
-            @if (expandedJob() === job.id + ':' + job.queue) {
-              <div class="job-detail">
-                <h4>Job Data</h4>
-                <pre class="json-block">{{ formatJson(job.data) }}</pre>
+        <ng-template #expandedRow let-row>
+          <div class="job-detail">
+            <h4>Job Data</h4>
+            <pre class="json-block">{{ formatJson(row.data) }}</pre>
 
-                @if (job.failedReason) {
-                  <h4>Error</h4>
-                  <pre class="error-block">{{ job.failedReason }}</pre>
-                }
+            @if (row.failedReason) {
+              <h4>Error</h4>
+              <pre class="error-block">{{ row.failedReason }}</pre>
+            }
 
-                @if (job.stacktrace && job.stacktrace.length > 0) {
-                  <h4>Stack Trace</h4>
-                  <pre class="error-block">{{ job.stacktrace.join('\\n') }}</pre>
-                }
-              </div>
+            @if (row.stacktrace && row.stacktrace.length > 0) {
+              <h4>Stack Trace</h4>
+              <pre class="error-block">{{ row.stacktrace.join('\n') }}</pre>
             }
           </div>
-        }
-      </div>
+        </ng-template>
+      </app-data-table>
 
       @if (total() > jobs().length) {
         <div class="load-more">
@@ -195,29 +232,6 @@ const ALL_QUEUES = [
     }
     .empty-icon { font-size: 40px; color: var(--color-success); }
 
-    .job-list { display: flex; flex-direction: column; gap: 8px; }
-
-    .job-card {
-      background: var(--bg-card);
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-card);
-      margin-bottom: 8px;
-      overflow: hidden;
-    }
-
-    .job-header {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      cursor: pointer;
-      transition: background 120ms ease;
-      flex-wrap: wrap;
-    }
-    .job-header:hover { background: var(--bg-hover); }
-
-    .job-main { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
-
     .job-queue-badge {
       font-size: 11px;
       font-weight: 500;
@@ -230,12 +244,11 @@ const ALL_QUEUES = [
     }
     .job-name { font-weight: 500; color: var(--text-primary); font-size: 14px; }
     .job-id { font-size: 12px; color: var(--text-tertiary); font-family: ui-monospace, monospace; }
-    .job-meta { display: flex; align-items: center; gap: 12px; font-size: 12px; color: var(--text-tertiary); white-space: nowrap; }
-    .job-attempts { font-family: ui-monospace, monospace; }
+    .job-attempts { font-family: ui-monospace, monospace; font-size: 12px; color: var(--text-tertiary); }
+    .job-time { font-size: 12px; color: var(--text-tertiary); white-space: nowrap; }
     .job-actions { display: flex; gap: 4px; }
 
     .job-reason {
-      padding: 0 16px 12px;
       font-size: 12px;
       color: var(--color-error);
       font-family: ui-monospace, monospace;
@@ -244,10 +257,7 @@ const ALL_QUEUES = [
       white-space: pre-wrap;
     }
 
-    .job-detail {
-      padding: 12px 16px;
-      border-top: 1px solid var(--border-light);
-    }
+    .job-detail { padding: 4px 0; }
     .job-detail h4 { margin: 12px 0 4px; font-size: 13px; color: var(--text-secondary); }
 
     .json-block, .error-block {
@@ -308,6 +318,14 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
       .filter(([, s]) => s.failed > 0)
       .map(([name, s]) => [name, s.failed] as [string, number])
       .sort((a, b) => b[1] - a[1]);
+  });
+
+  trackByJob = (job: FailedJob) => job.id + ':' + job.queue;
+
+  expandedRowItem = computed<FailedJob | null>(() => {
+    const key = this.expandedJob();
+    if (!key) return null;
+    return this.jobs().find(j => j.id + ':' + j.queue === key) ?? null;
   });
 
   ngOnInit(): void {

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -146,7 +146,7 @@ const ALL_QUEUES = [
         </ng-template>
 
         <ng-template #expandedRow let-row>
-          <div class="job-detail">
+          <div class="job-detail" (click)="$event.stopPropagation()">
             <h4>Job Data</h4>
             <pre class="json-block">{{ formatJson(row.data) }}</pre>
 

--- a/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
+++ b/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
@@ -154,8 +154,8 @@ import {
         </app-data-column>
 
         <ng-template #expandedRow let-row>
-          @if (expandedRun()) {
-            <div class="expanded-detail">
+          <div class="expanded-detail" (click)="$event.stopPropagation()">
+            @if (expandedRun()) {
               @if (expandedRun()!.error) {
                 <div class="run-error">{{ expandedRun()!.error }}</div>
               }
@@ -185,8 +185,10 @@ import {
                   }
                 </div>
               }
-            </div>
-          }
+            } @else {
+              <div class="detail-loading">Loading run details…</div>
+            }
+          </div>
         </ng-template>
       </app-data-table>
 
@@ -270,6 +272,10 @@ import {
       border-radius: var(--radius-sm); margin-bottom: 8px; font-family: var(--font-primary); font-size: 13px;
     }
     .expanded-detail { padding: 8px 0; }
+    .detail-loading {
+      font-family: var(--font-primary); font-size: 13px; color: var(--text-tertiary);
+      padding: 8px 0;
+    }
     .detail-step { padding: 6px 0; border-bottom: 1px solid var(--border-light); }
     .detail-step:last-child { border-bottom: none; }
     .detail-step-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }

--- a/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
+++ b/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
@@ -8,7 +8,14 @@ import {
   IngestionRunDetail,
 } from '../../core/services/ingestion.service';
 import { ClientService, Client } from '../../core/services/client.service';
-import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../shared/components/index.js';
+import {
+  SelectComponent,
+  IconComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  PaginatorComponent,
+  type PaginatorPageEvent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
@@ -16,9 +23,11 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
     FormsModule,
     RouterLink,
     DatePipe,
-    BroncoButtonComponent,
     SelectComponent,
     IconComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    PaginatorComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -74,103 +83,120 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
         <span class="total-count">{{ total() }} runs total</span>
       </div>
 
-      <!-- Runs table -->
-      @if (runs().length === 0) {
-        <div class="card empty-card">
-          <p class="empty">No ingestion runs found.</p>
-        </div>
-      } @else {
-        <div class="table-card">
-          <table class="runs-table">
-            <thead>
-              <tr>
-                <th>Status</th>
-                <th>Source</th>
-                <th>Client</th>
-                <th>Route</th>
-                <th>Ticket</th>
-                <th>Started</th>
-                <th>Duration</th>
-                <th>Steps</th>
-                <th class="col-expand"></th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (r of runs(); track r.id) {
-                <tr class="run-row" [class.expanded-row]="expandedRunId === r.id" (click)="toggleExpand(r)">
-                  <td><span class="badge" [class]="'badge-status-' + r.status">{{ r.status }}</span></td>
-                  <td><span class="badge badge-source">{{ r.source }}</span></td>
-                  <td>{{ r.client.shortCode }}</td>
-                  <td>{{ r.routeName ?? '—' }}</td>
-                  <td>
-                    @if (r.ticketId) {
-                      <a [routerLink]="['/tickets', r.ticketId]" class="ticket-link" (click)="$event.stopPropagation()">View</a>
-                    } @else {
-                      <span class="muted">—</span>
-                    }
-                  </td>
-                  <td>{{ r.startedAt | date:'short' }}</td>
-                  <td>{{ getDuration(r) }}</td>
-                  <td>{{ r.steps.length }}</td>
-                  <td class="col-expand">
-                    <button type="button" class="expand-btn"
-                      (click)="toggleExpand(r); $event.stopPropagation()"
-                      [attr.aria-label]="expandedRunId === r.id ? 'Collapse run details' : 'Expand run details'"
-                      [attr.aria-expanded]="expandedRunId === r.id">
-                      <app-icon [name]="expandedRunId === r.id ? 'chevron-up' : 'chevron-down'" size="sm" />
-                    </button>
-                  </td>
-                </tr>
-                @if (expandedRunId === r.id && expandedRun()) {
-                  <tr class="detail-row-visible">
-                    <td colspan="9">
-                      <div class="expanded-detail">
-                        @if (expandedRun()!.error) {
-                          <div class="run-error">{{ expandedRun()!.error }}</div>
-                        }
-                        @for (step of expandedRun()!.steps; track step.id) {
-                          <div class="detail-step" [class]="'detail-step-' + step.status"
-                            [class.step-highlight]="recentlyChanged().has(step.id)">
-                            <div class="detail-step-header">
-                              <span class="detail-step-order">{{ step.stepOrder }}.</span>
-                              <span class="detail-step-name">{{ step.stepName }}</span>
-                              <span class="badge small" [class]="'badge-status-' + step.status">{{ step.status }}</span>
-                              @if (step.status === 'processing') {
-                                <span class="pulse-dot" aria-hidden="true"></span>
-                              }
-                              <span class="badge small badge-step-type">{{ step.stepType }}</span>
-                              @if (step.durationMs != null) {
-                                <span class="detail-step-duration">{{ formatDuration(step.durationMs) }}</span>
-                              }
-                            </div>
-                            @if (step.error) {
-                              <div class="detail-step-error">{{ step.error }}</div>
-                            }
-                            @if (step.output) {
-                              <details class="detail-step-output">
-                                <summary>Output</summary>
-                                <pre class="detail-pre">{{ step.output }}</pre>
-                              </details>
-                            }
-                          </div>
-                        }
-                      </div>
-                    </td>
-                  </tr>
-                }
-              }
-            </tbody>
-          </table>
-        </div>
+      <app-data-table
+        [data]="runs()"
+        [trackBy]="trackById"
+        [expandedRow]="expandedRowItem()"
+        (rowClick)="toggleExpand($event)"
+        emptyMessage="No ingestion runs found.">
 
-        <!-- Pagination -->
-        @if (total() > pageSize) {
-          <div class="pagination">
-            <app-bronco-button variant="ghost" [disabled]="page === 0" (click)="page = page - 1; loadRuns()">Previous</app-bronco-button>
-            <span class="page-info">Page {{ page + 1 }} of {{ totalPages() }}</span>
-            <app-bronco-button variant="ghost" [disabled]="page >= totalPages() - 1" (click)="page = page + 1; loadRuns()">Next</app-bronco-button>
-          </div>
-        }
+        <app-data-column key="status" header="Status" width="110px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            <span class="badge" [class]="'badge-status-' + row.status">{{ row.status }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="source" header="Source" width="100px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            <span class="badge badge-source">{{ row.source }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="client" header="Client" width="100px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ row.client.shortCode }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="route" header="Route" [sortable]="false" mobilePriority="primary">
+          <ng-template #cell let-row>
+            <span class="route-name">{{ row.routeName ?? '—' }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="ticket" header="Ticket" width="80px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            @if (row.ticketId) {
+              <a [routerLink]="['/tickets', row.ticketId]" class="ticket-link" (click)="$event.stopPropagation()">View</a>
+            } @else {
+              <span class="muted">—</span>
+            }
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="started" header="Started" width="160px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ row.startedAt | date:'short' }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="duration" header="Duration" width="100px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ getDuration(row) }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="steps" header="Steps" width="80px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            {{ row.steps.length }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="expand" header="" width="48px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            <button type="button" class="expand-btn"
+              (click)="toggleExpand(row); $event.stopPropagation()"
+              [attr.aria-label]="expandedRunId === row.id ? 'Collapse run details' : 'Expand run details'"
+              [attr.aria-expanded]="expandedRunId === row.id">
+              <app-icon [name]="expandedRunId === row.id ? 'chevron-up' : 'chevron-down'" size="sm" />
+            </button>
+          </ng-template>
+        </app-data-column>
+
+        <ng-template #expandedRow let-row>
+          @if (expandedRun()) {
+            <div class="expanded-detail">
+              @if (expandedRun()!.error) {
+                <div class="run-error">{{ expandedRun()!.error }}</div>
+              }
+              @for (step of expandedRun()!.steps; track step.id) {
+                <div class="detail-step" [class]="'detail-step-' + step.status"
+                  [class.step-highlight]="recentlyChanged().has(step.id)">
+                  <div class="detail-step-header">
+                    <span class="detail-step-order">{{ step.stepOrder }}.</span>
+                    <span class="detail-step-name">{{ step.stepName }}</span>
+                    <span class="badge small" [class]="'badge-status-' + step.status">{{ step.status }}</span>
+                    @if (step.status === 'processing') {
+                      <span class="pulse-dot" aria-hidden="true"></span>
+                    }
+                    <span class="badge small badge-step-type">{{ step.stepType }}</span>
+                    @if (step.durationMs != null) {
+                      <span class="detail-step-duration">{{ formatDuration(step.durationMs) }}</span>
+                    }
+                  </div>
+                  @if (step.error) {
+                    <div class="detail-step-error">{{ step.error }}</div>
+                  }
+                  @if (step.output) {
+                    <details class="detail-step-output">
+                      <summary>Output</summary>
+                      <pre class="detail-pre">{{ step.output }}</pre>
+                    </details>
+                  }
+                </div>
+              }
+            </div>
+          }
+        </ng-template>
+      </app-data-table>
+
+      @if (total() > pageSize) {
+        <app-paginator
+          [length]="total()"
+          [pageSize]="pageSize"
+          [pageIndex]="page"
+          [pageSizeOptions]="[20, 50, 100]"
+          (page)="onPage($event)" />
       }
     </div>
   `,
@@ -214,30 +240,11 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
     .filters app-select { min-width: 160px; }
     .total-count { color: var(--text-tertiary); font-family: var(--font-primary); font-size: 13px; margin-left: auto; }
 
-    .table-card {
-      background: var(--bg-card); border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-card); overflow: hidden; margin-bottom: 16px;
-    }
-    .runs-table { width: 100%; border-collapse: collapse; }
-    .runs-table thead th {
-      text-align: left; padding: 10px 16px; font-family: var(--font-primary);
-      font-size: 12px; font-weight: 500; color: var(--text-tertiary);
-      border-bottom: 1px solid var(--border-light); user-select: none;
-    }
-    .runs-table tbody td {
-      padding: 12px 16px; font-family: var(--font-primary); font-size: 14px;
-      color: var(--text-secondary); border-bottom: 1px solid var(--border-light);
-    }
-    .col-expand { width: 48px; text-align: center; }
     .expand-btn {
       background: none; border: none; cursor: pointer; padding: 4px 8px;
       font-size: 14px; color: var(--text-secondary); border-radius: var(--radius-sm);
     }
     .expand-btn:hover { background: var(--bg-hover); }
-
-    .run-row { cursor: pointer; transition: background 120ms ease; }
-    .run-row:hover { background: var(--bg-hover); }
-    .expanded-row { background: var(--bg-active); }
 
     .badge {
       font-family: var(--font-primary); font-size: 11px; font-weight: 600;
@@ -253,11 +260,10 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
     .badge-source { background: rgba(0, 113, 227, 0.08); color: var(--accent); }
     .badge-step-type { background: var(--bg-muted); color: var(--text-tertiary); }
 
+    .route-name { color: var(--text-primary); font-weight: 500; }
     .ticket-link { color: var(--accent-link); text-decoration: none; font-family: var(--font-primary); font-weight: 500; }
     .ticket-link:hover { text-decoration: underline; }
     .muted { color: var(--text-tertiary); }
-
-    .detail-row-visible td { padding: 8px 16px !important; border-bottom: 1px solid var(--border-light); background: var(--bg-page); }
 
     .run-error {
       padding: 8px 12px; background: rgba(255, 59, 48, 0.08); color: var(--color-error);
@@ -266,7 +272,7 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
     .expanded-detail { padding: 8px 0; }
     .detail-step { padding: 6px 0; border-bottom: 1px solid var(--border-light); }
     .detail-step:last-child { border-bottom: none; }
-    .detail-step-header { display: flex; align-items: center; gap: 8px; }
+    .detail-step-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
     .detail-step-order { font-family: var(--font-primary); font-weight: 600; color: var(--text-tertiary); min-width: 20px; }
     .detail-step-name { font-family: var(--font-primary); font-weight: 500; color: var(--text-primary); }
     .detail-step-duration { font-family: var(--font-primary); font-size: 12px; color: var(--text-tertiary); }
@@ -285,15 +291,6 @@ import { BroncoButtonComponent, SelectComponent, IconComponent } from '../../sha
     .detail-pre {
       background: #1d1d1f; color: #f5f5f7; padding: 8px 12px; border-radius: var(--radius-sm);
       font-size: 12px; overflow-x: auto; max-height: 300px; white-space: pre-wrap; word-break: break-word;
-    }
-
-    .pagination { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 16px 0; }
-    .page-info { font-family: var(--font-primary); font-size: 13px; color: var(--text-tertiary); }
-    .empty { color: var(--text-tertiary); text-align: center; padding: 24px 16px; margin: 0; font-family: var(--font-primary); }
-    .empty-card { margin-bottom: 16px; }
-    .card {
-      background: var(--bg-card); border-radius: var(--radius-lg);
-      padding: 16px; box-shadow: var(--shadow-card);
     }
   `],
 })
@@ -325,6 +322,14 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
     { value: '', label: 'All Clients' },
     ...this.clients().map(c => ({ value: c.id, label: c.shortCode })),
   ]);
+
+  trackById = (item: IngestionRun) => item.id;
+
+  expandedRowItem = computed<IngestionRun | null>(() => {
+    const id = this.expandedRunId;
+    if (!id) return null;
+    return this.runs().find(r => r.id === id) ?? null;
+  });
 
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private detailPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -376,8 +381,10 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
     });
   }
 
-  totalPages(): number {
-    return Math.ceil(this.total() / this.pageSize);
+  onPage(event: PaginatorPageEvent): void {
+    this.pageSize = event.pageSize;
+    this.page = event.pageIndex;
+    this.loadRuns();
   }
 
   toggleExpand(run: IngestionRun): void {

--- a/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
+++ b/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
@@ -9,7 +9,14 @@ import {
   SlackConversationDetail,
 } from '../../core/services/slack-conversation.service';
 import { ClientService, Client } from '../../core/services/client.service';
-import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
+import {
+  BroncoButtonComponent,
+  SelectComponent,
+  PaginatorComponent,
+  type PaginatorPageEvent,
+  DataTableComponent,
+  DataTableColumnComponent,
+} from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
@@ -20,6 +27,8 @@ import { ToastService } from '../../core/services/toast.service';
     BroncoButtonComponent,
     SelectComponent,
     PaginatorComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -49,105 +58,110 @@ import { ToastService } from '../../core/services/toast.service';
         </div>
       </div>
 
-      <!-- Table -->
-      <div class="table-card">
-        @if (conversations().length === 0) {
-          <div class="table-empty">No conversations found.</div>
-        } @else {
-          <table class="conv-table">
-            <thead>
-              <tr>
-                <th>Operator</th>
-                <th>Client</th>
-                <th>Channel</th>
-                <th>Messages</th>
-                <th>Tokens</th>
-                <th>Started</th>
-                <th>Last Activity</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (row of conversations(); track row.id) {
-                <tr class="conv-row"
-                    tabindex="0"
-                    role="button"
-                    [attr.aria-expanded]="expandedId() === row.id"
-                    (click)="toggleExpand(row.id)"
-                    (keydown.enter)="toggleExpand(row.id)"
-                    (keydown.space)="$event.preventDefault(); toggleExpand(row.id)">
-                  <td>{{ row.operator.name }}</td>
-                  <td>{{ row.client?.name ?? '—' }}</td>
-                  <td><code>{{ row.channelId }}</code></td>
-                  <td>{{ row.messageCount }}</td>
-                  <td>
-                    @if (row.totalInputTokens || row.totalOutputTokens) {
-                      {{ (row.totalInputTokens ?? 0) + (row.totalOutputTokens ?? 0) | number }}
-                    } @else {
-                      —
-                    }
-                  </td>
-                  <td>{{ formatTime(row.createdAt) }}</td>
-                  <td>{{ formatTime(row.updatedAt) }}</td>
-                </tr>
-                @if (expandedId() === row.id) {
-                  <tr class="detail-row-visible">
-                    <td colspan="7">
-                      <div class="detail-panel">
-                        @if (loadingDetail()) {
-                          <div class="loading-state">Loading conversation details...</div>
-                        } @else if (detail()) {
-                          <!-- Cost summary -->
-                          <div class="cost-summary">
-                            <span class="cost-chip">Input: {{ detail()!.totalInputTokens ?? 0 | number }} tokens</span>
-                            <span class="cost-chip">Output: {{ detail()!.totalOutputTokens ?? 0 | number }} tokens</span>
-                          </div>
+      <app-data-table
+        [data]="conversations()"
+        [trackBy]="trackById"
+        [expandedRow]="expandedRowItem()"
+        emptyMessage="No conversations found."
+        (rowClick)="toggleExpand($event.id)">
 
-                          <!-- Messages -->
-                          <div class="chat-container">
-                            @for (msg of detail()!.messages; track $index) {
-                              <div class="chat-msg" [class.user-msg]="msg.role === 'user'" [class.assistant-msg]="msg.role === 'assistant'">
-                                <div class="msg-role">{{ msg.role === 'user' ? detail()!.operator.name : 'Hugo' }}</div>
-                                <div class="msg-content">{{ msg.content }}</div>
-                                <div class="msg-time">{{ formatTime(msg.timestamp) }}</div>
-                              </div>
-                            }
-                          </div>
+        <app-data-column key="operator" header="Operator" [sortable]="false" mobilePriority="primary">
+          <ng-template #cell let-row>
+            {{ row.operator.name }}
+          </ng-template>
+        </app-data-column>
 
-                          <!-- Tool calls -->
-                          @if (detail()!.toolCalls?.length) {
-                            <h4>Tool Calls</h4>
-                            <div class="tool-calls">
-                              @for (tc of detail()!.toolCalls; track $index) {
-                                <div class="tool-card" [class.tool-error]="tc.isError">
-                                  <div class="tool-header">
-                                    <code>{{ tc.tool }}</code>
-                                    <span class="tool-duration">{{ tc.durationMs }}ms</span>
-                                    @if (tc.isError) {
-                                      <span class="tool-error-icon">✕</span>
-                                    }
-                                  </div>
-                                  <div class="tool-result">{{ tc.resultPreview }}</div>
-                                </div>
-                              }
-                            </div>
-                          }
+        <app-data-column key="client" header="Client" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ row.client?.name ?? '—' }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="channel" header="Channel" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            <code>{{ row.channelId }}</code>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="messages" header="Messages" width="100px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ row.messageCount }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="tokens" header="Tokens" width="120px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            @if (row.totalInputTokens || row.totalOutputTokens) {
+              {{ (row.totalInputTokens ?? 0) + (row.totalOutputTokens ?? 0) | number }}
+            } @else {
+              —
+            }
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="started" header="Started" width="160px" [sortable]="false" mobilePriority="hidden">
+          <ng-template #cell let-row>
+            {{ formatTime(row.createdAt) }}
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="lastActivity" header="Last Activity" width="160px" [sortable]="false" mobilePriority="secondary">
+          <ng-template #cell let-row>
+            {{ formatTime(row.updatedAt) }}
+          </ng-template>
+        </app-data-column>
+
+        <ng-template #expandedRow let-row>
+          <div class="detail-panel">
+            @if (loadingDetail()) {
+              <div class="loading-state">Loading conversation details...</div>
+            } @else if (detail()) {
+              <!-- Cost summary -->
+              <div class="cost-summary">
+                <span class="cost-chip">Input: {{ detail()!.totalInputTokens ?? 0 | number }} tokens</span>
+                <span class="cost-chip">Output: {{ detail()!.totalOutputTokens ?? 0 | number }} tokens</span>
+              </div>
+
+              <!-- Messages -->
+              <div class="chat-container">
+                @for (msg of detail()!.messages; track $index) {
+                  <div class="chat-msg" [class.user-msg]="msg.role === 'user'" [class.assistant-msg]="msg.role === 'assistant'">
+                    <div class="msg-role">{{ msg.role === 'user' ? detail()!.operator.name : 'Hugo' }}</div>
+                    <div class="msg-content">{{ msg.content }}</div>
+                    <div class="msg-time">{{ formatTime(msg.timestamp) }}</div>
+                  </div>
+                }
+              </div>
+
+              <!-- Tool calls -->
+              @if (detail()!.toolCalls?.length) {
+                <h4>Tool Calls</h4>
+                <div class="tool-calls">
+                  @for (tc of detail()!.toolCalls; track $index) {
+                    <div class="tool-card" [class.tool-error]="tc.isError">
+                      <div class="tool-header">
+                        <code>{{ tc.tool }}</code>
+                        <span class="tool-duration">{{ tc.durationMs }}ms</span>
+                        @if (tc.isError) {
+                          <span class="tool-error-icon">✕</span>
                         }
                       </div>
-                    </td>
-                  </tr>
-                }
+                      <div class="tool-result">{{ tc.resultPreview }}</div>
+                    </div>
+                  }
+                </div>
               }
-            </tbody>
-          </table>
-        }
+            }
+          </div>
+        </ng-template>
+      </app-data-table>
 
-        <app-paginator
-          [length]="total()"
-          [pageSize]="pageSize"
-          [pageIndex]="pageIndex"
-          [pageSizeOptions]="[25, 50, 100]"
-          (page)="onPage($event)" />
-      </div>
+      <app-paginator
+        [length]="total()"
+        [pageSize]="pageSize"
+        [pageIndex]="pageIndex"
+        [pageSizeOptions]="[25, 50, 100]"
+        (page)="onPage($event)" />
     </div>
   `,
   styles: [`
@@ -170,37 +184,13 @@ import { ToastService } from '../../core/services/toast.service';
     }
     .text-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--focus-ring); }
 
-    .table-card {
-      background: var(--bg-card); border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-card); overflow: hidden;
-    }
-    .table-empty {
-      padding: 48px 24px; text-align: center;
-      font-family: var(--font-primary); font-size: 14px; color: var(--text-tertiary);
-    }
-    .conv-table { width: 100%; border-collapse: collapse; }
-    .conv-table thead th {
-      text-align: left; padding: 10px 16px; font-family: var(--font-primary);
-      font-size: 12px; font-weight: 500; color: var(--text-tertiary);
-      border-bottom: 1px solid var(--border-light); user-select: none;
-    }
-    .conv-table tbody td {
-      padding: 12px 16px; font-family: var(--font-primary); font-size: 14px;
-      color: var(--text-secondary); border-bottom: 1px solid var(--border-light);
-    }
     code {
       font-size: 12px; background: var(--bg-muted); padding: 2px 6px;
       border-radius: var(--radius-sm);
     }
-    .conv-row { cursor: pointer; transition: background 120ms ease; }
-    .conv-row:hover { background: var(--bg-hover); }
 
-    .detail-row-visible td {
-      padding: 0 !important; border-bottom: 1px solid var(--border-light);
-    }
     .detail-panel {
       padding: 16px 24px; background: var(--bg-page);
-      border-bottom: 1px solid var(--border-light);
     }
     .loading-state {
       font-family: var(--font-primary); font-size: 13px; color: var(--accent); padding: 8px 0;
@@ -278,6 +268,14 @@ export class SlackConversationsComponent implements OnInit, OnDestroy {
     { value: '', label: 'All Clients' },
     ...this.clients().map(c => ({ value: c.id, label: c.name })),
   ]);
+
+  expandedRowItem = computed<SlackConversationSummary | null>(() => {
+    const id = this.expandedId();
+    if (!id) return null;
+    return this.conversations().find(c => c.id === id) ?? null;
+  });
+
+  trackById = (item: SlackConversationSummary) => item.id;
 
   ngOnInit(): void {
     this.load();

--- a/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
+++ b/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
@@ -112,7 +112,7 @@ import { ToastService } from '../../core/services/toast.service';
         </app-data-column>
 
         <ng-template #expandedRow let-row>
-          <div class="detail-panel">
+          <div class="detail-panel" (click)="$event.stopPropagation()">
             @if (loadingDetail()) {
               <div class="loading-state">Loading conversation details...</div>
             } @else if (detail()) {

--- a/services/control-panel/src/app/features/system-issues/system-issues.component.ts
+++ b/services/control-panel/src/app/features/system-issues/system-issues.component.ts
@@ -114,7 +114,7 @@ import {
                 <app-data-column key="error" header="Error" [sortable]="false" mobilePriority="secondary">
                   <ng-template #cell let-row>
                     @if (row.error) {
-                      <div class="error-text">{{ row.error }}</div>
+                      <span class="error-text">{{ row.error }}</span>
                     } @else {
                       —
                     }
@@ -162,7 +162,7 @@ import {
 
                 <app-data-column key="description" header="Description" [sortable]="false" mobilePriority="secondary">
                   <ng-template #cell let-row>
-                    <div class="finding-description">{{ row.description }}</div>
+                    <span class="finding-description">{{ row.description }}</span>
                   </ng-template>
                 </app-data-column>
 
@@ -330,6 +330,7 @@ import {
     .link:hover { text-decoration: underline; }
 
     .error-text {
+      display: block;
       background: var(--bg-muted); padding: 6px 10px; border-radius: var(--radius-sm);
       font-family: monospace; font-size: 12px; color: var(--color-error);
       word-break: break-word; max-height: 80px; overflow-y: auto;

--- a/services/control-panel/src/app/features/system-issues/system-issues.component.ts
+++ b/services/control-panel/src/app/features/system-issues/system-issues.component.ts
@@ -9,8 +9,14 @@ import {
   type FailedIssueJob,
   type OpenFinding,
   type RecentError,
+  type FailedQueueInfo,
 } from '../../core/services/system-issues.service';
-import { BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
+import {
+  BroncoButtonComponent,
+  SelectComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+} from '../../shared/components/index.js';
 
 @Component({
   standalone: true,
@@ -20,6 +26,8 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
     FormsModule,
     BroncoButtonComponent,
     SelectComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
   ],
   template: `
     <div class="page-wrapper">
@@ -74,23 +82,51 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
                 Failed Issue Resolution Jobs
                 <span class="count-badge">{{ d.failedIssueJobs.length }}</span>
               </h2>
-              <div class="card-grid">
-                @for (job of d.failedIssueJobs; track job.id) {
-                  <div class="card issue-card severity-high">
-                    <div class="card-title">
-                      <a [routerLink]="['/tickets', job.ticketId]" class="link">{{ job.ticketSubject }}</a>
-                    </div>
-                    <div class="card-subtitle">{{ job.clientName }} &middot; {{ job.repoName }}</div>
-                    @if (job.error) {
-                      <div class="error-text">{{ job.error }}</div>
+              <app-data-table
+                [data]="d.failedIssueJobs"
+                [trackBy]="trackJobId"
+                [rowClickable]="false">
+
+                <app-data-column key="ticket" header="Ticket" [sortable]="false" mobilePriority="primary">
+                  <ng-template #cell let-row>
+                    <a [routerLink]="['/tickets', row.ticketId]" class="link">{{ row.ticketSubject }}</a>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="client" header="Client" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    {{ row.clientName }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="repo" header="Repo" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    {{ row.repoName }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="branch" header="Branch" width="200px" [sortable]="false" mobilePriority="hidden">
+                  <ng-template #cell let-row>
+                    <span class="mono">{{ row.branchName }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="error" header="Error" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    @if (row.error) {
+                      <div class="error-text">{{ row.error }}</div>
+                    } @else {
+                      —
                     }
-                    <div class="meta">
-                      <span class="mono">{{ job.branchName }}</span>
-                      <span class="timestamp">{{ job.failedAt | date:'short' }}</span>
-                    </div>
-                  </div>
-                }
-              </div>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="failedAt" header="Failed At" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span class="timestamp">{{ row.failedAt | date:'short' }}</span>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
             </section>
           }
 
@@ -101,25 +137,59 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
                 Open Database Findings
                 <span class="count-badge">{{ d.openFindings.length }}</span>
               </h2>
-              <div class="card-grid">
-                @for (finding of d.openFindings; track finding.id) {
-                  <div [class]="'card issue-card severity-' + finding.severity.toLowerCase()">
-                    <div class="card-title">{{ finding.title }}</div>
-                    <div class="card-subtitle">
-                      {{ finding.clientName }} &middot; {{ finding.systemName }}
-                    </div>
-                    <div class="finding-description">{{ finding.description }}</div>
-                    <div class="meta">
-                      <div class="chip-set">
-                        <span [class]="'chip severity-chip-' + finding.severity.toLowerCase()">{{ finding.severity }}</span>
-                        <span class="chip">{{ finding.category }}</span>
-                        <span class="chip">{{ finding.status }}</span>
-                      </div>
-                      <span class="timestamp">{{ finding.detectedAt | date:'short' }}</span>
-                    </div>
-                  </div>
-                }
-              </div>
+              <app-data-table
+                [data]="d.openFindings"
+                [trackBy]="trackFindingId"
+                [rowClickable]="false">
+
+                <app-data-column key="title" header="Finding" [sortable]="false" mobilePriority="primary">
+                  <ng-template #cell let-row>
+                    {{ row.title }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="client" header="Client" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    {{ row.clientName }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="system" header="System" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    {{ row.systemName }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="description" header="Description" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <div class="finding-description">{{ row.description }}</div>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="severity" header="Severity" width="100px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span [class]="'chip severity-chip-' + row.severity.toLowerCase()">{{ row.severity }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="category" header="Category" width="120px" [sortable]="false" mobilePriority="hidden">
+                  <ng-template #cell let-row>
+                    <span class="chip">{{ row.category }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="status" header="Status" width="100px" [sortable]="false" mobilePriority="hidden">
+                  <ng-template #cell let-row>
+                    <span class="chip">{{ row.status }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="detected" header="Detected" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span class="timestamp">{{ row.detectedAt | date:'short' }}</span>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
             </section>
           }
 
@@ -130,24 +200,29 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
                 Unresolved Error Logs
                 <span class="count-badge">{{ d.recentErrors.length }}</span>
               </h2>
-              <div class="error-table">
-                <div class="error-table-header">
-                  <span class="col-service">Service</span>
-                  <span class="col-message">Message</span>
-                  <span class="col-time">Time</span>
-                </div>
-                @for (err of d.recentErrors; track err.id) {
-                  <div class="error-row">
-                    <span class="col-service">
-                      <span class="service-badge">{{ err.service }}</span>
-                    </span>
-                    <span class="col-message" [title]="err.error ?? ''">
-                      {{ err.message }}
-                    </span>
-                    <span class="col-time">{{ err.createdAt | date:'short' }}</span>
-                  </div>
-                }
-              </div>
+              <app-data-table
+                [data]="d.recentErrors"
+                [trackBy]="trackErrorId"
+                [rowClickable]="false">
+
+                <app-data-column key="service" header="Service" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span class="service-badge">{{ row.service }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="message" header="Message" [sortable]="false" mobilePriority="primary">
+                  <ng-template #cell let-row>
+                    <span class="col-message" [title]="row.error ?? ''">{{ row.message }}</span>
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="time" header="Time" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span class="col-time">{{ row.createdAt | date:'short' }}</span>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
             </section>
           }
 
@@ -158,14 +233,23 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
                 Failed Queue Jobs
                 <span class="count-badge">{{ failedQueues().length }}</span>
               </h2>
-              <div class="card-grid">
-                @for (q of failedQueues(); track q.queue) {
-                  <div class="card issue-card severity-medium">
-                    <div class="card-title">{{ q.queue }}</div>
-                    <div class="queue-failed-count">{{ q.failed }} failed {{ q.failed === 1 ? 'job' : 'jobs' }}</div>
-                  </div>
-                }
-              </div>
+              <app-data-table
+                [data]="failedQueues()"
+                [trackBy]="trackQueueName"
+                [rowClickable]="false">
+
+                <app-data-column key="queue" header="Queue" [sortable]="false" mobilePriority="primary">
+                  <ng-template #cell let-row>
+                    {{ row.queue }}
+                  </ng-template>
+                </app-data-column>
+
+                <app-data-column key="failed" header="Failed Jobs" width="160px" [sortable]="false" mobilePriority="secondary">
+                  <ng-template #cell let-row>
+                    <span class="queue-failed-count">{{ row.failed }} failed {{ row.failed === 1 ? 'job' : 'jobs' }}</span>
+                  </ng-template>
+                </app-data-column>
+              </app-data-table>
             </section>
           }
         }
@@ -241,41 +325,26 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
       padding: 2px 10px; border-radius: var(--radius-pill);
       font-family: var(--font-primary); font-size: 13px; font-weight: 500;
     }
-    .card-grid {
-      display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px;
-    }
-    .issue-card { border-left: 4px solid var(--text-tertiary); }
-    .issue-card.severity-critical { border-left-color: var(--color-error); }
-    .issue-card.severity-high { border-left-color: var(--color-error); }
-    .issue-card.severity-medium { border-left-color: var(--color-warning); }
-    .issue-card.severity-low { border-left-color: var(--color-info); }
 
-    .card-title { font-family: var(--font-primary); font-size: 15px; font-weight: 500; color: var(--text-primary); margin-bottom: 4px; }
-    .card-subtitle { font-family: var(--font-primary); font-size: 13px; color: var(--text-tertiary); margin-bottom: 8px; }
     .link { color: var(--accent-link); text-decoration: none; }
     .link:hover { text-decoration: underline; }
 
     .error-text {
-      background: var(--bg-muted); padding: 8px 12px; border-radius: var(--radius-sm);
-      font-family: monospace; font-size: 13px; color: var(--color-error);
-      word-break: break-word; max-height: 80px; overflow-y: auto; margin-bottom: 8px;
+      background: var(--bg-muted); padding: 6px 10px; border-radius: var(--radius-sm);
+      font-family: monospace; font-size: 12px; color: var(--color-error);
+      word-break: break-word; max-height: 80px; overflow-y: auto;
     }
     .finding-description {
-      font-family: var(--font-primary); font-size: 14px; color: var(--text-tertiary);
-      margin-bottom: 8px; display: -webkit-box; -webkit-line-clamp: 3;
+      font-family: var(--font-primary); font-size: 13px; color: var(--text-tertiary);
+      display: -webkit-box; -webkit-line-clamp: 3;
       -webkit-box-orient: vertical; overflow: hidden;
-    }
-    .meta {
-      display: flex; align-items: center; justify-content: space-between;
-      flex-wrap: wrap; gap: 8px; font-size: 13px; color: var(--text-tertiary);
     }
     .mono {
       font-family: monospace; font-size: 12px; background: var(--bg-muted);
       padding: 2px 6px; border-radius: var(--radius-sm);
     }
-    .timestamp { white-space: nowrap; }
+    .timestamp { white-space: nowrap; font-size: 13px; color: var(--text-tertiary); }
 
-    .chip-set { display: flex; gap: 6px; flex-wrap: wrap; }
     .chip {
       font-family: var(--font-primary); font-size: 11px; font-weight: 500;
       padding: 2px 8px; border-radius: var(--radius-pill); background: var(--bg-muted);
@@ -286,23 +355,6 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
     .severity-chip-medium { background: rgba(255, 149, 0, 0.1); color: var(--color-warning); }
     .severity-chip-low { background: rgba(0, 122, 255, 0.1); color: var(--color-info); }
 
-    .error-table {
-      background: var(--bg-card); border-radius: var(--radius-lg);
-      overflow: hidden; border: 1px solid var(--border-light); box-shadow: var(--shadow-card);
-    }
-    .error-table-header {
-      display: grid; grid-template-columns: 150px 1fr 120px;
-      padding: 12px 16px; background: var(--bg-muted);
-      font-family: var(--font-primary); font-weight: 500; font-size: 13px;
-      color: var(--text-tertiary); border-bottom: 1px solid var(--border-light);
-    }
-    .error-row {
-      display: grid; grid-template-columns: 150px 1fr 120px;
-      padding: 10px 16px; border-bottom: 1px solid var(--border-light);
-      font-family: var(--font-primary); font-size: 13px; align-items: center;
-    }
-    .error-row:last-child { border-bottom: none; }
-    .error-row:hover { background: var(--bg-hover); }
     .service-badge {
       background: var(--color-info-subtle); color: var(--accent);
       padding: 2px 8px; border-radius: var(--radius-sm);
@@ -310,12 +362,12 @@ import { BroncoButtonComponent, SelectComponent } from '../../shared/components/
     }
     .col-message {
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-      padding-right: 12px; color: var(--text-secondary);
+      color: var(--text-secondary);
     }
-    .col-time { color: var(--text-tertiary); text-align: right; }
+    .col-time { color: var(--text-tertiary); }
 
     .queue-failed-count {
-      font-family: var(--font-primary); font-size: 20px;
+      font-family: var(--font-primary); font-size: 16px;
       font-weight: 500; color: var(--color-error);
     }
 
@@ -354,6 +406,11 @@ export class SystemIssuesComponent implements OnInit, OnDestroy {
     if (!d) return [];
     return d.failedQueues.filter(q => q.failed > 0);
   });
+
+  trackJobId = (job: FailedIssueJob) => job.id;
+  trackFindingId = (f: OpenFinding) => f.id;
+  trackErrorId = (e: RecentError) => e.id;
+  trackQueueName = (q: FailedQueueInfo) => q.queue;
 
   ngOnInit() {
     this.refresh();

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -11,6 +11,8 @@ import {
   DropdownMenuComponent,
   DropdownItemComponent,
   DialogComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
 } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
 
@@ -25,6 +27,8 @@ import { ToastService } from '../../core/services/toast.service';
     DropdownMenuComponent,
     DropdownItemComponent,
     DialogComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
     UserDialogComponent,
   ],
   template: `
@@ -39,51 +43,73 @@ import { ToastService } from '../../core/services/toast.service';
       @if (loading()) {
         <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
       } @else {
-        <div class="user-grid">
-          @for (user of users(); track user.id) {
-            <div class="user-card" [class.inactive]="!user.isActive">
-              <div class="card-header">
-                <div class="avatar" [class.admin-avatar]="user.role === 'ADMIN'">
-                  {{ user.name.charAt(0).toUpperCase() }}
+        <app-data-table
+          [data]="users()"
+          [trackBy]="trackById"
+          [rowClickable]="false"
+          emptyMessage="No users found.">
+
+          <app-data-column key="user" header="User" [sortable]="false" mobilePriority="primary">
+            <ng-template #cell let-row>
+              <div class="user-cell" [class.inactive]="!row.isActive">
+                <div class="avatar" [class.admin-avatar]="row.role === 'ADMIN'">
+                  {{ row.name.charAt(0).toUpperCase() }}
                 </div>
-                <div class="header-text">
-                  <div class="user-name">{{ user.name }}</div>
-                  <div class="user-email">{{ user.email }}</div>
-                </div>
-                <app-bronco-button variant="icon" size="sm" class="card-menu" [attr.aria-label]="'Actions for ' + user.name" #menuTrigger (click)="menu.toggle()">
-                  ...
-                </app-bronco-button>
-                <app-dropdown-menu #menu [trigger]="menuTrigger">
-                  <app-dropdown-item (action)="openEdit(user)">Edit</app-dropdown-item>
-                  <app-dropdown-item (action)="openResetPassword(user)">Reset Password</app-dropdown-item>
-                  @if (user.id !== currentUserId()) {
-                    @if (user.isActive) {
-                      <app-dropdown-item (action)="deactivate(user)">Deactivate</app-dropdown-item>
-                    } @else {
-                      <app-dropdown-item (action)="activate(user)">Activate</app-dropdown-item>
-                    }
-                  }
-                </app-dropdown-menu>
-              </div>
-              <div class="user-details">
-                <div class="detail-row">
-                  <span class="chip" [class]="'role-' + user.role.toLowerCase()">{{ user.role }}</span>
-                  @if (!user.isActive) {
-                    <span class="chip role-inactive">INACTIVE</span>
-                  }
-                </div>
-                <div class="detail-row muted">
-                  Last login: {{ user.lastLoginAt ? (user.lastLoginAt | date:'short') : 'Never' }}
-                </div>
-                <div class="detail-row muted">
-                  Created: {{ user.createdAt | date:'mediumDate' }}
+                <div class="user-text">
+                  <div class="user-name">{{ row.name }}</div>
+                  <div class="user-email">{{ row.email }}</div>
                 </div>
               </div>
-            </div>
-          } @empty {
-            <p class="empty-state">No users found.</p>
-          }
-        </div>
+            </ng-template>
+          </app-data-column>
+
+          <app-data-column key="role" header="Role" width="110px" [sortable]="false" mobilePriority="secondary">
+            <ng-template #cell let-row>
+              <span class="chip" [class]="'role-' + row.role.toLowerCase()">{{ row.role }}</span>
+            </ng-template>
+          </app-data-column>
+
+          <app-data-column key="status" header="Status" width="100px" [sortable]="false" mobilePriority="secondary">
+            <ng-template #cell let-row>
+              @if (row.isActive) {
+                <span class="status-active">Active</span>
+              } @else {
+                <span class="chip role-inactive">INACTIVE</span>
+              }
+            </ng-template>
+          </app-data-column>
+
+          <app-data-column key="lastLogin" header="Last Login" width="160px" [sortable]="false" mobilePriority="secondary">
+            <ng-template #cell let-row>
+              <span class="muted">{{ row.lastLoginAt ? (row.lastLoginAt | date:'short') : 'Never' }}</span>
+            </ng-template>
+          </app-data-column>
+
+          <app-data-column key="created" header="Created" width="140px" [sortable]="false" mobilePriority="hidden">
+            <ng-template #cell let-row>
+              <span class="muted">{{ row.createdAt | date:'mediumDate' }}</span>
+            </ng-template>
+          </app-data-column>
+
+          <app-data-column key="actions" header="" width="60px" [sortable]="false" mobilePriority="hidden">
+            <ng-template #cell let-row>
+              <app-bronco-button variant="icon" size="sm" [attr.aria-label]="'Actions for ' + row.name" #menuTrigger (click)="menu.toggle(); $event.stopPropagation()">
+                ...
+              </app-bronco-button>
+              <app-dropdown-menu #menu [trigger]="menuTrigger">
+                <app-dropdown-item (action)="openEdit(row)">Edit</app-dropdown-item>
+                <app-dropdown-item (action)="openResetPassword(row)">Reset Password</app-dropdown-item>
+                @if (row.id !== currentUserId()) {
+                  @if (row.isActive) {
+                    <app-dropdown-item (action)="deactivate(row)">Deactivate</app-dropdown-item>
+                  } @else {
+                    <app-dropdown-item (action)="activate(row)">Activate</app-dropdown-item>
+                  }
+                }
+              </app-dropdown-menu>
+            </ng-template>
+          </app-data-column>
+        </app-data-table>
       }
 
       @if (showUserDialog()) {
@@ -140,43 +166,29 @@ import { ToastService } from '../../core/services/toast.service';
     }
     .loading-text { color: var(--text-tertiary); font-size: 13px; }
 
-    .user-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-      gap: 16px;
-    }
-    .user-card {
-      background: var(--bg-card);
-      border-radius: var(--radius-lg);
-      padding: 20px;
-      box-shadow: var(--shadow-card);
-      position: relative;
-    }
-    .user-card.inactive { opacity: 0.6; }
-
-    .card-header {
+    .user-cell {
       display: flex;
       align-items: center;
       gap: 12px;
-      margin-bottom: 12px;
     }
+    .user-cell.inactive { opacity: 0.6; }
     .avatar {
-      width: 40px;
-      height: 40px;
+      width: 32px;
+      height: 32px;
       border-radius: 50%;
       background: var(--accent);
       color: var(--text-on-accent);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 17px;
+      font-size: 14px;
       font-weight: 600;
       flex-shrink: 0;
     }
     .admin-avatar { background: #5856d6; }
-    .header-text { flex: 1; min-width: 0; }
+    .user-text { min-width: 0; }
     .user-name {
-      font-size: 15px;
+      font-size: 14px;
       font-weight: 600;
       color: var(--text-primary);
       white-space: nowrap;
@@ -184,27 +196,22 @@ import { ToastService } from '../../core/services/toast.service';
       text-overflow: ellipsis;
     }
     .user-email {
-      font-size: 13px;
+      font-size: 12px;
       color: var(--text-tertiary);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    .card-menu { flex-shrink: 0; }
 
-    .user-details {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    .detail-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
     .muted {
       color: var(--text-tertiary);
       font-size: 13px;
+    }
+
+    .status-active {
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--color-success);
     }
 
     .chip {
@@ -217,12 +224,6 @@ import { ToastService } from '../../core/services/toast.service';
     .role-admin { background: rgba(88, 86, 214, 0.1); color: #5856d6; }
     .role-operator { background: rgba(52, 199, 89, 0.1); color: var(--color-success); }
     .role-inactive { background: rgba(255, 59, 48, 0.1); color: var(--color-error); }
-
-    .empty-state {
-      text-align: center;
-      color: var(--text-tertiary);
-      padding: 48px;
-    }
 
     .overlay {
       position: fixed;
@@ -293,6 +294,8 @@ export class UserListComponent implements OnInit {
   editingUser = signal<ControlPanelUser | null>(null);
 
   currentUserId = () => this.authService.currentUser()?.id;
+
+  trackById = (item: ControlPanelUser) => item.id;
 
   ngOnInit(): void {
     this.load();


### PR DESCRIPTION
## Summary

Phase 2.5 of the mobile-responsive control panel initiative (umbrella #224). Migrates 5 list pages from custom layouts to the shared `<app-data-table>` component so they automatically pick up Phase 2's mobile card rendering. Four pages deferred with reasoning.

- **Migrated (5):** `/users`, `/ingestion-jobs`, `/failed-jobs`, `/system-issues`, `/slack-conversations`. Each with `mobilePriority` annotations following the pattern established in Phase 2; `#expandedRow`/`#subtitle` templates used where row detail was needed. `/ingestion-jobs` also swaps its custom Prev/Next for `<app-paginator>`. `/system-issues` is now four inner DataTables (failed resolution jobs / open findings / recent errors / failed queue jobs).
- **Deferred (4):** `/ticket-routes` (hierarchical — tabs + route cards + nested steps subtable), `/system-analysis` (content-heavy review cards), `/release-notes` (intentional per-version markdown card UX), `/activity-feed` (timeline of variable-height markdown cards). Reasoning in the commit body; these will get bespoke mobile styling in Phase 4 (#228).
- **Bug caught during build:** `#expandedRow` template reference shadowed the class signal `expandedRow()` in ingestion-jobs and failed-jobs — Angular strict TS typecheck flagged it, renamed to `expandedRowItem`.
- **Follow-up tracked:** #233 captures a mobile UX gap surfaced by the migration — on `/users` and `/failed-jobs`, actions columns are `mobilePriority="hidden"`, leaving mobile operators unable to edit users or retry/discard jobs. Not a blocker for this PR (desktop behavior is correct); scoped to Phase 4 (#228).

No backend, business-logic, or `.js` import-extension changes. Codemod for `.js` extensions tracked separately in #232.

Targets `mobile-design/staging`. Closes #230.

## Test plan

**Desktop (≥768px — must be visually equivalent to staging):**
- [ ] `/users` renders the same columns; edit/reset-password/activate via dropdown menu works
- [ ] `/ingestion-jobs` renders with same columns; paginator Prev/Next functional
- [ ] `/failed-jobs` renders with queue filter, summary bar, retry/discard per row, auto-refresh
- [ ] `/system-issues` renders all four inner sections (failed resolution jobs, open findings, recent errors, failed queue jobs)
- [ ] `/slack-conversations` renders with expandable detail row (chat + tool calls)
- [ ] Row expansion still works on `/ingestion-jobs`, `/failed-jobs`, `/slack-conversations`

**Mobile (390px in DevTools device toolbar):**
- [ ] Each migrated page renders as stacked cards with sensible primary/secondary priority
- [ ] Row-tap behavior works (navigate or expand, as appropriate per page)
- [ ] Pagination controls stacked and tappable on `/ingestion-jobs`
- [ ] Deferred pages (`/ticket-routes`, `/system-analysis`, `/release-notes`, `/activity`) still render — not polished, but not broken
- [ ] Known limitation surfaced during review: `/users` and `/failed-jobs` have their action controls hidden on mobile (tracked in #233 for Phase 4)

**Build:**
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
