### PR TITLE
fix: single source of truth for theme → color map (fixes #277, fixes #278)

### DIFF
--- a/services/control-panel/package.json
+++ b/services/control-panel/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
     "dev": "ng serve --proxy-config proxy.conf.json",
+    "prebuild": "node scripts/check-theme-colors.mjs",
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "typecheck": "ng build --configuration production",

--- a/services/control-panel/scripts/check-theme-colors.mjs
+++ b/services/control-panel/scripts/check-theme-colors.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Drift-check: asserts that the inline THEME_COLORS map in src/index.html
- * matches the canonical map exported from theme-colors.ts.
+ * matches the canonical map exported from theme-colors.ts, AND that the
+ * static <meta name="theme-color"> tag matches THEME_COLORS[DEFAULT_THEME].
  *
  * Runs as a prebuild step so CI fails immediately on divergence rather than
  * silently shipping mismatched pre-boot colors.
@@ -13,6 +14,34 @@ import { join, dirname } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 
+/**
+ * Parse a block of `key: '#value',` lines into an object.
+ * Fails if no entries parsed or if the count of key/value pairs in the
+ * source doesn't match the parsed count (guards against silent regex drift
+ * if the source formatting ever changes — e.g. double quotes, quoted keys).
+ */
+function parseColorBlock(block, label) {
+  const parsed = {};
+  const lines = block.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+    if (m) parsed[m[1]] = m[2];
+  }
+  // Count lines that look like a key/value entry (a colon followed by a value
+  // that doesn't start with `{` or `[`), so we can detect silent parse skips.
+  const entryLines = lines.filter(l => /^\s*\S+\s*:\s*[^{[]/.test(l));
+  const parsedCount = Object.keys(parsed).length;
+  if (parsedCount === 0) {
+    console.error(`ERROR: parsed 0 entries from ${label} THEME_COLORS block; regex likely out of sync with source format.`);
+    process.exit(1);
+  }
+  if (parsedCount !== entryLines.length) {
+    console.error(`ERROR: ${label} THEME_COLORS has ${entryLines.length} entry lines but only ${parsedCount} parsed; regex likely out of sync with source format.`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 // --- Load the canonical source of truth ---
 const tsSource = readFileSync(join(root, 'src/app/core/services/theme-colors.ts'), 'utf8');
 
@@ -22,11 +51,7 @@ if (!tsColorsMatch) {
   console.error('ERROR: Could not parse THEME_COLORS from theme-colors.ts');
   process.exit(1);
 }
-const tsColors = {};
-for (const line of tsColorsMatch[1].split('\n')) {
-  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
-  if (m) tsColors[m[1]] = m[2];
-}
+const tsColors = parseColorBlock(tsColorsMatch[1], 'theme-colors.ts');
 
 // Parse DEFAULT_THEME from the TS source
 const tsDefaultMatch = tsSource.match(/export const DEFAULT_THEME[^=]*=\s*'(\w+)'/);
@@ -44,11 +69,7 @@ if (!htmlColorsMatch) {
   console.error('ERROR: Could not parse var THEME_COLORS from index.html');
   process.exit(1);
 }
-const htmlColors = {};
-for (const line of htmlColorsMatch[1].split('\n')) {
-  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
-  if (m) htmlColors[m[1]] = m[2];
-}
+const htmlColors = parseColorBlock(htmlColorsMatch[1], 'index.html');
 
 const htmlDefaultMatch = html.match(/var DEFAULT_THEME\s*=\s*'(\w+)'/);
 if (!htmlDefaultMatch) {
@@ -56,6 +77,15 @@ if (!htmlDefaultMatch) {
   process.exit(1);
 }
 const htmlDefault = htmlDefaultMatch[1];
+
+// Parse the static <meta name="theme-color" content="..."> tag — the color
+// Safari samples on first paint before the inline script runs.
+const metaMatch = html.match(/<meta\s+name=["']theme-color["']\s+content=["'](#[0-9a-fA-F]{3,8})["']/);
+if (!metaMatch) {
+  console.error('ERROR: Could not find <meta name="theme-color" content="..."> tag in index.html');
+  process.exit(1);
+}
+const metaColor = metaMatch[1];
 
 // --- Compare ---
 let failed = false;
@@ -79,8 +109,17 @@ if (tsDefault !== htmlDefault) {
   failed = true;
 }
 
+// The static <meta> tag Safari samples on first paint MUST equal the color
+// that THEME_COLORS[DEFAULT_THEME] resolves to — otherwise the default theme
+// flashes the wrong color before the inline script can update it.
+const expectedMetaColor = tsColors[tsDefault];
+if (expectedMetaColor && metaColor.toLowerCase() !== expectedMetaColor.toLowerCase()) {
+  console.error(`DRIFT: <meta name="theme-color"> content='${metaColor}' but THEME_COLORS[DEFAULT_THEME='${tsDefault}']='${expectedMetaColor}'`);
+  failed = true;
+}
+
 if (failed) {
-  console.error('\nFix: update index.html inline script to match theme-colors.ts (the single source of truth).');
+  console.error('\nFix: update index.html inline script and <meta name="theme-color"> tag to match theme-colors.ts (the single source of truth).');
   process.exit(1);
 }
 

--- a/services/control-panel/scripts/check-theme-colors.mjs
+++ b/services/control-panel/scripts/check-theme-colors.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Drift-check: asserts that the inline THEME_COLORS map in src/index.html
+ * matches the canonical map exported from theme-colors.ts.
+ *
+ * Runs as a prebuild step so CI fails immediately on divergence rather than
+ * silently shipping mismatched pre-boot colors.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// --- Load the canonical source of truth ---
+const tsSource = readFileSync(join(root, 'src/app/core/services/theme-colors.ts'), 'utf8');
+
+// Parse THEME_COLORS object entries from the TS source
+const tsColorsMatch = tsSource.match(/export const THEME_COLORS\s*=\s*\{([^}]+)\}/s);
+if (!tsColorsMatch) {
+  console.error('ERROR: Could not parse THEME_COLORS from theme-colors.ts');
+  process.exit(1);
+}
+const tsColors = {};
+for (const line of tsColorsMatch[1].split('\n')) {
+  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+  if (m) tsColors[m[1]] = m[2];
+}
+
+// Parse DEFAULT_THEME from the TS source
+const tsDefaultMatch = tsSource.match(/export const DEFAULT_THEME[^=]*=\s*'(\w+)'/);
+if (!tsDefaultMatch) {
+  console.error('ERROR: Could not parse DEFAULT_THEME from theme-colors.ts');
+  process.exit(1);
+}
+const tsDefault = tsDefaultMatch[1];
+
+// --- Load the inline script in index.html ---
+const html = readFileSync(join(root, 'src/index.html'), 'utf8');
+
+const htmlColorsMatch = html.match(/var THEME_COLORS\s*=\s*\{([^}]+)\}/s);
+if (!htmlColorsMatch) {
+  console.error('ERROR: Could not parse var THEME_COLORS from index.html');
+  process.exit(1);
+}
+const htmlColors = {};
+for (const line of htmlColorsMatch[1].split('\n')) {
+  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+  if (m) htmlColors[m[1]] = m[2];
+}
+
+const htmlDefaultMatch = html.match(/var DEFAULT_THEME\s*=\s*'(\w+)'/);
+if (!htmlDefaultMatch) {
+  console.error('ERROR: Could not parse var DEFAULT_THEME from index.html');
+  process.exit(1);
+}
+const htmlDefault = htmlDefaultMatch[1];
+
+// --- Compare ---
+let failed = false;
+
+const tsKeys = Object.keys(tsColors).sort();
+const htmlKeys = Object.keys(htmlColors).sort();
+if (JSON.stringify(tsKeys) !== JSON.stringify(htmlKeys)) {
+  console.error(`DRIFT: key sets differ.\n  theme-colors.ts: ${tsKeys.join(', ')}\n  index.html:      ${htmlKeys.join(', ')}`);
+  failed = true;
+}
+
+for (const key of tsKeys) {
+  if (tsColors[key] !== htmlColors[key]) {
+    console.error(`DRIFT: ${key}: theme-colors.ts='${tsColors[key]}' vs index.html='${htmlColors[key]}'`);
+    failed = true;
+  }
+}
+
+if (tsDefault !== htmlDefault) {
+  console.error(`DRIFT: DEFAULT_THEME: theme-colors.ts='${tsDefault}' vs index.html='${htmlDefault}'`);
+  failed = true;
+}
+
+if (failed) {
+  console.error('\nFix: update index.html inline script to match theme-colors.ts (the single source of truth).');
+  process.exit(1);
+}
+
+console.log('theme-colors check passed: index.html and theme-colors.ts are in sync.');

--- a/services/control-panel/src/app/core/services/theme-colors.ts
+++ b/services/control-panel/src/app/core/services/theme-colors.ts
@@ -1,0 +1,12 @@
+export const THEME_COLORS = {
+  apple: '#f5f5f7',
+  linear: '#08090a',
+  sentry: '#1f1633',
+  supabase: '#171717',
+  nvidia: '#000000',
+  vercel: '#ffffff',
+} as const;
+
+export type ThemeId = keyof typeof THEME_COLORS;
+
+export const DEFAULT_THEME: ThemeId = 'apple';

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -2,9 +2,10 @@ import { Injectable, effect, inject, signal } from '@angular/core';
 import { AuthService } from './auth.service.js';
 import { ApiService } from './api.service.js';
 import { ToastService } from './toast.service.js';
+import { THEME_COLORS, DEFAULT_THEME, type ThemeId } from './theme-colors.js';
 
 export interface ThemeOption {
-  id: string;
+  id: ThemeId;
   name: string;
   bodyClass: string;
   description: string;
@@ -109,7 +110,9 @@ export class ThemeService {
   private applyThemeColorMeta(): void {
     const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
     if (!meta) return;
-    const color = getComputedStyle(document.body).getPropertyValue('--bg-page').trim() || '#08090a';
+    const theme = this.currentTheme();
+    const computed = getComputedStyle(document.body).getPropertyValue('--bg-page').trim();
+    const color = computed || THEME_COLORS[theme.id] || THEME_COLORS[DEFAULT_THEME];
     meta.content = color;
     // Clear the inline background style set by the pre-boot script in
     // index.html. That inline style exists only to cover first-paint on iOS

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -126,6 +126,13 @@ export class ThemeService {
 
   private resolveInitial(): ThemeOption {
     const saved = localStorage.getItem(STORAGE_KEY);
-    return THEMES.find(t => t.id === saved) ?? THEMES[0];
+    // Fall back to DEFAULT_THEME (single source of truth in theme-colors.ts)
+    // rather than THEMES[0], so changing the default doesn't require reordering
+    // the array. THEMES[0] remains only as a last-resort safety net.
+    return (
+      THEMES.find(t => t.id === saved) ??
+      THEMES.find(t => t.id === DEFAULT_THEME) ??
+      THEMES[0]
+    );
   }
 }

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -5,10 +5,9 @@
   <title>iTrack 3 — Control Panel</title>
   <base href="/cp/">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <!-- Initial theme-color matches the default Apple theme (--bg-page: #f5f5f7).
-       The inline script below updates this before Safari samples it if the
-       user has a different theme saved in localStorage. Kept in sync with
-       THEMES[0] in services/control-panel/src/app/core/services/theme.service.ts. -->
+  <!-- Initial theme-color matches THEME_COLORS[DEFAULT_THEME] from theme-colors.ts
+       (currently #f5f5f7 for Apple). The inline script below updates this before
+       Safari samples it if the user has a different theme saved in localStorage. -->
   <meta name="theme-color" content="#f5f5f7">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -38,9 +37,11 @@
      * applies the correct body class on boot, and the inline <html> background
      * + <meta> cover the gap.
      *
-     * Kept in sync with the THEMES list in
-     * services/control-panel/src/app/core/services/theme.service.ts.
-     * If a theme is added or renamed there, update the map here.
+     * Single source of truth: theme-colors.ts
+     * (services/control-panel/src/app/core/services/theme-colors.ts)
+     * The map below MUST match THEME_COLORS exported from that file.
+     * The prebuild script (scripts/check-theme-colors.mjs) enforces this and
+     * will fail CI if the two maps diverge.
      */
     (function () {
       var THEME_COLORS = {

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -52,8 +52,9 @@
         nvidia: '#000000',
         vercel: '#ffffff'
       };
-      // Default matches THEMES[0] in theme.service.ts. Used when localStorage
-      // is empty (first-time visitor) or holds an unknown theme id.
+      // Must match DEFAULT_THEME from theme-colors.ts. Used when localStorage
+      // is empty (first-time visitor) or holds an unknown theme id. The
+      // prebuild drift-check enforces this stays in sync.
       var DEFAULT_THEME = 'apple';
       var saved;
       try {


### PR DESCRIPTION
- Extract THEME_COLORS + DEFAULT_THEME to theme-colors.ts
- ThemeService.applyThemeColorMeta falls back through the static map
  instead of the magic #08090a literal
- Add drift-check (prebuild script) so index.html and
  theme-colors.ts cannot diverge silently
- Update comments in index.html to reference the new source of truth

https://claude.ai/code/session_01JZQpycygb7MQJ5ZcovXaUB