### PR TITLE
feat: command palette — Phase B (tickets + mutating commands)

### DIFF
--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -5,6 +5,86 @@ import type { ServerDeps } from '../server.js';
 
 export function registerTicketTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_tickets',
+    'Search tickets by query across ticket number, subject, client name, and client short code. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(1).describe('Search query (ticket number, subject, client name, or short code)'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const ticketNumberMatch = /^\d+$/.test(q) ? Number(q) : null;
+      const qLower = q.toLowerCase();
+
+      const selectShape = {
+        id: true,
+        ticketNumber: true,
+        subject: true,
+        status: true,
+        priority: true,
+        clientId: true,
+        createdAt: true,
+        client: { select: { name: true, shortCode: true } },
+      } as const;
+
+      // For numeric queries, fetch the exact ticketNumber match separately so
+      // it's guaranteed to appear in the result — otherwise a broad subject
+      // match could fill the `take` limit and push the exact match out of the
+      // DB slice before the in-memory ranker sees it. Mirrors the REST handler
+      // in services/copilot-api/src/routes/tickets.ts.
+      const exactPromise = ticketNumberMatch !== null
+        ? db.ticket.findFirst({
+            where: { ticketNumber: ticketNumberMatch },
+            select: selectShape,
+          })
+        : Promise.resolve(null);
+
+      const broadPromise = db.ticket.findMany({
+        where: {
+          OR: [
+            { subject: { contains: q, mode: 'insensitive' as const } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: selectShape,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+      });
+
+      const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
+
+      const byId = new Map<string, typeof broad[number]>();
+      if (exact) byId.set(exact.id, exact);
+      for (const row of broad) byId.set(row.id, row);
+      const merged = Array.from(byId.values());
+
+      merged.sort((a, b) => {
+        const aExact = ticketNumberMatch !== null && a.ticketNumber === ticketNumberMatch ? 0 : 1;
+        const bExact = ticketNumberMatch !== null && b.ticketNumber === ticketNumberMatch ? 0 : 1;
+        if (aExact !== bExact) return aExact - bExact;
+        const aStarts = a.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      });
+
+      const result = merged.slice(0, limit).map(t => ({
+        id: t.id,
+        ticketNumber: t.ticketNumber,
+        subject: t.subject,
+        status: t.status,
+        priority: t.priority,
+        clientId: t.clientId,
+        clientName: t.client.name,
+        clientShortCode: t.client.shortCode,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_tickets',
     'List tickets with optional filters. Returns summary array with id, ticketNumber, subject, status, priority, category, client name, createdAt, and analysisStatus.',
     {

--- a/services/control-panel/src/app/core/guards/scoped-ops-allowlist.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops-allowlist.ts
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for which routes a scoped ops user is allowed to see.
+ *
+ * Consumed by:
+ * - `scopedOpsGuard` — blocks direct navigation to disallowed routes
+ * - `CommandPaletteComponent` — filters the Navigate section
+ *
+ * Keep the list and the matcher here so both consumers stay in sync when
+ * routes are added or removed.
+ */
+
+export const SCOPED_ALLOWED_PREFIXES = [
+  '/dashboard',   // dashboard is rewritten to client detail in the default redirect
+  '/tickets',     // list + detail
+  '/profile',
+  '/login',
+];
+
+/**
+ * True if `url` is a route a scoped ops user is allowed to access.
+ *
+ * - Any `/clients/:id` route is allowed (own client only — the data layer
+ *   scopes the response). `/clients` list itself is NOT allowed.
+ * - Any route under a prefix in `SCOPED_ALLOWED_PREFIXES` is allowed.
+ */
+export function isScopedOpsAllowedPath(url: string): boolean {
+  if (url === '/clients' || url.startsWith('/clients?')) return false;
+  if (url.startsWith('/clients/')) return true;
+  return SCOPED_ALLOWED_PREFIXES.some(
+    prefix => url === prefix || url.startsWith(`${prefix}/`) || url.startsWith(`${prefix}?`),
+  );
+}

--- a/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
@@ -1,26 +1,14 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { AuthService } from '../services/auth.service.js';
+import { isScopedOpsAllowedPath } from './scoped-ops-allowlist.js';
 
 /**
- * Routes a scoped ops user (client-side Person with hasOpsAccess) is allowed
- * to visit directly. Anything else is redirected to their own client detail
- * page. This guard is a no-op for operators.
+ * Blocks scoped ops users (portal users with ops access) from reaching routes
+ * outside their permitted surface. The allowed route list lives in
+ * `scoped-ops-allowlist.ts` so the command palette can share the same source
+ * of truth. No-op for operators.
  */
-const SCOPED_ALLOWED_PREFIXES = [
-  '/dashboard',   // dashboard is rewritten to client detail in the default redirect
-  '/tickets',     // list + detail
-  '/profile',
-  '/login',
-];
-
-function isAllowedPath(url: string): boolean {
-  // /clients/:id is allowed, but /clients (the list) is not
-  if (url === '/clients' || url.startsWith('/clients?')) return false;
-  if (url.startsWith('/clients/')) return true;
-  return SCOPED_ALLOWED_PREFIXES.some(prefix => url === prefix || url.startsWith(`${prefix}/`) || url.startsWith(`${prefix}?`));
-}
-
 export const scopedOpsGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
   const router = inject(Router);
@@ -34,7 +22,7 @@ export const scopedOpsGuard: CanActivateFn = (_route, state) => {
   const clientId = user.clientId;
   const fallback = clientId ? router.parseUrl(`/clients/${clientId}`) : router.parseUrl('/profile');
 
-  if (isAllowedPath(state.url)) {
+  if (isScopedOpsAllowedPath(state.url)) {
     return true;
   }
   return fallback;

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -59,6 +59,14 @@ export class ThemeService {
     this.applyTheme();
   }
 
+  cycleToNext(): ThemeOption {
+    const current = this._currentTheme();
+    const idx = THEMES.findIndex(t => t.id === current.id);
+    const next = THEMES[(idx + 1) % THEMES.length];
+    this.setTheme(next.id);
+    return next;
+  }
+
   setTheme(id: string): void {
     const theme = THEMES.find(t => t.id === id);
     if (!theme) return;

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -264,9 +264,24 @@ export class TicketService {
     return this.api.get<TicketArtifact[]>(`/tickets/${ticketId}/artifacts`);
   }
 
+  searchTickets(q: string, limit = 20): Observable<TicketSearchResult[]> {
+    return this.api.get<TicketSearchResult[]>('/search/tickets', { q, limit });
+  }
+
   getArtifactDownloadUrl(artifactId: string): string {
     return `/api/artifacts/${artifactId}/download`;
   }
+}
+
+export interface TicketSearchResult {
+  id: string;
+  ticketNumber: number | null;
+  subject: string;
+  status: string;
+  priority: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
 }
 
 export interface AiHelpResponse {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, effect, inject, OnInit, signal, input, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component.js';
@@ -128,19 +127,23 @@ export class ClientDetailComponent implements OnInit {
     // input — fixes the 9 tabs that only fetch their data in ngOnInit and
     // would otherwise display the previous client's systems/people/repos/etc.
     // The brief "Loading…" flash is acceptable and makes the switch legible.
-    effect((onCleanup) => {
-      const cid = this.id();
+    //
+    // With `withComponentInputBinding()` in app.config.ts, the router binds
+    // `id` before this effect's first run. The try/catch is a defensive guard
+    // against the documented edge case where a required input is read before
+    // binding — extremely unlikely for a routed loadComponent but zero-cost.
+    effect(() => {
+      let cid: string;
+      try {
+        cid = this.id();
+      } catch {
+        return;
+      }
       if (!cid) return;
-      let sub: Subscription | null = null;
       untracked(() => {
         this.client.set(null);
-        sub = this.clientService.getClient(cid).subscribe(c => {
-          // Guard against stale responses: only apply if this is still the
-          // active client id when the request resolves.
-          if (this.id() === cid) this.client.set(c);
-        });
+        this.load(cid);
       });
-      onCleanup(() => sub?.unsubscribe());
     });
   }
 

--- a/services/control-panel/src/app/features/clients/client-list.component.ts
+++ b/services/control-panel/src/app/features/clients/client-list.component.ts
@@ -1,4 +1,6 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ClientService, Client } from '../../core/services/client.service.js';
 import { ClientDialogComponent } from './client-dialog.component.js';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
@@ -76,6 +78,9 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, Di
 export class ClientListComponent implements OnInit {
   private clientService = inject(ClientService);
   private detailPanel = inject(DetailPanelService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   clients = signal<Client[]>([]);
   showClientDialog = signal(false);
@@ -83,6 +88,20 @@ export class ClientListComponent implements OnInit {
 
   ngOnInit(): void {
     this.load();
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.showClientDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   load(): void {

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgClass } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import {
   DataTableComponent,
   DataTableColumnComponent,
@@ -190,6 +191,9 @@ export class ProbeListComponent implements OnInit {
   private toast = inject(ToastService);
   private detailPanel = inject(DetailPanelService);
   readonly viewport = inject(ViewportService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   showProbeDialog = signal(false);
   editingProbe = signal<ScheduledProbe | null>(null);
@@ -219,6 +223,21 @@ export class ProbeListComponent implements OnInit {
       for (const t of tools) this.builtinToolNames.add(t.name);
     });
     this.loadProbes();
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.editingProbe.set(null);
+    this.showProbeDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   loadProbes(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service.js';
 import { ClientService, Client } from '../../core/services/client.service.js';
@@ -421,6 +422,7 @@ export class TicketListComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
 
   tickets = signal<Ticket[]>([]);
   presets = signal<TicketFilterPreset[]>([]);
@@ -498,6 +500,11 @@ export class TicketListComponent implements OnInit {
   ngOnInit(): void {
     this.clientIdFilter.set(this.route.snapshot.queryParams['clientId'] ?? '');
     this.clientService.getClients().subscribe(clients => this.clients.set(clients));
+    // Subscribe to queryParamMap so subsequent palette activations fire while
+    // already on /tickets.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
     this.loadPresets({
       next: () => {
         const defaultPreset = this.presets().find(p => p.isDefault);
@@ -614,6 +621,17 @@ export class TicketListComponent implements OnInit {
   isSelectedPresetDefault(): boolean {
     const selected = this.presets().find(p => p.id === this.selectedPresetId());
     return selected?.isDefault ?? false;
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.showCreateDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   onTicketCreated(result: { id: string }): void {

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { forkJoin, of, Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, forkJoin, of, Subject, switchMap } from 'rxjs';
 import { catchError, map, takeUntil } from 'rxjs/operators';
 import { DialogComponent } from './dialog.component.js';
 import { IconComponent } from './icon.component.js';
@@ -22,33 +22,43 @@ import { ClientService, type Client } from '../../core/services/client.service.j
 import { ScheduledProbeService, type ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { PersonService, type Person } from '../../core/services/person.service.js';
+import { TicketService, type TicketSearchResult } from '../../core/services/ticket.service.js';
+import { ThemeService } from '../../core/services/theme.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
+import { isScopedOpsAllowedPath } from '../../core/guards/scoped-ops-allowlist.js';
 
 interface PaletteItem {
   id: string;
   label: string;
   secondary?: string;
   icon: IconName;
-  route: readonly string[];
+  route?: readonly string[];
   /** Optional query params applied when the item is activated. */
   queryParams?: Record<string, string>;
+  /** Callback fired on activation — exclusive with route. */
+  action?: () => void;
   section: PaletteSection;
   searchText: string;
 }
 
-type PaletteSection = 'clients' | 'probes' | 'users' | 'people' | 'navigate';
+type PaletteSection = 'clients' | 'tickets' | 'probes' | 'users' | 'people' | 'commands' | 'navigate';
 
 interface SectionGroup {
   section: PaletteSection;
+  label: string;
   items: PaletteItem[];
+  loading?: boolean;
 }
 
-const SECTION_ORDER: PaletteSection[] = ['clients', 'probes', 'users', 'people', 'navigate'];
+const SECTION_ORDER: PaletteSection[] = ['clients', 'tickets', 'probes', 'users', 'people', 'commands', 'navigate'];
 
 const SECTION_LABELS: Record<PaletteSection, string> = {
   clients: 'Clients',
+  tickets: 'Tickets',
   probes: 'Scheduled Probes',
   users: 'Users',
   people: 'People',
+  commands: 'Commands',
   navigate: 'Navigate',
 };
 
@@ -83,16 +93,6 @@ const ALL_NAV_ROUTES: NavRoute[] = [
   { label: 'Notifications', route: '/notification-preferences', icon: 'bell' },
 ];
 
-const SCOPED_ALLOWED_PREFIXES = ['/dashboard', '/tickets', '/profile', '/login'];
-
-function isAllowedForScoped(url: string): boolean {
-  if (url === '/clients' || url.startsWith('/clients?')) return false;
-  if (url.startsWith('/clients/')) return true;
-  return SCOPED_ALLOWED_PREFIXES.some(
-    p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`),
-  );
-}
-
 @Component({
   selector: 'app-command-palette',
   standalone: true,
@@ -108,14 +108,14 @@ function isAllowedForScoped(url: string): boolean {
           #searchInput
           type="text"
           class="palette-input"
-          placeholder="Search clients, probes, users, people, or navigate…"
+          placeholder="Search clients, tickets, probes, users, people, or navigate…"
           autocomplete="off"
           spellcheck="false"
           role="combobox"
-          aria-autocomplete="list"
-          aria-controls="palette-listbox"
+          aria-controls="command-palette-listbox"
           [attr.aria-expanded]="filteredSections().length > 0"
-          [attr.aria-activedescendant]="selectedItem() ? 'palette-item-' + selectedItem()!.id : null"
+          aria-autocomplete="list"
+          [attr.aria-activedescendant]="selectedItem() ? itemDomId(selectedItem()!) : null"
           [value]="query()"
           (input)="onQueryInput($event)"
           (keydown)="onInputKeydown($event)"
@@ -126,14 +126,19 @@ function isAllowedForScoped(url: string): boolean {
       </div>
 
       @if (filteredSections().length > 0) {
-        <div class="palette-results" id="palette-listbox" role="listbox">
+        <div class="palette-results" role="listbox" id="command-palette-listbox">
           @for (group of filteredSections(); track group.section) {
-            <div class="section-header" role="presentation">{{ sectionLabels[group.section] }}</div>
+            <div class="section-header" role="presentation">
+              {{ group.label }}
+              @if (group.loading) {
+                <app-icon name="spinner" size="sm" class="section-spinner" />
+              }
+            </div>
             @for (item of group.items; track item.id) {
               <div
                 class="palette-item"
                 role="option"
-                [id]="'palette-item-' + item.id"
+                [id]="itemDomId(item)"
                 [attr.aria-selected]="selectedItem() === item"
                 [class.palette-item-selected]="selectedItem() === item"
                 (click)="activate(item)"
@@ -194,12 +199,19 @@ function isAllowedForScoped(url: string): boolean {
       overflow-y: auto;
     }
     .section-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
       padding: 10px 4px 4px;
       font-size: 11px;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.5px;
       color: var(--text-tertiary);
+    }
+    .section-spinner {
+      color: var(--text-tertiary);
+      animation: palette-spin 1s linear infinite;
     }
     .palette-item {
       display: flex;
@@ -254,16 +266,21 @@ export class CommandPaletteComponent {
   private readonly probeService = inject(ScheduledProbeService);
   private readonly userService = inject(UserService);
   private readonly personService = inject(PersonService);
+  private readonly ticketService = inject(TicketService);
+  private readonly theme = inject(ThemeService);
+  private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
   private readonly cancelLoad$ = new Subject<void>();
+  private readonly ticketSearch$ = new Subject<string>();
 
-  readonly sectionLabels = SECTION_LABELS;
   readonly query = signal('');
   readonly items = signal<PaletteItem[]>([]);
+  readonly ticketItems = signal<PaletteItem[]>([]);
   readonly loading = signal(false);
+  readonly ticketsLoading = signal(false);
   readonly selectedIndex = signal(0);
 
   readonly filteredItems = computed(() => {
@@ -287,16 +304,31 @@ export class CommandPaletteComponent {
       bucket.push(item);
       itemMap.set(item.section, bucket);
     }
+
+    // Ticket items are pre-filtered server-side; merge them separately.
+    const tickets = this.ticketItems();
+    const isTicketsLoading = this.ticketsLoading();
+    if (tickets.length > 0 || isTicketsLoading) {
+      itemMap.set('tickets', tickets);
+    }
+
     return SECTION_ORDER
       .filter(s => itemMap.has(s))
-      .map(s => ({ section: s, items: itemMap.get(s)! }));
+      .map(s => ({
+        section: s,
+        label: SECTION_LABELS[s],
+        items: itemMap.get(s)!,
+        loading: s === 'tickets' && isTicketsLoading,
+      }));
   });
 
   readonly selectedItem = computed(() => {
     const idx = this.selectedIndex();
     const items = this.filteredItems();
-    if (idx < 0 || idx >= items.length) return null;
-    return items[idx];
+    // Flatten all section items for keyboard nav (includes ticket items)
+    const allVisible = this.filteredSections().flatMap(g => g.items);
+    if (idx < 0 || idx >= allVisible.length) return null;
+    return allVisible[idx];
   });
 
   constructor() {
@@ -307,7 +339,9 @@ export class CommandPaletteComponent {
         untracked(() => {
           this.query.set('');
           this.items.set([]);
+          this.ticketItems.set([]);
           this.loading.set(false);
+          this.ticketsLoading.set(false);
           this.selectedIndex.set(0);
         });
         return;
@@ -328,6 +362,42 @@ export class CommandPaletteComponent {
       untracked(() => this.selectedIndex.set(0));
     });
 
+    // Drive the debounced ticket search from the query signal.
+    effect(() => {
+      const q = this.query().trim();
+      untracked(() => this.ticketSearch$.next(q));
+    });
+
+    this.ticketSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.ticketsLoading.set(false);
+            this.ticketItems.set([]);
+            return of([] as TicketSearchResult[]);
+          }
+          this.ticketsLoading.set(true);
+          return this.ticketService.searchTickets(q, 20).pipe(
+            catchError(() => of([] as TicketSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.ticketsLoading.set(false);
+        this.ticketItems.set(results.map(t => ({
+          id: `ticket:${t.id}`,
+          label: t.subject,
+          secondary: `#${t.ticketNumber ?? '?'} · ${t.clientShortCode}`,
+          icon: 'ticket' as IconName,
+          route: ['/tickets', t.id] as const,
+          section: 'tickets' as const,
+          searchText: `${t.subject} ${t.ticketNumber ?? ''} ${t.clientShortCode} ${t.clientName}`.toLowerCase(),
+        })));
+      });
+
     this.destroyRef.onDestroy(() => this.cancelLoad$.complete());
   }
 
@@ -340,17 +410,15 @@ export class CommandPaletteComponent {
   }
 
   onInputKeydown(e: KeyboardEvent): void {
-    const items = this.filteredItems();
+    const allVisible = this.filteredSections().flatMap(g => g.items);
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (items.length === 0) return;
-      const lastIndex = items.length - 1;
-      this.selectedIndex.update(i => Math.max(0, Math.min(i + 1, lastIndex)));
+      if (allVisible.length === 0) return;
+      this.selectedIndex.update(i => Math.min(i + 1, allVisible.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      if (items.length === 0) return;
-      const lastIndex = items.length - 1;
-      this.selectedIndex.update(i => Math.max(0, Math.min(i - 1, lastIndex)));
+      if (allVisible.length === 0) return;
+      this.selectedIndex.update(i => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const item = this.selectedItem();
@@ -359,12 +427,27 @@ export class CommandPaletteComponent {
   }
 
   onItemHover(item: PaletteItem): void {
-    const idx = this.filteredItems().indexOf(item);
+    const allVisible = this.filteredSections().flatMap(g => g.items);
+    const idx = allVisible.indexOf(item);
     if (idx >= 0) this.selectedIndex.set(idx);
   }
 
+  /**
+   * Stable DOM id for each option row, consumed by the input's
+   * `aria-activedescendant` so screen readers announce the active option
+   * without the results container needing its own focus.
+   */
+  itemDomId(item: PaletteItem): string {
+    // Replace colons so the id is a valid CSS/DOM id — `client:abc` → `client_abc`.
+    return `cp-item-${item.id.replace(/:/g, '_')}`;
+  }
+
   activate(item: PaletteItem): void {
-    this.router.navigate([...item.route], item.queryParams ? { queryParams: item.queryParams } : undefined);
+    if (item.action) {
+      item.action();
+    } else if (item.route) {
+      this.router.navigate([...item.route], item.queryParams ? { queryParams: item.queryParams } : undefined);
+    }
     this.paletteService.close();
   }
 
@@ -461,8 +544,60 @@ export class CommandPaletteComponent {
             });
           }
 
+          // Commands — static actions; Create commands hidden for scoped users.
+          if (!isScoped) {
+            newItems.push({
+              id: 'cmd:create-ticket',
+              label: 'Create Ticket',
+              icon: 'add',
+              route: ['/tickets'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create ticket',
+            });
+            newItems.push({
+              id: 'cmd:create-client',
+              label: 'Create Client',
+              icon: 'add',
+              route: ['/clients'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create client',
+            });
+            newItems.push({
+              id: 'cmd:create-probe',
+              label: 'Create Scheduled Probe',
+              icon: 'add',
+              route: ['/scheduled-probes'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create scheduled probe',
+            });
+          }
+
+          newItems.push({
+            id: 'cmd:switch-theme',
+            label: 'Switch Theme',
+            icon: 'sparkles',
+            action: () => {
+              const next = this.theme.cycleToNext();
+              this.toast.info(`Theme: ${next.name}`);
+            },
+            section: 'commands',
+            searchText: 'switch theme',
+          });
+
+          newItems.push({
+            id: 'cmd:logout',
+            label: 'Logout',
+            icon: 'close',
+            action: () => this.auth.logout(),
+            section: 'commands',
+            searchText: 'logout',
+          });
+
           const navRoutes = isScoped
-            ? ALL_NAV_ROUTES.filter(r => isAllowedForScoped(r.route))
+            ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
             : ALL_NAV_ROUTES;
 
           for (const r of navRoutes) {

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -5,7 +5,7 @@ import { ensureClientUser, Prisma } from '@bronco/db';
 import { TicketStatus, TicketCategory, TicketEventType, Priority, TicketSource, TaskType, isClosedStatus, AnalysisStatus, SufficiencyStatus, LogLevel } from '@bronco/shared-types';
 import { getSelfAnalysisConfig } from '@bronco/shared-utils';
 import type { TicketCreatedJob, IngestionJob } from '@bronco/shared-types';
-import { resolveClientScope, getOperatorClientIds } from '../plugins/client-scope.js';
+import { resolveClientScope, getOperatorClientIds, scopeToWhere } from '../plugins/client-scope.js';
 
 interface TicketRouteOpts {
   logSummarizeQueue?: Queue;
@@ -139,6 +139,96 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         take,
         skip,
       });
+    },
+  );
+
+  // GET /api/search/tickets — lightweight full-text search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/tickets',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      const clientWhere = scopeToWhere(scope);
+      const ticketNumberMatch = /^\d+$/.test(rawQ) ? Number(rawQ) : null;
+
+      const selectShape = {
+        id: true,
+        ticketNumber: true,
+        subject: true,
+        status: true,
+        priority: true,
+        clientId: true,
+        createdAt: true,
+        client: { select: { name: true, shortCode: true } },
+      } as const;
+
+      // For numeric queries, fetch the exact ticketNumber match separately so
+      // it's guaranteed to appear in the result — otherwise a broad subject
+      // match could fill the `take` limit and push the exact match out of the
+      // DB slice before the in-memory ranker sees it.
+      const exactPromise = ticketNumberMatch !== null
+        ? fastify.db.ticket.findFirst({
+            where: { ...clientWhere, ticketNumber: ticketNumberMatch },
+            select: selectShape,
+          })
+        : Promise.resolve(null);
+
+      const broadPromise = fastify.db.ticket.findMany({
+        where: {
+          ...clientWhere,
+          OR: [
+            { subject: { contains: rawQ, mode: 'insensitive' as const } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' as const } } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: selectShape,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+      });
+
+      const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
+
+      // Merge + dedupe by id (exact match may also appear in the broad set
+      // via subject contains, e.g. `q="42"` and a ticket with subject "42 bug").
+      const byId = new Map<string, typeof broad[number]>();
+      if (exact) byId.set(exact.id, exact);
+      for (const row of broad) byId.set(row.id, row);
+      const merged = Array.from(byId.values());
+
+      const qLower = rawQ.toLowerCase();
+      merged.sort((a, b) => {
+        const aExact = ticketNumberMatch !== null && a.ticketNumber === ticketNumberMatch ? 0 : 1;
+        const bExact = ticketNumberMatch !== null && b.ticketNumber === ticketNumberMatch ? 0 : 1;
+        if (aExact !== bExact) return aExact - bExact;
+        const aStarts = a.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      });
+
+      return merged.slice(0, limit).map(t => ({
+        id: t.id,
+        ticketNumber: t.ticketNumber,
+        subject: t.subject,
+        status: t.status,
+        priority: t.priority,
+        clientId: t.clientId,
+        clientName: t.client.name,
+        clientShortCode: t.client.shortCode,
+      }));
     },
   );
 


### PR DESCRIPTION
## Summary

Phase B of the command palette initiative (#260). Closes #266. Builds on Phase A (#262).

Adds server-side ticket search + a commands section for common mutating actions (Create X / Switch Theme / Logout), completing the palette's scope per the initiative plan.

- **Backend** — `GET /api/search/tickets?q=&limit=` in `copilot-api/src/routes/tickets.ts`. Prisma query across `ticketNumber`, `subject`, `client.shortCode`, `client.name`. Scoped-ops filtering via `scopeToWhere` (mirrors the existing ticket list pattern). Post-sorted in JS: exact ticket-number match → subject starts-with → recent `createdAt` desc.
- **MCP** — `search_tickets` tool in `mcp-servers/platform/src/tools/tickets.ts` mirrors the REST contract (same query shape, same result projection). MCP is trusted service so no scope filter.
- **Frontend — tickets section** — new `ticketItems` signal in `CommandPaletteComponent`, driven by a 200ms debounced `Subject<string>` (min 2 chars). Per-section spinner while in-flight. Empty query shows the other sections normally; tickets only appear once the user types. `TicketService.searchTickets(q, limit)` + `TicketSearchResult` interface added.
- **Frontend — commands section** — `PaletteItem.action?: () => void` field; `activate()` dispatches action or route. Commands: Create Ticket / Create Client / Create Scheduled Probe (all hidden for scoped-ops) / Switch Theme / Logout. `ThemeService.cycleToNext()` cycles the theme list and fires a toast with the new name.
- **Create-dialog deep-link** — `ticket-list`, `client-list`, `probe-list` each subscribe to `queryParamMap` and call `handleCreateQueryParam('create')` to auto-open the create dialog on `?create=1`. Mirrors Phase A's `?edit=<id>` pattern in user-list. Consumes the param after opening so palette re-entrancy works.

Keyboard nav updated to use `filteredSections().flatMap()` so ticket items are addressable alongside the pre-loaded sections.

Targets `search-palette/staging`. Verified `pnpm typecheck` across control-panel, copilot-api, and mcp-platform; `pnpm build` green on control-panel.

## Test plan

**Backend (copilot-api):**
- [ ] `GET /api/search/tickets?q=<word>&limit=5` returns matching tickets as the auth'd user's scope permits
- [ ] `q=<number>` promotes the exact `ticketNumber` match to position 0
- [ ] `q=` (missing / empty) → 400 Bad Request
- [ ] `limit=99` → 400 Bad Request
- [ ] Scoped-ops user sees only their client's tickets

**MCP:**
- [ ] `curl http://localhost:3110/mcp/tools | jq '.tools[] | select(.name == "search_tickets")'` shows the tool schema

**Frontend (dev server or Hugo):**
- [ ] ⌘K → type a ticket subject word → tickets section appears grouped, with a spinner while loading
- [ ] Type fast, clear, retype → no rapid-fire calls (debounce)
- [ ] Empty query → clients/probes/users/people/commands/navigate visible; tickets section absent
- [ ] Commands section shows Create Ticket / Create Client / Create Scheduled Probe / Switch Theme / Logout
- [ ] Select Create Ticket → `/tickets?create=1` → create dialog opens, query param cleared
- [ ] Switch Theme → theme changes, toast shows new theme name
- [ ] Logout → signed out, redirected to `/login`
- [ ] Scoped-ops user: Create Ticket / Create Client / Create Scheduled Probe hidden; Switch Theme + Logout visible

**Regression check (Phase A didn't break):**
- [ ] User edit via palette still works on first click (no two-click bug)
- [ ] Client swap via palette still re-renders tab data (no stale systems/people/etc.)
- [ ] User dialog still re-syncs when switching users via palette while open
