### PR TITLE
fix: iOS Safari status-bar + safe-area theme color at first paint

### DIFF
--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -103,6 +103,14 @@ export class ThemeService {
     if (!meta) return;
     const color = getComputedStyle(document.body).getPropertyValue('--bg-page').trim() || '#08090a';
     meta.content = color;
+    // Clear the inline background style set by the pre-boot script in
+    // index.html. That inline style exists only to cover first-paint on iOS
+    // Safari; after Angular boots and applies the body class, the CSS rule
+    // `html, body { background: var(--bg-page) }` takes over. If we leave
+    // the inline style in place, it beats the CSS rule via specificity and
+    // the safe-area strip stays pinned to whatever the initial theme was
+    // even after the user switches themes.
+    document.documentElement.style.removeProperty('background');
   }
 
   private resolveInitial(): ThemeOption {

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -6,10 +6,67 @@
   <base href="/cp/">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#08090a">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="iTrack">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
   <link rel="icon" type="image/svg+xml" href="logo.svg">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script>
+    /*
+     * Pre-boot theme application.
+     *
+     * Two first-paint problems this solves:
+     *
+     * 1. iOS Safari reads <meta name="theme-color"> at FIRST PAINT to tint the
+     *    URL bar / status-bar region. Angular's ThemeService updates the meta
+     *    after boot — too late. This sets it before Safari samples.
+     *
+     * 2. `html, body { background: var(--bg-page) }` in styles.scss fills the
+     *    safe-area region with the theme background, but var(--bg-page)
+     *    resolves to the :root default (Apple cream) until the body class
+     *    is applied. Setting inline background on <html> overrides that for
+     *    first paint so the safe-area doesn't flash cream on dark themes.
+     *
+     * The body class itself cannot be set here — this script runs while <body>
+     * is still being parsed, so `document.body` is null. Angular's ThemeService
+     * applies the correct body class on boot, and the inline <html> background
+     * + <meta> cover the gap.
+     *
+     * Kept in sync with the THEMES list in
+     * services/control-panel/src/app/core/services/theme.service.ts.
+     * If a theme is added or renamed there, update the map here.
+     */
+    (function () {
+      try {
+        var THEME_COLORS = {
+          apple: '#f5f5f7',
+          linear: '#08090a',
+          sentry: '#1f1633',
+          supabase: '#171717',
+          nvidia: '#000000',
+          vercel: '#ffffff'
+        };
+        var saved = localStorage.getItem('bronco-theme');
+        var color = saved && THEME_COLORS[saved];
+        if (color) {
+          var meta = document.querySelector('meta[name="theme-color"]');
+          if (meta) meta.setAttribute('content', color);
+          document.documentElement.style.background = color;
+        }
+      } catch (e) { /* localStorage unavailable → fall through to default */ }
+    })();
+  </script>
+  <style>
+    /*
+     * Fill the full viewport (including iOS safe-area regions) with the
+     * current theme's --bg-page. Without this, Safari paints the safe-area
+     * strip at the bottom (behind its floating URL pill) with its default
+     * white, creating a visible white band when the app is dark-themed.
+     */
+    html, body { background: var(--bg-page); }
+  </style>
 </head>
 <body>
   <app-root></app-root>

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -5,7 +5,11 @@
   <title>iTrack 3 — Control Panel</title>
   <base href="/cp/">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#08090a">
+  <!-- Initial theme-color matches the default Apple theme (--bg-page: #f5f5f7).
+       The inline script below updates this before Safari samples it if the
+       user has a different theme saved in localStorage. Kept in sync with
+       THEMES[0] in services/control-panel/src/app/core/services/theme.service.ts. -->
+  <meta name="theme-color" content="#f5f5f7">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="iTrack">
@@ -39,23 +43,32 @@
      * If a theme is added or renamed there, update the map here.
      */
     (function () {
+      var THEME_COLORS = {
+        apple: '#f5f5f7',
+        linear: '#08090a',
+        sentry: '#1f1633',
+        supabase: '#171717',
+        nvidia: '#000000',
+        vercel: '#ffffff'
+      };
+      // Default matches THEMES[0] in theme.service.ts. Used when localStorage
+      // is empty (first-time visitor) or holds an unknown theme id.
+      var DEFAULT_THEME = 'apple';
+      var saved;
       try {
-        var THEME_COLORS = {
-          apple: '#f5f5f7',
-          linear: '#08090a',
-          sentry: '#1f1633',
-          supabase: '#171717',
-          nvidia: '#000000',
-          vercel: '#ffffff'
-        };
-        var saved = localStorage.getItem('bronco-theme');
-        var color = saved && THEME_COLORS[saved];
-        if (color) {
-          var meta = document.querySelector('meta[name="theme-color"]');
-          if (meta) meta.setAttribute('content', color);
-          document.documentElement.style.background = color;
-        }
-      } catch (e) { /* localStorage unavailable → fall through to default */ }
+        saved = localStorage.getItem('bronco-theme');
+      } catch (e) { /* localStorage unavailable */ }
+      var themeId = (saved && THEME_COLORS[saved]) ? saved : DEFAULT_THEME;
+      var color = THEME_COLORS[themeId];
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute('content', color);
+      // Only override the <html> background for non-default themes — leaving
+      // the default theme to the CSS rule avoids a specificity win that would
+      // need clearing later. For custom themes, ThemeService.applyThemeColorMeta
+      // clears this inline style after the body class is applied.
+      if (themeId !== DEFAULT_THEME) {
+        document.documentElement.style.background = color;
+      }
     })();
   </script>
   <style>

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -6,6 +6,15 @@ html, body {
   height: 100%;
   margin: 0;
   font-family: var(--font-primary, -apple-system, 'SF Pro Text', 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  /*
+   * Fill the full viewport (including iOS safe-area regions) with the current
+   * theme's --bg-page. Without this, Safari paints the safe-area strip at the
+   * bottom (behind its floating URL pill) with its default white, creating a
+   * visible white band when the app is dark-themed. An inline <html> style in
+   * index.html covers the first-paint gap before Angular applies the body
+   * class and --bg-page resolves correctly.
+   */
+  background: var(--bg-page);
 }
 
 .spacer {


### PR DESCRIPTION
## Summary

Two first-paint issues on iOS Safari surfaced when testing the deployed `itrack.siirial.com` from an iPhone:

1. **Status bar showed cream/white** regardless of selected theme. Safari reads `<meta name="theme-color">` at initial paint to tint the top chrome; `ThemeService.applyThemeColorMeta()` updated it after Angular boot, which is too late.
2. **Safe-area strip at the bottom** (behind Safari's floating URL pill) painted white/cream on dark themes. `html, body` had no background, so Safari filled the safe-area region with its default white.

## Fix

**`index.html`** — inline pre-boot script that reads `bronco-theme` from localStorage and:
- Updates the `theme-color` meta before Safari samples it
- Sets an inline `background` on `<html>` to cover the first-paint gap before `--bg-page` resolves from the body class

Also added iOS PWA metas (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style="black-translucent"`, `apple-mobile-web-app-title="iTrack"`) so Add-to-Home-Screen launches the app full-screen with a proper dark status bar.

**`styles.scss`** — `html, body` now carry `background: var(--bg-page)` so post-boot the safe-area fills with the current theme.

## Test plan

Deploy to `itrack.siirial.com` and on iPhone Safari:
- [ ] Load the site → iOS status bar area tints to match the current theme on first paint (no cream/white flash)
- [ ] Switch themes via the command palette or profile → status bar updates to new theme color
- [ ] Scroll content past the bottom → no white strip visible behind Safari's URL pill on dark themes
- [ ] Share → Add to Home Screen → launch from icon → app renders edge-to-edge, status bar overlaid translucent
- [ ] `pnpm typecheck` / `pnpm build` pass

## Theme color map

The inline script duplicates the theme → `#rrggbb` map from `theme.service.ts`'s THEMES list. A comment in the script notes the sync requirement; if a theme is added or renamed in `theme.service.ts`, update the map in `index.html` too.
