### PR TITLE
chore: post-mobile-release cleanup bundle

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^20.0.0
         version: 20.3.18(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@angular/service-worker':
-        specifier: ^20.0.0
-        version: 20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+        specifier: 20.3.18
+        version: 20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@awesome.me/kit-9a8becfc3a':
         specifier: ^1.0.2
         version: 1.0.2
@@ -293,7 +293,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.0.0
-        version: 20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@1.21.7)(less@4.2.2)(postcss@8.5.6)(tailwindcss@3.4.19(tsx@4.21.0))(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)
+        version: 20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@1.21.7)(less@4.2.2)(postcss@8.5.6)(tailwindcss@3.4.19(tsx@4.21.0))(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)
       '@angular/cli':
         specifier: ^20.0.0
         version: 20.3.22(@types/node@25.3.0)(chokidar@4.0.3)
@@ -720,7 +720,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.0.0
-        version: 20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)
+        version: 20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)
       '@angular/cli':
         specifier: ^20.0.0
         version: 20.3.22(@types/node@25.3.0)(chokidar@4.0.3)
@@ -961,12 +961,12 @@ packages:
       '@angular/platform-browser': 20.3.18
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/service-worker@20.3.19':
-    resolution: {integrity: sha512-djGCXrKw3TavjwKydtR5DXOZaSq9CK6O29OCDC4pCjw4SJmT5bV/PnntOH7jlpxzvWD9/ofO/89M1e2lBzoAWA==}
+  '@angular/service-worker@20.3.18':
+    resolution: {integrity: sha512-OYhObPIuehCrLcEFuy+Li0+oUwvUEA0s0CQRI3xIroXn37CslBy0StPT8DgBI7c4dIpTXI9b1eCeK+U3uVRr3w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/core': 20.3.19
+      '@angular/core': 20.3.18
       rxjs: ^6.5.3 || ^7.4.0
 
   '@anthropic-ai/sdk@0.39.0':
@@ -4960,7 +4960,7 @@ snapshots:
       '@angular/core': 20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)
       tslib: 2.8.1
 
-  '@angular/build@20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@1.21.7)(less@4.2.2)(postcss@8.5.6)(tailwindcss@3.4.19(tsx@4.21.0))(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)':
+  '@angular/build@20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@1.21.7)(less@4.2.2)(postcss@8.5.6)(tailwindcss@3.4.19(tsx@4.21.0))(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.22(chokidar@4.0.3)
@@ -4995,7 +4995,7 @@ snapshots:
     optionalDependencies:
       '@angular/core': 20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))
-      '@angular/service-worker': 20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/service-worker': 20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       less: 4.2.2
       lmdb: 3.4.2
       postcss: 8.5.6
@@ -5013,7 +5013,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)':
+  '@angular/build@20.3.22(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.8.3))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/service-worker@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@types/node@25.3.0)(chokidar@4.0.3)(jiti@2.6.1)(less@4.2.2)(postcss@8.5.6)(tailwindcss@4.2.2)(terser@5.39.0)(tslib@2.8.1)(tsx@4.21.0)(typescript@5.8.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.22(chokidar@4.0.3)
@@ -5048,7 +5048,7 @@ snapshots:
     optionalDependencies:
       '@angular/core': 20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))
-      '@angular/service-worker': 20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/service-worker': 20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       less: 4.2.2
       lmdb: 3.4.2
       postcss: 8.5.6
@@ -5176,7 +5176,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/service-worker@20.3.19(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+  '@angular/service-worker@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
     dependencies:
       '@angular/core': 20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)
       rxjs: 7.8.2

--- a/services/control-panel/package.json
+++ b/services/control-panel/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^20.0.0",
     "@angular/platform-browser-dynamic": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@angular/service-worker": "^20.0.0",
+    "@angular/service-worker": "20.3.18",
     "@awesome.me/kit-9a8becfc3a": "^1.0.2",
     "@bronco/shared-ui": "workspace:*",
     "@fortawesome/angular-fontawesome": "^3.0.0",

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -95,6 +95,14 @@ export class ThemeService {
       classList.add(theme.bodyClass);
     }
     localStorage.setItem(STORAGE_KEY, theme.id);
+    this.applyThemeColorMeta();
+  }
+
+  private applyThemeColorMeta(): void {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    if (!meta) return;
+    const color = getComputedStyle(document.body).getPropertyValue('--bg-page').trim() || '#08090a';
+    meta.content = color;
   }
 
   private resolveInitial(): ThemeOption {

--- a/services/control-panel/src/app/shell/detail-panel.component.ts
+++ b/services/control-panel/src/app/shell/detail-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, effect, inject, signal } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Subscription, timer, switchMap, tap, takeWhile } from 'rxjs';
 import { Router, RouterLink } from '@angular/router';
 import { DatePipe, DecimalPipe, SlicePipe } from '@angular/common';
 import { DetailPanelService, DetailEntityType } from '../core/services/detail-panel.service.js';
@@ -1329,39 +1329,17 @@ export class DetailPanelComponent {
             error: () => { this.error.set(true); this.loading.set(false); },
           });
           break;
