### PR TITLE
fix: PR #263 review — card-actions width + CSS comment accuracy

### DIFF
--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -77,40 +77,42 @@ import { ToastService } from '../../core/services/toast.service.js';
 
         <app-card>
           <h2 class="section-title">Change Password</h2>
-          <form class="form-grid" (ngSubmit)="changePassword()" autocomplete="on">
-            <input
-              type="text"
-              name="username"
-              autocomplete="username"
-              [value]="user.email"
-              readonly
-              tabindex="-1"
-              aria-hidden="true"
-              class="pw-username-hint" />
-            <app-form-field label="Current Password">
+          <form (ngSubmit)="changePassword()" autocomplete="on">
+            <div class="form-grid">
               <input
-                class="text-input"
-                type="password"
-                name="currentPassword"
-                autocomplete="current-password"
-                [(ngModel)]="currentPassword" />
-            </app-form-field>
-            <app-form-field label="New Password">
-              <input
-                class="text-input"
-                type="password"
-                name="newPassword"
-                autocomplete="new-password"
-                [(ngModel)]="newPassword" />
-            </app-form-field>
-            <app-form-field label="Confirm New Password">
-              <input
-                class="text-input"
-                type="password"
-                name="confirmPassword"
-                autocomplete="new-password"
-                [(ngModel)]="confirmPassword" />
-            </app-form-field>
+                type="text"
+                name="username"
+                autocomplete="username"
+                [value]="user.email"
+                readonly
+                tabindex="-1"
+                aria-hidden="true"
+                class="pw-username-hint" />
+              <app-form-field label="Current Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="currentPassword"
+                  autocomplete="current-password"
+                  [(ngModel)]="currentPassword" />
+              </app-form-field>
+              <app-form-field label="New Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="newPassword"
+                  autocomplete="new-password"
+                  [(ngModel)]="newPassword" />
+              </app-form-field>
+              <app-form-field label="Confirm New Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="confirmPassword"
+                  autocomplete="new-password"
+                  [(ngModel)]="confirmPassword" />
+              </app-form-field>
+            </div>
             <div class="card-actions">
               <app-bronco-button type="submit" variant="destructive" [disabled]="passwordSaving">
                 Change Password
@@ -221,8 +223,10 @@ import { ToastService } from '../../core/services/toast.service.js';
     }
 
     /* Hidden-but-discoverable username input so Safari/1Password can
-       correlate the password change to the saved credential. Keeping the
-       element in layout (not display:none) is what makes autofill see it. */
+       correlate the password change to the saved credential. The element
+       must stay in the DOM — display:none / visibility:hidden would make
+       autofill skip it. Absolute positioning + 1px/opacity:0 keeps it
+       parseable by autofill while visually invisible. */
     .pw-username-hint {
       position: absolute;
       width: 1px;


### PR DESCRIPTION
## Summary

Follow-up to PR #263 addressing two Copilot review comments that landed after merge:

1. **`.card-actions` width constraint** — #263 put `.card-actions` inside the form element which also carried `class="form-grid"` (max-width: 600px). The border-top divider and button row were clipped to 600px instead of spanning the full card like the Edit Profile section. Move the wrapper structure so `.form-grid` and `.card-actions` are siblings inside the form, each with their original width behavior.

2. **Misleading CSS comment** — the note on `.pw-username-hint` said "Keeping the element in layout" but the rule uses `position: absolute`, which removes it from flow. Corrected to explain the actual autofill requirement: the element must stay in the DOM (not `display:none` / `visibility:hidden`), positioning and visual styling don't matter.

## Test plan
- [x] Control panel build passes
- [ ] Visual check on `/cp/profile`: Change Password card's border-top divider now spans the full card width, matching the Edit Profile section
- [ ] Safari still prompts to update the saved password (no behavior change from the structural tweak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
