### PR TITLE
feat: mobile phase 4 — page polish + action access + critical fixes

### DIFF
--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -28,7 +28,7 @@ export class DetailPanelService {
     probe: '/scheduled-probes',
     system: '/system-status',
     analysis: '/system-analysis',
-    job: '/failed-jobs',
+    job: '/ingestion-jobs',
   };
 
   readonly entityType = signal<DetailEntityType | null>(null);

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -193,8 +193,13 @@ export class TicketService {
   getStats(clientId?: string): Observable<TicketStats> {
     return this.api.get<TicketStats>('/tickets/stats', clientId ? { clientId } : undefined).pipe(
       tap((stats) => {
-        const count = TicketService.ACTIVE_STATUSES.reduce((sum, s) => sum + (stats.byStatus[s] ?? 0), 0);
-        this.activeCount.set(count);
+        // Only update the sidebar badge from GLOBAL stats calls. Client-scoped
+        // calls are used for per-client dashboards and must not overwrite the
+        // sidebar's global count.
+        if (!clientId) {
+          const count = TicketService.ACTIVE_STATUSES.reduce((sum, s) => sum + (stats.byStatus[s] ?? 0), 0);
+          this.activeCount.set(count);
+        }
       }),
     );
   }

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -110,6 +110,38 @@ import {
       line-height: 1.4;
       text-align: right;
     }
+
+    /*
+     * Mobile: the title row + notification toggle share a tight row and
+     * the 320px right-side block pushes the title into overflow. Stack the
+     * two sides and left-align the notification hint so it reads naturally.
+     */
+    @media (max-width: 767.98px) {
+      .page-header {
+        flex-direction: column;
+        gap: 8px;
+      }
+      .title-row {
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+      .page-title {
+        font-size: 20px;
+        word-break: break-word;
+      }
+      .header-right {
+        justify-content: flex-start;
+        padding-top: 0;
+        width: 100%;
+      }
+      .notif-mode {
+        align-items: flex-start;
+        max-width: none;
+      }
+      .notif-hint {
+        text-align: left;
+      }
+    }
   `],
 })
 export class ClientHeaderComponent {

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -12,6 +12,7 @@ import {
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service';
+import { ViewportService } from '../../core/services/viewport.service';
 
 const ALL_QUEUES = [
   'issue-resolve', 'log-summarize', 'email-ingestion', 'ticket-analysis',
@@ -159,6 +160,22 @@ const ALL_QUEUES = [
               <h4>Stack Trace</h4>
               <pre class="error-block">{{ row.stacktrace.join('\n') }}</pre>
             }
+
+            <!--
+              Mobile: the actions column is hidden (mobilePriority="hidden"),
+              so expose Retry / Discard inline in the expanded detail. Desktop
+              already shows the icon buttons in the actions column.
+            -->
+            @if (viewport.isMobile()) {
+              <div class="job-detail-actions">
+                <app-bronco-button variant="secondary" size="sm" [fullWidth]="true" (click)="retry(row)" [disabled]="acting()">
+                  Retry
+                </app-bronco-button>
+                <app-bronco-button variant="destructive" size="sm" [fullWidth]="true" (click)="discard(row)" [disabled]="acting()">
+                  Discard
+                </app-bronco-button>
+              </div>
+            }
           </div>
         </ng-template>
       </app-data-table>
@@ -259,6 +276,13 @@ const ALL_QUEUES = [
 
     .job-detail { padding: 4px 0; }
     .job-detail h4 { margin: 12px 0 4px; font-size: 13px; color: var(--text-secondary); }
+    .job-detail-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border-light);
+    }
 
     .json-block, .error-block {
       font-family: ui-monospace, monospace;
@@ -288,6 +312,7 @@ export class FailedJobListComponent implements OnInit, OnDestroy {
   private statusService = inject(SystemStatusService);
   private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
+  readonly viewport = inject(ViewportService);
   private refreshInterval: ReturnType<typeof setInterval> | null = null;
   private sub: Subscription | undefined;
   private statusSub: Subscription | undefined;

--- a/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
+++ b/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
@@ -5,9 +5,9 @@ import { DatePipe } from '@angular/common';
 import {
   IngestionService,
   IngestionRun,
-  IngestionRunDetail,
 } from '../../core/services/ingestion.service';
 import { ClientService, Client } from '../../core/services/client.service';
+import { DetailPanelService } from '../../core/services/detail-panel.service';
 import {
   SelectComponent,
   IconComponent,
@@ -86,8 +86,7 @@ import {
       <app-data-table
         [data]="runs()"
         [trackBy]="trackById"
-        [expandedRow]="expandedRowItem()"
-        (rowClick)="toggleExpand($event)"
+        (rowClick)="openDetail($event)"
         emptyMessage="No ingestion runs found.">
 
         <app-data-column key="status" header="Status" width="110px" [sortable]="false" mobilePriority="secondary">
@@ -141,55 +140,6 @@ import {
             {{ row.steps.length }}
           </ng-template>
         </app-data-column>
-
-        <app-data-column key="expand" header="" width="48px" [sortable]="false" mobilePriority="hidden">
-          <ng-template #cell let-row>
-            <button type="button" class="expand-btn"
-              (click)="toggleExpand(row); $event.stopPropagation()"
-              [attr.aria-label]="expandedRunId === row.id ? 'Collapse run details' : 'Expand run details'"
-              [attr.aria-expanded]="expandedRunId === row.id">
-              <app-icon [name]="expandedRunId === row.id ? 'chevron-up' : 'chevron-down'" size="sm" />
-            </button>
-          </ng-template>
-        </app-data-column>
-
-        <ng-template #expandedRow let-row>
-          <div class="expanded-detail" (click)="$event.stopPropagation()">
-            @if (expandedRun()) {
-              @if (expandedRun()!.error) {
-                <div class="run-error">{{ expandedRun()!.error }}</div>
-              }
-              @for (step of expandedRun()!.steps; track step.id) {
-                <div class="detail-step" [class]="'detail-step-' + step.status"
-                  [class.step-highlight]="recentlyChanged().has(step.id)">
-                  <div class="detail-step-header">
-                    <span class="detail-step-order">{{ step.stepOrder }}.</span>
-                    <span class="detail-step-name">{{ step.stepName }}</span>
-                    <span class="badge small" [class]="'badge-status-' + step.status">{{ step.status }}</span>
-                    @if (step.status === 'processing') {
-                      <span class="pulse-dot" aria-hidden="true"></span>
-                    }
-                    <span class="badge small badge-step-type">{{ step.stepType }}</span>
-                    @if (step.durationMs != null) {
-                      <span class="detail-step-duration">{{ formatDuration(step.durationMs) }}</span>
-                    }
-                  </div>
-                  @if (step.error) {
-                    <div class="detail-step-error">{{ step.error }}</div>
-                  }
-                  @if (step.output) {
-                    <details class="detail-step-output">
-                      <summary>Output</summary>
-                      <pre class="detail-pre">{{ step.output }}</pre>
-                    </details>
-                  }
-                </div>
-              }
-            } @else {
-              <div class="detail-loading">Loading run details…</div>
-            }
-          </div>
-        </ng-template>
       </app-data-table>
 
       @if (total() > pageSize) {
@@ -242,17 +192,10 @@ import {
     .filters app-select { min-width: 160px; }
     .total-count { color: var(--text-tertiary); font-family: var(--font-primary); font-size: 13px; margin-left: auto; }
 
-    .expand-btn {
-      background: none; border: none; cursor: pointer; padding: 4px 8px;
-      font-size: 14px; color: var(--text-secondary); border-radius: var(--radius-sm);
-    }
-    .expand-btn:hover { background: var(--bg-hover); }
-
     .badge {
       font-family: var(--font-primary); font-size: 11px; font-weight: 600;
       padding: 2px 8px; border-radius: var(--radius-sm); white-space: nowrap;
     }
-    .badge.small { font-size: 10px; padding: 1px 6px; }
     .badge-status-success { background: rgba(52, 199, 89, 0.12); color: var(--color-success); }
     .badge-status-error { background: rgba(255, 59, 48, 0.1); color: var(--color-error); }
     .badge-status-no_route { background: var(--bg-muted); color: var(--text-tertiary); }
@@ -260,55 +203,21 @@ import {
     .badge-status-pending { background: var(--bg-muted); color: var(--text-tertiary); }
     .badge-status-skipped { background: rgba(255, 149, 0, 0.1); color: var(--color-warning); }
     .badge-source { background: rgba(0, 113, 227, 0.08); color: var(--accent); }
-    .badge-step-type { background: var(--bg-muted); color: var(--text-tertiary); }
 
     .route-name { color: var(--text-primary); font-weight: 500; }
     .ticket-link { color: var(--accent-link); text-decoration: none; font-family: var(--font-primary); font-weight: 500; }
     .ticket-link:hover { text-decoration: underline; }
     .muted { color: var(--text-tertiary); }
-
-    .run-error {
-      padding: 8px 12px; background: rgba(255, 59, 48, 0.08); color: var(--color-error);
-      border-radius: var(--radius-sm); margin-bottom: 8px; font-family: var(--font-primary); font-size: 13px;
-    }
-    .expanded-detail { padding: 8px 0; }
-    .detail-loading {
-      font-family: var(--font-primary); font-size: 13px; color: var(--text-tertiary);
-      padding: 8px 0;
-    }
-    .detail-step { padding: 6px 0; border-bottom: 1px solid var(--border-light); }
-    .detail-step:last-child { border-bottom: none; }
-    .detail-step-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-    .detail-step-order { font-family: var(--font-primary); font-weight: 600; color: var(--text-tertiary); min-width: 20px; }
-    .detail-step-name { font-family: var(--font-primary); font-weight: 500; color: var(--text-primary); }
-    .detail-step-duration { font-family: var(--font-primary); font-size: 12px; color: var(--text-tertiary); }
-    .detail-step-error {
-      margin-top: 4px; padding: 6px 8px; background: rgba(255, 59, 48, 0.08);
-      color: var(--color-error); border-radius: var(--radius-sm); font-family: var(--font-primary); font-size: 13px;
-    }
-    .detail-step-output { margin-top: 4px; }
-    .pulse-dot {
-      width: 8px; height: 8px; border-radius: 50%; background: var(--accent);
-      animation: pulse 1.5s ease-in-out infinite;
-    }
-    .step-highlight { animation: highlight-fade 1.5s ease-out; }
-    @keyframes highlight-fade { from { background: rgba(52, 199, 89, 0.15); } to { background: transparent; } }
-    .detail-step-output summary { cursor: pointer; color: var(--accent-link); font-family: var(--font-primary); font-size: 12px; }
-    .detail-pre {
-      background: #1d1d1f; color: #f5f5f7; padding: 8px 12px; border-radius: var(--radius-sm);
-      font-size: 12px; overflow-x: auto; max-height: 300px; white-space: pre-wrap; word-break: break-word;
-    }
   `],
 })
 export class IngestionJobListComponent implements OnInit, OnDestroy {
   private ingestionService = inject(IngestionService);
   private clientService = inject(ClientService);
+  private detailPanel = inject(DetailPanelService);
 
   runs = signal<IngestionRun[]>([]);
   total = signal(0);
   clients = signal<Client[]>([]);
-  expandedRunId: string | null = null;
-  expandedRun = signal<IngestionRunDetail | null>(null);
   processingRun = signal<IngestionRun | null>(null);
 
   filterStatus = '';
@@ -331,18 +240,7 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
 
   trackById = (item: IngestionRun) => item.id;
 
-  expandedRowItem = computed<IngestionRun | null>(() => {
-    const id = this.expandedRunId;
-    if (!id) return null;
-    return this.runs().find(r => r.id === id) ?? null;
-  });
-
   private pollTimer: ReturnType<typeof setInterval> | null = null;
-  private detailPollTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Pending recentlyChanged clear timeouts — cleared in stopDetailPolling/ngOnDestroy. */
-  private recentlyChangedTimers = new Set<ReturnType<typeof setTimeout>>();
-  /** Track step statuses to detect transitions for highlight animation. */
-  recentlyChanged = signal<Set<string>>(new Set());
 
   ngOnInit(): void {
     this.clientService.getClients().subscribe((c) => this.clients.set(c));
@@ -351,9 +249,6 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopPolling();
-    this.stopDetailPolling();
-    for (const t of this.recentlyChangedTimers) clearTimeout(t);
-    this.recentlyChangedTimers.clear();
   }
 
   loadRuns(): void {
@@ -393,28 +288,8 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
     this.loadRuns();
   }
 
-  toggleExpand(run: IngestionRun): void {
-    if (this.expandedRunId === run.id) {
-      this.expandedRunId = null;
-      this.expandedRun.set(null);
-      this.stopDetailPolling();
-      return;
-    }
-    const runId = run.id;
-    this.expandedRunId = runId;
-    this.expandedRun.set(null);
-    this.stopDetailPolling();
-    this.ingestionService.getRun(runId).subscribe({
-      next: (fullRun) => {
-        // Guard against stale responses — user may have collapsed while the request was in flight
-        if (this.expandedRunId !== runId) return;
-        this.expandedRun.set(fullRun);
-        if (fullRun.status === 'processing') {
-          this.startDetailPolling(runId);
-        }
-      },
-      error: (err) => console.error('Failed to load run detail', err),
-    });
+  openDetail(run: IngestionRun): void {
+    this.detailPanel.open('job', run.id);
   }
 
   getDuration(run: IngestionRun): string {
@@ -434,67 +309,6 @@ export class IngestionJobListComponent implements OnInit, OnDestroy {
   getElapsed(run: IngestionRun): string {
     const elapsed = Date.now() - new Date(run.startedAt).getTime();
     return this.formatDuration(elapsed) + ' elapsed';
-  }
-
-  private startDetailPolling(runId: string): void {
-    // Clear any existing timer before scheduling a new one
-    this.stopDetailPolling();
-
-    const scheduleNext = (): void => {
-      this.detailPollTimer = setTimeout(() => {
-        this.ingestionService.getRun(runId).subscribe({
-          next: (fullRun) => {
-            // Detect step status transitions for highlight animation using O(1) Map lookup
-            const prev = this.expandedRun();
-            if (prev) {
-              const prevMap = new Map(prev.steps.map((s) => [s.id, s]));
-              const changed = new Set<string>();
-              for (const step of fullRun.steps) {
-                const prevStep = prevMap.get(step.id);
-                if (prevStep && prevStep.status !== step.status && step.status !== 'processing') {
-                  changed.add(step.id);
-                }
-              }
-              if (changed.size > 0) {
-                this.recentlyChanged.set(changed);
-                const t = setTimeout(() => {
-                  this.recentlyChanged.set(new Set());
-                  this.recentlyChangedTimers.delete(t);
-                }, 1500);
-                this.recentlyChangedTimers.add(t);
-              }
-            }
-
-            this.expandedRun.set(fullRun);
-
-            // Stop polling when complete; otherwise schedule the next tick
-            if (fullRun.status !== 'processing') {
-              this.stopDetailPolling();
-              // Refresh the list to update the row status
-              this.loadRuns();
-            } else {
-              scheduleNext();
-            }
-          },
-          error: (err) => {
-            // Transient error — log but keep polling
-            console.warn('Failed to poll run detail (will retry)', err);
-            scheduleNext();
-          },
-        });
-      }, 4000);
-    };
-
-    scheduleNext();
-  }
-
-  private stopDetailPolling(): void {
-    if (this.detailPollTimer) {
-      clearTimeout(this.detailPollTimer);
-      this.detailPollTimer = null;
-    }
-    for (const t of this.recentlyChangedTimers) clearTimeout(t);
-    this.recentlyChangedTimers.clear();
   }
 
   private stopPolling(): void {

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -144,10 +144,10 @@ const ACTION_LABELS: Record<string, string> = {
           -->
           @if (viewport.isMobile()) {
             <div class="probe-mobile-actions" (click)="$event.stopPropagation()">
-              <app-bronco-button variant="icon" size="sm" aria-label="Run history" [routerLink]="['/scheduled-probes', row.id, 'runs']"><app-icon name="clipboard" size="sm" /></app-bronco-button>
-              <app-bronco-button variant="icon" size="sm" aria-label="Run now" (click)="runNow(row)"><app-icon name="play" size="sm" /></app-bronco-button>
-              <app-bronco-button variant="icon" size="sm" aria-label="Edit" (click)="editProbe(row)"><app-icon name="edit" size="sm" /></app-bronco-button>
-              <app-bronco-button variant="icon" size="sm" aria-label="Delete" (click)="deleteProbe(row)"><app-icon name="close" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Run history" [routerLink]="['/scheduled-probes', row.id, 'runs']"><app-icon name="clipboard" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Run now" (click)="runNow(row)"><app-icon name="play" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Edit" (click)="editProbe(row)"><app-icon name="edit" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" ariaLabel="Delete" (click)="deleteProbe(row)"><app-icon name="close" size="sm" /></app-bronco-button>
             </div>
           }
         </ng-template>

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../../shared/components/index.js';
 import { DialogComponent } from '../../shared/components/dialog.component';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
+import { ViewportService } from '../../core/services/viewport.service';
 import { ScheduledProbeService, ScheduledProbe } from '../../core/services/scheduled-probe.service';
 import { ClientService, Client } from '../../core/services/client.service';
 import { CATEGORY_OPTIONS } from '../../core/services/client-memory.service';
@@ -133,7 +134,21 @@ const ACTION_LABELS: Record<string, string> = {
 
         <ng-template #subtitle let-row>
           @if (row.description) {
-            {{ row.description }}
+            <div>{{ row.description }}</div>
+          }
+          <!--
+            Mobile: the actions column is hidden (mobilePriority="hidden")
+            so card taps open the detail pane. Surface run / edit / delete
+            here so operators can act on a probe without leaving the list.
+            Desktop renders actions in the trailing column, so skip here.
+          -->
+          @if (viewport.isMobile()) {
+            <div class="probe-mobile-actions" (click)="$event.stopPropagation()">
+              <app-bronco-button variant="icon" size="sm" aria-label="Run history" [routerLink]="['/scheduled-probes', row.id, 'runs']"><app-icon name="clipboard" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" aria-label="Run now" (click)="runNow(row)"><app-icon name="play" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" aria-label="Edit" (click)="editProbe(row)"><app-icon name="edit" size="sm" /></app-bronco-button>
+              <app-bronco-button variant="icon" size="sm" aria-label="Delete" (click)="deleteProbe(row)"><app-icon name="close" size="sm" /></app-bronco-button>
+            </div>
           }
         </ng-template>
       </app-data-table>
@@ -162,6 +177,11 @@ const ACTION_LABELS: Record<string, string> = {
     .run-success { background: rgba(52,199,89,0.08); color: var(--color-success); }
     .run-error { background: rgba(255,59,48,0.08); color: var(--color-error); }
     .run-skipped { background: var(--bg-muted); color: var(--text-tertiary); }
+    .probe-mobile-actions {
+      display: flex;
+      gap: 4px;
+      margin-top: 6px;
+    }
   `],
 })
 export class ProbeListComponent implements OnInit {
@@ -169,6 +189,7 @@ export class ProbeListComponent implements OnInit {
   private clientService = inject(ClientService);
   private toast = inject(ToastService);
   private detailPanel = inject(DetailPanelService);
+  readonly viewport = inject(ViewportService);
 
   showProbeDialog = signal(false);
   editingProbe = signal<ScheduledProbe | null>(null);

--- a/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
@@ -156,6 +156,22 @@ import { type TicketCostResponse } from '../../core/services/ai-usage.service';
     .call-duration { color: var(--text-tertiary); }
     .call-time { color: var(--text-tertiary); margin-left: auto; }
 
+    /* Mobile: call rows overflow under 375px. Stack vertically and let
+       each chip wrap naturally instead of fighting for horizontal space. */
+    @media (max-width: 767.98px) {
+      .call-row {
+        flex-wrap: wrap;
+        gap: 4px 8px;
+      }
+      .call-task {
+        min-width: 0;
+        width: 100%;
+      }
+      .call-time {
+        margin-left: 0;
+      }
+    }
+
     .provider-chip {
       font-weight: 600;
       font-size: 10px;

--- a/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.css
@@ -26,6 +26,26 @@
   width: 180px;
 }
 
+/*
+ * Mobile: the 180px select plus the refresh button squeeze the row.
+ * Stack the header vertically and let the select fill the width.
+ */
+@media (max-width: 767.98px) {
+  .timeline-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+  .timeline-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+  .timeline-controls app-form-field {
+    width: 100%;
+  }
+}
+
 .timeline {
   display: flex;
   flex-direction: column;

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -52,6 +52,36 @@
   display: inline-block;
   min-width: 140px;
 }
+
+/*
+ * Mobile (< 768px): the ticket meta row has 3 form-field selects plus
+ * source/date/analysis chips. The 140px select min-width overflows
+ * 375px screens. Stretch each app-form-field to fill the row so Priority,
+ * Status, Category stack vertically. The metadata chips keep flex-wrap
+ * so they pile below.
+ */
+@media (max-width: 767.98px) {
+  .page-header {
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .page-title {
+    font-size: 18px;
+    line-height: 1.3;
+    word-break: break-word;
+  }
+  .ticket-meta {
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .ticket-meta app-form-field {
+    flex: 1 1 100%;
+  }
+  .ticket-meta app-select {
+    width: 100%;
+    min-width: 0;
+  }
+}
 .source {
   color: var(--text-tertiary);
   font-size: 13px;

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -102,8 +102,16 @@ import { ToastService } from '../../core/services/toast.service';
           </app-data-column>
         </app-data-table>
 
-        @if (openMenuRow(); as activeRow) {
-          <app-dropdown-menu #menu [trigger]="menuTriggerEl" (closed)="openMenuRow.set(null)">
+        <!--
+          Always render the dropdown so ViewChild resolves on first render.
+          Gating the whole dropdown on @if (openMenuRow()) caused the
+          ViewChild to be undefined on the first click, requiring a second
+          click to open. The dropdown's internal state (isOpen) controls
+          visibility; only the content (which needs the active row) is
+          conditionally rendered.
+        -->
+        <app-dropdown-menu #menu [trigger]="menuTriggerEl" (closed)="openMenuRow.set(null)">
+          @if (openMenuRow(); as activeRow) {
             <app-dropdown-item (action)="openEdit(activeRow)">Edit</app-dropdown-item>
             <app-dropdown-item (action)="openResetPassword(activeRow)">Reset Password</app-dropdown-item>
             @if (activeRow.id !== currentUserId()) {
@@ -113,8 +121,8 @@ import { ToastService } from '../../core/services/toast.service';
                 <app-dropdown-item (action)="activate(activeRow)">Activate</app-dropdown-item>
               }
             }
-          </app-dropdown-menu>
-        }
+          }
+        </app-dropdown-menu>
       }
 
       @if (showUserDialog()) {
@@ -340,8 +348,7 @@ export class UserListComponent implements OnInit {
     const currentTarget = event.currentTarget;
     this.menuTriggerEl = currentTarget instanceof HTMLElement ? currentTarget : null;
     this.openMenuRow.set(user);
-    // Wait for @if to render the dropdown before calling open().
-    queueMicrotask(() => this.menu?.open());
+    this.menu?.open();
   }
 
   // On mobile, tapping the card is the primary edit affordance since the

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service';
@@ -14,6 +14,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
+import { ViewportService } from '../../core/services/viewport.service';
 import { ToastService } from '../../core/services/toast.service';
 
 @Component({
@@ -46,7 +47,8 @@ import { ToastService } from '../../core/services/toast.service';
         <app-data-table
           [data]="users()"
           [trackBy]="trackById"
-          [rowClickable]="false"
+          [rowClickable]="viewport.isMobile()"
+          (rowClick)="onRowClick($event)"
           emptyMessage="No users found.">
 
           <app-data-column key="user" header="User" [sortable]="false" mobilePriority="primary">
@@ -93,23 +95,26 @@ import { ToastService } from '../../core/services/toast.service';
 
           <app-data-column key="actions" header="" width="60px" [sortable]="false" mobilePriority="hidden">
             <ng-template #cell let-row>
-              <app-bronco-button variant="icon" size="sm" [attr.aria-label]="'Actions for ' + row.name" #menuTrigger (click)="menu.toggle(); $event.stopPropagation()">
+              <app-bronco-button variant="icon" size="sm" [attr.aria-label]="'Actions for ' + row.name" (click)="onActionsClick(row, $event)">
                 ...
               </app-bronco-button>
-              <app-dropdown-menu #menu [trigger]="menuTrigger">
-                <app-dropdown-item (action)="openEdit(row)">Edit</app-dropdown-item>
-                <app-dropdown-item (action)="openResetPassword(row)">Reset Password</app-dropdown-item>
-                @if (row.id !== currentUserId()) {
-                  @if (row.isActive) {
-                    <app-dropdown-item (action)="deactivate(row)">Deactivate</app-dropdown-item>
-                  } @else {
-                    <app-dropdown-item (action)="activate(row)">Activate</app-dropdown-item>
-                  }
-                }
-              </app-dropdown-menu>
             </ng-template>
           </app-data-column>
         </app-data-table>
+
+        @if (openMenuRow(); as activeRow) {
+          <app-dropdown-menu #menu [trigger]="menuTriggerEl" (closed)="openMenuRow.set(null)">
+            <app-dropdown-item (action)="openEdit(activeRow)">Edit</app-dropdown-item>
+            <app-dropdown-item (action)="openResetPassword(activeRow)">Reset Password</app-dropdown-item>
+            @if (activeRow.id !== currentUserId()) {
+              @if (activeRow.isActive) {
+                <app-dropdown-item (action)="deactivate(activeRow)">Deactivate</app-dropdown-item>
+              } @else {
+                <app-dropdown-item (action)="activate(activeRow)">Activate</app-dropdown-item>
+              }
+            }
+          </app-dropdown-menu>
+        }
       }
 
       @if (showUserDialog()) {
@@ -285,6 +290,9 @@ export class UserListComponent implements OnInit {
   private userService = inject(UserService);
   private authService = inject(AuthService);
   private toast = inject(ToastService);
+  readonly viewport = inject(ViewportService);
+
+  @ViewChild('menu') private menu?: DropdownMenuComponent;
 
   users = signal<ControlPanelUser[]>([]);
   loading = signal(false);
@@ -292,6 +300,8 @@ export class UserListComponent implements OnInit {
   resetPassword = '';
   showUserDialog = signal(false);
   editingUser = signal<ControlPanelUser | null>(null);
+  openMenuRow = signal<ControlPanelUser | null>(null);
+  menuTriggerEl: HTMLElement | null = null;
 
   currentUserId = () => this.authService.currentUser()?.id;
 
@@ -323,6 +333,22 @@ export class UserListComponent implements OnInit {
   openEdit(user: ControlPanelUser): void {
     this.editingUser.set(user);
     this.showUserDialog.set(true);
+  }
+
+  onActionsClick(user: ControlPanelUser, event: Event): void {
+    event.stopPropagation();
+    const currentTarget = event.currentTarget;
+    this.menuTriggerEl = currentTarget instanceof HTMLElement ? currentTarget : null;
+    this.openMenuRow.set(user);
+    // Wait for @if to render the dropdown before calling open().
+    queueMicrotask(() => this.menu?.open());
+  }
+
+  // On mobile, tapping the card is the primary edit affordance since the
+  // overflow menu column is hidden. Desktop has rowClickable=false, so
+  // this is a no-op there.
+  onRowClick(user: ControlPanelUser): void {
+    this.openEdit(user);
   }
 
   onUserSaved(): void {

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -348,7 +348,13 @@ export class UserListComponent implements OnInit {
     const currentTarget = event.currentTarget;
     this.menuTriggerEl = currentTarget instanceof HTMLElement ? currentTarget : null;
     this.openMenuRow.set(user);
-    this.menu?.open();
+    // Set the trigger on the menu directly — the `[trigger]` template binding
+    // doesn't propagate until the next CD cycle, so calling open() synchronously
+    // after updating menuTriggerEl would see the stale trigger and no-op.
+    if (this.menu) {
+      this.menu.trigger = this.menuTriggerEl;
+      this.menu.open();
+    }
   }
 
   // On mobile, tapping the card is the primary edit affordance since the

--- a/services/control-panel/src/app/shared/components/bronco-button.component.ts
+++ b/services/control-panel/src/app/shared/components/bronco-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, ElementRef, inject, input } from '@angular/core';
 
 @Component({
   selector: 'app-bronco-button',
@@ -90,6 +90,8 @@ import { Component, input } from '@angular/core';
   `],
 })
 export class BroncoButtonComponent {
+  readonly elementRef = inject(ElementRef<HTMLElement>);
+
   variant = input<'primary' | 'secondary' | 'ghost' | 'destructive' | 'icon'>('secondary');
   size = input<'sm' | 'md' | 'lg'>('md');
   disabled = input<boolean>(false);

--- a/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
+++ b/services/control-panel/src/app/shared/components/dropdown-menu.component.ts
@@ -164,6 +164,8 @@ export class DropdownMenuComponent implements OnDestroy {
   // Accepts HTMLElement, ElementRef, or a component instance (resolves nativeElement from host)
   @Input() trigger!: unknown;
 
+  @Output() closed = new EventEmitter<void>();
+
   isOpen = signal(false);
   posX = signal(0);
   posY = signal(0);
@@ -180,9 +182,20 @@ export class DropdownMenuComponent implements OnDestroy {
     const t = this.trigger;
     if (t instanceof HTMLElement) return t;
     if (t instanceof ElementRef) return t.nativeElement;
-    // Angular component ref — walk up to find the host element
+    // ElementRef-shaped object
     if (t && typeof t === 'object' && 'nativeElement' in (t as object)) {
       return (t as ElementRef).nativeElement;
+    }
+    // Component instance that exposes its host via an `elementRef` field
+    // (Angular template refs on a `<app-foo>` tag without `exportAs` resolve
+    // to the component instance, not its host element, so we have to look
+    // inside.)
+    if (t && typeof t === 'object' && 'elementRef' in (t as object)) {
+      const ref = (t as { elementRef: unknown }).elementRef;
+      if (ref instanceof ElementRef) return ref.nativeElement;
+      if (ref && typeof ref === 'object' && 'nativeElement' in (ref as object)) {
+        return (ref as ElementRef).nativeElement;
+      }
     }
     return null;
   }
@@ -262,7 +275,9 @@ export class DropdownMenuComponent implements OnDestroy {
   }
 
   close(): void {
+    const wasOpen = this.isOpen();
     this.isOpen.set(false);
+    if (wasOpen) this.closed.emit();
   }
 
   @HostListener('document:keydown.escape')

--- a/services/control-panel/src/app/shared/components/tab-group.component.ts
+++ b/services/control-panel/src/app/shared/components/tab-group.component.ts
@@ -48,6 +48,7 @@ import { TabComponent } from './tab.component';
       margin-bottom: -1px;
       cursor: pointer;
       transition: all 120ms ease;
+      white-space: nowrap;
     }
 
     .tab-btn:hover {
@@ -61,6 +62,29 @@ import { TabComponent } from './tab.component';
 
     .tab-content {
       padding: 16px 0 0;
+    }
+
+    /*
+     * Mobile (< 768px): tab rows with many items (ticket detail ~10, client
+     * detail ~10) overflow the viewport. Switch the bar to horizontal
+     * scrolling so every tab stays reachable. Momentum scrolling keeps it
+     * feeling native. Scrollbar hidden — the active underline is the
+     * position cue. Desktop behavior above is untouched.
+     */
+    @media (max-width: 767.98px) {
+      .tab-bar {
+        overflow-x: auto;
+        overflow-y: hidden;
+        flex-wrap: nowrap;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+      }
+      .tab-bar::-webkit-scrollbar {
+        display: none;
+      }
+      .tab-btn {
+        flex-shrink: 0;
+      }
     }
   `],
 })

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1329,12 +1329,39 @@ export class DetailPanelComponent {
             error: () => { this.error.set(true); this.loading.set(false); },
           });
           break;
-        case 'job':
-          sub = this.ingestionService.getRun(id).subscribe({
-            next: (j) => { this.job.set(j); this.loading.set(false); },
+        case 'job': {
+          // Keep the detail view live while the run is processing. The list
+          // page polls its own rows every 3s but doesn't push updates into
+          // this panel, so without our own poll an operator watching a live
+          // ingestion would see a frozen snapshot until they reopen the panel.
+          let pollTimer: ReturnType<typeof setInterval> | null = null;
+          const stopPoll = () => {
+            if (pollTimer) {
+              clearInterval(pollTimer);
+              pollTimer = null;
+            }
+          };
+          const jobSub = this.ingestionService.getRun(id).subscribe({
+            next: (j) => {
+              this.job.set(j);
+              this.loading.set(false);
+              if (j.status === 'processing' && !pollTimer) {
+                pollTimer = setInterval(() => {
+                  this.ingestionService.getRun(id).subscribe({
+                    next: (updated) => {
+                      this.job.set(updated);
+                      if (updated.status !== 'processing') stopPoll();
+                    },
+                    error: () => stopPoll(),
+                  });
+                }, 4000);
+              }
+            },
             error: () => { this.error.set(true); this.loading.set(false); },
           });
+          sub = { unsubscribe: () => { jobSub.unsubscribe(); stopPoll(); } } as Subscription;
           break;
+        }
         default:
           this.loading.set(false);
       }

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -139,8 +139,8 @@ app-dialog .dialog-body [dialogFooter] {
   min-height: 0;
 }
 .detail-route-page .detail-panel {
-  width: 100%;
-  min-width: 0;
+  width: 100% !important;
+  min-width: 0 !important;
   height: 100%;
   border-left: none;
   animation: none;


### PR DESCRIPTION
## Summary

Phase 4 of the mobile-responsive control panel initiative (umbrella #224). Three parts: critical bug fixes surfaced in prior phases, mobile action access on migrated list pages, and priority page polish for tickets/clients/users.

**Bug fixes**
- `/users` dropdown menu opens on desktop and mobile. Root-cause fix at the component layer: `BroncoButton` exposes `elementRef`; `DropdownMenu` recognizes component instances with an `elementRef` field. User-list converted to signal-based per-row state with a page-level shared dropdown (Closes #233's dropdown-bug part; Closes #241 for the two-click follow-up).
- Sidebar ticket badge no longer drops when `getStats()` is called with a `clientId`. Badge only updates from global stats calls. Closes #236.
- `/ingestion-jobs` row click opens the detail pane / routed view instead of inline expansion. Closes #235 and #238 (signal-dep bug obsolete with expansion removal).
- Detail-route view at narrow-desktop widths no longer renders as a 380px island — `!important` width override beats the component's encapsulated rule. Full three-mode redesign tracked in #243.

**Mobile action access**
- `/failed-jobs` expansion includes Retry + Discard buttons on mobile. Desktop still uses the trailing icon column.
- `/scheduled-probes` cards show run / history / edit / delete icons in the mobile subtitle.
- `/tickets` intentionally unchanged — the ticket detail page carries all actions.

**Page polish (#228)**
- `app-tab-group` horizontally scrolls on mobile (hidden scrollbar, momentum). Fixes overflow on ticket detail (~10 tabs) and client detail (~11 tabs).
- Ticket detail: meta row stacks selects full-width on mobile; cost call rows wrap; timeline controls stack.
- Client header: notification mode stacks under title on mobile.
- `/users`: data table becomes row-clickable on mobile — card tap opens Edit (actions column is hidden on mobile by design).

No backend changes. No `.js` import-extension sweep (tracked separately in #232). Known follow-ups tracked in #233 (other mobile action gaps), #239 (iOS zoom verify post-deploy), #240 (DataTable right-column clipping), #243 (viewport-mode redesign).

Targets `mobile-design/staging`.

## Test plan

**Desktop (≥768px — must be unchanged except for the dropdown fix)**
- [ ] `/users` kebab menu opens on first click; actions work
- [ ] Dashboard with ticket pane open — sidebar badge stays correct across navigation
- [ ] `/clients/:id` load — per-client ticket stats don't touch the sidebar badge
- [ ] `/ingestion-jobs` — row click opens the 380px side pane with run details (not an inline expansion)
- [ ] Tab groups on `/tickets/:id` and `/clients/:id` render as flex at desktop (no scroll)
- [ ] `/failed-jobs` retry + discard buttons in the trailing column work as before
- [ ] `/scheduled-probes` trailing action icons work as before

**Mobile (390px, DevTools iPhone 14)**
- [ ] `/users` — card tap opens Edit directly (no menu)
- [ ] `/failed-jobs` — tap a row to expand → Retry + Discard buttons visible at the bottom
- [ ] `/scheduled-probes` — cards show 4 action icons below the description
- [ ] `/tickets/:id` — tab row horizontally scrolls; can reach all tabs; no page overflow
- [ ] `/clients/:id` — tab row horizontally scrolls
- [ ] Ticket detail meta row stacks full-width on mobile; cost rows wrap
- [ ] Client detail header: notification mode under title, left-aligned hint

**Build**
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