-        case 'job': {
-          // Keep the detail view live while the run is processing. The list
-          // page polls its own rows every 3s but doesn't push updates into
-          // this panel, so without our own poll an operator watching a live
-          // ingestion would see a frozen snapshot until they reopen the panel.
-          let pollTimer: ReturnType<typeof setInterval> | null = null;
-          const stopPoll = () => {
-            if (pollTimer) {
-              clearInterval(pollTimer);
-              pollTimer = null;
-            }
-          };
-          const jobSub = this.ingestionService.getRun(id).subscribe({
-            next: (j) => {
-              this.job.set(j);
-              this.loading.set(false);
-              if (j.status === 'processing' && !pollTimer) {
-                pollTimer = setInterval(() => {
-                  this.ingestionService.getRun(id).subscribe({
-                    next: (updated) => {
-                      this.job.set(updated);
-                      if (updated.status !== 'processing') stopPoll();
-                    },
-                    error: () => stopPoll(),
-                  });
-                }, 4000);
-              }
-            },
+        case 'job':
+          // Poll every 4s while processing; switchMap cancels in-flight
+          // requests on each new tick so requests cannot overlap.
+          sub = timer(0, 4000).pipe(
+            switchMap(() => this.ingestionService.getRun(id)),
+            tap(j => { this.job.set(j); this.loading.set(false); }),
+            takeWhile(j => j.status === 'processing', true),
+          ).subscribe({
             error: () => { this.error.set(true); this.loading.set(false); },
           });
-          sub = { unsubscribe: () => { jobSub.unsubscribe(); stopPoll(); } } as Subscription;
           break;
-        }
         default:
           this.loading.set(false);
       }

--- a/services/control-panel/src/app/shell/sidebar-drawer.component.ts
+++ b/services/control-panel/src/app/shell/sidebar-drawer.component.ts
@@ -5,8 +5,9 @@ import { SidebarComponent } from './sidebar.component.js';
 /**
  * Mobile drawer wrapper around `SidebarComponent`.
  *
- * Attached to a CDK Overlay by `AppShellComponent` when `viewport.isMobile()`
- * is true and the drawer is open. Applies a focus trap so keyboard Tab stays
+ * Attached to a CDK Overlay by `AppShellComponent` when
+ * `viewport.isCompactLayout()` is true (< 1200px) and the drawer is open.
+ * Applies a focus trap so keyboard Tab stays
  * within the drawer while open. The drawer chrome (width, slide animation,
  * tap-target overrides) is styled globally via `.sidebar-drawer-pane` in
  * styles.scss — `SidebarComponent` itself stays untouched.

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -10,8 +10,6 @@
   <link rel="apple-touch-icon" href="icons/icon-192.png">
   <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary

Post-mobile-release cleanup bundle — 5 small follow-ups surfaced during gap analysis on the release promotion PR (#254). Target: next minor version bump.

- **#255** (docs) Updated stale JSDoc in `sidebar-drawer.component.ts` to reference `viewport.isCompactLayout()` / 1200px boundary after the viewport split in #247.
- **#256** (cleanup) Removed dead Google Fonts (Roboto) and Material Icons `<link>` tags from `index.html`. Material is replaced by the custom design system; icons come from Font Awesome Pro via `IconComponent`; primary font is CSS-variable-driven. Two cross-origin render-blocking requests eliminated.
- **#253** (hygiene) Pinned `@angular/service-worker` to `20.3.18` (Option B) to match the rest of the Angular suite and clear the pnpm peer-dependency warning.
- **#252** (refactor) Converted ingestion run polling in `DetailPanelComponent` from `setInterval` + nested `subscribe` to `timer(0, 4000)` + `switchMap` + `takeWhile(..., true)`. `switchMap` cancels in-flight requests on new ticks (no overlap), inclusive `takeWhile` emits the final non-processing value and completes, and cleanup is handled by the effect's existing `sub.unsubscribe()`.
- **#257** (feature) `ThemeService.applyTheme()` now updates the `<meta name="theme-color">` content at runtime from the active theme's `--bg-page` CSS variable. iOS Safari status bar and installed-PWA title bar follow the selected theme. The static `manifest.webmanifest` keeps `#08090a` for the install-time splash (renders before JS loads).

Zero overlap between the five — a clean bundle.

## Note on #253 lockfile

The remote session couldn't run `pnpm install` because `npm.fontawesome.com` is unreachable in that sandbox. The lockfile was edited manually (`20.3.19 → 20.3.18` + matching integrity hash from public npm). I validated locally with `pnpm install --frozen-lockfile` — clean, no peer warnings. CI will confirm.

## Test plan

- [ ] `pnpm install --frozen-lockfile` succeeds with no peer warnings
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `/ingestion-jobs` — open a processing run in the detail pane, watch DevTools Network: `getRun` call every 4s, stops when status changes, no overlapping requests
- [ ] `/profile` → Appearance → cycle through all 6 themes, `<meta name="theme-color">` content updates in DevTools Elements panel
- [ ] `index.html` has no references to `fonts.googleapis.com`
- [ ] Control panel visually identical across all pages (no Roboto / Material Icons regression)
