### PR TITLE
feat: three-mode viewport layout + /login redirect guard

### DIFF
--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes, RedirectFunction } from '@angular/router';
 import { inject } from '@angular/core';
 import { authGuard } from './core/guards/auth.guard';
 import { scopedOpsGuard } from './core/guards/scoped-ops.guard';
+import { loginRedirectGuard } from './core/guards/login-redirect.guard';
 import { AuthService } from './core/services/auth.service';
 
 /**
@@ -20,6 +21,7 @@ const defaultRedirect: RedirectFunction = () => {
 export const routes: Routes = [
   {
     path: 'login',
+    canActivate: [loginRedirectGuard],
     loadComponent: () => import('./features/login/login.component').then(m => m.LoginComponent),
   },
   {

--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -2,7 +2,7 @@ import { Routes, RedirectFunction } from '@angular/router';
 import { inject } from '@angular/core';
 import { authGuard } from './core/guards/auth.guard';
 import { scopedOpsGuard } from './core/guards/scoped-ops.guard';
-import { loginRedirectGuard } from './core/guards/login-redirect.guard';
+import { loginRedirectGuard } from './core/guards/login-redirect.guard.js';
 import { AuthService } from './core/services/auth.service';
 
 /**

--- a/services/control-panel/src/app/core/guards/login-redirect.guard.ts
+++ b/services/control-panel/src/app/core/guards/login-redirect.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Bounce already-authenticated users away from `/login` so they don't see the
+ * login form floating inside the fully-rendered shell. Operators land on the
+ * dashboard; scoped portal-ops users land on their client detail page.
+ */
+export const loginRedirectGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  const user = auth.currentUser();
+  if (!user) return true;
+  if (user.isPortalOpsUser && user.clientId) {
+    return router.parseUrl(`/clients/${user.clientId}`);
+  }
+  return router.parseUrl('/dashboard');
+};

