### PR TITLE
feat: command palette — ship initiative (closes #260)

### DIFF
--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -27,17 +27,22 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
         client: { select: { name: true, shortCode: true } },
       } as const;
 
-      // For numeric queries, fetch the exact ticketNumber match separately so
-      // it's guaranteed to appear in the result — otherwise a broad subject
-      // match could fill the `take` limit and push the exact match out of the
-      // DB slice before the in-memory ranker sees it. Mirrors the REST handler
-      // in services/copilot-api/src/routes/tickets.ts.
-      const exactPromise = ticketNumberMatch !== null
-        ? db.ticket.findFirst({
-            where: { ticketNumber: ticketNumberMatch },
-            select: selectShape,
-          })
-        : Promise.resolve(null);
+      // For numeric queries, fetch exact ticketNumber matches separately so
+      // they're guaranteed to appear regardless of how many broad matches
+      // exist — otherwise the broad query's `take: limit` could push them
+      // out before the in-memory ranker sees them.
+      //
+      // ticketNumber is unique per-client (@@unique([clientId, ticketNumber]))
+      // so a numeric query may match one ticket per client. findMany returns
+      // all of them; the MCP platform tool is trusted and unscoped. Mirrors
+      // the REST handler in services/copilot-api/src/routes/tickets.ts.
+      const exactPromise: Promise<Array<Prisma.TicketGetPayload<{ select: typeof selectShape }>>> =
+        ticketNumberMatch !== null
+          ? db.ticket.findMany({
+              where: { ticketNumber: ticketNumberMatch },
+              select: selectShape,
+            })
+          : Promise.resolve([]);
 
       const broadPromise = db.ticket.findMany({
         where: {
@@ -55,7 +60,7 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
       const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
 
       const byId = new Map<string, typeof broad[number]>();
-      if (exact) byId.set(exact.id, exact);
+      for (const row of exact) byId.set(row.id, row);
       for (const row of broad) byId.set(row.id, row);
       const merged = Array.from(byId.values());
 

--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -5,6 +5,86 @@ import type { ServerDeps } from '../server.js';
 
 export function registerTicketTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_tickets',
+    'Search tickets by query across ticket number, subject, client name, and client short code. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(1).describe('Search query (ticket number, subject, client name, or short code)'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const ticketNumberMatch = /^\d+$/.test(q) ? Number(q) : null;
+      const qLower = q.toLowerCase();
+
+      const selectShape = {
+        id: true,
+        ticketNumber: true,
+        subject: true,
+        status: true,
+        priority: true,
+        clientId: true,
+        createdAt: true,
+        client: { select: { name: true, shortCode: true } },
+      } as const;
+
+      // For numeric queries, fetch the exact ticketNumber match separately so
+      // it's guaranteed to appear in the result — otherwise a broad subject
+      // match could fill the `take` limit and push the exact match out of the
+      // DB slice before the in-memory ranker sees it. Mirrors the REST handler
+      // in services/copilot-api/src/routes/tickets.ts.
+      const exactPromise = ticketNumberMatch !== null
+        ? db.ticket.findFirst({
+            where: { ticketNumber: ticketNumberMatch },
+            select: selectShape,
+          })
+        : Promise.resolve(null);
+
+      const broadPromise = db.ticket.findMany({
+        where: {
+          OR: [
+            { subject: { contains: q, mode: 'insensitive' as const } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: selectShape,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+      });
+
+      const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
+
+      const byId = new Map<string, typeof broad[number]>();
+      if (exact) byId.set(exact.id, exact);
+      for (const row of broad) byId.set(row.id, row);
+      const merged = Array.from(byId.values());
+
+      merged.sort((a, b) => {
+        const aExact = ticketNumberMatch !== null && a.ticketNumber === ticketNumberMatch ? 0 : 1;
+        const bExact = ticketNumberMatch !== null && b.ticketNumber === ticketNumberMatch ? 0 : 1;
+        if (aExact !== bExact) return aExact - bExact;
+        const aStarts = a.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      });
+
+      const result = merged.slice(0, limit).map(t => ({
+        id: t.id,
+        ticketNumber: t.ticketNumber,
+        subject: t.subject,
+        status: t.status,
+        priority: t.priority,
+        clientId: t.clientId,
+        clientName: t.client.name,
+        clientShortCode: t.client.shortCode,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_tickets',
     'List tickets with optional filters. Returns summary array with id, ticketNumber, subject, status, priority, category, client name, createdAt, and analysisStatus.',
     {

--- a/services/control-panel/src/app/app.component.ts
+++ b/services/control-panel/src/app/app.component.ts
@@ -2,17 +2,25 @@ import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AppShellComponent } from './shell/app-shell.component.js';
 import { AuthService } from './core/services/auth.service.js';
+import { ToastContainerComponent } from './shared/components/toast-container.component.js';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, AppShellComponent],
+  imports: [RouterOutlet, AppShellComponent, ToastContainerComponent],
   template: `
     @if (authService.currentUser()) {
       <app-shell />
     } @else {
       <router-outlet />
     }
+    <!--
+      Toast container lives at the app root so it renders for both the
+      shell (authenticated) and the bare router-outlet (login, etc.).
+      Previously it was inside AppShellComponent only — login failures
+      fired toasts into the void.
+    -->
+    <app-toast-container />
   `,
 })
 export class AppComponent {

--- a/services/control-panel/src/app/core/guards/scoped-ops-allowlist.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops-allowlist.ts
@@ -1,0 +1,32 @@
+/**
+ * Single source of truth for which routes a scoped ops user is allowed to see.
+ *
+ * Consumed by:
+ * - `scopedOpsGuard` — blocks direct navigation to disallowed routes
+ * - `CommandPaletteComponent` — filters the Navigate section
+ *
+ * Keep the list and the matcher here so both consumers stay in sync when
+ * routes are added or removed.
+ */
+
+export const SCOPED_ALLOWED_PREFIXES = [
+  '/dashboard',   // dashboard is rewritten to client detail in the default redirect
+  '/tickets',     // list + detail
+  '/profile',
+  '/login',
+];
+
+/**
+ * True if `url` is a route a scoped ops user is allowed to access.
+ *
+ * - Any `/clients/:id` route is allowed (own client only — the data layer
+ *   scopes the response). `/clients` list itself is NOT allowed.
+ * - Any route under a prefix in `SCOPED_ALLOWED_PREFIXES` is allowed.
+ */
+export function isScopedOpsAllowedPath(url: string): boolean {
+  if (url === '/clients' || url.startsWith('/clients?')) return false;
+  if (url.startsWith('/clients/')) return true;
+  return SCOPED_ALLOWED_PREFIXES.some(
+    prefix => url === prefix || url.startsWith(`${prefix}/`) || url.startsWith(`${prefix}?`),
+  );
+}

--- a/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
+++ b/services/control-panel/src/app/core/guards/scoped-ops.guard.ts
@@ -1,26 +1,14 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { AuthService } from '../services/auth.service.js';
+import { isScopedOpsAllowedPath } from './scoped-ops-allowlist.js';
 
 /**
- * Routes a scoped ops user (client-side Person with hasOpsAccess) is allowed
- * to visit directly. Anything else is redirected to their own client detail
- * page. This guard is a no-op for operators.
+ * Blocks scoped ops users (portal users with ops access) from reaching routes
+ * outside their permitted surface. The allowed route list lives in
+ * `scoped-ops-allowlist.ts` so the command palette can share the same source
+ * of truth. No-op for operators.
  */
-const SCOPED_ALLOWED_PREFIXES = [
-  '/dashboard',   // dashboard is rewritten to client detail in the default redirect
-  '/tickets',     // list + detail
-  '/profile',
-  '/login',
-];
-
-function isAllowedPath(url: string): boolean {
-  // /clients/:id is allowed, but /clients (the list) is not
-  if (url === '/clients' || url.startsWith('/clients?')) return false;
-  if (url.startsWith('/clients/')) return true;
-  return SCOPED_ALLOWED_PREFIXES.some(prefix => url === prefix || url.startsWith(`${prefix}/`) || url.startsWith(`${prefix}?`));
-}
-
 export const scopedOpsGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
   const router = inject(Router);
@@ -34,7 +22,7 @@ export const scopedOpsGuard: CanActivateFn = (_route, state) => {
   const clientId = user.clientId;
   const fallback = clientId ? router.parseUrl(`/clients/${clientId}`) : router.parseUrl('/profile');
 
-  if (isAllowedPath(state.url)) {
+  if (isScopedOpsAllowedPath(state.url)) {
     return true;
   }
   return fallback;

--- a/services/control-panel/src/app/core/services/command-palette.service.ts
+++ b/services/control-panel/src/app/core/services/command-palette.service.ts
@@ -1,0 +1,8 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CommandPaletteService {
+  readonly isOpen = signal(false);
+  open(): void { this.isOpen.set(true); }
+  close(): void { this.isOpen.set(false); }
+}

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -59,6 +59,14 @@ export class ThemeService {
     this.applyTheme();
   }
 
+  cycleToNext(): ThemeOption {
+    const current = this._currentTheme();
+    const idx = THEMES.findIndex(t => t.id === current.id);
+    const next = THEMES[(idx + 1) % THEMES.length];
+    this.setTheme(next.id);
+    return next;
+  }
+
   setTheme(id: string): void {
     const theme = THEMES.find(t => t.id === id);
     if (!theme) return;

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -264,9 +264,24 @@ export class TicketService {
     return this.api.get<TicketArtifact[]>(`/tickets/${ticketId}/artifacts`);
   }
 
+  searchTickets(q: string, limit = 20): Observable<TicketSearchResult[]> {
+    return this.api.get<TicketSearchResult[]>('/search/tickets', { q, limit });
+  }
+
   getArtifactDownloadUrl(artifactId: string): string {
     return `/api/artifacts/${artifactId}/download`;
   }
+}
+
+export interface TicketSearchResult {
+  id: string;
+  ticketNumber: number | null;
+  subject: string;
+  status: string;
+  priority: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
 }
 
 export interface AiHelpResponse {

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -128,17 +128,14 @@ export class ClientDetailComponent implements OnInit {
     // would otherwise display the previous client's systems/people/repos/etc.
     // The brief "Loading…" flash is acceptable and makes the switch legible.
     //
-    // With `withComponentInputBinding()` in app.config.ts, the router binds
-    // `id` before this effect's first run. The try/catch is a defensive guard
-    // against the documented edge case where a required input is read before
-    // binding — extremely unlikely for a routed loadComponent but zero-cost.
+    // `withComponentInputBinding()` in app.config.ts guarantees `id` is bound
+    // before this constructor effect's first run, so reading `this.id()`
+    // directly is safe. Any throw here is a genuine bug we want to surface,
+    // not swallow — reading through a try/catch would also prevent the
+    // effect from tracking the signal dependency, so the effect would never
+    // re-run on subsequent route changes.
     effect(() => {
-      let cid: string;
-      try {
-        cid = this.id();
-      } catch {
-        return;
-      }
+      const cid = this.id();
       if (!cid) return;
       untracked(() => {
         this.client.set(null);

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -1,5 +1,6 @@
-import { Component, DestroyRef, inject, OnInit, signal, input } from '@angular/core';
+import { Component, DestroyRef, effect, inject, OnInit, signal, input, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component.js';
@@ -115,6 +116,34 @@ export class ClientDetailComponent implements OnInit {
   client = signal<Client | null>(null);
   selectedTab = signal(0);
 
+  constructor() {
+    // Re-fetch whenever the :id route param changes. Without this, navigating
+    // from /clients/A to /clients/B via the command palette (or any intra-
+    // component router navigation) reuses the component instance and the
+    // displayed client stays stale.
+    //
+    // Clearing client() to null first tears down the whole tab subtree via
+    // the `@if (client(); as c)` guard in the template. When the new client
+    // resolves, every tab component is reconstructed with the new clientId
+    // input — fixes the 9 tabs that only fetch their data in ngOnInit and
+    // would otherwise display the previous client's systems/people/repos/etc.
+    // The brief "Loading…" flash is acceptable and makes the switch legible.
+    effect((onCleanup) => {
+      const cid = this.id();
+      if (!cid) return;
+      let sub: Subscription | null = null;
+      untracked(() => {
+        this.client.set(null);
+        sub = this.clientService.getClient(cid).subscribe(c => {
+          // Guard against stale responses: only apply if this is still the
+          // active client id when the request resolves.
+          if (this.id() === cid) this.client.set(c);
+        });
+      });
+      onCleanup(() => sub?.unsubscribe());
+    });
+  }
+
   ngOnInit(): void {
     const tabParam = this.route.snapshot.queryParamMap.get('tab');
     if (tabParam !== null) {
@@ -129,7 +158,6 @@ export class ClientDetailComponent implements OnInit {
         }
       }
     }
-    this.load();
   }
 
   onTabChange(index: number): void {
@@ -138,8 +166,7 @@ export class ClientDetailComponent implements OnInit {
     this.router.navigate([], { queryParams: { tab: slug }, queryParamsHandling: 'merge', replaceUrl: true });
   }
 
-  load(): void {
-    const cid = this.id();
+  load(cid: string = this.id()): void {
     this.clientService.getClient(cid).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(c => this.client.set(c));
   }
 

--- a/services/control-panel/src/app/features/clients/client-detail.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, effect, inject, OnInit, signal, input, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TabGroupComponent, TabComponent } from '../../shared/components/index.js';
 import { ClientHeaderComponent } from './client-detail/client-header.component.js';
@@ -128,19 +127,23 @@ export class ClientDetailComponent implements OnInit {
     // input — fixes the 9 tabs that only fetch their data in ngOnInit and
     // would otherwise display the previous client's systems/people/repos/etc.
     // The brief "Loading…" flash is acceptable and makes the switch legible.
-    effect((onCleanup) => {
-      const cid = this.id();
+    //
+    // With `withComponentInputBinding()` in app.config.ts, the router binds
+    // `id` before this effect's first run. The try/catch is a defensive guard
+    // against the documented edge case where a required input is read before
+    // binding — extremely unlikely for a routed loadComponent but zero-cost.
+    effect(() => {
+      let cid: string;
+      try {
+        cid = this.id();
+      } catch {
+        return;
+      }
       if (!cid) return;
-      let sub: Subscription | null = null;
       untracked(() => {
         this.client.set(null);
-        sub = this.clientService.getClient(cid).subscribe(c => {
-          // Guard against stale responses: only apply if this is still the
-          // active client id when the request resolves.
-          if (this.id() === cid) this.client.set(c);
-        });
+        this.load(cid);
       });
-      onCleanup(() => sub?.unsubscribe());
     });
   }
 

--- a/services/control-panel/src/app/features/clients/client-list.component.ts
+++ b/services/control-panel/src/app/features/clients/client-list.component.ts
@@ -1,4 +1,6 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ClientService, Client } from '../../core/services/client.service.js';
 import { ClientDialogComponent } from './client-dialog.component.js';
 import { DetailPanelService } from '../../core/services/detail-panel.service.js';
@@ -76,6 +78,9 @@ import { DataTableComponent, DataTableColumnComponent, BroncoButtonComponent, Di
 export class ClientListComponent implements OnInit {
   private clientService = inject(ClientService);
   private detailPanel = inject(DetailPanelService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   clients = signal<Client[]>([]);
   showClientDialog = signal(false);
@@ -83,6 +88,20 @@ export class ClientListComponent implements OnInit {
 
   ngOnInit(): void {
     this.load();
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.showClientDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   load(): void {

--- a/services/control-panel/src/app/features/login/login.component.ts
+++ b/services/control-panel/src/app/features/login/login.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { AuthService } from '../../core/services/auth.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
 import {
@@ -108,11 +109,34 @@ export class LoginComponent {
 
     this.loading.set(true);
     this.authService.login(this.email, this.password).subscribe({
-      error: (err) => {
+      error: (err: HttpErrorResponse) => {
         this.loading.set(false);
-        const message = err.error?.error ?? 'Login failed';
-        this.toast.error(message);
+        this.toast.error(describeLoginError(err));
       },
     });
   }
+}
+
+/**
+ * Produce a user-facing message from an auth-login HTTP error. Covers four
+ * common shapes so the operator isn't left squinting at a generic "Login
+ * failed" toast while the real cause hides in DevTools.
+ */
+function describeLoginError(err: HttpErrorResponse): string {
+  // status 0 = browser couldn't reach the server (CORS, DNS, offline, proxy
+  // refused the upstream). Message the network layer, not the app.
+  if (err.status === 0) {
+    return 'Cannot reach the server. Check your connection or that the API is running.';
+  }
+  // Body-provided error from copilot-api (e.g., { error: 'Invalid credentials' }).
+  const bodyMessage = typeof err.error === 'object' && err.error !== null
+    ? (err.error as { error?: string; message?: string }).error
+      ?? (err.error as { error?: string; message?: string }).message
+    : typeof err.error === 'string' ? err.error : undefined;
+  if (bodyMessage) return bodyMessage;
+  // Generic status-based fallbacks.
+  if (err.status === 401) return 'Invalid email or password.';
+  if (err.status === 403) return 'Account is inactive or does not have control panel access.';
+  if (err.status >= 500) return `Server error (${err.status}). Try again in a moment.`;
+  return err.message ?? 'Login failed.';
 }

--- a/services/control-panel/src/app/features/profile/profile.component.ts
+++ b/services/control-panel/src/app/features/profile/profile.component.ts
@@ -77,40 +77,42 @@ import { ToastService } from '../../core/services/toast.service.js';
 
         <app-card>
           <h2 class="section-title">Change Password</h2>
-          <form class="form-grid" (ngSubmit)="changePassword()" autocomplete="on">
-            <input
-              type="text"
-              name="username"
-              autocomplete="username"
-              [value]="user.email"
-              readonly
-              tabindex="-1"
-              aria-hidden="true"
-              class="pw-username-hint" />
-            <app-form-field label="Current Password">
+          <form (ngSubmit)="changePassword()" autocomplete="on">
+            <div class="form-grid">
               <input
-                class="text-input"
-                type="password"
-                name="currentPassword"
-                autocomplete="current-password"
-                [(ngModel)]="currentPassword" />
-            </app-form-field>
-            <app-form-field label="New Password">
-              <input
-                class="text-input"
-                type="password"
-                name="newPassword"
-                autocomplete="new-password"
-                [(ngModel)]="newPassword" />
-            </app-form-field>
-            <app-form-field label="Confirm New Password">
-              <input
-                class="text-input"
-                type="password"
-                name="confirmPassword"
-                autocomplete="new-password"
-                [(ngModel)]="confirmPassword" />
-            </app-form-field>
+                type="text"
+                name="username"
+                autocomplete="username"
+                [value]="user.email"
+                readonly
+                tabindex="-1"
+                aria-hidden="true"
+                class="pw-username-hint" />
+              <app-form-field label="Current Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="currentPassword"
+                  autocomplete="current-password"
+                  [(ngModel)]="currentPassword" />
+              </app-form-field>
+              <app-form-field label="New Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="newPassword"
+                  autocomplete="new-password"
+                  [(ngModel)]="newPassword" />
+              </app-form-field>
+              <app-form-field label="Confirm New Password">
+                <input
+                  class="text-input"
+                  type="password"
+                  name="confirmPassword"
+                  autocomplete="new-password"
+                  [(ngModel)]="confirmPassword" />
+              </app-form-field>
+            </div>
             <div class="card-actions">
               <app-bronco-button type="submit" variant="destructive" [disabled]="passwordSaving">
                 Change Password
@@ -221,8 +223,10 @@ import { ToastService } from '../../core/services/toast.service.js';
     }
 
     /* Hidden-but-discoverable username input so Safari/1Password can
-       correlate the password change to the saved credential. Keeping the
-       element in layout (not display:none) is what makes autofill see it. */
+       correlate the password change to the saved credential. The element
+       must stay in the DOM — display:none / visibility:hidden would make
+       autofill skip it. Absolute positioning + 1px/opacity:0 keeps it
+       parseable by autofill while visually invisible. */
     .pw-username-hint {
       position: absolute;
       width: 1px;

--- a/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-list.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgClass } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import {
   DataTableComponent,
   DataTableColumnComponent,
@@ -190,6 +191,9 @@ export class ProbeListComponent implements OnInit {
   private toast = inject(ToastService);
   private detailPanel = inject(DetailPanelService);
   readonly viewport = inject(ViewportService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   showProbeDialog = signal(false);
   editingProbe = signal<ScheduledProbe | null>(null);
@@ -219,6 +223,21 @@ export class ProbeListComponent implements OnInit {
       for (const t of tools) this.builtinToolNames.add(t.name);
     });
     this.loadProbes();
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.editingProbe.set(null);
+    this.showProbeDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   loadProbes(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { TicketService, Ticket, ACTIVE_STATUS_FILTER } from '../../core/services/ticket.service.js';
 import { ClientService, Client } from '../../core/services/client.service.js';
@@ -421,6 +422,7 @@ export class TicketListComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
 
   tickets = signal<Ticket[]>([]);
   presets = signal<TicketFilterPreset[]>([]);
@@ -498,6 +500,11 @@ export class TicketListComponent implements OnInit {
   ngOnInit(): void {
     this.clientIdFilter.set(this.route.snapshot.queryParams['clientId'] ?? '');
     this.clientService.getClients().subscribe(clients => this.clients.set(clients));
+    // Subscribe to queryParamMap so subsequent palette activations fire while
+    // already on /tickets.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleCreateQueryParam(params.get('create')));
     this.loadPresets({
       next: () => {
         const defaultPreset = this.presets().find(p => p.isDefault);
@@ -614,6 +621,17 @@ export class TicketListComponent implements OnInit {
   isSelectedPresetDefault(): boolean {
     const selected = this.presets().find(p => p.id === this.selectedPresetId());
     return selected?.isDefault ?? false;
+  }
+
+  private handleCreateQueryParam(create: string | null): void {
+    if (!create) return;
+    this.showCreateDialog.set(true);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { create: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   onTicketCreated(result: { id: string }): void {

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, output, OnInit } from '@angular/core';
+import { Component, effect, inject, input, output, untracked } from '@angular/core';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
@@ -48,7 +48,7 @@ import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchCo
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
   `],
 })
-export class UserDialogComponent implements OnInit {
+export class UserDialogComponent {
   private userService = inject(UserService);
   private toast = inject(ToastService);
 
@@ -70,16 +70,34 @@ export class UserDialogComponent implements OnInit {
     { value: 'OPERATOR', label: 'Operator' },
   ];
 
-  ngOnInit(): void {
-    const u = this.user();
-    if (u) {
-      this.name = u.name;
-      this.email = u.email;
-      this.role = u.role;
-      this.slackUserId = u.slackUserId ?? '';
-      this.isActive = u.isActive;
-      this.isSelf = u.id === this.currentUserId();
-    }
+  constructor() {
+    // Re-sync form fields whenever the `user` input changes — e.g. when the
+    // operator picks a different user via the command palette while the
+    // dialog is already open. ngOnInit only ran once and left stale values
+    // in the form for subsequent swaps.
+    effect(() => {
+      const u = this.user();
+      const currentId = this.currentUserId();
+      untracked(() => {
+        if (u) {
+          this.name = u.name;
+          this.email = u.email;
+          this.role = u.role;
+          this.slackUserId = u.slackUserId ?? '';
+          this.isActive = u.isActive;
+          this.isSelf = u.id === currentId;
+          this.password = ''; // never carry a typed-but-unsaved password across user swaps
+        } else {
+          this.name = '';
+          this.email = '';
+          this.role = 'OPERATOR';
+          this.slackUserId = '';
+          this.isActive = true;
+          this.isSelf = false;
+          this.password = '';
+        }
+      });
+    });
   }
 
   save(): void {

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -1,4 +1,6 @@
-import { Component, inject, signal, OnInit, ViewChild } from '@angular/core';
+import { Component, DestroyRef, inject, signal, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
@@ -298,6 +300,9 @@ export class UserListComponent implements OnInit {
   private userService = inject(UserService);
   private authService = inject(AuthService);
   private toast = inject(ToastService);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
   readonly viewport = inject(ViewportService);
 
   @ViewChild('menu') private menu?: DropdownMenuComponent;
@@ -317,6 +322,11 @@ export class UserListComponent implements OnInit {
 
   ngOnInit(): void {
     this.load();
+    // Subscribe to queryParamMap so subsequent palette activations fire while
+    // already on /users. The snapshot alone only catches the first-load case.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => this.handleEditQueryParam(params.get('edit')));
   }
 
   load(): void {
@@ -325,11 +335,29 @@ export class UserListComponent implements OnInit {
       next: (users) => {
         this.users.set(users);
         this.loading.set(false);
+        // Re-evaluate after users arrive (queryParamMap may have fired
+        // before the fetch completed).
+        this.handleEditQueryParam(this.route.snapshot.queryParamMap.get('edit'));
       },
       error: (err) => {
         this.loading.set(false);
         this.toast.error(err.error?.message ?? err.error?.error ?? 'Failed to load users');
       },
+    });
+  }
+
+  private handleEditQueryParam(editId: string | null): void {
+    if (!editId) return;
+    const target = this.users().find(u => u.id === editId);
+    if (!target) return; // Users not loaded yet, or no match — no-op.
+    this.openEdit(target);
+    // Consume the param so back/forward doesn't re-open and a subsequent
+    // palette pick with the same id still fires a new queryParamMap event.
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { edit: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
     });
   }
 

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -1,0 +1,487 @@
+import {
+  Component,
+  computed,
+  DestroyRef,
+  effect,
+  ElementRef,
+  inject,
+  signal,
+  untracked,
+  viewChild,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { forkJoin, of, Subject } from 'rxjs';
+import { catchError, map, takeUntil } from 'rxjs/operators';
+import { DialogComponent } from './dialog.component.js';
+import { IconComponent } from './icon.component.js';
+import type { IconName } from './icon-registry.js';
+import { CommandPaletteService } from '../../core/services/command-palette.service.js';
+import { AuthService } from '../../core/services/auth.service.js';
+import { ClientService, type Client } from '../../core/services/client.service.js';
+import { ScheduledProbeService, type ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
+import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
+import { PersonService, type Person } from '../../core/services/person.service.js';
+
+interface PaletteItem {
+  id: string;
+  label: string;
+  secondary?: string;
+  icon: IconName;
+  route: readonly string[];
+  /** Optional query params applied when the item is activated. */
+  queryParams?: Record<string, string>;
+  section: PaletteSection;
+  searchText: string;
+}
+
+type PaletteSection = 'clients' | 'probes' | 'users' | 'people' | 'navigate';
+
+interface SectionGroup {
+  section: PaletteSection;
+  items: PaletteItem[];
+}
+
+const SECTION_ORDER: PaletteSection[] = ['clients', 'probes', 'users', 'people', 'navigate'];
+
+const SECTION_LABELS: Record<PaletteSection, string> = {
+  clients: 'Clients',
+  probes: 'Scheduled Probes',
+  users: 'Users',
+  people: 'People',
+  navigate: 'Navigate',
+};
+
+interface NavRoute {
+  label: string;
+  route: string;
+  icon: IconName;
+}
+
+const ALL_NAV_ROUTES: NavRoute[] = [
+  { label: 'Dashboard', route: '/dashboard', icon: 'home' },
+  { label: 'Tickets', route: '/tickets', icon: 'ticket' },
+  { label: 'Activity Feed', route: '/activity', icon: 'bell' },
+  { label: 'Clients', route: '/clients', icon: 'building' },
+  { label: 'Scheduled Probes', route: '/scheduled-probes', icon: 'clock' },
+  { label: 'Ingestion Jobs', route: '/ingestion-jobs', icon: 'play' },
+  { label: 'Failed Jobs', route: '/failed-jobs', icon: 'warning' },
+  { label: 'Logs', route: '/logs', icon: 'file' },
+  { label: 'Email Log', route: '/email-logs', icon: 'email' },
+  { label: 'AI Prompts', route: '/prompts', icon: 'sparkles' },
+  { label: 'AI Providers', route: '/ai-providers', icon: 'robot' },
+  { label: 'AI Usage', route: '/ai-usage', icon: 'bolt' },
+  { label: 'Ticket Routes', route: '/ticket-routes', icon: 'tag' },
+  { label: 'System Analysis', route: '/system-analysis', icon: 'search' },
+  { label: 'System Issues', route: '/system-issues', icon: 'warning' },
+  { label: 'Slack Conversations', route: '/slack-conversations', icon: 'comment' },
+  { label: 'Release Notes', route: '/release-notes', icon: 'book' },
+  { label: 'System Status', route: '/system-status', icon: 'server' },
+  { label: 'Settings', route: '/settings', icon: 'gear' },
+  { label: 'User Maintenance', route: '/users', icon: 'user' },
+  { label: 'Profile', route: '/profile', icon: 'user' },
+  { label: 'Notifications', route: '/notification-preferences', icon: 'bell' },
+];
+
+const SCOPED_ALLOWED_PREFIXES = ['/dashboard', '/tickets', '/profile', '/login'];
+
+function isAllowedForScoped(url: string): boolean {
+  if (url === '/clients' || url.startsWith('/clients?')) return false;
+  if (url.startsWith('/clients/')) return true;
+  return SCOPED_ALLOWED_PREFIXES.some(
+    p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`),
+  );
+}
+
+@Component({
+  selector: 'app-command-palette',
+  standalone: true,
+  imports: [DialogComponent, IconComponent],
+  template: `
+    <app-dialog
+      [open]="paletteService.isOpen()"
+      [maxWidth]="'640px'"
+      (openChange)="onOpenChange($event)">
+      <div class="palette-search-row">
+        <app-icon name="search" size="md" class="search-icon" />
+        <input
+          #searchInput
+          type="text"
+          class="palette-input"
+          placeholder="Search clients, probes, users, people, or navigate…"
+          autocomplete="off"
+          spellcheck="false"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="palette-listbox"
+          [attr.aria-expanded]="filteredSections().length > 0"
+          [attr.aria-activedescendant]="selectedItem() ? 'palette-item-' + selectedItem()!.id : null"
+          [value]="query()"
+          (input)="onQueryInput($event)"
+          (keydown)="onInputKeydown($event)"
+        />
+        @if (loading()) {
+          <app-icon name="spinner" size="sm" class="loading-icon" />
+        }
+      </div>
+
+      @if (filteredSections().length > 0) {
+        <div class="palette-results" id="palette-listbox" role="listbox">
+          @for (group of filteredSections(); track group.section) {
+            <div class="section-header" role="presentation">{{ sectionLabels[group.section] }}</div>
+            @for (item of group.items; track item.id) {
+              <div
+                class="palette-item"
+                role="option"
+                [id]="'palette-item-' + item.id"
+                [attr.aria-selected]="selectedItem() === item"
+                [class.palette-item-selected]="selectedItem() === item"
+                (click)="activate(item)"
+                (mouseenter)="onItemHover(item)">
+                <app-icon [name]="item.icon" size="md" class="item-icon" />
+                <span class="item-label">{{ item.label }}</span>
+                @if (item.secondary) {
+                  <span class="item-secondary">{{ item.secondary }}</span>
+                }
+              </div>
+            }
+          }
+        </div>
+      } @else if (query().trim()) {
+        <div class="palette-empty">No results.</div>
+      } @else if (!loading() && items().length === 0) {
+        <div class="palette-empty">Loading…</div>
+      }
+    </app-dialog>
+  `,
+  styles: [`
+    .palette-search-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border-light);
+      margin-bottom: 4px;
+    }
+    .search-icon {
+      color: var(--text-tertiary);
+      flex-shrink: 0;
+    }
+    .palette-input {
+      flex: 1;
+      background: none;
+      border: none;
+      outline: none;
+      font-family: var(--font-primary);
+      font-size: 16px;
+      color: var(--text-primary);
+      min-width: 0;
+    }
+    .palette-input::placeholder {
+      color: var(--text-tertiary);
+    }
+    .loading-icon {
+      color: var(--text-tertiary);
+      flex-shrink: 0;
+      animation: palette-spin 1s linear infinite;
+    }
+    @keyframes palette-spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+    .palette-results {
+      max-height: 440px;
+      overflow-y: auto;
+    }
+    .section-header {
+      padding: 10px 4px 4px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-tertiary);
+    }
+    .palette-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      transition: background 80ms ease;
+      color: var(--text-secondary);
+    }
+    .palette-item:hover {
+      background: var(--bg-hover);
+    }
+    .palette-item-selected {
+      background: var(--bg-active);
+      color: var(--accent);
+    }
+    .palette-item-selected .item-secondary {
+      color: var(--accent);
+      opacity: 0.75;
+    }
+    .item-icon {
+      flex-shrink: 0;
+      color: currentColor;
+    }
+    .item-label {
+      flex: 1;
+      font-size: 13px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+    .item-secondary {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      flex-shrink: 0;
+    }
+    .palette-empty {
+      padding: 32px 8px;
+      text-align: center;
+      font-size: 13px;
+      color: var(--text-tertiary);
+    }
+  `],
+})
+export class CommandPaletteComponent {
+  readonly paletteService = inject(CommandPaletteService);
+  private readonly auth = inject(AuthService);
+  private readonly clientService = inject(ClientService);
+  private readonly probeService = inject(ScheduledProbeService);
+  private readonly userService = inject(UserService);
+  private readonly personService = inject(PersonService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
+  private readonly cancelLoad$ = new Subject<void>();
+
+  readonly sectionLabels = SECTION_LABELS;
+  readonly query = signal('');
+  readonly items = signal<PaletteItem[]>([]);
+  readonly loading = signal(false);
+  readonly selectedIndex = signal(0);
+
+  readonly filteredItems = computed(() => {
+    const q = this.query().toLowerCase().trim();
+    const all = this.items();
+    if (!q) return all;
+    const filtered = all.filter(it => it.searchText.includes(q));
+    return [...filtered].sort((a, b) => {
+      const sectionDiff = SECTION_ORDER.indexOf(a.section) - SECTION_ORDER.indexOf(b.section);
+      if (sectionDiff !== 0) return sectionDiff;
+      const aStarts = a.label.toLowerCase().startsWith(q) ? 0 : 1;
+      const bStarts = b.label.toLowerCase().startsWith(q) ? 0 : 1;
+      return aStarts - bStarts;
+    });
+  });
+
+  readonly filteredSections = computed<SectionGroup[]>(() => {
+    const itemMap = new Map<PaletteSection, PaletteItem[]>();
+    for (const item of this.filteredItems()) {
+      const bucket = itemMap.get(item.section) ?? [];
+      bucket.push(item);
+      itemMap.set(item.section, bucket);
+    }
+    return SECTION_ORDER
+      .filter(s => itemMap.has(s))
+      .map(s => ({ section: s, items: itemMap.get(s)! }));
+  });
+
+  readonly selectedItem = computed(() => {
+    const idx = this.selectedIndex();
+    const items = this.filteredItems();
+    if (idx < 0 || idx >= items.length) return null;
+    return items[idx];
+  });
+
+  constructor() {
+    // Palette open/close lifecycle: fetch data on open, reset on close.
+    effect((onCleanup) => {
+      if (!this.paletteService.isOpen()) {
+        this.cancelLoad$.next();
+        untracked(() => {
+          this.query.set('');
+          this.items.set([]);
+          this.loading.set(false);
+          this.selectedIndex.set(0);
+        });
+        return;
+      }
+      untracked(() => this.loadItems());
+      // Refocus the search input after Angular renders the dialog content and
+      // after DialogComponent's own queueMicrotask auto-focus (which targets
+      // the close button) has already run.
+      const handle = setTimeout(() => {
+        this.searchInputRef()?.nativeElement.focus();
+      }, 0);
+      onCleanup(() => clearTimeout(handle));
+    });
+
+    // Reset selection to first item whenever the query changes.
+    effect(() => {
+      this.query();
+      untracked(() => this.selectedIndex.set(0));
+    });
+
+    this.destroyRef.onDestroy(() => this.cancelLoad$.complete());
+  }
+
+  onOpenChange(open: boolean): void {
+    if (!open) this.paletteService.close();
+  }
+
+  onQueryInput(e: Event): void {
+    this.query.set((e.target as HTMLInputElement).value);
+  }
+
+  onInputKeydown(e: KeyboardEvent): void {
+    const items = this.filteredItems();
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (items.length === 0) return;
+      const lastIndex = items.length - 1;
+      this.selectedIndex.update(i => Math.max(0, Math.min(i + 1, lastIndex)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (items.length === 0) return;
+      const lastIndex = items.length - 1;
+      this.selectedIndex.update(i => Math.max(0, Math.min(i - 1, lastIndex)));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const item = this.selectedItem();
+      if (item) this.activate(item);
+    }
+  }
+
+  onItemHover(item: PaletteItem): void {
+    const idx = this.filteredItems().indexOf(item);
+    if (idx >= 0) this.selectedIndex.set(idx);
+  }
+
+  activate(item: PaletteItem): void {
+    this.router.navigate([...item.route], item.queryParams ? { queryParams: item.queryParams } : undefined);
+    this.paletteService.close();
+  }
+
+  private loadItems(): void {
+    const user = this.auth.currentUser();
+    const isScoped = user?.isPortalOpsUser === true && !!user.clientId;
+    const clientId = user?.clientId ?? null;
+
+    this.loading.set(true);
+
+    const clients$ = isScoped && clientId
+      ? this.clientService.getClient(clientId).pipe(map(c => [c] as Client[]))
+      : this.clientService.getClients();
+
+    const probes$ = this.probeService.getProbes(
+      isScoped && clientId ? { clientId } : undefined,
+    );
+
+    // Scoped ops users cannot access /users (operator accounts).
+    const users$ = isScoped
+      ? of([] as ControlPanelUser[])
+      : this.userService.getUsers();
+
+    // PersonService.getPeople requires a clientId. For full operators without a
+    // client scope, the people section is omitted. A dedicated all-people search
+    // endpoint would be needed to support it (tracked for Phase B).
+    const people$ = clientId
+      ? this.personService.getPeople(clientId)
+      : of([] as Person[]);
+
+    forkJoin({
+      clients: clients$.pipe(catchError(() => of([] as Client[]))),
+      probes: probes$.pipe(catchError(() => of([] as ScheduledProbe[]))),
+      users: users$.pipe(catchError(() => of([] as ControlPanelUser[]))),
+      people: people$.pipe(catchError(() => of([] as Person[]))),
+    })
+      .pipe(
+        takeUntil(this.cancelLoad$),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: ({ clients, probes, users, people }) => {
+          const newItems: PaletteItem[] = [];
+
+          for (const c of clients) {
+            newItems.push({
+              id: `client:${c.id}`,
+              label: c.name,
+              secondary: c.shortCode,
+              icon: 'building',
+              route: ['/clients', c.id],
+              section: 'clients',
+              searchText: `${c.name} ${c.shortCode}`.toLowerCase(),
+            });
+          }
+
+          for (const p of probes) {
+            newItems.push({
+              id: `probe:${p.id}`,
+              label: p.name,
+              secondary: p.client?.name,
+              icon: 'clock',
+              route: ['/scheduled-probes', p.id, 'runs'],
+              section: 'probes',
+              searchText: `${p.name} ${p.client?.name ?? ''}`.toLowerCase(),
+            });
+          }
+
+          for (const u of users) {
+            newItems.push({
+              id: `user:${u.id}`,
+              label: u.name,
+              // Email disambiguates multiple users with the same display name —
+              // role (ADMIN / OPERATOR) doesn't.
+              secondary: u.email,
+              icon: 'user',
+              route: ['/users'],
+              // user-list reads ?edit=<id> and auto-opens the edit dialog.
+              queryParams: { edit: u.id },
+              section: 'users',
+              searchText: `${u.name} ${u.email} ${u.role}`.toLowerCase(),
+            });
+          }
+
+          for (const p of people) {
+            newItems.push({
+              id: `person:${p.id}`,
+              label: p.name,
+              secondary: p.client?.name,
+              icon: 'user',
+              route: ['/clients', p.clientId],
+              section: 'people',
+              searchText: `${p.name} ${p.email} ${p.client?.name ?? ''}`.toLowerCase(),
+            });
+          }
+
+          const navRoutes = isScoped
+            ? ALL_NAV_ROUTES.filter(r => isAllowedForScoped(r.route))
+            : ALL_NAV_ROUTES;
+
+          for (const r of navRoutes) {
+            newItems.push({
+              id: `nav:${r.route}`,
+              label: `Go to ${r.label}`,
+              icon: r.icon,
+              route: [r.route],
+              section: 'navigate',
+              searchText: `go to ${r.label}`.toLowerCase(),
+            });
+          }
+
+          this.items.set(newItems);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.loading.set(false);
+        },
+      });
+  }
+}

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { forkJoin, of, Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, forkJoin, of, Subject, switchMap } from 'rxjs';
 import { catchError, map, takeUntil } from 'rxjs/operators';
 import { DialogComponent } from './dialog.component.js';
 import { IconComponent } from './icon.component.js';
@@ -22,33 +22,43 @@ import { ClientService, type Client } from '../../core/services/client.service.j
 import { ScheduledProbeService, type ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { PersonService, type Person } from '../../core/services/person.service.js';
+import { TicketService, type TicketSearchResult } from '../../core/services/ticket.service.js';
+import { ThemeService } from '../../core/services/theme.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
+import { isScopedOpsAllowedPath } from '../../core/guards/scoped-ops-allowlist.js';
 
 interface PaletteItem {
   id: string;
   label: string;
   secondary?: string;
   icon: IconName;
-  route: readonly string[];
+  route?: readonly string[];
   /** Optional query params applied when the item is activated. */
   queryParams?: Record<string, string>;
+  /** Callback fired on activation — exclusive with route. */
+  action?: () => void;
   section: PaletteSection;
   searchText: string;
 }
 
-type PaletteSection = 'clients' | 'probes' | 'users' | 'people' | 'navigate';
+type PaletteSection = 'clients' | 'tickets' | 'probes' | 'users' | 'people' | 'commands' | 'navigate';
 
 interface SectionGroup {
   section: PaletteSection;
+  label: string;
   items: PaletteItem[];
+  loading?: boolean;
 }
 
-const SECTION_ORDER: PaletteSection[] = ['clients', 'probes', 'users', 'people', 'navigate'];
+const SECTION_ORDER: PaletteSection[] = ['clients', 'tickets', 'probes', 'users', 'people', 'commands', 'navigate'];
 
 const SECTION_LABELS: Record<PaletteSection, string> = {
   clients: 'Clients',
+  tickets: 'Tickets',
   probes: 'Scheduled Probes',
   users: 'Users',
   people: 'People',
+  commands: 'Commands',
   navigate: 'Navigate',
 };
 
@@ -83,16 +93,6 @@ const ALL_NAV_ROUTES: NavRoute[] = [
   { label: 'Notifications', route: '/notification-preferences', icon: 'bell' },
 ];
 
-const SCOPED_ALLOWED_PREFIXES = ['/dashboard', '/tickets', '/profile', '/login'];
-
-function isAllowedForScoped(url: string): boolean {
-  if (url === '/clients' || url.startsWith('/clients?')) return false;
-  if (url.startsWith('/clients/')) return true;
-  return SCOPED_ALLOWED_PREFIXES.some(
-    p => url === p || url.startsWith(`${p}/`) || url.startsWith(`${p}?`),
-  );
-}
-
 @Component({
   selector: 'app-command-palette',
   standalone: true,
@@ -108,14 +108,14 @@ function isAllowedForScoped(url: string): boolean {
           #searchInput
           type="text"
           class="palette-input"
-          placeholder="Search clients, probes, users, people, or navigate…"
+          placeholder="Search clients, tickets, probes, users, people, or navigate…"
           autocomplete="off"
           spellcheck="false"
           role="combobox"
-          aria-autocomplete="list"
-          aria-controls="palette-listbox"
+          aria-controls="command-palette-listbox"
           [attr.aria-expanded]="filteredSections().length > 0"
-          [attr.aria-activedescendant]="selectedItem() ? 'palette-item-' + selectedItem()!.id : null"
+          aria-autocomplete="list"
+          [attr.aria-activedescendant]="selectedItem() ? itemDomId(selectedItem()!) : null"
           [value]="query()"
           (input)="onQueryInput($event)"
           (keydown)="onInputKeydown($event)"
@@ -126,14 +126,19 @@ function isAllowedForScoped(url: string): boolean {
       </div>
 
       @if (filteredSections().length > 0) {
-        <div class="palette-results" id="palette-listbox" role="listbox">
+        <div class="palette-results" role="listbox" id="command-palette-listbox">
           @for (group of filteredSections(); track group.section) {
-            <div class="section-header" role="presentation">{{ sectionLabels[group.section] }}</div>
+            <div class="section-header" role="presentation">
+              {{ group.label }}
+              @if (group.loading) {
+                <app-icon name="spinner" size="sm" class="section-spinner" />
+              }
+            </div>
             @for (item of group.items; track item.id) {
               <div
                 class="palette-item"
                 role="option"
-                [id]="'palette-item-' + item.id"
+                [id]="itemDomId(item)"
                 [attr.aria-selected]="selectedItem() === item"
                 [class.palette-item-selected]="selectedItem() === item"
                 (click)="activate(item)"
@@ -194,12 +199,19 @@ function isAllowedForScoped(url: string): boolean {
       overflow-y: auto;
     }
     .section-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
       padding: 10px 4px 4px;
       font-size: 11px;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.5px;
       color: var(--text-tertiary);
+    }
+    .section-spinner {
+      color: var(--text-tertiary);
+      animation: palette-spin 1s linear infinite;
     }
     .palette-item {
       display: flex;
@@ -254,16 +266,21 @@ export class CommandPaletteComponent {
   private readonly probeService = inject(ScheduledProbeService);
   private readonly userService = inject(UserService);
   private readonly personService = inject(PersonService);
+  private readonly ticketService = inject(TicketService);
+  private readonly theme = inject(ThemeService);
+  private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
   private readonly cancelLoad$ = new Subject<void>();
+  private readonly ticketSearch$ = new Subject<string>();
 
-  readonly sectionLabels = SECTION_LABELS;
   readonly query = signal('');
   readonly items = signal<PaletteItem[]>([]);
+  readonly ticketItems = signal<PaletteItem[]>([]);
   readonly loading = signal(false);
+  readonly ticketsLoading = signal(false);
   readonly selectedIndex = signal(0);
 
   readonly filteredItems = computed(() => {
@@ -287,16 +304,31 @@ export class CommandPaletteComponent {
       bucket.push(item);
       itemMap.set(item.section, bucket);
     }
+
+    // Ticket items are pre-filtered server-side; merge them separately.
+    const tickets = this.ticketItems();
+    const isTicketsLoading = this.ticketsLoading();
+    if (tickets.length > 0 || isTicketsLoading) {
+      itemMap.set('tickets', tickets);
+    }
+
     return SECTION_ORDER
       .filter(s => itemMap.has(s))
-      .map(s => ({ section: s, items: itemMap.get(s)! }));
+      .map(s => ({
+        section: s,
+        label: SECTION_LABELS[s],
+        items: itemMap.get(s)!,
+        loading: s === 'tickets' && isTicketsLoading,
+      }));
   });
 
   readonly selectedItem = computed(() => {
     const idx = this.selectedIndex();
     const items = this.filteredItems();
-    if (idx < 0 || idx >= items.length) return null;
-    return items[idx];
+    // Flatten all section items for keyboard nav (includes ticket items)
+    const allVisible = this.filteredSections().flatMap(g => g.items);
+    if (idx < 0 || idx >= allVisible.length) return null;
+    return allVisible[idx];
   });
 
   constructor() {
@@ -307,7 +339,9 @@ export class CommandPaletteComponent {
         untracked(() => {
           this.query.set('');
           this.items.set([]);
+          this.ticketItems.set([]);
           this.loading.set(false);
+          this.ticketsLoading.set(false);
           this.selectedIndex.set(0);
         });
         return;
@@ -328,6 +362,42 @@ export class CommandPaletteComponent {
       untracked(() => this.selectedIndex.set(0));
     });
 
+    // Drive the debounced ticket search from the query signal.
+    effect(() => {
+      const q = this.query().trim();
+      untracked(() => this.ticketSearch$.next(q));
+    });
+
+    this.ticketSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.ticketsLoading.set(false);
+            this.ticketItems.set([]);
+            return of([] as TicketSearchResult[]);
+          }
+          this.ticketsLoading.set(true);
+          return this.ticketService.searchTickets(q, 20).pipe(
+            catchError(() => of([] as TicketSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.ticketsLoading.set(false);
+        this.ticketItems.set(results.map(t => ({
+          id: `ticket:${t.id}`,
+          label: t.subject,
+          secondary: `#${t.ticketNumber ?? '?'} · ${t.clientShortCode}`,
+          icon: 'ticket' as IconName,
+          route: ['/tickets', t.id] as const,
+          section: 'tickets' as const,
+          searchText: `${t.subject} ${t.ticketNumber ?? ''} ${t.clientShortCode} ${t.clientName}`.toLowerCase(),
+        })));
+      });
+
     this.destroyRef.onDestroy(() => this.cancelLoad$.complete());
   }
 
@@ -340,17 +410,15 @@ export class CommandPaletteComponent {
   }
 
   onInputKeydown(e: KeyboardEvent): void {
-    const items = this.filteredItems();
+    const allVisible = this.filteredSections().flatMap(g => g.items);
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (items.length === 0) return;
-      const lastIndex = items.length - 1;
-      this.selectedIndex.update(i => Math.max(0, Math.min(i + 1, lastIndex)));
+      if (allVisible.length === 0) return;
+      this.selectedIndex.update(i => Math.min(i + 1, allVisible.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      if (items.length === 0) return;
-      const lastIndex = items.length - 1;
-      this.selectedIndex.update(i => Math.max(0, Math.min(i - 1, lastIndex)));
+      if (allVisible.length === 0) return;
+      this.selectedIndex.update(i => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const item = this.selectedItem();
@@ -359,12 +427,27 @@ export class CommandPaletteComponent {
   }
 
   onItemHover(item: PaletteItem): void {
-    const idx = this.filteredItems().indexOf(item);
+    const allVisible = this.filteredSections().flatMap(g => g.items);
+    const idx = allVisible.indexOf(item);
     if (idx >= 0) this.selectedIndex.set(idx);
   }
 
+  /**
+   * Stable DOM id for each option row, consumed by the input's
+   * `aria-activedescendant` so screen readers announce the active option
+   * without the results container needing its own focus.
+   */
+  itemDomId(item: PaletteItem): string {
+    // Replace colons so the id is a valid CSS/DOM id — `client:abc` → `client_abc`.
+    return `cp-item-${item.id.replace(/:/g, '_')}`;
+  }
+
   activate(item: PaletteItem): void {
-    this.router.navigate([...item.route], item.queryParams ? { queryParams: item.queryParams } : undefined);
+    if (item.action) {
+      item.action();
+    } else if (item.route) {
+      this.router.navigate([...item.route], item.queryParams ? { queryParams: item.queryParams } : undefined);
+    }
     this.paletteService.close();
   }
 
@@ -461,8 +544,60 @@ export class CommandPaletteComponent {
             });
           }
 
+          // Commands — static actions; Create commands hidden for scoped users.
+          if (!isScoped) {
+            newItems.push({
+              id: 'cmd:create-ticket',
+              label: 'Create Ticket',
+              icon: 'add',
+              route: ['/tickets'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create ticket',
+            });
+            newItems.push({
+              id: 'cmd:create-client',
+              label: 'Create Client',
+              icon: 'add',
+              route: ['/clients'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create client',
+            });
+            newItems.push({
+              id: 'cmd:create-probe',
+              label: 'Create Scheduled Probe',
+              icon: 'add',
+              route: ['/scheduled-probes'],
+              queryParams: { create: '1' },
+              section: 'commands',
+              searchText: 'create scheduled probe',
+            });
+          }
+
+          newItems.push({
+            id: 'cmd:switch-theme',
+            label: 'Switch Theme',
+            icon: 'sparkles',
+            action: () => {
+              const next = this.theme.cycleToNext();
+              this.toast.info(`Theme: ${next.name}`);
+            },
+            section: 'commands',
+            searchText: 'switch theme',
+          });
+
+          newItems.push({
+            id: 'cmd:logout',
+            label: 'Logout',
+            icon: 'close',
+            action: () => this.auth.logout(),
+            section: 'commands',
+            searchText: 'logout',
+          });
+
           const navRoutes = isScoped
-            ? ALL_NAV_ROUTES.filter(r => isAllowedForScoped(r.route))
+            ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
             : ALL_NAV_ROUTES;
 
           for (const r of navRoutes) {

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -14,7 +14,8 @@ import { SidebarService } from '../core/services/sidebar.service.js';
 import { AuthService } from '../core/services/auth.service.js';
 import { TicketService } from '../core/services/ticket.service.js';
 import { FailedJobsService } from '../core/services/failed-jobs.service.js';
-import { ToastContainerComponent } from '../shared/components/toast-container.component.js';
+import { CommandPaletteComponent } from '../shared/components/command-palette.component.js';
+import { CommandPaletteService } from '../core/services/command-palette.service.js';
 
 const ROUTE_TITLE_MAP: Record<string, string> = {
   dashboard: 'Dashboard',
@@ -46,7 +47,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent, ToastContainerComponent],
+  imports: [RouterOutlet, SidebarComponent, HeaderBarComponent, DetailPanelComponent, CommandPaletteComponent],
   template: `
     <div class="shell">
       @if (!viewport.isCompactLayout()) {
@@ -62,7 +63,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
         <app-detail-panel />
       }
     </div>
-    <app-toast-container />
+    <app-command-palette />
   `,
   styles: [`
     .shell {
@@ -98,6 +99,7 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
 export class AppShellComponent implements OnInit {
   readonly detailPanel = inject(DetailPanelService);
   readonly viewport = inject(ViewportService);
+  readonly paletteService = inject(CommandPaletteService);
   private readonly sidebar = inject(SidebarService);
   private readonly theme = inject(ThemeService);
   private readonly auth = inject(AuthService);
@@ -110,6 +112,17 @@ export class AppShellComponent implements OnInit {
   readonly onDetailRoute = signal(false);
 
   private drawerRef: OverlayRef | null = null;
+
+  /**
+   * Global ⌘K / Ctrl+K handler — opens the command palette.
+   */
+  @HostListener('document:keydown', ['$event'])
+  private onDocumentKeydown(e: KeyboardEvent): void {
+    if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+      e.preventDefault();
+      this.paletteService.open();
+    }
+  }
 
   /**
    * Global Escape handler for the sidebar drawer.

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, input } from '@angular/core';
 import { IconComponent } from '../shared/components/icon.component.js';
 import { ViewportService } from '../core/services/viewport.service.js';
 import { SidebarService } from '../core/services/sidebar.service.js';
+import { CommandPaletteService } from '../core/services/command-palette.service.js';
 
 const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
@@ -24,7 +25,7 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
         }
         <span class="page-title">{{ title() }}</span>
       </div>
-      <button class="search-trigger" type="button" aria-label="Search">
+      <button class="search-trigger" type="button" aria-label="Search" (click)="paletteService.open()">
         <app-icon class="search-icon" name="search" size="sm" />
         <span class="search-text">Search...</span>
         @if (!viewport.isCompactLayout()) {
@@ -136,6 +137,7 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
 export class HeaderBarComponent {
   readonly viewport = inject(ViewportService);
   readonly sidebar = inject(SidebarService);
+  readonly paletteService = inject(CommandPaletteService);
   title = input<string>('Dashboard');
   readonly shortcutHint = isMac ? '⌘K' : 'Ctrl+K';
 }

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -5,7 +5,7 @@ import { ensureClientUser, Prisma } from '@bronco/db';
 import { TicketStatus, TicketCategory, TicketEventType, Priority, TicketSource, TaskType, isClosedStatus, AnalysisStatus, SufficiencyStatus, LogLevel } from '@bronco/shared-types';
 import { getSelfAnalysisConfig } from '@bronco/shared-utils';
 import type { TicketCreatedJob, IngestionJob } from '@bronco/shared-types';
-import { resolveClientScope, getOperatorClientIds } from '../plugins/client-scope.js';
+import { resolveClientScope, getOperatorClientIds, scopeToWhere } from '../plugins/client-scope.js';
 
 interface TicketRouteOpts {
   logSummarizeQueue?: Queue;
@@ -139,6 +139,96 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         take,
         skip,
       });
+    },
+  );
+
+  // GET /api/search/tickets — lightweight full-text search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/tickets',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      const clientWhere = scopeToWhere(scope);
+      const ticketNumberMatch = /^\d+$/.test(rawQ) ? Number(rawQ) : null;
+
+      const selectShape = {
+        id: true,
+        ticketNumber: true,
+        subject: true,
+        status: true,
+        priority: true,
+        clientId: true,
+        createdAt: true,
+        client: { select: { name: true, shortCode: true } },
+      } as const;
+
+      // For numeric queries, fetch the exact ticketNumber match separately so
+      // it's guaranteed to appear in the result — otherwise a broad subject
+      // match could fill the `take` limit and push the exact match out of the
+      // DB slice before the in-memory ranker sees it.
+      const exactPromise = ticketNumberMatch !== null
+        ? fastify.db.ticket.findFirst({
+            where: { ...clientWhere, ticketNumber: ticketNumberMatch },
+            select: selectShape,
+          })
+        : Promise.resolve(null);
+
+      const broadPromise = fastify.db.ticket.findMany({
+        where: {
+          ...clientWhere,
+          OR: [
+            { subject: { contains: rawQ, mode: 'insensitive' as const } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' as const } } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: selectShape,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+      });
+
+      const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
+
+      // Merge + dedupe by id (exact match may also appear in the broad set
+      // via subject contains, e.g. `q="42"` and a ticket with subject "42 bug").
+      const byId = new Map<string, typeof broad[number]>();
+      if (exact) byId.set(exact.id, exact);
+      for (const row of broad) byId.set(row.id, row);
+      const merged = Array.from(byId.values());
+
+      const qLower = rawQ.toLowerCase();
+      merged.sort((a, b) => {
+        const aExact = ticketNumberMatch !== null && a.ticketNumber === ticketNumberMatch ? 0 : 1;
+        const bExact = ticketNumberMatch !== null && b.ticketNumber === ticketNumberMatch ? 0 : 1;
+        if (aExact !== bExact) return aExact - bExact;
+        const aStarts = a.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.subject.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      });
+
+      return merged.slice(0, limit).map(t => ({
+        id: t.id,
+        ticketNumber: t.ticketNumber,
+        subject: t.subject,
+        status: t.status,
+        priority: t.priority,
+        clientId: t.clientId,
+        clientName: t.client.name,
+        clientShortCode: t.client.shortCode,
+      }));
     },
   );
 

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -174,16 +174,21 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         client: { select: { name: true, shortCode: true } },
       } as const;
 
-      // For numeric queries, fetch the exact ticketNumber match separately so
-      // it's guaranteed to appear in the result — otherwise a broad subject
-      // match could fill the `take` limit and push the exact match out of the
-      // DB slice before the in-memory ranker sees it.
-      const exactPromise = ticketNumberMatch !== null
-        ? fastify.db.ticket.findFirst({
-            where: { ...clientWhere, ticketNumber: ticketNumberMatch },
-            select: selectShape,
-          })
-        : Promise.resolve(null);
+      // For numeric queries, fetch exact ticketNumber matches separately so
+      // they're guaranteed to appear regardless of how many broad (subject/
+      // client) matches exist — otherwise the broad query's `take: limit`
+      // could push them out before the in-memory ranker sees them.
+      //
+      // ticketNumber is unique per-client (@@unique([clientId, ticketNumber]))
+      // so a numeric query may match multiple tickets across the caller's
+      // accessible clients. findMany + clientWhere covers all of them.
+      const exactPromise: Promise<Array<Prisma.TicketGetPayload<{ select: typeof selectShape }>>> =
+        ticketNumberMatch !== null
+          ? fastify.db.ticket.findMany({
+              where: { ...clientWhere, ticketNumber: ticketNumberMatch },
+              select: selectShape,
+            })
+          : Promise.resolve([]);
 
       const broadPromise = fastify.db.ticket.findMany({
         where: {
@@ -201,10 +206,11 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
 
       const [exact, broad] = await Promise.all([exactPromise, broadPromise]);
 
-      // Merge + dedupe by id (exact match may also appear in the broad set
-      // via subject contains, e.g. `q="42"` and a ticket with subject "42 bug").
+      // Merge + dedupe by id (an exact-number row may also appear in the
+      // broad set via subject contains, e.g. `q="42"` and a ticket with
+      // subject "42 bug").
       const byId = new Map<string, typeof broad[number]>();
-      if (exact) byId.set(exact.id, exact);
+      for (const row of exact) byId.set(row.id, row);
       for (const row of broad) byId.set(row.id, row);
       const merged = Array.from(byId.values());
 


### PR DESCRIPTION
## Summary

Ships the command palette initiative (#260) from `search-palette/staging` into `staging`. Three merged PRs worth of work land as one atomic feature.

Closes #260.

## What's in it

**Phase A (#262)** — ⌘K/Ctrl+K palette with client-side search across Clients, Scheduled Probes, Users, People, Navigate. Reuses Phase 3 `DialogComponent` for mobile full-screen + desktop centered rendering. Scoped-ops users see only their own client and allowed routes.

**Phase B (#269)** — adds Tickets (debounced server-side search, min 2 chars) and Commands sections. Backend: `GET /api/search/tickets?q=&limit=` in copilot-api + matching `search_tickets` MCP tool, with exact-ticketNumber-match promotion and scoped-ops filter. Commands section: Create Ticket / Create Client / Create Scheduled Probe (hidden for scoped-ops) / Switch Theme / Logout. Mutating-command support via `PaletteItem.action`. Ticket/Client/Probe list pages subscribe to `?create=1` query param to auto-open their create dialog, mirroring Phase A's `?edit=<id>` pattern in user-list. `ThemeService.cycleToNext()` cycles themes with a toast.

**Accessibility** — `role="listbox"` / `role="option"` / `role="combobox"`; dynamic `aria-expanded` + `aria-activedescendant`; empty-list arrow-key navigation guard.

**Reliability fixes** — ticketNumber exact match fetched separately (Promise.all) so it's never pushed out of the DB result by broad subject matches; shared scoped-ops allowlist extracted to `core/guards/scoped-ops-allowlist.ts` so palette Navigate filter and `scopedOpsGuard` stay in sync; defensive guard around `input.required()` read in client-detail effect.

**Toast + login error surfacing** (bundled from Phase A work) — toast container moved from `AppShellComponent` to `AppComponent` so login page can display toasts; login error path produces actionable messages for connection/401/403/5xx cases.

## Targets

`search-palette/staging` → `staging`. Will retire `search-palette/staging` after merge.

## Test plan

- [ ] `pnpm typecheck` / `pnpm build` pass
- [ ] ⌘K / Ctrl+K from any route opens the palette
- [ ] Empty query → all non-ticket sections visible; Tickets section absent
- [ ] Type a ticket subject word → tickets appear (debounced); exact numeric query promotes exact match to top
- [ ] Create Ticket / Client / Scheduled Probe commands navigate to the list and auto-open the create dialog
- [ ] Switch Theme cycles themes + shows toast
- [ ] Logout signs out
- [ ] Scoped-ops user: Create commands hidden; Clients/Probes/Users/People scoped to own client
- [ ] Keyboard nav: ↑/↓ selects across all sections; Enter activates; Esc closes
- [ ] Screen reader: palette announces as listbox; option selection tracked via aria-activedescendant
- [ ] Backend: `GET /api/search/tickets?q=<word>` returns matching tickets; `q=<number>` promotes exact match; scoped-ops filter applied
- [ ] MCP `search_tickets` tool schema visible on `/mcp/tools`
