### PR TITLE
fix: password manager autocomplete on /cp/profile change-password form

### DIFF
--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -77,22 +77,46 @@ import { ToastService } from '../../core/services/toast.service.js';
 
         <app-card>
           <h2 class="section-title">Change Password</h2>
-          <div class="form-grid">
+          <form class="form-grid" (ngSubmit)="changePassword()" autocomplete="on">
+            <input
+              type="text"
+              name="username"
+              autocomplete="username"
+              [value]="user.email"
+              readonly
+              tabindex="-1"
+              aria-hidden="true"
+              class="pw-username-hint" />
             <app-form-field label="Current Password">
-              <input class="text-input" type="password" [(ngModel)]="currentPassword" />
+              <input
+                class="text-input"
+                type="password"
+                name="currentPassword"
+                autocomplete="current-password"
+                [(ngModel)]="currentPassword" />
             </app-form-field>
             <app-form-field label="New Password">
-              <input class="text-input" type="password" [(ngModel)]="newPassword" />
+              <input
+                class="text-input"
+                type="password"
+                name="newPassword"
+                autocomplete="new-password"
+                [(ngModel)]="newPassword" />
             </app-form-field>
             <app-form-field label="Confirm New Password">
-              <input class="text-input" type="password" [(ngModel)]="confirmPassword" />
+              <input
+                class="text-input"
+                type="password"
+                name="confirmPassword"
+                autocomplete="new-password"
+                [(ngModel)]="confirmPassword" />
             </app-form-field>
-          </div>
-          <div class="card-actions">
-            <app-bronco-button variant="destructive" (click)="changePassword()" [disabled]="passwordSaving">
-              Change Password
-            </app-bronco-button>
-          </div>
+            <div class="card-actions">
+              <app-bronco-button type="submit" variant="destructive" [disabled]="passwordSaving">
+                Change Password
+              </app-bronco-button>
+            </div>
+          </form>
         </app-card>
       }
     </div>
@@ -194,6 +218,19 @@ import { ToastService } from '../../core/services/toast.service.js';
       margin-top: 16px;
       padding-top: 16px;
       border-top: 1px solid var(--border-light);
+    }
+
+    /* Hidden-but-discoverable username input so Safari/1Password can
+       correlate the password change to the saved credential. Keeping the
+       element in layout (not display:none) is what makes autofill see it. */
+    .pw-username-hint {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      opacity: 0;
+      pointer-events: none;
+      border: 0;
+      padding: 0;
     }
 
     .theme-grid {

--- a/services/control-panel/src/app/shared/components/bronco-button.component.ts
+++ b/services/control-panel/src/app/shared/components/bronco-button.component.ts
@@ -6,7 +6,7 @@ import { Component, ElementRef, inject, input } from '@angular/core';
   host: { '[class.full-width]': 'fullWidth()' },
   template: `
     <button
-      type="button"
+      [attr.type]="type()"
       [class]="'btn btn-' + variant() + ' btn-' + size() + (fullWidth() ? ' btn-full-width' : '')"
       [disabled]="disabled()"
       [attr.aria-label]="ariaLabel() || null"
@@ -94,6 +94,7 @@ export class BroncoButtonComponent {
 
   variant = input<'primary' | 'secondary' | 'ghost' | 'destructive' | 'icon'>('secondary');
   size = input<'sm' | 'md' | 'lg'>('md');
+  type = input<'button' | 'submit' | 'reset'>('button');
   disabled = input<boolean>(false);
   ariaLabel = input<string>('');
   fullWidth = input<boolean>(false);


### PR DESCRIPTION
## Summary

Fixes Safari (and other password managers) not detecting password changes made on the `/cp/profile` page. The strong-password suggestion popup was appearing, but the "Update saved password?" prompt never fired, leaving the old password in the keychain.

## Root cause

The Change Password section was a bare `<div>` with three `<input type="password">` fields and no `autocomplete` attributes. Submission was via a JS click handler on a `type="button"` button. Three problems for password autofill:

1. No `<form>` element → no submit event for Safari to hook.
2. No `autocomplete="username"` field → Safari can't correlate the new password to the saved credential for `itrack.siirial.com`, so it defaults to treating the new-password input as new-account creation.
3. No `current-password` / `new-password` autocomplete hints.

## Changes

- Wrap the password fields in a `<form (ngSubmit)="changePassword()">`.
- Add a readonly, visually-hidden-but-DOM-present `autocomplete="username"` input populated from the current user's email so Safari can match against the saved credential.
- Tag fields with `autocomplete="current-password"` and `autocomplete="new-password"`.
- Extend `BroncoButtonComponent` with a `type` input (`'button' | 'submit' | 'reset'`, default `'button'`) so the Change Password button can trigger form submission.

## Test plan
- [x] Typecheck passes
- [ ] On `/cp/profile`, fill current + new + confirm → click Change Password → Safari prompts "Update saved password for chadjdreier@gmail.com?"
- [ ] Same flow from iPhone cellular (mobile Safari)
- [ ] Strong-password suggestion popup no longer appears (Safari now knows this is an existing account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