--- a/services/control-panel/src/app/core/guards/login-redirect.guard.ts
+++ b/services/control-panel/src/app/core/guards/login-redirect.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '../services/auth.service.js';
 
 /**
  * Bounce already-authenticated users away from `/login` so they don't see the

--- a/services/control-panel/src/app/core/services/detail-panel.service.ts
+++ b/services/control-panel/src/app/core/services/detail-panel.service.ts
@@ -39,17 +39,18 @@ export class DetailPanelService {
   /**
    * Open a detail view for the given entity. Behavior depends on viewport:
    *
-   * - Desktop (`>= 768px`): set signals and merge `detail`/`type`/`mode` into
-   *   the current URL's query params. The inline side pane renders.
-   * - Mobile (`< 768px`): set signals AND navigate to `/detail/:type/:id`.
-   *   The routed `DetailViewComponent` renders the same panel full-screen.
+   * - Desktop (`>= 1200px`): set signals and merge `detail`/`type`/`mode`
+   *   into the current URL's query params. The inline side pane renders.
+   * - Compact layout (`< 1200px`, phone + tablet + narrow desktop): set
+   *   signals AND navigate to `/detail/:type/:id`. The routed
+   *   `DetailViewComponent` renders the same panel as a full-width takeover.
    *
    * Signals are always set so components observing the panel state work
    * identically across both code paths.
    */
   open(type: DetailEntityType, id: string, mode: DetailPanelMode = 'full'): void {
     this.setState(type, id, mode);
-    if (this.viewport.isMobile()) {
+    if (this.viewport.isCompactLayout()) {
       // No `queryParamsHandling: 'merge'` — we're changing path into
       // /detail/:type/:id, so we don't want list-page query params (e.g.
       // `?clientId=…` on /tickets, `?tab=…` on settings-style pages, or

--- a/services/control-panel/src/app/core/services/viewport.service.ts
+++ b/services/control-panel/src/app/core/services/viewport.service.ts
@@ -6,18 +6,34 @@ import { map } from 'rxjs';
 /**
  * Responsive viewport service.
  *
- * Exposes `isMobile` as a signal backed by CDK BreakpointObserver. The single
- * shell breakpoint — `(max-width: 767.98px)` — must be kept in sync with the
- * media queries used in component CSS (sidebar, header, shell content, etc.)
- * so the CSS branches and the template branches agree.
+ * Two breakpoints:
+ *   - `isMobile` (< 768px) governs phone-only behavior: form-input sizing
+ *     (iOS zoom prevention), DataTable card mode, full-screen dialogs, mobile
+ *     action affordances, etc.
+ *   - `isCompactLayout` (< 1200px) governs the shell: at narrower widths the
+ *     sidebar + main + 380px detail pane can't comfortably coexist inline, so
+ *     the sidebar collapses to a drawer and the detail view becomes a routed
+ *     full-width takeover.
+ *
+ * Each signal must stay in sync with the matching media queries used in
+ * component CSS so the template branches and CSS branches agree.
  */
 @Injectable({ providedIn: 'root' })
 export class ViewportService {
   private readonly bp = inject(BreakpointObserver);
 
-  /** True when viewport is below the shell mobile breakpoint. */
+  /** True when viewport is below the shell mobile breakpoint (< 768px). */
   readonly isMobile = toSignal(
     this.bp.observe('(max-width: 767.98px)').pipe(map(r => r.matches)),
+    { initialValue: false },
+  );
+
+  /**
+   * True when viewport is narrow enough that sidebar + detail pane can't
+   * comfortably coexist inline with main content (< 1200px).
+   */
+  readonly isCompactLayout = toSignal(
+    this.bp.observe('(max-width: 1199.98px)').pipe(map(r => r.matches)),
     { initialValue: false },
   );
 }

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -49,7 +49,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
   imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent, ToastContainerComponent],
   template: `
     <div class="shell">
-      @if (!viewport.isMobile()) {
+      @if (!viewport.isCompactLayout()) {
         <app-sidebar />
       }
       <div class="shell-main">
@@ -58,7 +58,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
           <router-outlet />
         </main>
       </div>
-      @if (!viewport.isMobile() && detailPanel.isOpen() && !onDetailRoute()) {
+      @if (!viewport.isCompactLayout() && detailPanel.isOpen() && !onDetailRoute()) {
         <app-detail-panel />
       }
     </div>
@@ -134,9 +134,9 @@ export class AppShellComponent implements OnInit {
     // Drawer open/close ↔ CDK Overlay attach/detach.
     effect(() => {
       const open = this.sidebar.isOpen();
-      const mobile = this.viewport.isMobile();
+      const compact = this.viewport.isCompactLayout();
       untracked(() => {
-        if (open && mobile) {
+        if (open && compact) {
           this.openDrawer();
         } else {
           this.closeDrawer();
@@ -144,27 +144,27 @@ export class AppShellComponent implements OnInit {
       });
     });
 
-    // Viewport flip: keep the pane visible across the 768px boundary by
-    // swapping presentations, not by destroying state.
-    //   Desktop → mobile: side pane open on /dashboard?detail=… →
-    //     navigate to /detail/:type/:id (routed full-screen view).
-    //   Mobile → desktop: routed view at /detail/:type/:id →
+    // Viewport flip: keep the pane visible across the compact-layout boundary
+    // (1200px) by swapping presentations, not by destroying state.
+    //   Desktop → compact: side pane open on /dashboard?detail=… →
+    //     navigate to /detail/:type/:id (routed takeover view).
+    //   Compact → desktop: routed view at /detail/:type/:id →
     //     navigate to parent list with ?detail=…&type=…&mode=… query
     //     params so the inline side pane renders.
-    // For the mobile→desktop direction, DetailViewComponent.ngOnDestroy
+    // For the compact→desktop direction, DetailViewComponent.ngOnDestroy
     // would otherwise dismiss the signals mid-transition and blank the
     // pane; we suppress that one dismiss so the inline pane picks up
     // the existing state.
     effect(() => {
-      const mobile = this.viewport.isMobile();
+      const compact = this.viewport.isCompactLayout();
       untracked(() => {
         const onDetailRoute = this.router.url.startsWith('/detail/');
         const type = this.detailPanel.entityType();
         const id = this.detailPanel.entityId();
         const mode = this.detailPanel.mode();
 
-        if (mobile && this.detailPanel.isOpen() && !onDetailRoute) {
-          // Desktop → mobile with side pane active.
+        if (compact && this.detailPanel.isOpen() && !onDetailRoute) {
+          // Desktop → compact with side pane active.
           if (!type || !id) return;
           this.router.navigate(['/detail', type, id], {
             queryParams: mode === 'full' ? undefined : { mode },
@@ -172,8 +172,8 @@ export class AppShellComponent implements OnInit {
           return;
         }
 
-        if (!mobile && onDetailRoute) {
-          // Mobile → desktop on routed view: restore parent list + pane.
+        if (!compact && onDetailRoute) {
+          // Compact → desktop on routed view: restore parent list + pane.
           if (!type || !id) return;
           const parent = DetailPanelService.PARENT_LIST[type] ?? '/dashboard';
           this.detailPanel.suppressNextDismiss();

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -27,7 +27,7 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
       <button class="search-trigger" type="button" aria-label="Search">
         <app-icon class="search-icon" name="search" size="sm" />
         <span class="search-text">Search...</span>
-        @if (!viewport.isMobile()) {
+        @if (!viewport.isCompactLayout()) {
           <kbd class="search-kbd">{{ shortcutHint }}</kbd>
         }
       </button>
@@ -112,13 +112,12 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
     }
 
     /*
-     * Mobile compact mode: reduce horizontal padding, collapse the search
-     * trigger to an icon-only 44x44 hit area, and hide the "Search..." text
-     * and kbd hint. The hamburger already satisfies the 44px tap target on
-     * the left. The title stretches to fill the middle and truncates with
-     * ellipsis when it doesn't fit.
+     * Compact-layout mode: reduce horizontal padding, collapse the search
+     * trigger to an icon-only 44x44 hit area, and hide the "Search..." text.
+     * The kbd hint is hidden via the template @if (isCompactLayout). The
+     * hamburger satisfies the 44px tap target on the left.
      */
-    @media (max-width: 767.98px) {
+    @media (max-width: 1199.98px) {
       .header-bar { padding: 0 12px; }
       .search-trigger {
         width: 44px;

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -12,7 +12,7 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
   template: `
     <header class="header-bar">
       <div class="header-left">
-        @if (viewport.isMobile()) {
+        @if (viewport.isCompactLayout()) {
           <button
             class="hamburger-btn"
             type="button"

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -226,15 +226,13 @@ import { FailedJobsService } from '../core/services/failed-jobs.service';
     }
 
     /*
-     * Mobile shell chrome tap targets.
+     * Compact-layout shell chrome tap targets.
      *
-     * Under 768px the sidebar is rendered inside a CDK Overlay drawer. Nav
-     * items, the logout button, the theme-indicator link, and the version
-     * label all get >= 44px hit areas so they're reliably tappable. This is
-     * scoped to the media query so desktop layout is byte-identical to the
-     * current mobile-design/staging.
+     * Under 1200px the sidebar is rendered inside a CDK Overlay drawer.
+     * Nav items, the logout button, the theme-indicator link, and the
+     * version label all get >= 44px hit areas so they're reliably tappable.
      */
-    @media (max-width: 767.98px) {
+    @media (max-width: 1199.98px) {
       .nav-item {
         padding: 12px 16px;
         font-size: 14px;

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -123,15 +123,26 @@ app-dialog .dialog-body [dialogFooter] {
 }
 
 /*
- * Routed detail view renders the panel full-screen. The inline desktop pane
- * uses a fixed 380px width; on the routed page (both mobile flow and desktop
- * deep-link) we override that so the panel fills the shell content area.
- * Not scoped to the mobile media query because /detail/:type/:id is advertised
- * as a valid desktop deep-link too — without this override, desktop direct
- * nav would render a narrow 380px pane inside `shell-content`.
+ * Routed detail view (`/detail/:type/:id`) renders the same panel as the
+ * inline side pane, but full-width inside `shell-content`. The inline pane is
+ * a fixed 380px; here we widen it to fill the available area and present it
+ * differently per viewport:
+ *
+ *   - Phone (< 480px): edge-to-edge dialog look — break out of shell-content
+ *     padding, pin a sticky header, no slide animation.
+ *   - Tablet / narrow-desktop (480–1199px): right-slide takeover that covers
+ *     the main content area, keeping the shell header visible above it.
+ *   - Desktop (>= 1200px): the routed view is a deep-link entry point; the
+ *     panel simply fills shell-content with no animation (matches the
+ *     unanimated inline pane on first paint).
+ *
+ * Not scoped to a single media query because `/detail/:type/:id` is a valid
+ * desktop deep-link — without the base width override, desktop direct nav
+ * would render a narrow 380px pane inside `shell-content`.
  */
 .detail-route-page {
   height: 100%;
+  background: var(--bg-page);
 }
 .detail-route-page app-detail-panel {
   display: flex;
@@ -144,33 +155,39 @@ app-dialog .dialog-body [dialogFooter] {
   height: 100%;
   border-left: none;
   animation: none;
+  background: var(--bg-page);
+}
+.detail-route-page .panel-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-page);
 }
 
-/*
- * On mobile the routed detail view should feel like a full-screen page, not
- * a panel-inside-a-panel. The shell-content has 12px padding at < 768px
- * (Phase 1) which would frame the panel, and the panel itself has its own
- * padding + a rounded card background. We:
- *   1. Break out of shell-content's padding via negative margins so the
- *      panel fills the viewport edge-to-edge.
- *   2. Pin the panel header so the title/actions stay visible while the
- *      body scrolls — matches the sticky-header pattern of our mobile
- *      dialogs.
- * The inline desktop side pane is unaffected because it's not wrapped in
- * .detail-route-page.
- */
-@media (max-width: 767.98px) {
+/* Phone (< 480): dialog look. Break out of shell-content's 12px padding. */
+@media (max-width: 479.98px) {
   .detail-route-page {
     margin: -12px;
     height: calc(100% + 24px);
   }
-  .detail-route-page .detail-panel {
-    background: var(--bg-page);
+}
+
+/* Tablet / narrow-desktop (480-1199): takeover with slide-in from right.
+   Negative margin matches shell-content padding at this range: 12px under
+   768 and 24px at 768+. */
+@media (min-width: 480px) and (max-width: 1199.98px) {
+  .detail-route-page {
+    animation: detail-route-slide-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
   }
-  .detail-route-page .panel-header {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--bg-page);
-  }
+}
+@media (min-width: 480px) and (max-width: 767.98px) {
+  .detail-route-page { margin: -12px; height: calc(100% + 24px); }
+}
+@media (min-width: 768px) and (max-width: 1199.98px) {
+  .detail-route-page { margin: -24px; height: calc(100% + 48px); }
+}
+
+@keyframes detail-route-slide-in {
+  from { transform: translateX(100%); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
 }


### PR DESCRIPTION
## Summary

Closes #245 (authenticated `/login` redirect). Partially refs #243 (three-mode viewport layout).

- **`ViewportService.isCompactLayout`** (< 1200px) added as a second breakpoint signal alongside `isMobile` (< 768px). Phone-specific behavior (DataTable cards, dialog full-screen, form-input sizing, iOS zoom prevention, mobile action affordances) stays on `isMobile`. Shell layout (sidebar inline vs drawer, inline pane vs routed takeover) moves to `isCompactLayout`.
- **Three routed-detail presentations** via CSS in `styles.scss`:
  - Phone (< 480px): edge-to-edge dialog look, sticky header
  - Tablet / narrow-desktop (480-1199px): right-slide takeover covering main content, shell header stays visible
  - Desktop (≥ 1200px): deep-link entry — panel fills `shell-content`
- **Viewport-flip preservation** (from Phase 1) now swings at 1200px instead of 768px. Desktop → compact: side pane becomes routed takeover. Compact → desktop: routed view restores inline pane via query params.
- **`loginRedirectGuard`** bounces authenticated users away from `/login` (operator → `/dashboard`; scoped portal-ops user → their client detail). Dodges the "login form inside the fully-rendered shell" bug from #245.

Targets `mobile-design/staging`. Verified `pnpm typecheck` and `pnpm build`.

## Merge order note

Overlaps with PR #246 (`.js` extensions sweep) on 3 files: `app.routes.ts`, `app-shell.component.ts`, `header-bar.component.ts`. **Merge #246 first.** This branch adds a new import (`login-redirect.guard`) without `.js` suffix — will need a one-line fixup during rebase.

## Test plan

**Desktop (≥ 1200px — must be byte-identical to current):**
- [ ] `/dashboard` sidebar inline at 240px
- [ ] Click client from `/clients` → inline side pane at 380px slides in
- [ ] Refresh on `?detail=…&type=…&mode=…` → pane restores

**Tablet (850px — new takeover behavior):**
- [ ] Sidebar hidden, hamburger in header
- [ ] Click client → routed `/detail/client/:id` slides in from right, covering main content; hamburger still reachable
- [ ] Browser back returns to `/clients`
- [ ] DataTable still renders as tables (card mode stays at < 768)
- [ ] Dialogs still centered (full-screen dialog stays at < 768)

**Phone (390px — must be unchanged):**
- [ ] Sidebar drawer, hamburger, routed detail dialog-style

**Resize:**
- [ ] 1400 → 800 with side pane open → navigates to routed takeover, pane content stays visible
- [ ] 800 → 1400 on routed detail → navigates back to parent list with query params, inline pane restores

**Login redirect:**
- [ ] Authenticated operator visits `/login` → redirected to `/dashboard`
- [ ] Authenticated scoped ops user visits `/login` → redirected to `/clients/:theirClientId`
- [ ] Logged out visits `/login` → login form renders normally

**Build:**
- [ ] `pnpm typecheck`
- [ ] `pnpm build`
