### PR TITLE
feat: mobile phase 3 — dialogs and forms responsive

### DIFF
--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -52,6 +52,10 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButton
     .row { display: flex; gap: 12px; }
     .row app-form-field { flex: 1; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+    @media (max-width: 767.98px) {
+      .row { flex-direction: column; gap: 12px; }
+    }
   `],
 })
 export class RepoDialogComponent implements OnInit {

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -83,7 +83,7 @@ const COMMON_TIMEZONES = [
         @if (toolParamFields.length > 0) {
           <div class="params-section">
             <h4>Tool Parameters</h4>
-            @for (field of toolParamFields; track field.name) {
+            @for (field of toolParamFields; track $index) {
               <app-form-field [label]="field.name" [hint]="field.description">
                 <app-text-input [value]="getToolParam(field.name)" [type]="field.type === 'number' ? 'number' : 'text'" [placeholder]="field.description" (valueChange)="setToolParam(field.name, $event, field.type)"></app-text-input>
               </app-form-field>

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -211,7 +211,7 @@ const COMMON_TIMEZONES = [
     @media (max-width: 767.98px) {
       .dialog-content { min-width: 0; }
       .time-row, .retention-row { flex-direction: column; gap: 12px; }
-      .checkbox-item, .form-checkbox { min-height: 32px; }
+      .checkbox-item, .form-checkbox { min-height: 44px; }
     }
   `],
 })

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -207,6 +207,12 @@ const COMMON_TIMEZONES = [
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
     .checkbox-item { display: flex; align-items: center; gap: 6px; font-size: 13px; cursor: pointer; }
     .form-checkbox { width: 15px; height: 15px; cursor: pointer; accent-color: var(--accent); }
+
+    @media (max-width: 767.98px) {
+      .dialog-content { min-width: 0; }
+      .time-row, .retention-row { flex-direction: column; gap: 12px; }
+      .checkbox-item, .form-checkbox { min-height: 32px; }
+    }
   `],
 })
 export class ProbeDialogComponent implements OnInit {

--- a/services/control-panel/src/app/features/systems/system-dialog.component.ts
+++ b/services/control-panel/src/app/features/systems/system-dialog.component.ts
@@ -30,7 +30,7 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
             [value]="form.host"
             (valueChange)="form.host = $event" />
         </app-form-field>
-        <div style="width: 120px; flex-shrink: 0">
+        <div class="port-field">
           <app-form-field label="Port">
             <app-text-input
               [value]="form.port.toString()"
@@ -84,7 +84,13 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectCompon
     .form-grid { display: flex; flex-direction: column; gap: 12px; }
     .row { display: flex; gap: 12px; }
     .row app-form-field { flex: 1; }
+    .port-field { width: 120px; flex-shrink: 0; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+    @media (max-width: 767.98px) {
+      .row { flex-direction: column; gap: 12px; }
+      .port-field { width: 100%; }
+    }
   `],
 })
 export class SystemDialogComponent implements OnInit {

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
@@ -296,6 +296,13 @@ import { ToastService } from '../../core/services/toast.service';
     .query-tool-field { flex: 0 0 180px; }
     .query-params-field { flex: 1; min-width: 150px; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+    @media (max-width: 767.98px) {
+      .mode-group { flex-direction: column; gap: 8px; }
+      .rule-row, .query-row { flex-direction: column; align-items: stretch; gap: 8px; }
+      .query-tool-field { flex: 1 1 auto; }
+      .query-params-field { min-width: 0; }
+    }
     .select-native {
       width: 100%;
       box-sizing: border-box;

--- a/services/control-panel/src/app/features/tickets/ticket-filter-dialog.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-filter-dialog.component.ts
@@ -207,6 +207,10 @@ export const EMPTY_ADVANCED_FILTERS: AdvancedFilters = {
       gap: 12px;
     }
 
+    @media (max-width: 767.98px) {
+      .date-range { grid-template-columns: 1fr; }
+    }
+
     .date-input {
       width: 100%;
       box-sizing: border-box;

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -104,6 +104,42 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
       from { opacity: 0; transform: scale(0.95); }
       to { opacity: 1; transform: scale(1); }
     }
+
+    /*
+     * Mobile full-screen variant. Below 768px the dialog fills the viewport:
+     * no centering, no rounded corners, no max-width cap (the consumer's
+     * inline max-width is overridden via !important). The header is the
+     * first flex child of .dialog-panel and naturally pins to the top
+     * because only .dialog-body scrolls. The action bar (marked
+     * [dialogFooter] inside the projected content) is pinned via a global
+     * position: sticky rule in styles.scss — view encapsulation would
+     * otherwise block reaching into projected content.
+     */
+    @media (max-width: 767.98px) {
+      .dialog-backdrop {
+        align-items: stretch;
+        justify-content: stretch;
+        animation: none;
+      }
+      .dialog-panel {
+        width: 100% !important;
+        max-width: none !important;
+        height: 100%;
+        max-height: 100%;
+        border-radius: 0;
+        animation: slideUp 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+      .dialog-close {
+        width: 44px;
+        height: 44px;
+        font-size: 24px;
+      }
+    }
+
+    @keyframes slideUp {
+      from { transform: translateY(16px); opacity: 0; }
+      to   { transform: translateY(0); opacity: 1; }
+    }
   `],
 })
 export class DialogComponent {

--- a/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
+++ b/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
@@ -194,13 +194,14 @@ export class DropdownMenuComponent implements OnDestroy {
 
     const rect: DOMRect = triggerEl.getBoundingClientRect();
     const menuWidth = 180; // approximate, will adjust after render
-    const menuHeightEstimate = 240; // upper bound; menu max-height clamps to viewport
+    // Initial height estimate — refined after render via queueMicrotask once
+    // the panel is in the DOM and we can measure it.
+    const menuHeightEstimate = 240;
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
 
     // Position below trigger, right-aligned by default
     let x = rect.right - menuWidth;
-    let y = rect.bottom + 4;
 
     // If would overflow left, flip to left-aligned
     if (x < 8) {
@@ -212,22 +213,52 @@ export class DropdownMenuComponent implements OnDestroy {
       x = viewportWidth - menuWidth - 8;
     }
 
-    // If would overflow bottom, flip above the trigger when there is more
-    // room there; otherwise clamp into the visible area. Important on mobile
-    // where row-action menus near the bottom would otherwise be cut off.
-    if (y + menuHeightEstimate > viewportHeight - 8) {
+    this.posX.set(x);
+    this.posY.set(this.computeY(rect, menuHeightEstimate, viewportHeight));
+    this.isOpen.set(true);
+
+    // Re-measure after the panel renders. The hardcoded 240px estimate can
+    // diverge from the real rendered height (tall menus, dense content), and
+    // the CSS max-height only caps overflow — it doesn't correct the top
+    // position we computed against the estimate. Queue a microtask so the
+    // template runs and the DOM node exists, then recompute with the actual
+    // height and re-measure the trigger (in case layout shifted).
+    queueMicrotask(() => {
+      if (!this.isOpen()) return;
+      const host = this.el.nativeElement as HTMLElement;
+      const panel = host.querySelector<HTMLElement>('.dropdown-panel');
+      if (!panel) return;
+      const triggerNow = this.resolveTriggerElement();
+      if (!triggerNow) return;
+      const triggerRect = triggerNow.getBoundingClientRect();
+      const actualHeight = panel.getBoundingClientRect().height;
+      const adjusted = this.computeY(triggerRect, actualHeight, window.innerHeight);
+      if (adjusted !== this.posY()) {
+        this.posY.set(adjusted);
+      }
+    });
+  }
+
+  /**
+   * Compute the menu's top coordinate given the trigger rect, the menu's
+   * height, and the current viewport height. Places the menu below the
+   * trigger by default. If that overflows the viewport bottom, flips above
+   * the trigger when there is more room there; otherwise clamps into the
+   * visible area. Important on mobile where row-action menus near the
+   * bottom would otherwise be cut off.
+   */
+  private computeY(rect: DOMRect, menuHeight: number, viewportHeight: number): number {
+    let y = rect.bottom + 4;
+    if (y + menuHeight > viewportHeight - 8) {
       const spaceAbove = rect.top - 8;
       const spaceBelow = viewportHeight - rect.bottom - 8;
       if (spaceAbove > spaceBelow) {
-        y = Math.max(8, rect.top - menuHeightEstimate - 4);
+        y = Math.max(8, rect.top - menuHeight - 4);
       } else {
-        y = Math.max(8, viewportHeight - menuHeightEstimate - 8);
+        y = Math.max(8, viewportHeight - menuHeight - 8);
       }
     }
-
-    this.posX.set(x);
-    this.posY.set(y);
-    this.isOpen.set(true);
+    return y;
   }
 
   close(): void {

--- a/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
+++ b/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
@@ -134,6 +134,8 @@ export class DropdownItemComponent {
       position: fixed;
       z-index: 1000;
       min-width: 160px;
+      max-height: calc(100vh - 16px);
+      overflow-y: auto;
       padding: 4px 0;
       background: var(--bg-card);
       border: 1px solid var(--border-light);
@@ -192,11 +194,13 @@ export class DropdownMenuComponent implements OnDestroy {
 
     const rect: DOMRect = triggerEl.getBoundingClientRect();
     const menuWidth = 180; // approximate, will adjust after render
+    const menuHeightEstimate = 240; // upper bound; menu max-height clamps to viewport
     const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
 
     // Position below trigger, right-aligned by default
     let x = rect.right - menuWidth;
-    const y = rect.bottom + 4;
+    let y = rect.bottom + 4;
 
     // If would overflow left, flip to left-aligned
     if (x < 8) {
@@ -206,6 +210,19 @@ export class DropdownMenuComponent implements OnDestroy {
     // If would overflow right, clamp
     if (x + menuWidth > viewportWidth - 8) {
       x = viewportWidth - menuWidth - 8;
+    }
+
+    // If would overflow bottom, flip above the trigger when there is more
+    // room there; otherwise clamp into the visible area. Important on mobile
+    // where row-action menus near the bottom would otherwise be cut off.
+    if (y + menuHeightEstimate > viewportHeight - 8) {
+      const spaceAbove = rect.top - 8;
+      const spaceBelow = viewportHeight - rect.bottom - 8;
+      if (spaceAbove > spaceBelow) {
+        y = Math.max(8, rect.top - menuHeightEstimate - 4);
+      } else {
+        y = Math.max(8, viewportHeight - menuHeightEstimate - 8);
+      }
     }
 
     this.posX.set(x);

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -45,14 +45,26 @@ app-dialog .dialog-body [dialogFooter] {
 }
 
 /*
- * iOS Safari auto-zooms on focus when an input has font-size < 16px. This
- * single rule blocks that behavior across the whole app on mobile widths.
- * It overrides the 14px default in TextInput/Textarea/Select primitives
- * (kept at 14px on desktop for visual density). Form-field tap targets
- * also get bumped to a 44px minimum height for thumb usability.
+ * iOS Safari auto-zooms on focus when an input has font-size < 16px. The
+ * native-element selectors alone aren't enough: the primitives set their
+ * own 14px via view-encapsulated attribute selectors (e.g.
+ * `.text-input[_ngcontent-xxx]`), which have higher specificity than the
+ * global `input { ... }` rule. So the mobile override targets both the
+ * native elements AND the primitive classes by name, guaranteeing the 16px
+ * wins on small screens. Desktop keeps the 14px default for density.
+ * Form-field tap targets also get bumped to a 44px minimum height.
  */
 @media (max-width: 767.98px) {
-  input, textarea, select { font-size: 16px; }
+  input,
+  textarea,
+  select,
+  app-text-input .text-input,
+  app-textarea .textarea-input,
+  app-select .select-input,
+  .date-input {
+    font-size: 16px;
+  }
+
   app-text-input .text-input,
   app-textarea .textarea-input,
   app-select .select-input {

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -23,36 +23,25 @@ html, body {
  * to mimic a real footer (top border, padding extending to the body edges).
  * Global styles work here because they bypass component view encapsulation
  * and reach into projected content.
+ *
+ * The footer is sticky by default — so in tall dialogs on any viewport,
+ * Save/Cancel stay reachable as the body scrolls. bottom: -20px pins to the
+ * visible bottom edge of .dialog-body, compensating for the existing
+ * margin-bottom: -20px (which makes the footer extend through the body's
+ * bottom padding to align with the panel edge).
  */
 app-dialog .dialog-body [dialogFooter] {
+  position: sticky;
+  bottom: -20px;
   display: flex;
   justify-content: flex-end;
   gap: 8px;
   margin: 16px -20px -20px;
   padding: 12px 20px;
+  background: var(--bg-card);
   border-top: 1px solid var(--border-light);
-}
-
-/*
- * Mobile dialog action-bar pinning.
- *
- * The dialog goes full-screen below 768px (see DialogComponent). When a
- * dialog has more form content than the viewport can show, the user has
- * to scroll, and the action bar would scroll out of reach. position: sticky
- * with bottom: -20px keeps the [dialogFooter] pinned to the visible bottom
- * edge of .dialog-body — the negative offset compensates for the existing
- * margin-bottom: -20px (which makes the footer extend through the body's
- * bottom padding to align with the panel edge). A solid background and
- * top shadow keep it readable over scrolling content.
- */
-@media (max-width: 767.98px) {
-  app-dialog .dialog-body [dialogFooter] {
-    position: sticky;
-    bottom: -20px;
-    background: var(--bg-card);
-    z-index: 1;
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.04);
-  }
+  z-index: 1;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.04);
 }
 
 /*
@@ -143,4 +132,33 @@ app-dialog .dialog-body [dialogFooter] {
   height: 100%;
   border-left: none;
   animation: none;
+}
+
+/*
+ * On mobile the routed detail view should feel like a full-screen page, not
+ * a panel-inside-a-panel. The shell-content has 12px padding at < 768px
+ * (Phase 1) which would frame the panel, and the panel itself has its own
+ * padding + a rounded card background. We:
+ *   1. Break out of shell-content's padding via negative margins so the
+ *      panel fills the viewport edge-to-edge.
+ *   2. Pin the panel header so the title/actions stay visible while the
+ *      body scrolls — matches the sticky-header pattern of our mobile
+ *      dialogs.
+ * The inline desktop side pane is unaffected because it's not wrapped in
+ * .detail-route-page.
+ */
+@media (max-width: 767.98px) {
+  .detail-route-page {
+    margin: -12px;
+    height: calc(100% + 24px);
+  }
+  .detail-route-page .detail-panel {
+    background: var(--bg-page);
+  }
+  .detail-route-page .panel-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg-page);
+  }
 }

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -33,6 +33,43 @@ app-dialog .dialog-body [dialogFooter] {
   border-top: 1px solid var(--border-light);
 }
 
+/*
+ * Mobile dialog action-bar pinning.
+ *
+ * The dialog goes full-screen below 768px (see DialogComponent). When a
+ * dialog has more form content than the viewport can show, the user has
+ * to scroll, and the action bar would scroll out of reach. position: sticky
+ * with bottom: -20px keeps the [dialogFooter] pinned to the visible bottom
+ * edge of .dialog-body — the negative offset compensates for the existing
+ * margin-bottom: -20px (which makes the footer extend through the body's
+ * bottom padding to align with the panel edge). A solid background and
+ * top shadow keep it readable over scrolling content.
+ */
+@media (max-width: 767.98px) {
+  app-dialog .dialog-body [dialogFooter] {
+    position: sticky;
+    bottom: -20px;
+    background: var(--bg-card);
+    z-index: 1;
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.04);
+  }
+}
+
+/*
+ * iOS Safari auto-zooms on focus when an input has font-size < 16px. This
+ * single rule blocks that behavior across the whole app on mobile widths.
+ * It overrides the 14px default in TextInput/Textarea/Select primitives
+ * (kept at 14px on desktop for visual density). Form-field tap targets
+ * also get bumped to a 44px minimum height for thumb usability.
+ */
+@media (max-width: 767.98px) {
+  input, textarea, select { font-size: 16px; }
+  app-text-input .text-input,
+  app-textarea .textarea-input,
+  app-select .select-input {
+    min-height: 44px;
+  }
+}
 
 @media (max-width: 767px) {
   h1 { font-size: 1.5rem; }


### PR DESCRIPTION
## Summary

Phase 3 of the mobile-responsive control panel initiative (umbrella #224). Makes dialogs and forms usable on phone via shared-primitive changes — small, CSS-dominant diff that unlocks every modal flow at once.

- **`DialogComponent` full-screen below 768px** — width/height fill viewport, no rounded corners, slide-up animation, 44×44 close button. Desktop centered-modal behavior byte-identical (CSS-only under `@media` with `!important` to override consumer inline `maxWidth` bindings).
- **Sticky `[dialogFooter]` on mobile** (`styles.scss`) — pins the action bar to the viewport bottom when forms scroll, so Save/Cancel stay reachable.
- **Global 16px input font-size on mobile** — blocks iOS Safari auto-zoom on focus (the universal fix). Inputs also get a 44px minimum tap height via descendant selectors on `app-text-input`/`app-textarea`/`app-select`. Keeps the primitive components untouched.
- **`DropdownMenuComponent` positioning** — max-height clamps to viewport with scroll; `open()` flips above the trigger when there's more room above than below. Fixes the row-action-menu-cut-off-at-viewport-bottom case.
- **Heavy-dialog grid collapses** — `system-dialog`, `probe-dialog`, `ticket-route-step-dialog`, `repo-dialog`, `ticket-filter-dialog` all have `.row`/`.date-range`/`.time-row`/etc. grids that collapse to single column below 768px. Fixed-width inline styles refactored into CSS classes where needed so media queries can override them.
- **Audited clean without changes:** `client-dialog`, `user-dialog`, `ai-model-dialog`, `generate-invoice-dialog`, `integration-dialog`.

No backend, business-logic, or `.js` import-extension changes. Codemod for `.js` extensions tracked separately in #232.

Parallel to Phase 2.5 (#234) — no file overlap. Either order merges cleanly.

Targets `mobile-design/staging`. Closes #227.

## Test plan

**Desktop (≥768px — must be byte-identical):**
- [ ] Open any dialog (e.g., `/tickets` → Filters) — centered modal with backdrop, same max-width as staging
- [ ] Two-column forms (system-dialog, probe-dialog, etc.) render side-by-side as before
- [ ] Dropdown row-action menus (e.g., `/users` edit menu) open in the same position as today when there's room below
- [ ] No visual diff on any form or dialog

**Mobile (390px in DevTools device toolbar):**
- [ ] Opening a dialog renders full-screen with sticky header (title + X close)
- [ ] X close button is a 44×44 tap target
- [ ] Action bar (Save/Cancel) sticks to bottom when content scrolls
- [ ] Form labels above inputs; inputs ≥44px tall and full-width
- [ ] Tapping any text input does NOT cause iOS zoom (test on real iOS Safari if possible; Chrome DevTools doesn't simulate this)
- [ ] Two-column grids in system-dialog, probe-dialog, ticket-route-step-dialog, repo-dialog, ticket-filter-dialog all collapse to single column
- [ ] Row-action dropdown near the bottom of the list flips above the trigger instead of being cut off
- [ ] All 6 themes render dialog chrome correctly

**Build:**
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
