### PR TITLE
chore: unify .js extensions on relative imports in control panel

### DIFF
--- a/services/control-panel/src/app/app.config.ts
+++ b/services/control-panel/src/app/app.config.ts
@@ -3,10 +3,10 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { firstValueFrom } from 'rxjs';
-import { routes } from './app.routes';
-import { authInterceptor } from './core/interceptors/auth.interceptor';
-import { apiKeyInterceptor } from './core/interceptors/api-key.interceptor';
-import { AuthService } from './core/services/auth.service';
+import { routes } from './app.routes.js';
+import { authInterceptor } from './core/interceptors/auth.interceptor.js';
+import { apiKeyInterceptor } from './core/interceptors/api-key.interceptor.js';
+import { AuthService } from './core/services/auth.service.js';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -1,8 +1,8 @@
 import { Routes, RedirectFunction } from '@angular/router';
 import { inject } from '@angular/core';
-import { authGuard } from './core/guards/auth.guard';
-import { scopedOpsGuard } from './core/guards/scoped-ops.guard';
-import { AuthService } from './core/services/auth.service';
+import { authGuard } from './core/guards/auth.guard.js';
+import { scopedOpsGuard } from './core/guards/scoped-ops.guard.js';
+import { AuthService } from './core/services/auth.service.js';
 
 /**
  * Default redirect for the `/` path. Operators go to /dashboard; scoped ops
@@ -20,7 +20,7 @@ const defaultRedirect: RedirectFunction = () => {
 export const routes: Routes = [
   {
     path: 'login',
-    loadComponent: () => import('./features/login/login.component').then(m => m.LoginComponent),
+    loadComponent: () => import('./features/login/login.component.js').then(m => m.LoginComponent),
   },
   {
     path: '',
@@ -30,93 +30,93 @@ export const routes: Routes = [
       {
         path: 'dashboard',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/dashboard/dashboard.component').then(m => m.DashboardComponent),
+        loadComponent: () => import('./features/dashboard/dashboard.component.js').then(m => m.DashboardComponent),
       },
       {
         path: 'clients',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/clients/client-list.component').then(m => m.ClientListComponent),
+        loadComponent: () => import('./features/clients/client-list.component.js').then(m => m.ClientListComponent),
       },
       {
         path: 'clients/:id',
-        loadComponent: () => import('./features/clients/client-detail.component').then(m => m.ClientDetailComponent),
+        loadComponent: () => import('./features/clients/client-detail.component.js').then(m => m.ClientDetailComponent),
       },
       {
         path: 'tickets',
-        loadComponent: () => import('./features/tickets/ticket-list.component').then(m => m.TicketListComponent),
+        loadComponent: () => import('./features/tickets/ticket-list.component.js').then(m => m.TicketListComponent),
       },
       {
         path: 'tickets/:id',
-        loadComponent: () => import('./features/tickets/ticket-detail.component').then(m => m.TicketDetailComponent),
+        loadComponent: () => import('./features/tickets/ticket-detail.component.js').then(m => m.TicketDetailComponent),
       },
       {
         path: 'prompts',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/prompts/prompt-list.component').then(m => m.PromptListComponent),
+        loadComponent: () => import('./features/prompts/prompt-list.component.js').then(m => m.PromptListComponent),
       },
       {
         path: 'prompts/:key',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/prompts/prompt-detail.component').then(m => m.PromptDetailComponent),
+        loadComponent: () => import('./features/prompts/prompt-detail.component.js').then(m => m.PromptDetailComponent),
       },
       {
         path: 'logs',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/logs/log-viewer.component').then(m => m.LogViewerComponent),
+        loadComponent: () => import('./features/logs/log-viewer.component.js').then(m => m.LogViewerComponent),
       },
       {
         path: 'email-logs',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/email-logs/email-log.component').then(m => m.EmailLogComponent),
+        loadComponent: () => import('./features/email-logs/email-log.component.js').then(m => m.EmailLogComponent),
       },
       {
         path: 'slack-conversations',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/slack-conversations/slack-conversations.component').then(m => m.SlackConversationsComponent),
+        loadComponent: () => import('./features/slack-conversations/slack-conversations.component.js').then(m => m.SlackConversationsComponent),
       },
       {
         path: 'ai-usage',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/ai-usage/ai-usage.component').then(m => m.AiUsageComponent),
+        loadComponent: () => import('./features/ai-usage/ai-usage.component.js').then(m => m.AiUsageComponent),
       },
       {
         path: 'ai-providers',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/ai-providers/ai-providers.component').then(m => m.AiProvidersComponent),
+        loadComponent: () => import('./features/ai-providers/ai-providers.component.js').then(m => m.AiProvidersComponent),
       },
       {
         path: 'activity',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/activity-feed/activity-feed.component').then(m => m.ActivityFeedComponent),
+        loadComponent: () => import('./features/activity-feed/activity-feed.component.js').then(m => m.ActivityFeedComponent),
       },
       {
         path: 'profile',
-        loadComponent: () => import('./features/profile/profile.component').then(m => m.ProfileComponent),
+        loadComponent: () => import('./features/profile/profile.component.js').then(m => m.ProfileComponent),
       },
       {
         path: 'system-status',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/system-status/system-status.component').then(m => m.SystemStatusComponent),
+        loadComponent: () => import('./features/system-status/system-status.component.js').then(m => m.SystemStatusComponent),
       },
       {
         path: 'failed-jobs',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/failed-jobs/failed-job-list.component').then(m => m.FailedJobListComponent),
+        loadComponent: () => import('./features/failed-jobs/failed-job-list.component.js').then(m => m.FailedJobListComponent),
       },
       {
         path: 'system-issues',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/system-issues/system-issues.component').then(m => m.SystemIssuesComponent),
+        loadComponent: () => import('./features/system-issues/system-issues.component.js').then(m => m.SystemIssuesComponent),
       },
       {
         path: 'system-analysis',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/system-analysis/system-analysis.component').then(m => m.SystemAnalysisComponent),
+        loadComponent: () => import('./features/system-analysis/system-analysis.component.js').then(m => m.SystemAnalysisComponent),
       },
       {
         path: 'notification-preferences',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/notification-preferences/notification-preferences.component').then(m => m.NotificationPreferencesComponent),
+        loadComponent: () => import('./features/notification-preferences/notification-preferences.component.js').then(m => m.NotificationPreferencesComponent),
       },
       {
         path: 'system-settings',
@@ -126,37 +126,37 @@ export const routes: Routes = [
       {
         path: 'settings',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/settings/settings.component').then(m => m.SettingsComponent),
+        loadComponent: () => import('./features/settings/settings.component.js').then(m => m.SettingsComponent),
       },
       {
         path: 'release-notes',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/release-notes/release-notes.component').then(m => m.ReleaseNotesComponent),
+        loadComponent: () => import('./features/release-notes/release-notes.component.js').then(m => m.ReleaseNotesComponent),
       },
       {
         path: 'ticket-routes',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/ticket-routes/ticket-route-list.component').then(m => m.TicketRouteListComponent),
+        loadComponent: () => import('./features/ticket-routes/ticket-route-list.component.js').then(m => m.TicketRouteListComponent),
       },
       {
         path: 'ingestion-jobs',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/ingestion-jobs/ingestion-job-list.component').then(m => m.IngestionJobListComponent),
+        loadComponent: () => import('./features/ingestion-jobs/ingestion-job-list.component.js').then(m => m.IngestionJobListComponent),
       },
       {
         path: 'scheduled-probes',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/scheduled-probes/probe-list.component').then(m => m.ProbeListComponent),
+        loadComponent: () => import('./features/scheduled-probes/probe-list.component.js').then(m => m.ProbeListComponent),
       },
       {
         path: 'scheduled-probes/:id/runs',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/scheduled-probes/probe-runs.component').then(m => m.ProbeRunsComponent),
+        loadComponent: () => import('./features/scheduled-probes/probe-runs.component.js').then(m => m.ProbeRunsComponent),
       },
       {
         path: 'users',
         canActivate: [scopedOpsGuard],
-        loadComponent: () => import('./features/users/user-list.component').then(m => m.UserListComponent),
+        loadComponent: () => import('./features/users/user-list.component.js').then(m => m.UserListComponent),
       },
       {
         // Mobile-only routed full-screen detail view. Desktop never navigates
@@ -165,7 +165,7 @@ export const routes: Routes = [
         // direct deep links); the shell's detail-view wrapper just renders
         // the same panel full-width.
         path: 'detail/:type/:id',
-        loadComponent: () => import('./shell/detail-view.component').then(m => m.DetailViewComponent),
+        loadComponent: () => import('./shell/detail-view.component.js').then(m => m.DetailViewComponent),
       },
     ],
   },

--- a/services/control-panel/src/app/core/guards/auth.guard.ts
+++ b/services/control-panel/src/app/core/guards/auth.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { map } from 'rxjs';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '../services/auth.service.js';
 
 export const authGuard: CanActivateFn = () => {
   const authService = inject(AuthService);

--- a/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '../services/auth.service.js';
 
 /**
  * Routes a scoped ops user (client-side Person with hasOpsAccess) is allowed

--- a/services/control-panel/src/app/core/interceptors/auth.interceptor.ts
+++ b/services/control-panel/src/app/core/interceptors/auth.interceptor.ts
@@ -1,7 +1,7 @@
 import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { catchError, switchMap, throwError } from 'rxjs';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '../services/auth.service.js';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);

--- a/services/control-panel/src/app/core/services/ai-config.service.ts
+++ b/services/control-panel/src/app/core/services/ai-config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface TaskTypeDefault {
   taskType: string;

--- a/services/control-panel/src/app/core/services/ai-provider.service.ts
+++ b/services/control-panel/src/app/core/services/ai-provider.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 // --- Provider (one per type: LOCAL, CLAUDE, OPENAI, etc.) ---
 

--- a/services/control-panel/src/app/core/services/ai-usage.service.ts
+++ b/services/control-panel/src/app/core/services/ai-usage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface AiUsageSummary {
   provider: string;

--- a/services/control-panel/src/app/core/services/api.service.ts
+++ b/services/control-panel/src/app/core/services/api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../../environments/environment';
+import { environment } from '../../../environments/environment.js';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {

--- a/services/control-panel/src/app/core/services/auth.service.ts
+++ b/services/control-panel/src/app/core/services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, of, tap, map, catchError, shareReplay, finalize, switchMap, throwError } from 'rxjs';
-import { environment } from '../../../environments/environment';
+import { environment } from '../../../environments/environment.js';
 
 export type PortalUserType = 'ADMIN' | 'OPERATOR' | 'USER';
 

--- a/services/control-panel/src/app/core/services/client-ai-credential.service.ts
+++ b/services/control-panel/src/app/core/services/client-ai-credential.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ClientAiCredential {
   id: string;

--- a/services/control-panel/src/app/core/services/client-environment.service.ts
+++ b/services/control-panel/src/app/core/services/client-environment.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ClientEnvironment {
   id: string;

--- a/services/control-panel/src/app/core/services/client-memory.service.ts
+++ b/services/control-panel/src/app/core/services/client-memory.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 /** Canonical memory type option list — single source of truth for the UI. */
 export const MEMORY_TYPE_OPTIONS = [

--- a/services/control-panel/src/app/core/services/client.service.ts
+++ b/services/control-panel/src/app/core/services/client.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
-import type { Person } from './person.service';
+import { ApiService } from './api.service.js';
+import type { Person } from './person.service.js';
 
 export interface Client {
   id: string;

--- a/services/control-panel/src/app/core/services/email-log.service.ts
+++ b/services/control-panel/src/app/core/services/email-log.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface EmailProcessingLog {
   id: string;

--- a/services/control-panel/src/app/core/services/external-service.service.ts
+++ b/services/control-panel/src/app/core/services/external-service.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ExternalService {
   id: string;

--- a/services/control-panel/src/app/core/services/failed-jobs.service.ts
+++ b/services/control-panel/src/app/core/services/failed-jobs.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface FailedJob {
   id: string;

--- a/services/control-panel/src/app/core/services/ingestion.service.ts
+++ b/services/control-panel/src/app/core/services/ingestion.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 /** Step summary returned by the list endpoint (no output/error). */
 export interface IngestionRunStepSummary {

--- a/services/control-panel/src/app/core/services/integration.service.ts
+++ b/services/control-panel/src/app/core/services/integration.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface McpToolInfo {
   name: string;

--- a/services/control-panel/src/app/core/services/invoice.service.ts
+++ b/services/control-panel/src/app/core/services/invoice.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface Invoice {
   id: string;

--- a/services/control-panel/src/app/core/services/log-summary.service.ts
+++ b/services/control-panel/src/app/core/services/log-summary.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export type LogSummaryType = 'TICKET' | 'ORPHAN' | 'SERVICE' | 'UNCATEGORIZED';
 export type AttentionLevel = 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH';

--- a/services/control-panel/src/app/core/services/log.service.ts
+++ b/services/control-panel/src/app/core/services/log.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface AppLog {
   id: string;

--- a/services/control-panel/src/app/core/services/notification-channel.service.ts
+++ b/services/control-panel/src/app/core/services/notification-channel.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface NotificationChannel {
   id: string;

--- a/services/control-panel/src/app/core/services/person.service.ts
+++ b/services/control-panel/src/app/core/services/person.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface Person {
   id: string;

--- a/services/control-panel/src/app/core/services/prompt.service.ts
+++ b/services/control-panel/src/app/core/services/prompt.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface PromptSummary {
   key: string;

--- a/services/control-panel/src/app/core/services/release-notes.service.ts
+++ b/services/control-panel/src/app/core/services/release-notes.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export type ReleaseNoteType = 'FEATURE' | 'FIX' | 'MAINTENANCE' | 'OTHER';
 

--- a/services/control-panel/src/app/core/services/repo.service.ts
+++ b/services/control-panel/src/app/core/services/repo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface CodeRepo {
   id: string;

--- a/services/control-panel/src/app/core/services/scheduled-probe.service.ts
+++ b/services/control-panel/src/app/core/services/scheduled-probe.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ProbeRunStep {
   id: string;

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface TicketStatusConfig {
   value: string;

--- a/services/control-panel/src/app/core/services/slack-conversation.service.ts
+++ b/services/control-panel/src/app/core/services/slack-conversation.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import type { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface SlackConversationSummary {
   id: string;

--- a/services/control-panel/src/app/core/services/system-analysis.service.ts
+++ b/services/control-panel/src/app/core/services/system-analysis.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface SystemAnalysis {
   id: string;

--- a/services/control-panel/src/app/core/services/system-issues.service.ts
+++ b/services/control-panel/src/app/core/services/system-issues.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface FailedIssueJob {
   id: string;

--- a/services/control-panel/src/app/core/services/system-status.service.ts
+++ b/services/control-panel/src/app/core/services/system-status.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ComponentStatus {
   name: string;

--- a/services/control-panel/src/app/core/services/system.service.ts
+++ b/services/control-panel/src/app/core/services/system.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
-import { System } from './client.service';
+import { ApiService } from './api.service.js';
+import { System } from './client.service.js';
 
 @Injectable({ providedIn: 'root' })
 export class SystemService {

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, effect, inject, signal } from '@angular/core';
-import { AuthService } from './auth.service';
-import { ApiService } from './api.service';
-import { ToastService } from './toast.service';
+import { AuthService } from './auth.service.js';
+import { ApiService } from './api.service.js';
+import { ToastService } from './toast.service.js';
 
 export interface ThemeOption {
   id: string;

--- a/services/control-panel/src/app/core/services/ticket-filter-preset.service.ts
+++ b/services/control-panel/src/app/core/services/ticket-filter-preset.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface TicketFilterPreset {
   id: string;

--- a/services/control-panel/src/app/core/services/ticket-route.service.ts
+++ b/services/control-panel/src/app/core/services/ticket-route.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export type RouteType = 'INGESTION' | 'ANALYSIS';
 

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 /** Comma-separated active status values for API queries. Single source of truth for the UI. */
 export const ACTIVE_STATUS_FILTER = 'OPEN,IN_PROGRESS,WAITING';

--- a/services/control-panel/src/app/core/services/user.service.ts
+++ b/services/control-panel/src/app/core/services/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 export interface ControlPanelUser {
   id: string;

--- a/services/control-panel/src/app/core/services/version.service.ts
+++ b/services/control-panel/src/app/core/services/version.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { map, catchError, of } from 'rxjs';
-import { ApiService } from './api.service';
+import { ApiService } from './api.service.js';
 
 @Injectable({ providedIn: 'root' })
 export class VersionService {

--- a/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
+++ b/services/control-panel/src/app/features/activity-feed/activity-feed.component.ts
@@ -2,10 +2,10 @@ import { Component, OnInit, OnDestroy, inject, signal } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { LogSummaryService, type LogSummary, type LogSummaryType, type AttentionLevel } from '../../core/services/log-summary.service';
+import { LogSummaryService, type LogSummary, type LogSummaryType, type AttentionLevel } from '../../core/services/log-summary.service.js';
 import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const TYPE_META: Record<LogSummaryType, { label: string; color: string }> = {
   TICKET: { label: 'Ticket', color: 'var(--accent)' },

--- a/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
+++ b/services/control-panel/src/app/features/ai-providers/ai-providers.component.ts
@@ -1,8 +1,8 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiProviderService, AiProvider, AiProviderModel } from '../../core/services/ai-provider.service';
-import { AiProviderDialogComponent } from '../prompts/ai-provider-dialog.component';
-import { AiModelDialogComponent } from '../prompts/ai-model-dialog.component';
+import { AiProviderService, AiProvider, AiProviderModel } from '../../core/services/ai-provider.service.js';
+import { AiProviderDialogComponent } from '../prompts/ai-provider-dialog.component.js';
+import { AiModelDialogComponent } from '../prompts/ai-model-dialog.component.js';
 import {
   BroncoButtonComponent,
   ToggleSwitchComponent,
@@ -11,7 +11,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/ai-usage.component.ts
@@ -6,8 +6,8 @@ import { FormsModule } from '@angular/forms';
 import { Subject, debounceTime } from 'rxjs';
 import {
   AiUsageService, AiUsageSummary, AiModelCost, AiUsageLogEntry, AiUsageLogDetail,
-} from '../../core/services/ai-usage.service';
-import { ModelCostDialogComponent } from './model-cost-dialog.component';
+} from '../../core/services/ai-usage.service.js';
+import { ModelCostDialogComponent } from './model-cost-dialog.component.js';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -19,7 +19,7 @@ import {
   DialogComponent,
   type PaginatorPageEvent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 interface DatePreset {
   label: string;

--- a/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
+++ b/services/control-panel/src/app/features/ai-usage/model-cost-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiUsageService, AiModelCost } from '../../core/services/ai-usage.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AiUsageService, AiModelCost } from '../../core/services/ai-usage.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -2,19 +2,19 @@ import { Component, DestroyRef, inject, OnInit, signal, input } from '@angular/c
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
-import { ClientHeaderComponent } from './client-detail/client-header.component';
-import { ClientService, Client } from '../../core/services/client.service';
-import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component';
-import { ClientPeopleTabComponent } from './client-detail/tabs/people-tab.component';
-import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component';
-import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component';
-import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component';
-import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component';
-import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component';
-import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component';
-import { ClientInvoicesTabComponent } from './client-detail/tabs/invoices-tab.component';
-import { ClientAiUsageTabComponent } from './client-detail/tabs/ai-usage-tab.component';
-import { ClientConfigTabComponent } from './client-detail/tabs/config-tab.component';
+import { ClientHeaderComponent } from './client-detail/client-header.component.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { ClientSystemsTabComponent } from './client-detail/tabs/systems-tab.component.js';
+import { ClientPeopleTabComponent } from './client-detail/tabs/people-tab.component.js';
+import { ClientReposTabComponent } from './client-detail/tabs/repos-tab.component.js';
+import { ClientIntegrationsTabComponent } from './client-detail/tabs/integrations-tab.component.js';
+import { ClientTicketsTabComponent } from './client-detail/tabs/tickets-tab.component.js';
+import { ClientMemoryTabComponent } from './client-detail/tabs/memory-tab.component.js';
+import { ClientEnvironmentsTabComponent } from './client-detail/tabs/environments-tab.component.js';
+import { ClientAiCredentialsTabComponent } from './client-detail/tabs/ai-credentials-tab.component.js';
+import { ClientInvoicesTabComponent } from './client-detail/tabs/invoices-tab.component.js';
+import { ClientAiUsageTabComponent } from './client-detail/tabs/ai-usage-tab.component.js';
+import { ClientConfigTabComponent } from './client-detail/tabs/config-tab.component.js';
 
 const CLIENT_DETAIL_TAB_SLUGS = [
   'systems',

--- a/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/client-header.component.ts
@@ -1,9 +1,9 @@
 import { Component, DestroyRef, computed, inject, input, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { Client, ClientService } from '../../../core/services/client.service';
-import { AuthService } from '../../../core/services/auth.service';
-import { ToastService } from '../../../core/services/toast.service';
+import { Client, ClientService } from '../../../core/services/client.service.js';
+import { AuthService } from '../../../core/services/auth.service.js';
+import { ToastService } from '../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   ToggleSwitchComponent,

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ClientAiCredential, ClientAiCredentialService } from '../../../../core/services/client-ai-credential.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { ClientAiCredential, ClientAiCredentialService } from '../../../../core/services/client-ai-credential.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-usage-tab.component.ts
@@ -5,7 +5,7 @@ import {
   AiUsageClientSummary,
   AiUsageLogEntry,
   AiUsageService,
-} from '../../../../core/services/ai-usage.service';
+} from '../../../../core/services/ai-usage.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, output, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Client, ClientService } from '../../../../core/services/client.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { Client, ClientService } from '../../../../core/services/client.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   ToggleSwitchComponent,

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/environments-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/environments-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ClientEnvironment, ClientEnvironmentService } from '../../../../core/services/client-environment.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { ClientEnvironment, ClientEnvironmentService } from '../../../../core/services/client-environment.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -9,7 +9,7 @@ import {
   ToggleSwitchComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { ClientEnvironmentDialogComponent } from '../../client-environment-dialog.component';
+import { ClientEnvironmentDialogComponent } from '../../client-environment-dialog.component.js';
 
 @Component({
   selector: 'app-client-environments-tab',

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
@@ -1,8 +1,8 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { JsonPipe } from '@angular/common';
-import { ClientIntegration, IntegrationService } from '../../../../core/services/integration.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { ClientIntegration, IntegrationService } from '../../../../core/services/integration.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -10,8 +10,8 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { McpServerInfoComponent } from '../../../../shared/components/mcp-server-info.component';
-import { IntegrationDialogComponent } from '../../../integrations/integration-dialog.component';
+import { McpServerInfoComponent } from '../../../../shared/components/mcp-server-info.component.js';
+import { IntegrationDialogComponent } from '../../../integrations/integration-dialog.component.js';
 
 const SENSITIVE_KEYS = ['encryptedPassword', 'encryptedPat', 'encryptedBotToken', 'encryptedAppToken', 'password', 'pat', 'token', 'secret', 'apiKey'];
 

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/invoices-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/invoices-tab.component.ts
@@ -1,8 +1,8 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DatePipe, DecimalPipe } from '@angular/common';
-import { Invoice, InvoiceService } from '../../../../core/services/invoice.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { Invoice, InvoiceService } from '../../../../core/services/invoice.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   DataTableComponent,
@@ -10,7 +10,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { GenerateInvoiceDialogComponent } from '../../generate-invoice-dialog.component';
+import { GenerateInvoiceDialogComponent } from '../../generate-invoice-dialog.component.js';
 
 @Component({
   selector: 'app-client-invoices-tab',

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/memory-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/memory-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ClientMemory, ClientMemoryService } from '../../../../core/services/client-memory.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { ClientMemory, ClientMemoryService } from '../../../../core/services/client-memory.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -10,7 +10,7 @@ import {
   ToggleSwitchComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { ClientMemoryDialogComponent } from '../../client-memory-dialog.component';
+import { ClientMemoryDialogComponent } from '../../client-memory-dialog.component.js';
 
 const SOURCE_OPTIONS = [
   { value: '', label: 'All sources' },

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/people-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Person, PersonService } from '../../../../core/services/person.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { Person, PersonService } from '../../../../core/services/person.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   DataTableComponent,
@@ -9,7 +9,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { PersonDialogComponent } from '../../../people/person-dialog.component';
+import { PersonDialogComponent } from '../../../people/person-dialog.component.js';
 
 @Component({
   selector: 'app-client-people-tab',

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CodeRepo, RepoService } from '../../../../core/services/repo.service';
-import { ToastService } from '../../../../core/services/toast.service';
+import { CodeRepo, RepoService } from '../../../../core/services/repo.service.js';
+import { ToastService } from '../../../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   DataTableComponent,
@@ -9,7 +9,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../../../shared/components/index.js';
-import { RepoDialogComponent } from '../../../repos/repo-dialog.component';
+import { RepoDialogComponent } from '../../../repos/repo-dialog.component.js';
 
 @Component({
   selector: 'app-client-repos-tab',

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
@@ -1,14 +1,14 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { System } from '../../../../core/services/client.service';
-import { SystemService } from '../../../../core/services/system.service';
+import { System } from '../../../../core/services/client.service.js';
+import { SystemService } from '../../../../core/services/system.service.js';
 import {
   BroncoButtonComponent,
   DataTableComponent,
   DataTableColumnComponent,
   DialogComponent,
 } from '../../../../shared/components/index.js';
-import { SystemDialogComponent } from '../../../systems/system-dialog.component';
+import { SystemDialogComponent } from '../../../systems/system-dialog.component.js';
 
 @Component({
   selector: 'app-client-systems-tab',

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/tickets-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/tickets-tab.component.ts
@@ -1,7 +1,7 @@
 import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { Ticket, TicketService } from '../../../../core/services/ticket.service';
+import { Ticket, TicketService } from '../../../../core/services/ticket.service.js';
 import {
   BroncoButtonComponent,
   CategoryChipComponent,
@@ -10,7 +10,7 @@ import {
   DialogComponent,
   PriorityPillComponent,
 } from '../../../../shared/components/index.js';
-import { TicketDialogComponent } from '../../../tickets/ticket-dialog.component';
+import { TicketDialogComponent } from '../../../tickets/ticket-dialog.component.js';
 
 type Priority = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
 

--- a/services/control-panel/src/app/features/clients/client-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ClientService } from '../../core/services/client.service';
-import { ToastService } from '../../core/services/toast.service';
+import { ClientService } from '../../core/services/client.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-environment-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service';
-import { ToastService } from '../../core/services/toast.service';
+import { ClientEnvironmentService, type ClientEnvironment } from '../../core/services/client-environment.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/client-memory-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ClientMemoryService, type ClientMemory, MEMORY_TYPE_OPTIONS, CATEGORY_OPTIONS } from '../../core/services/client-memory.service';
-import { ToastService } from '../../core/services/toast.service';
+import { ClientMemoryService, type ClientMemory, MEMORY_TYPE_OPTIONS, CATEGORY_OPTIONS } from '../../core/services/client-memory.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
+++ b/services/control-panel/src/app/features/clients/generate-invoice-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { InvoiceService } from '../../core/services/invoice.service';
-import { ToastService } from '../../core/services/toast.service';
+import { InvoiceService } from '../../core/services/invoice.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/dashboard/dashboard.component.ts
+++ b/services/control-panel/src/app/features/dashboard/dashboard.component.ts
@@ -1,9 +1,9 @@
 import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ClientService, Client } from '../../core/services/client.service';
-import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service';
-import { SystemStatusService, SystemStatusResponse } from '../../core/services/system-status.service';
-import { DetailPanelService } from '../../core/services/detail-panel.service';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service.js';
+import { SystemStatusService, SystemStatusResponse } from '../../core/services/system-status.service.js';
+import { DetailPanelService } from '../../core/services/detail-panel.service.js';
 import {
   StatCardComponent,
   DataTableComponent,

--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { Subject, EMPTY, switchMap, timer } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
-import { EmailLogService, EmailProcessingLog, EmailLogStats } from '../../core/services/email-log.service';
+import { EmailLogService, EmailProcessingLog, EmailLogStats } from '../../core/services/email-log.service.js';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -18,7 +18,7 @@ import {
   DropdownDividerComponent,
   DropdownLabelComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, OnInit, OnDestroy, signal, computed } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import type { Subscription } from 'rxjs';
-import { FailedJobsService, FailedJob } from '../../core/services/failed-jobs.service';
-import { SystemStatusService, QueueStats } from '../../core/services/system-status.service';
+import { FailedJobsService, FailedJob } from '../../core/services/failed-jobs.service.js';
+import { SystemStatusService, QueueStats } from '../../core/services/system-status.service.js';
 import {
   BroncoButtonComponent,
   ToolbarComponent,
@@ -11,8 +11,8 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
-import { ViewportService } from '../../core/services/viewport.service';
+import { ToastService } from '../../core/services/toast.service.js';
+import { ViewportService } from '../../core/services/viewport.service.js';
 
 const ALL_QUEUES = [
   'issue-resolve', 'log-summarize', 'email-ingestion', 'ticket-analysis',

--- a/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
+++ b/services/control-panel/src/app/features/ingestion-jobs/ingestion-job-list.component.ts
@@ -5,9 +5,9 @@ import { DatePipe } from '@angular/common';
 import {
   IngestionService,
   IngestionRun,
-} from '../../core/services/ingestion.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { DetailPanelService } from '../../core/services/detail-panel.service';
+} from '../../core/services/ingestion.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { DetailPanelService } from '../../core/services/detail-panel.service.js';
 import {
   SelectComponent,
   IconComponent,

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -1,9 +1,9 @@
 import { Component, inject, input, output, OnInit, signal } from '@angular/core';
-import { IntegrationService } from '../../core/services/integration.service';
-import type { ClientIntegration } from '../../core/services/integration.service';
-import { AuthService } from '../../core/services/auth.service';
-import { McpToolVisibilityDialogComponent } from './mcp-tool-visibility-dialog.component';
-import { ToastService } from '../../core/services/toast.service';
+import { IntegrationService } from '../../core/services/integration.service.js';
+import type { ClientIntegration } from '../../core/services/integration.service.js';
+import { AuthService } from '../../core/services/auth.service.js';
+import { McpToolVisibilityDialogComponent } from './mcp-tool-visibility-dialog.component.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/login/login.component.ts
+++ b/services/control-panel/src/app/features/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal } from '@angular/core';
-import { AuthService } from '../../core/services/auth.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AuthService } from '../../core/services/auth.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import {
   CardComponent,
   FormFieldComponent,

--- a/services/control-panel/src/app/features/logs/log-viewer.component.ts
+++ b/services/control-panel/src/app/features/logs/log-viewer.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
 import { EMPTY, Subject, switchMap, timer } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
-import { LogService, AppLog } from '../../core/services/log.service';
+import { LogService, AppLog } from '../../core/services/log.service.js';
 import {
   BroncoButtonComponent,
   SelectComponent,

--- a/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channel-dialog.component.ts
@@ -2,8 +2,8 @@ import { Component, inject, input, output, OnInit } from '@angular/core';
 import {
   NotificationChannelService,
   NotificationChannel,
-} from '../../core/services/notification-channel.service';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/notification-channel.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
+++ b/services/control-panel/src/app/features/notification-channels/notification-channels.component.ts
@@ -2,9 +2,9 @@ import { Component, inject, OnInit, signal } from '@angular/core';
 import {
   NotificationChannelService,
   NotificationChannel,
-} from '../../core/services/notification-channel.service';
-import { NotificationChannelDialogComponent } from './notification-channel-dialog.component';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/notification-channel.service.js';
+import { NotificationChannelDialogComponent } from './notification-channel-dialog.component.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,

--- a/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
+++ b/services/control-panel/src/app/features/notification-preferences/notification-preferences.component.ts
@@ -2,11 +2,11 @@ import { Component, inject, signal, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
-import { environment } from '../../../environments/environment';
+import { environment } from '../../../environments/environment.js';
 import {
   DEFAULT_OPERATIONAL_ALERT_CONFIG,
   OperationalAlertConfig,
-} from '../../core/services/settings.service';
+} from '../../core/services/settings.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -18,7 +18,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 interface NotificationPreference {
   id: string;

--- a/services/control-panel/src/app/features/people/person-dialog.component.ts
+++ b/services/control-panel/src/app/features/people/person-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { PersonService, type Person } from '../../core/services/person.service';
-import { ToastService } from '../../core/services/toast.service';
+import { PersonService, type Person } from '../../core/services/person.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import {
   FormFieldComponent,
   TextInputComponent,

--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -1,14 +1,14 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AuthService } from '../../core/services/auth.service';
-import { ThemeService } from '../../core/services/theme.service';
+import { AuthService } from '../../core/services/auth.service.js';
+import { ThemeService } from '../../core/services/theme.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
   FormFieldComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-config-dialog.component.ts
@@ -1,10 +1,10 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiConfigService, AiModelConfig } from '../../core/services/ai-config.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service';
-import { AiProviderService, ProviderType } from '../../core/services/ai-provider.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AiConfigService, AiModelConfig } from '../../core/services/ai-config.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service.js';
+import { AiProviderService, ProviderType } from '../../core/services/ai-provider.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-model-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiProviderService, AiProvider, AiProviderModel, AppScopeItem } from '../../core/services/ai-provider.service';
-import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AiProviderService, AiProvider, AiProviderModel, AppScopeItem } from '../../core/services/ai-provider.service.js';
+import { AiUsageService, CatalogModel } from '../../core/services/ai-usage.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 const CAPABILITY_LEVELS = [

--- a/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/ai-provider-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { AiProviderService, AiProvider, ProviderType } from '../../core/services/ai-provider.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AiProviderService, AiProvider, ProviderType } from '../../core/services/ai-provider.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/keyword-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { PromptService, PromptKeyword } from '../../core/services/prompt.service';
-import { ToastService } from '../../core/services/toast.service';
+import { PromptService, PromptKeyword } from '../../core/services/prompt.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 const CATEGORIES = ['TICKET', 'EMAIL', 'DEVOPS', 'CODE', 'DATABASE', 'GENERAL'];

--- a/services/control-panel/src/app/features/prompts/override-dialog.component.ts
+++ b/services/control-panel/src/app/features/prompts/override-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, ViewChild, ElementRef, input, output, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { PromptService, PromptOverride, PromptKeyword } from '../../core/services/prompt.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { ToastService } from '../../core/services/toast.service';
+import { PromptService, PromptOverride, PromptKeyword } from '../../core/services/prompt.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-detail.component.ts
@@ -1,9 +1,9 @@
 import { Component, DestroyRef, inject, OnInit, signal, input } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { PromptService, PromptDetail, PromptOverride, PreviewResult } from '../../core/services/prompt.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { OverrideDialogComponent } from './override-dialog.component';
+import { PromptService, PromptDetail, PromptOverride, PreviewResult } from '../../core/services/prompt.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { OverrideDialogComponent } from './override-dialog.component.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -13,7 +13,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/prompts/prompt-list.component.ts
+++ b/services/control-panel/src/app/features/prompts/prompt-list.component.ts
@@ -1,11 +1,11 @@
 import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { PromptService, PromptSummary, PromptKeyword } from '../../core/services/prompt.service';
-import { AiConfigService, TaskTypeDefault, AiModelConfig } from '../../core/services/ai-config.service';
+import { PromptService, PromptSummary, PromptKeyword } from '../../core/services/prompt.service.js';
+import { AiConfigService, TaskTypeDefault, AiModelConfig } from '../../core/services/ai-config.service.js';
 import { forkJoin } from 'rxjs';
-import { KeywordDialogComponent } from './keyword-dialog.component';
-import { AiConfigDialogComponent } from './ai-config-dialog.component';
+import { KeywordDialogComponent } from './keyword-dialog.component.js';
+import { AiConfigDialogComponent } from './ai-config-dialog.component.js';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -18,7 +18,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const TAB_LABELS = ['Prompts', 'Keywords', 'AI Tasks'] as const;
 

--- a/services/control-panel/src/app/features/release-notes/release-notes.component.ts
+++ b/services/control-panel/src/app/features/release-notes/release-notes.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ReleaseNotesService, type ReleaseNote, type ReleaseNoteType } from '../../core/services/release-notes.service';
-import { BackfillDialogComponent } from './backfill-dialog.component';
-import { DialogComponent } from '../../shared/components/dialog.component';
+import { ReleaseNotesService, type ReleaseNote, type ReleaseNoteType } from '../../core/services/release-notes.service.js';
+import { BackfillDialogComponent } from './backfill-dialog.component.js';
+import { DialogComponent } from '../../shared/components/dialog.component.js';
 import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const CHANGE_TYPE_META: Record<ReleaseNoteType, { label: string; color: string }> = {
   FEATURE: { label: 'Feature', color: 'var(--color-success)' },

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -1,10 +1,10 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
-import { ScheduledProbeService, ScheduledProbe, CreateProbeRequest, UpdateProbeRequest } from '../../core/services/scheduled-probe.service';
-import { IntegrationService, ClientIntegration } from '../../core/services/integration.service';
-import { Client } from '../../core/services/client.service';
-import { ToastService } from '../../core/services/toast.service';
+import { ScheduledProbeService, ScheduledProbe, CreateProbeRequest, UpdateProbeRequest } from '../../core/services/scheduled-probe.service.js';
+import { IntegrationService, ClientIntegration } from '../../core/services/integration.service.js';
+import { Client } from '../../core/services/client.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 interface ToolInfo {
   name: string;

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -10,14 +10,14 @@ import {
   ToggleSwitchComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { DialogComponent } from '../../shared/components/dialog.component';
+import { DialogComponent } from '../../shared/components/dialog.component.js';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
-import { ViewportService } from '../../core/services/viewport.service';
-import { ScheduledProbeService, ScheduledProbe } from '../../core/services/scheduled-probe.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { CATEGORY_OPTIONS } from '../../core/services/client-memory.service';
-import { ProbeDialogComponent } from './probe-dialog.component';
-import { ToastService } from '../../core/services/toast.service';
+import { ViewportService } from '../../core/services/viewport.service.js';
+import { ScheduledProbeService, ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { CATEGORY_OPTIONS } from '../../core/services/client-memory.service.js';
+import { ProbeDialogComponent } from './probe-dialog.component.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const CATEGORIES = CATEGORY_OPTIONS;
 

--- a/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
@@ -19,8 +19,8 @@ import {
   ScheduledProbe,
   ProbeRun,
   ProbeRunStep,
-} from '../../core/services/scheduled-probe.service';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/scheduled-probe.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/category-config-dialog.component.ts
@@ -3,8 +3,8 @@ import { FormsModule } from '@angular/forms';
 import {
   SettingsService,
   TicketCategoryConfig,
-} from '../../core/services/settings.service';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/settings.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/external-service-dialog.component.ts
@@ -3,8 +3,8 @@ import { FormsModule } from '@angular/forms';
 import {
   ExternalServiceService,
   ExternalService,
-} from '../../core/services/external-service.service';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/external-service.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -4,8 +4,8 @@ import { FormsModule } from '@angular/forms';
 import {
   ExternalServiceService,
   ExternalService,
-} from '../../core/services/external-service.service';
-import { UserService, ControlPanelUser } from '../../core/services/user.service';
+} from '../../core/services/external-service.service.js';
+import { UserService, ControlPanelUser } from '../../core/services/user.service.js';
 import {
   SettingsService,
   TicketStatusConfig,
@@ -17,10 +17,10 @@ import {
   ImapSystemConfig,
   SlackSystemConfig,
   PromptRetentionConfig,
-} from '../../core/services/settings.service';
-import { ExternalServiceDialogComponent } from './external-service-dialog.component';
-import { StatusConfigDialogComponent } from './status-config-dialog.component';
-import { CategoryConfigDialogComponent } from './category-config-dialog.component';
+} from '../../core/services/settings.service.js';
+import { ExternalServiceDialogComponent } from './external-service-dialog.component.js';
+import { StatusConfigDialogComponent } from './status-config-dialog.component.js';
+import { CategoryConfigDialogComponent } from './category-config-dialog.component.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -36,7 +36,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis Strategy', 'Self Analysis', 'SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention'] as const;
 

--- a/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
+++ b/services/control-panel/src/app/features/settings/status-config-dialog.component.ts
@@ -3,8 +3,8 @@ import { FormsModule } from '@angular/forms';
 import {
   SettingsService,
   TicketStatusConfig,
-} from '../../core/services/settings.service';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/settings.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
+++ b/services/control-panel/src/app/features/slack-conversations/slack-conversations.component.ts
@@ -7,8 +7,8 @@ import {
   SlackConversationService,
   SlackConversationSummary,
   SlackConversationDetail,
-} from '../../core/services/slack-conversation.service';
-import { ClientService, Client } from '../../core/services/client.service';
+} from '../../core/services/slack-conversation.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -17,7 +17,7 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
+++ b/services/control-panel/src/app/features/system-analysis/system-analysis.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { SystemAnalysisService, type SystemAnalysis, type SystemAnalysisStats } from '../../core/services/system-analysis.service';
-import { RejectDialogComponent } from './reject-dialog.component';
-import { DialogComponent } from '../../shared/components/dialog.component';
+import { SystemAnalysisService, type SystemAnalysis, type SystemAnalysisStats } from '../../core/services/system-analysis.service.js';
+import { RejectDialogComponent } from './reject-dialog.component.js';
+import { DialogComponent } from '../../shared/components/dialog.component.js';
 import { BroncoButtonComponent, SelectComponent, PaginatorComponent, type PaginatorPageEvent } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const STATUS_META: Record<string, { label: string; color: string }> = {
   PENDING: { label: 'Pending Review', color: 'var(--color-warning)' },

--- a/services/control-panel/src/app/features/system-issues/system-issues.component.ts
+++ b/services/control-panel/src/app/features/system-issues/system-issues.component.ts
@@ -10,7 +10,7 @@ import {
   type OpenFinding,
   type RecentError,
   type FailedQueueInfo,
-} from '../../core/services/system-issues.service';
+} from '../../core/services/system-issues.service.js';
 import {
   BroncoButtonComponent,
   SelectComponent,

--- a/services/control-panel/src/app/features/system-settings/system-settings.component.ts
+++ b/services/control-panel/src/app/features/system-settings/system-settings.component.ts
@@ -9,7 +9,7 @@ import {
   ImapSystemConfig,
   SlackSystemConfig,
   PromptRetentionConfig,
-} from '../../core/services/settings.service';
+} from '../../core/services/settings.service.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -18,7 +18,7 @@ import {
   TabComponent,
   TabGroupComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const TAB_LABELS = ['SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention'] as const;
 

--- a/services/control-panel/src/app/features/system-status/system-status.component.ts
+++ b/services/control-panel/src/app/features/system-status/system-status.component.ts
@@ -6,12 +6,12 @@ import {
   SystemStatusResponse,
   QueueStats,
   McpServerStatus,
-} from '../../core/services/system-status.service';
-import type { McpDiscoveryMetadata } from '../../core/services/integration.service';
-import { AiProviderService } from '../../core/services/ai-provider.service';
-import { NotificationChannelsComponent } from '../notification-channels/notification-channels.component';
-import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component';
-import { ToastService } from '../../core/services/toast.service';
+} from '../../core/services/system-status.service.js';
+import type { McpDiscoveryMetadata } from '../../core/services/integration.service.js';
+import { AiProviderService } from '../../core/services/ai-provider.service.js';
+import { NotificationChannelsComponent } from '../notification-channels/notification-channels.component.js';
+import { McpServerInfoComponent } from '../../shared/components/mcp-server-info.component.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import {
   DropdownMenuComponent,
   DropdownItemComponent,

--- a/services/control-panel/src/app/features/systems/system-dialog.component.ts
+++ b/services/control-panel/src/app/features/systems/system-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, input, OnInit, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { SystemService } from '../../core/services/system.service';
-import { System } from '../../core/services/client.service';
-import { ToastService } from '../../core/services/toast.service';
+import { SystemService } from '../../core/services/system.service.js';
+import { System } from '../../core/services/client.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-dialog.component.ts
@@ -1,9 +1,9 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { TicketRouteService, TicketRoute } from '../../core/services/ticket-route.service';
-import type { RouteType } from '../../core/services/ticket-route.service';
-import { Client } from '../../core/services/client.service';
-import { ToastService } from '../../core/services/toast.service';
+import { TicketRouteService, TicketRoute } from '../../core/services/ticket-route.service.js';
+import type { RouteType } from '../../core/services/ticket-route.service.js';
+import { Client } from '../../core/services/client.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 const SOURCES = [

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-list.component.ts
@@ -2,12 +2,12 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { TicketRouteService, TicketRoute, TicketRouteStep, RouteStepTypeInfo } from '../../core/services/ticket-route.service';
-import type { RouteType } from '../../core/services/ticket-route.service';
-import { ClientService, Client } from '../../core/services/client.service';
-import { TicketRouteDialogComponent } from './ticket-route-dialog.component';
-import { TicketRouteStepDialogComponent } from './ticket-route-step-dialog.component';
-import { DialogComponent } from '../../shared/components/dialog.component';
+import { TicketRouteService, TicketRoute, TicketRouteStep, RouteStepTypeInfo } from '../../core/services/ticket-route.service.js';
+import type { RouteType } from '../../core/services/ticket-route.service.js';
+import { ClientService, Client } from '../../core/services/client.service.js';
+import { TicketRouteDialogComponent } from './ticket-route-dialog.component.js';
+import { TicketRouteStepDialogComponent } from './ticket-route-step-dialog.component.js';
+import { DialogComponent } from '../../shared/components/dialog.component.js';
 import {
   BroncoButtonComponent,
   SelectComponent,
@@ -15,7 +15,7 @@ import {
   TabGroupComponent,
   ToggleSwitchComponent,
 } from '../../shared/components/index.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 const TAB_LABELS = ['Ingestion Routes', 'Analysis Routes'] as const;
 

--- a/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
+++ b/services/control-panel/src/app/features/ticket-routes/ticket-route-step-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, inject, OnInit, signal, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
-import { TicketRouteService, TicketRouteStep, RouteStepTypeInfo, DispatchPreviewEntry, WithWarnings } from '../../core/services/ticket-route.service';
-import { ToastService } from '../../core/services/toast.service';
+import { TicketRouteService, TicketRouteStep, RouteStepTypeInfo, DispatchPreviewEntry, WithWarnings } from '../../core/services/ticket-route.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   selector: 'app-ticket-route-step-dialog-content',

--- a/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
+++ b/services/control-panel/src/app/features/tickets/ai-log-entry.component.ts
@@ -1,7 +1,7 @@
 import { Component, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BroncoButtonComponent } from '../../shared/components/index.js';
-import { type UnifiedLogEntry } from '../../core/services/ticket.service';
+import { type UnifiedLogEntry } from '../../core/services/ticket.service.js';
 
 @Component({
   selector: 'app-ai-log-entry',

--- a/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-cost.component.ts
@@ -1,7 +1,7 @@
 import { Component, input, signal } from '@angular/core';
 import { DatePipe, DecimalPipe } from '@angular/common';
 import { CardComponent, BroncoButtonComponent, IconComponent } from '../../shared/components/index.js';
-import { type TicketCostResponse } from '../../core/services/ai-usage.service';
+import { type TicketCostResponse } from '../../core/services/ai-usage.service.js';
 
 @Component({
   selector: 'app-ticket-detail-cost',

--- a/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-knowledge.component.ts
@@ -1,7 +1,7 @@
 import { Component, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BroncoButtonComponent, TextareaComponent, IconComponent } from '../../shared/components/index.js';
-import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
+import { MarkdownPipe } from '../../shared/pipes/markdown.pipe.js';
 
 @Component({
   selector: 'app-ticket-detail-knowledge',

--- a/services/control-panel/src/app/features/tickets/ticket-detail-log-digest.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-log-digest.component.ts
@@ -1,7 +1,7 @@
 import { Component, input, output } from '@angular/core';
 import { BroncoButtonComponent, IconComponent } from '../../shared/components/index.js';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe.js';
-import { type LogSummary } from '../../core/services/log-summary.service';
+import { type LogSummary } from '../../core/services/log-summary.service.js';
 
 @Component({
   selector: 'app-ticket-detail-log-digest',

--- a/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-timeline.component.ts
@@ -1,9 +1,9 @@
 import { Component, computed, input, output, signal } from '@angular/core';
 import { CommonModule, DecimalPipe } from '@angular/common';
 import { CardComponent, BroncoButtonComponent, SelectComponent, FormFieldComponent, IconComponent, type IconName } from '../../shared/components/index.js';
-import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
-import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe';
-import { type TicketEvent } from '../../core/services/ticket.service';
+import { MarkdownPipe } from '../../shared/pipes/markdown.pipe.js';
+import { RelativeTimePipe } from '../../shared/pipes/relative-time.pipe.js';
+import { type TicketEvent } from '../../core/services/ticket.service.js';
 
 @Component({
   selector: 'app-ticket-detail-timeline',

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -4,10 +4,10 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule, DatePipe, DecimalPipe, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { firstValueFrom } from 'rxjs';
-import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse, type TicketArtifact } from '../../core/services/ticket.service';
-import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service';
-import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service';
-import { AiHelpDialogComponent } from '../../shared/components/ai-help-dialog.component';
+import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse, type TicketArtifact } from '../../core/services/ticket.service.js';
+import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service.js';
+import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service.js';
+import { AiHelpDialogComponent } from '../../shared/components/ai-help-dialog.component.js';
 import {
   CardComponent,
   BroncoButtonComponent,
@@ -19,7 +19,7 @@ import {
   DialogComponent,
   IconComponent,
 } from '../../shared/components/index.js';
-import { AiLogEntryComponent } from './ai-log-entry.component';
+import { AiLogEntryComponent } from './ai-log-entry.component.js';
 import { TicketDetailSummaryComponent } from './ticket-detail-summary.component.js';
 import { TicketDetailResolutionComponent } from './ticket-detail-resolution.component.js';
 import { TicketDetailDetailsComponent } from './ticket-detail-details.component.js';
@@ -28,7 +28,7 @@ import { TicketDetailLogDigestComponent } from './ticket-detail-log-digest.compo
 import { TicketDetailFlowComponent, type FlowNode } from './ticket-detail-flow.component.js';
 import { TicketDetailCostComponent } from './ticket-detail-cost.component.js';
 import { TicketDetailTimelineComponent } from './ticket-detail-timeline.component.js';
-import { ToastService } from '../../core/services/toast.service';
+import { ToastService } from '../../core/services/toast.service.js';
 
 interface StepGroup {
   stepName: string;

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, input, output, OnInit } from '@angular/core';
-import { UserService, type ControlPanelUser } from '../../core/services/user.service';
-import { ToastService } from '../../core/services/toast.service';
+import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -1,9 +1,9 @@
 import { Component, inject, signal, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
-import { UserService, type ControlPanelUser } from '../../core/services/user.service';
-import { AuthService } from '../../core/services/auth.service';
-import { UserDialogComponent } from './user-dialog.component';
+import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
+import { AuthService } from '../../core/services/auth.service.js';
+import { UserDialogComponent } from './user-dialog.component.js';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -14,8 +14,8 @@ import {
   DataTableComponent,
   DataTableColumnComponent,
 } from '../../shared/components/index.js';
-import { ViewportService } from '../../core/services/viewport.service';
-import { ToastService } from '../../core/services/toast.service';
+import { ViewportService } from '../../core/services/viewport.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   standalone: true,

--- a/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/ai-help-dialog.component.ts
@@ -1,8 +1,8 @@
 import { Component, DestroyRef, inject, input, output, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { AiProviderService } from '../../core/services/ai-provider.service';
-import type { AiHelpResponse } from '../../core/services/ticket.service';
-import { ToastService } from '../../core/services/toast.service';
+import { AiProviderService } from '../../core/services/ai-provider.service.js';
+import type { AiHelpResponse } from '../../core/services/ticket.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from './index.js';
 
 /** @deprecated Use AiHelpResponse from ticket.service instead. */

--- a/services/control-panel/src/app/shared/components/data-table.component.ts
+++ b/services/control-panel/src/app/shared/components/data-table.component.ts
@@ -1,8 +1,8 @@
 import { Component, computed, contentChild, contentChildren, inject, input, output, TemplateRef } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import { DataTableColumnComponent } from './data-table-column.component';
-import { IconComponent } from './icon.component';
-import { ViewportService } from '../../core/services/viewport.service';
+import { DataTableColumnComponent } from './data-table-column.component.js';
+import { IconComponent } from './icon.component.js';
+import { ViewportService } from '../../core/services/viewport.service.js';
 
 @Component({
   selector: 'app-data-table',

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -1,27 +1,27 @@
-export { BroncoButtonComponent } from './bronco-button.component';
-export { StatusBadgeComponent } from './status-badge.component';
-export { PriorityPillComponent } from './priority-pill.component';
-export { CategoryChipComponent } from './category-chip.component';
-export { StatCardComponent } from './stat-card.component';
-export { DataTableComponent } from './data-table.component';
-export { DataTableColumnComponent } from './data-table-column.component';
-export { FormFieldComponent } from './form-field.component';
-export { TextInputComponent } from './text-input.component';
-export { TextareaComponent } from './textarea.component';
-export { SelectComponent } from './select.component';
-export { ToggleSwitchComponent } from './toggle-switch.component';
-export { CardComponent } from './card.component';
-export { TabComponent } from './tab.component';
-export { TabGroupComponent } from './tab-group.component';
-export { DialogComponent } from './dialog.component';
-export { ToolbarComponent } from './toolbar.component';
-export { ToastContainerComponent } from './toast-container.component';
-export { PaginatorComponent, type PaginatorPageEvent } from './paginator.component';
+export { BroncoButtonComponent } from './bronco-button.component.js';
+export { StatusBadgeComponent } from './status-badge.component.js';
+export { PriorityPillComponent } from './priority-pill.component.js';
+export { CategoryChipComponent } from './category-chip.component.js';
+export { StatCardComponent } from './stat-card.component.js';
+export { DataTableComponent } from './data-table.component.js';
+export { DataTableColumnComponent } from './data-table-column.component.js';
+export { FormFieldComponent } from './form-field.component.js';
+export { TextInputComponent } from './text-input.component.js';
+export { TextareaComponent } from './textarea.component.js';
+export { SelectComponent } from './select.component.js';
+export { ToggleSwitchComponent } from './toggle-switch.component.js';
+export { CardComponent } from './card.component.js';
+export { TabComponent } from './tab.component.js';
+export { TabGroupComponent } from './tab-group.component.js';
+export { DialogComponent } from './dialog.component.js';
+export { ToolbarComponent } from './toolbar.component.js';
+export { ToastContainerComponent } from './toast-container.component.js';
+export { PaginatorComponent, type PaginatorPageEvent } from './paginator.component.js';
 export {
   DropdownMenuComponent,
   DropdownItemComponent,
   DropdownDividerComponent,
   DropdownLabelComponent,
-} from './dropdown-menu.component';
-export { IconComponent, type IconSize } from './icon.component';
-export { ICON_REGISTRY, type IconName } from './icon-registry';
+} from './dropdown-menu.component.js';
+export { IconComponent, type IconSize } from './icon.component.js';
+export { ICON_REGISTRY, type IconName } from './icon-registry.js';

--- a/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
+++ b/services/control-panel/src/app/shared/components/mcp-server-info.component.ts
@@ -1,8 +1,8 @@
 import { Component, input, output, inject } from '@angular/core';
 import { BroncoButtonComponent } from './bronco-button.component.js';
 import { IconComponent } from './index.js';
-import { IntegrationService, type McpDiscoveryMetadata } from '../../core/services/integration.service';
-import { ToastService } from '../../core/services/toast.service';
+import { IntegrationService, type McpDiscoveryMetadata } from '../../core/services/integration.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
 
 @Component({
   selector: 'app-mcp-server-info',

--- a/services/control-panel/src/app/shared/components/paginator.component.ts
+++ b/services/control-panel/src/app/shared/components/paginator.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, input, output } from '@angular/core';
-import { IconComponent } from './icon.component';
+import { IconComponent } from './icon.component.js';
 
 export interface PaginatorPageEvent {
   pageSize: number;

--- a/services/control-panel/src/app/shared/components/select.component.ts
+++ b/services/control-panel/src/app/shared/components/select.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, input, output } from '@angular/core';
-import { FormFieldComponent } from './form-field.component';
+import { FormFieldComponent } from './form-field.component.js';
 
 let standaloneSelectCounter = 0;
 

--- a/services/control-panel/src/app/shared/components/tab-group.component.ts
+++ b/services/control-panel/src/app/shared/components/tab-group.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, contentChildren, input, output } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
-import { TabComponent } from './tab.component';
+import { TabComponent } from './tab.component.js';
 
 @Component({
   selector: 'app-tab-group',

--- a/services/control-panel/src/app/shared/components/text-input.component.ts
+++ b/services/control-panel/src/app/shared/components/text-input.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, input, output } from '@angular/core';
-import { FormFieldComponent } from './form-field.component';
+import { FormFieldComponent } from './form-field.component.js';
 
 let standaloneInputCounter = 0;
 

--- a/services/control-panel/src/app/shared/components/textarea.component.ts
+++ b/services/control-panel/src/app/shared/components/textarea.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, input, output } from '@angular/core';
-import { FormFieldComponent } from './form-field.component';
+import { FormFieldComponent } from './form-field.component.js';
 
 let standaloneTextareaCounter = 0;
 

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -3,18 +3,18 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { SidebarComponent } from './sidebar.component';
-import { SidebarDrawerComponent } from './sidebar-drawer.component';
-import { HeaderBarComponent } from './header-bar.component';
-import { DetailPanelComponent } from './detail-panel.component';
-import { DetailPanelService } from '../core/services/detail-panel.service';
-import { ThemeService } from '../core/services/theme.service';
-import { ViewportService } from '../core/services/viewport.service';
-import { SidebarService } from '../core/services/sidebar.service';
-import { AuthService } from '../core/services/auth.service';
-import { TicketService } from '../core/services/ticket.service';
-import { FailedJobsService } from '../core/services/failed-jobs.service';
-import { ToastContainerComponent } from '../shared/components/toast-container.component';
+import { SidebarComponent } from './sidebar.component.js';
+import { SidebarDrawerComponent } from './sidebar-drawer.component.js';
+import { HeaderBarComponent } from './header-bar.component.js';
+import { DetailPanelComponent } from './detail-panel.component.js';
+import { DetailPanelService } from '../core/services/detail-panel.service.js';
+import { ThemeService } from '../core/services/theme.service.js';
+import { ViewportService } from '../core/services/viewport.service.js';
+import { SidebarService } from '../core/services/sidebar.service.js';
+import { AuthService } from '../core/services/auth.service.js';
+import { TicketService } from '../core/services/ticket.service.js';
+import { FailedJobsService } from '../core/services/failed-jobs.service.js';
+import { ToastContainerComponent } from '../shared/components/toast-container.component.js';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
   dashboard: 'Dashboard',

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -2,14 +2,14 @@ import { Component, effect, inject, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Router, RouterLink } from '@angular/router';
 import { DatePipe, DecimalPipe, SlicePipe } from '@angular/common';
-import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service';
-import { TicketService, Ticket, TicketEvent, TicketAiUsageLog, UnifiedLogEntry } from '../core/services/ticket.service';
-import { ClientService, Client } from '../core/services/client.service';
-import { AiUsageService, type AiUsageClientSummary } from '../core/services/ai-usage.service';
-import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service';
-import { SystemStatusService, ComponentStatus, QueueStats, SystemStatusResponse } from '../core/services/system-status.service';
-import { SystemAnalysisService, SystemAnalysis } from '../core/services/system-analysis.service';
-import { IngestionService, IngestionRunDetail } from '../core/services/ingestion.service';
+import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service.js';
+import { TicketService, Ticket, TicketEvent, TicketAiUsageLog, UnifiedLogEntry } from '../core/services/ticket.service.js';
+import { ClientService, Client } from '../core/services/client.service.js';
+import { AiUsageService, type AiUsageClientSummary } from '../core/services/ai-usage.service.js';
+import { ScheduledProbeService, ScheduledProbe } from '../core/services/scheduled-probe.service.js';
+import { SystemStatusService, ComponentStatus, QueueStats, SystemStatusResponse } from '../core/services/system-status.service.js';
+import { SystemAnalysisService, SystemAnalysis } from '../core/services/system-analysis.service.js';
+import { IngestionService, IngestionRunDetail } from '../core/services/ingestion.service.js';
 import {
   StatusBadgeComponent,
   PriorityPillComponent,

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input } from '@angular/core';
-import { IconComponent } from '../shared/components/icon.component';
-import { ViewportService } from '../core/services/viewport.service';
-import { SidebarService } from '../core/services/sidebar.service';
+import { IconComponent } from '../shared/components/icon.component.js';
+import { ViewportService } from '../core/services/viewport.service.js';
+import { SidebarService } from '../core/services/sidebar.service.js';
 
 const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
 

--- a/services/control-panel/src/app/shell/index.ts
+++ b/services/control-panel/src/app/shell/index.ts
@@ -1,5 +1,5 @@
-export { AppShellComponent } from './app-shell.component';
-export { SidebarComponent } from './sidebar.component';
-export { HeaderBarComponent } from './header-bar.component';
-export { DetailPanelComponent } from './detail-panel.component';
-export { DetailPanelService } from '../core/services/detail-panel.service';
+export { AppShellComponent } from './app-shell.component.js';
+export { SidebarComponent } from './sidebar.component.js';
+export { HeaderBarComponent } from './header-bar.component.js';
+export { DetailPanelComponent } from './detail-panel.component.js';
+export { DetailPanelService } from '../core/services/detail-panel.service.js';

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -1,11 +1,11 @@
 import { Component, computed, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { AuthService } from '../core/services/auth.service';
-import { ThemeService } from '../core/services/theme.service';
-import { VersionService } from '../core/services/version.service';
-import { TicketService } from '../core/services/ticket.service';
-import { FailedJobsService } from '../core/services/failed-jobs.service';
+import { AuthService } from '../core/services/auth.service.js';
+import { ThemeService } from '../core/services/theme.service.js';
+import { VersionService } from '../core/services/version.service.js';
+import { TicketService } from '../core/services/ticket.service.js';
+import { FailedJobsService } from '../core/services/failed-jobs.service.js';
 
 @Component({
   selector: 'app-sidebar',

--- a/services/control-panel/src/main.ts
+++ b/services/control-panel/src/main.ts
@@ -1,6 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
-import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config.js';
+import { AppComponent } from './app/app.component.js';
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary

Closes #232. Mechanical codemod — unifies `.js` extension usage on relative ESM imports in the control panel per CLAUDE.md convention.

120 files, 351 additions / 351 deletions. Every change is `from './x'` → `from './x.js'` (or the same for export re-exports and dynamic `import('./x')`). No logic touched, no reordering, no grouping.

Targets `mobile-design/staging`. Verified `pnpm typecheck` and `pnpm build` pass.

## Merge order note

Overlaps with PR #TBD (three-mode viewport layout) on 3 files: `app.routes.ts`, `app-shell.component.ts`, `header-bar.component.ts`. Recommend merging this PR first — the viewport PR has a small number of new imports that will need `.js` suffixes manually added after this lands (one-line fixup during rebase).

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] Control panel loads and navigates normally (smoke test — if any import silently broke, it'd surface immediately)
- [ ] Spot-check diff: every change is `import` or `export ... from` getting `.js` appended; no logic/formatting changes
