### PR TITLE
feat: palette server-side search for clients, probes, users, people (fixes #275)

### DIFF
--- a/mcp-servers/platform/src/tools/clients.ts
+++ b/mcp-servers/platform/src/tools/clients.ts
@@ -29,12 +29,21 @@ export function registerClientTools(server: McpServer, { db }: ServerDeps): void
           isActive: true,
         },
         take: limit * 2,
+        orderBy: { name: 'asc' },
       });
 
+      const getRank = (name: string, shortCode: string): number => {
+        const nameLower = name.toLowerCase();
+        const shortCodeLower = shortCode.toLowerCase();
+        if (shortCodeLower === qLower) return 0;
+        if (shortCodeLower.startsWith(qLower)) return 1;
+        if (nameLower === qLower) return 2;
+        if (nameLower.startsWith(qLower)) return 3;
+        return 4;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        if (aStarts !== bStarts) return aStarts - bStarts;
+        const rankDiff = getRank(a.name, a.shortCode) - getRank(b.name, b.shortCode);
+        if (rankDiff !== 0) return rankDiff;
         return a.name.localeCompare(b.name);
       });
 

--- a/mcp-servers/platform/src/tools/clients.ts
+++ b/mcp-servers/platform/src/tools/clients.ts
@@ -4,6 +4,45 @@ import type { ServerDeps } from '../server.js';
 
 export function registerClientTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_clients',
+    'Search clients by name or short code. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name or short code). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.client.findMany({
+        where: {
+          isInternal: false,
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { shortCode: { contains: q, mode: 'insensitive' as const } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          shortCode: true,
+          isActive: true,
+        },
+        take: limit * 2,
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.name.localeCompare(b.name);
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_clients',
     'List all clients with system count and ticket count.',
     {},

--- a/mcp-servers/platform/src/tools/index.ts
+++ b/mcp-servers/platform/src/tools/index.ts
@@ -13,11 +13,13 @@ import { registerClientMemoryTools } from './client-memory.js';
 import { registerSettingsTools } from './settings.js';
 import { registerSystemStatusTools } from './system-status.js';
 import { registerSlackConversationTools } from './slack-conversations.js';
+import { registerUserTools } from './users.js';
 
 export function registerAllTools(server: McpServer, deps: ServerDeps): void {
   registerTicketTools(server, deps);
   registerPeopleTools(server, deps);
   registerClientTools(server, deps);
+  registerUserTools(server, deps);
   registerSystemTools(server, deps);
   registerProbeTools(server, deps);
   registerIssueJobTools(server, deps);

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -4,6 +4,60 @@ import type { ServerDeps } from '../server.js';
 
 export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_people',
+    'Search people (unified contacts + portal users) by name, email, or client. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name, email, or client). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.person.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { email: { contains: q, mode: 'insensitive' as const } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          clientId: true,
+          role: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      const result = results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        email: p.email,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        role: p.role,
+        isActive: p.isActive,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_people',
     'List people (unified contacts + portal users), optionally filtered by client.',
     {

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -37,9 +37,18 @@ export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void
       });
 
       results.sort((a, b) => {
+        const aEmailExact = a.email.toLowerCase() === qLower ? 0 : 1;
+        const bEmailExact = b.email.toLowerCase() === qLower ? 0 : 1;
+        if (aEmailExact !== bEmailExact) return aEmailExact - bEmailExact;
+
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const nameCompare = a.name.localeCompare(b.name);
+        if (nameCompare !== 0) return nameCompare;
+
+        return a.email.localeCompare(b.email);
       });
 
       const result = results.slice(0, limit).map(p => ({

--- a/mcp-servers/platform/src/tools/probes.ts
+++ b/mcp-servers/platform/src/tools/probes.ts
@@ -4,6 +4,58 @@ import type { ServerDeps } from '../server.js';
 
 export function registerProbeTools(server: McpServer, { db, probeQueue }: ServerDeps): void {
   server.tool(
+    'search_scheduled_probes',
+    'Search scheduled probes by name, description, or client. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name, description, or client). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.scheduledProbe.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { description: { contains: q, mode: 'insensitive' as const } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          clientId: true,
+          toolName: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      const result = results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        toolName: p.toolName,
+        isActive: p.isActive,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_probes',
     'List scheduled probes with last run info. Optionally filter by client.',
     {

--- a/mcp-servers/platform/src/tools/probes.ts
+++ b/mcp-servers/platform/src/tools/probes.ts
@@ -26,19 +26,25 @@ export function registerProbeTools(server: McpServer, { db, probeQueue }: Server
         select: {
           id: true,
           name: true,
+          createdAt: true,
           clientId: true,
           toolName: true,
           isActive: true,
           client: { select: { name: true, shortCode: true } },
         },
         take: limit,
-        orderBy: { name: 'asc' },
+        orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
       });
 
       results.sort((a, b) => {
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+        if (createdAtDiff !== 0) return createdAtDiff;
+
+        return a.name.localeCompare(b.name);
       });
 
       const result = results.slice(0, limit).map(p => ({

--- a/mcp-servers/platform/src/tools/users.ts
+++ b/mcp-servers/platform/src/tools/users.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ServerDeps } from '../server.js';
+
+export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
+  server.tool(
+    'search_users',
+    'Search control panel users by name or email. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name or email). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.user.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { email: { contains: q, mode: 'insensitive' as const } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          isActive: true,
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };
+    },
+  );
+}

--- a/mcp-servers/platform/src/tools/users.ts
+++ b/mcp-servers/platform/src/tools/users.ts
@@ -32,10 +32,19 @@ export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
         orderBy: { name: 'asc' },
       });
 
+      const getRank = (user: { name: string; email: string }): number => {
+        const nameLower = user.name.toLowerCase();
+        const emailLower = user.email.toLowerCase();
+        if (emailLower === qLower) return 0;
+        if (nameLower.startsWith(qLower) || emailLower.startsWith(qLower)) return 1;
+        return 2;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        const rankDiff = getRank(a) - getRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        const nameDiff = a.name.localeCompare(b.name);
+        if (nameDiff !== 0) return nameDiff;
+        return a.email.localeCompare(b.email);
       });
 
       return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };

--- a/services/control-panel/src/app/core/services/client.service.ts
+++ b/services/control-panel/src/app/core/services/client.service.ts
@@ -81,4 +81,15 @@ export class ClientService {
   updateClient(id: string, data: Partial<Client>): Observable<Client> {
     return this.api.patch<Client>(`/clients/${id}`, data);
   }
+
+  searchClients(q: string, limit = 20): Observable<ClientSearchResult[]> {
+    return this.api.get<ClientSearchResult[]>('/search/clients', { q, limit });
+  }
+}
+
+export interface ClientSearchResult {
+  id: string;
+  name: string;
+  shortCode: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/person.service.ts
+++ b/services/control-panel/src/app/core/services/person.service.ts
@@ -48,4 +48,19 @@ export class PersonService {
   resetPassword(id: string, password: string): Observable<{ message: string }> {
     return this.api.post<{ message: string }>(`/people/${id}/reset-password`, { password });
   }
+
+  searchPeople(q: string, limit = 20): Observable<PersonSearchResult[]> {
+    return this.api.get<PersonSearchResult[]>('/search/people', { q, limit });
+  }
+}
+
+export interface PersonSearchResult {
+  id: string;
+  name: string;
+  email: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
+  role: string | null;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/scheduled-probe.service.ts
+++ b/services/control-panel/src/app/core/services/scheduled-probe.service.ts
@@ -143,4 +143,18 @@ export class ScheduledProbeService {
   getBuiltinTools(): Observable<Array<{ name: string; description: string; inputSchema?: Record<string, unknown> }>> {
     return this.api.get('/scheduled-probes/builtin-tools');
   }
+
+  searchProbes(q: string, limit = 20): Observable<ProbeSearchResult[]> {
+    return this.api.get<ProbeSearchResult[]>('/search/scheduled-probes', { q, limit });
+  }
+}
+
+export interface ProbeSearchResult {
+  id: string;
+  name: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
+  toolName: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/user.service.ts
+++ b/services/control-panel/src/app/core/services/user.service.ts
@@ -37,4 +37,16 @@ export class UserService {
   resetPassword(id: string, password: string): Observable<{ message: string }> {
     return this.api.post<{ message: string }>(`/users/${id}/reset-password`, { password });
   }
+
+  searchUsers(q: string, limit = 20): Observable<UserSearchResult[]> {
+    return this.api.get<UserSearchResult[]>('/search/users', { q, limit });
+  }
+}
+
+export interface UserSearchResult {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -11,17 +11,17 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { debounceTime, distinctUntilChanged, forkJoin, of, Subject, switchMap } from 'rxjs';
-import { catchError, map, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, of, Subject, switchMap } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { DialogComponent } from './dialog.component.js';
 import { IconComponent } from './icon.component.js';
 import type { IconName } from './icon-registry.js';
 import { CommandPaletteService } from '../../core/services/command-palette.service.js';
 import { AuthService } from '../../core/services/auth.service.js';
-import { ClientService, type Client } from '../../core/services/client.service.js';
-import { ScheduledProbeService, type ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
-import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
-import { PersonService, type Person } from '../../core/services/person.service.js';
+import { ClientService, type ClientSearchResult } from '../../core/services/client.service.js';
+import { ScheduledProbeService, type ProbeSearchResult } from '../../core/services/scheduled-probe.service.js';
+import { UserService, type UserSearchResult } from '../../core/services/user.service.js';
+import { PersonService, type PersonSearchResult } from '../../core/services/person.service.js';
 import { TicketService, type TicketSearchResult } from '../../core/services/ticket.service.js';
 import { ThemeService } from '../../core/services/theme.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
@@ -273,14 +273,32 @@ export class CommandPaletteComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
-  private readonly cancelLoad$ = new Subject<void>();
   private readonly ticketSearch$ = new Subject<string>();
+  private readonly clientSearch$ = new Subject<string>();
+  private readonly probeSearch$ = new Subject<string>();
+  private readonly userSearch$ = new Subject<string>();
+  private readonly personSearch$ = new Subject<string>();
+  private readonly isScoped = computed(() => {
+    const user = this.auth.currentUser();
+    return user?.isPortalOpsUser === true && !!user?.clientId;
+  });
 
   readonly query = signal('');
   readonly items = signal<PaletteItem[]>([]);
   readonly ticketItems = signal<PaletteItem[]>([]);
-  readonly loading = signal(false);
+  readonly clientItems = signal<PaletteItem[]>([]);
+  readonly probeItems = signal<PaletteItem[]>([]);
+  readonly userItems = signal<PaletteItem[]>([]);
+  readonly personItems = signal<PaletteItem[]>([]);
   readonly ticketsLoading = signal(false);
+  readonly clientsLoading = signal(false);
+  readonly probesLoading = signal(false);
+  readonly usersLoading = signal(false);
+  readonly peopleLoading = signal(false);
+  readonly loading = computed(() =>
+    this.ticketsLoading() || this.clientsLoading() || this.probesLoading() ||
+    this.usersLoading() || this.peopleLoading()
+  );
   readonly selectedIndex = signal(0);
 
   readonly filteredItems = computed(() => {
@@ -305,12 +323,26 @@ export class CommandPaletteComponent {
       itemMap.set(item.section, bucket);
     }
 
-    // Ticket items are pre-filtered server-side; merge them separately.
+    // Server-side search sections — merge results independently of filteredItems().
+    const clients = this.clientItems();
+    const isClientsLoading = this.clientsLoading();
+    if (clients.length > 0 || isClientsLoading) itemMap.set('clients', clients);
+
     const tickets = this.ticketItems();
     const isTicketsLoading = this.ticketsLoading();
-    if (tickets.length > 0 || isTicketsLoading) {
-      itemMap.set('tickets', tickets);
-    }
+    if (tickets.length > 0 || isTicketsLoading) itemMap.set('tickets', tickets);
+
+    const probes = this.probeItems();
+    const isProbesLoading = this.probesLoading();
+    if (probes.length > 0 || isProbesLoading) itemMap.set('probes', probes);
+
+    const users = this.userItems();
+    const isUsersLoading = this.usersLoading();
+    if (users.length > 0 || isUsersLoading) itemMap.set('users', users);
+
+    const people = this.personItems();
+    const isPeopleLoading = this.peopleLoading();
+    if (people.length > 0 || isPeopleLoading) itemMap.set('people', people);
 
     return SECTION_ORDER
       .filter(s => itemMap.has(s))
@@ -318,7 +350,11 @@ export class CommandPaletteComponent {
         section: s,
         label: SECTION_LABELS[s],
         items: itemMap.get(s)!,
-        loading: s === 'tickets' && isTicketsLoading,
+        loading: (s === 'clients' && isClientsLoading)
+               || (s === 'tickets' && isTicketsLoading)
+               || (s === 'probes' && isProbesLoading)
+               || (s === 'users' && isUsersLoading)
+               || (s === 'people' && isPeopleLoading),
       }));
   });
 
@@ -335,13 +371,19 @@ export class CommandPaletteComponent {
     // Palette open/close lifecycle: fetch data on open, reset on close.
     effect((onCleanup) => {
       if (!this.paletteService.isOpen()) {
-        this.cancelLoad$.next();
         untracked(() => {
           this.query.set('');
           this.items.set([]);
           this.ticketItems.set([]);
-          this.loading.set(false);
+          this.clientItems.set([]);
+          this.probeItems.set([]);
+          this.userItems.set([]);
+          this.personItems.set([]);
           this.ticketsLoading.set(false);
+          this.clientsLoading.set(false);
+          this.probesLoading.set(false);
+          this.usersLoading.set(false);
+          this.peopleLoading.set(false);
           this.selectedIndex.set(0);
         });
         return;
@@ -362,10 +404,16 @@ export class CommandPaletteComponent {
       untracked(() => this.selectedIndex.set(0));
     });
 
-    // Drive the debounced ticket search from the query signal.
+    // Fan out the query to all server-side search streams.
     effect(() => {
       const q = this.query().trim();
-      untracked(() => this.ticketSearch$.next(q));
+      untracked(() => {
+        this.ticketSearch$.next(q);
+        this.clientSearch$.next(q);
+        this.probeSearch$.next(q);
+        this.userSearch$.next(q);
+        this.personSearch$.next(q);
+      });
     });
 
     this.ticketSearch$
@@ -398,7 +446,126 @@ export class CommandPaletteComponent {
         })));
       });
 
-    this.destroyRef.onDestroy(() => this.cancelLoad$.complete());
+    this.clientSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.clientsLoading.set(false);
+            this.clientItems.set([]);
+            return of([] as ClientSearchResult[]);
+          }
+          this.clientsLoading.set(true);
+          return this.clientService.searchClients(q, 20).pipe(
+            catchError(() => of([] as ClientSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.clientsLoading.set(false);
+        this.clientItems.set(results.map(c => ({
+          id: `client:${c.id}`,
+          label: c.name,
+          secondary: c.shortCode,
+          icon: 'building' as IconName,
+          route: ['/clients', c.id] as const,
+          section: 'clients' as const,
+          searchText: `${c.name} ${c.shortCode}`.toLowerCase(),
+        })));
+      });
+
+    this.probeSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.probesLoading.set(false);
+            this.probeItems.set([]);
+            return of([] as ProbeSearchResult[]);
+          }
+          this.probesLoading.set(true);
+          return this.probeService.searchProbes(q, 20).pipe(
+            catchError(() => of([] as ProbeSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.probesLoading.set(false);
+        this.probeItems.set(results.map(p => ({
+          id: `probe:${p.id}`,
+          label: p.name,
+          secondary: p.clientName,
+          icon: 'clock' as IconName,
+          route: ['/scheduled-probes', p.id, 'runs'] as const,
+          section: 'probes' as const,
+          searchText: `${p.name} ${p.clientName}`.toLowerCase(),
+        })));
+      });
+
+    this.userSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (untracked(() => this.isScoped()) || q.length < 2) {
+            this.usersLoading.set(false);
+            this.userItems.set([]);
+            return of([] as UserSearchResult[]);
+          }
+          this.usersLoading.set(true);
+          return this.userService.searchUsers(q, 20).pipe(
+            catchError(() => of([] as UserSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.usersLoading.set(false);
+        this.userItems.set(results.map(u => ({
+          id: `user:${u.id}`,
+          label: u.name,
+          secondary: u.email,
+          icon: 'user' as IconName,
+          route: ['/users'] as const,
+          queryParams: { edit: u.id },
+          section: 'users' as const,
+          searchText: `${u.name} ${u.email} ${u.role}`.toLowerCase(),
+        })));
+      });
+
+    this.personSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.peopleLoading.set(false);
+            this.personItems.set([]);
+            return of([] as PersonSearchResult[]);
+          }
+          this.peopleLoading.set(true);
+          return this.personService.searchPeople(q, 20).pipe(
+            catchError(() => of([] as PersonSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.peopleLoading.set(false);
+        this.personItems.set(results.map(p => ({
+          id: `person:${p.id}`,
+          label: p.name,
+          secondary: p.clientName,
+          icon: 'user' as IconName,
+          route: ['/clients', p.clientId] as const,
+          section: 'people' as const,
+          searchText: `${p.name} ${p.email} ${p.clientName}`.toLowerCase(),
+        })));
+      });
   }
 
   onOpenChange(open: boolean): void {
@@ -453,170 +620,77 @@ export class CommandPaletteComponent {
 
   private loadItems(): void {
     const user = this.auth.currentUser();
-    const isScoped = user?.isPortalOpsUser === true && !!user.clientId;
-    const clientId = user?.clientId ?? null;
+    const isScoped = user?.isPortalOpsUser === true && !!user?.clientId;
 
-    this.loading.set(true);
+    const newItems: PaletteItem[] = [];
 
-    const clients$ = isScoped && clientId
-      ? this.clientService.getClient(clientId).pipe(map(c => [c] as Client[]))
-      : this.clientService.getClients();
-
-    const probes$ = this.probeService.getProbes(
-      isScoped && clientId ? { clientId } : undefined,
-    );
-
-    // Scoped ops users cannot access /users (operator accounts).
-    const users$ = isScoped
-      ? of([] as ControlPanelUser[])
-      : this.userService.getUsers();
-
-    // PersonService.getPeople requires a clientId. For full operators without a
-    // client scope, the people section is omitted. A dedicated all-people search
-    // endpoint would be needed to support it (tracked for Phase B).
-    const people$ = clientId
-      ? this.personService.getPeople(clientId)
-      : of([] as Person[]);
-
-    forkJoin({
-      clients: clients$.pipe(catchError(() => of([] as Client[]))),
-      probes: probes$.pipe(catchError(() => of([] as ScheduledProbe[]))),
-      users: users$.pipe(catchError(() => of([] as ControlPanelUser[]))),
-      people: people$.pipe(catchError(() => of([] as Person[]))),
-    })
-      .pipe(
-        takeUntil(this.cancelLoad$),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: ({ clients, probes, users, people }) => {
-          const newItems: PaletteItem[] = [];
-
-          for (const c of clients) {
-            newItems.push({
-              id: `client:${c.id}`,
-              label: c.name,
-              secondary: c.shortCode,
-              icon: 'building',
-              route: ['/clients', c.id],
-              section: 'clients',
-              searchText: `${c.name} ${c.shortCode}`.toLowerCase(),
-            });
-          }
-
-          for (const p of probes) {
-            newItems.push({
-              id: `probe:${p.id}`,
-              label: p.name,
-              secondary: p.client?.name,
-              icon: 'clock',
-              route: ['/scheduled-probes', p.id, 'runs'],
-              section: 'probes',
-              searchText: `${p.name} ${p.client?.name ?? ''}`.toLowerCase(),
-            });
-          }
-
-          for (const u of users) {
-            newItems.push({
-              id: `user:${u.id}`,
-              label: u.name,
-              // Email disambiguates multiple users with the same display name —
-              // role (ADMIN / OPERATOR) doesn't.
-              secondary: u.email,
-              icon: 'user',
-              route: ['/users'],
-              // user-list reads ?edit=<id> and auto-opens the edit dialog.
-              queryParams: { edit: u.id },
-              section: 'users',
-              searchText: `${u.name} ${u.email} ${u.role}`.toLowerCase(),
-            });
-          }
-
-          for (const p of people) {
-            newItems.push({
-              id: `person:${p.id}`,
-              label: p.name,
-              secondary: p.client?.name,
-              icon: 'user',
-              route: ['/clients', p.clientId],
-              section: 'people',
-              searchText: `${p.name} ${p.email} ${p.client?.name ?? ''}`.toLowerCase(),
-            });
-          }
-
-          // Commands — static actions; Create commands hidden for scoped users.
-          if (!isScoped) {
-            newItems.push({
-              id: 'cmd:create-ticket',
-              label: 'Create Ticket',
-              icon: 'add',
-              route: ['/tickets'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create ticket',
-            });
-            newItems.push({
-              id: 'cmd:create-client',
-              label: 'Create Client',
-              icon: 'add',
-              route: ['/clients'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create client',
-            });
-            newItems.push({
-              id: 'cmd:create-probe',
-              label: 'Create Scheduled Probe',
-              icon: 'add',
-              route: ['/scheduled-probes'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create scheduled probe',
-            });
-          }
-
-          newItems.push({
-            id: 'cmd:switch-theme',
-            label: 'Switch Theme',
-            icon: 'sparkles',
-            action: () => {
-              const next = this.theme.cycleToNext();
-              this.toast.info(`Theme: ${next.name}`);
-            },
-            section: 'commands',
-            searchText: 'switch theme',
-          });
-
-          newItems.push({
-            id: 'cmd:logout',
-            label: 'Logout',
-            icon: 'close',
-            action: () => this.auth.logout(),
-            section: 'commands',
-            searchText: 'logout',
-          });
-
-          const navRoutes = isScoped
-            ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
-            : ALL_NAV_ROUTES;
-
-          for (const r of navRoutes) {
-            newItems.push({
-              id: `nav:${r.route}`,
-              label: `Go to ${r.label}`,
-              icon: r.icon,
-              route: [r.route],
-              section: 'navigate',
-              searchText: `go to ${r.label}`.toLowerCase(),
-            });
-          }
-
-          this.items.set(newItems);
-          this.loading.set(false);
-        },
-        error: () => {
-          this.loading.set(false);
-        },
+    // Commands — static actions; Create commands hidden for scoped users.
+    if (!isScoped) {
+      newItems.push({
+        id: 'cmd:create-ticket',
+        label: 'Create Ticket',
+        icon: 'add',
+        route: ['/tickets'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create ticket',
       });
+      newItems.push({
+        id: 'cmd:create-client',
+        label: 'Create Client',
+        icon: 'add',
+        route: ['/clients'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create client',
+      });
+      newItems.push({
+        id: 'cmd:create-probe',
+        label: 'Create Scheduled Probe',
+        icon: 'add',
+        route: ['/scheduled-probes'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create scheduled probe',
+      });
+    }
+
+    newItems.push({
+      id: 'cmd:switch-theme',
+      label: 'Switch Theme',
+      icon: 'sparkles',
+      action: () => {
+        const next = this.theme.cycleToNext();
+        this.toast.info(`Theme: ${next.name}`);
+      },
+      section: 'commands',
+      searchText: 'switch theme',
+    });
+
+    newItems.push({
+      id: 'cmd:logout',
+      label: 'Logout',
+      icon: 'close',
+      action: () => this.auth.logout(),
+      section: 'commands',
+      searchText: 'logout',
+    });
+
+    const navRoutes = isScoped
+      ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
+      : ALL_NAV_ROUTES;
+
+    for (const r of navRoutes) {
+      newItems.push({
+        id: `nav:${r.route}`,
+        label: `Go to ${r.label}`,
+        icon: r.icon,
+        route: [r.route],
+        section: 'navigate',
+        searchText: `go to ${r.label}`.toLowerCase(),
+      });
+    }
+
+    this.items.set(newItems);
   }
 }

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -18,6 +18,59 @@ function validateDomainMappings(domains: string[] | undefined): string[] | undef
 }
 
 export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
+  // GET /api/search/clients — lightweight search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/clients',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      // Translate clientId scope to id filter (clients are queried by their own id).
+      const scopeWhere = scopeToWhere(scope);
+      const idFilter = scopeWhere.clientId !== undefined ? { id: scopeWhere.clientId } : {};
+
+      const results = await fastify.db.client.findMany({
+        where: {
+          isInternal: false,
+          ...idFilter,
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { shortCode: { contains: rawQ, mode: 'insensitive' } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          shortCode: true,
+          isActive: true,
+        },
+        take: limit * 2,
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.name.localeCompare(b.name);
+      });
+
+      return results.slice(0, limit);
+    },
+  );
+
   fastify.get('/api/clients', async (request) => {
     const scope = await resolveClientScope(request, (operatorId) =>
       getOperatorClientIds(fastify.db, operatorId),

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -57,13 +57,22 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
           isActive: true,
         },
         take: limit * 2,
+        orderBy: { name: 'asc' },
       });
 
       const qLower = rawQ.toLowerCase();
+      const getRank = (name: string, shortCode: string): number => {
+        const nameLower = name.toLowerCase();
+        const shortCodeLower = shortCode.toLowerCase();
+        if (shortCodeLower === qLower) return 0;
+        if (shortCodeLower.startsWith(qLower)) return 1;
+        if (nameLower === qLower) return 2;
+        if (nameLower.startsWith(qLower)) return 3;
+        return 4;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        if (aStarts !== bStarts) return aStarts - bStarts;
+        const rankDiff = getRank(a.name, a.shortCode) - getRank(b.name, b.shortCode);
+        if (rankDiff !== 0) return rankDiff;
         return a.name.localeCompare(b.name);
       });
 

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -49,6 +49,78 @@ function canManagePeople(request: FastifyRequest): boolean {
 
 export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
   /**
+   * GET /api/search/people
+   * Lightweight search for the command palette. Mirrors scope branching from GET /api/people.
+   */
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/people',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+
+      let scopedClientIdFilter: string | { in: string[] } | undefined;
+      if (scope.type === 'assigned') {
+        if (scope.clientIds.length === 0) return [];
+        scopedClientIdFilter = { in: scope.clientIds };
+      } else if (scope.type === 'single') {
+        scopedClientIdFilter = scope.clientId;
+      }
+
+      const results = await fastify.db.person.findMany({
+        where: {
+          ...(scopedClientIdFilter !== undefined && { clientId: scopedClientIdFilter }),
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { email: { contains: rawQ, mode: 'insensitive' } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' } } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          clientId: true,
+          role: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        email: p.email,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        role: p.role,
+        isActive: p.isActive,
+      }));
+    },
+  );
+
+  /**
    * GET /api/people?clientId=X
    * List people for a client, ordered by name.
    */

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -102,9 +102,18 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
 
       const qLower = rawQ.toLowerCase();
       results.sort((a, b) => {
+        const aEmailExact = a.email.toLowerCase() === qLower ? 0 : 1;
+        const bEmailExact = b.email.toLowerCase() === qLower ? 0 : 1;
+        if (aEmailExact !== bEmailExact) return aEmailExact - bEmailExact;
+
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const nameCompare = a.name.localeCompare(b.name);
+        if (nameCompare !== 0) return nameCompare;
+
+        return a.email.localeCompare(b.email);
       });
 
       return results.slice(0, limit).map(p => ({

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -131,20 +131,26 @@ export async function scheduledProbeRoutes(
         select: {
           id: true,
           name: true,
+          createdAt: true,
           clientId: true,
           toolName: true,
           isActive: true,
           client: { select: { name: true, shortCode: true } },
         },
         take: limit,
-        orderBy: { name: 'asc' },
+        orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
       });
 
       const qLower = rawQ.toLowerCase();
       results.sort((a, b) => {
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+        if (createdAtDiff !== 0) return createdAtDiff;
+
+        return a.name.localeCompare(b.name);
       });
 
       return results.slice(0, limit).map(p => ({

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -6,6 +6,7 @@ import cronParser from 'cron-parser';
 const { parseExpression } = cronParser;
 import { ProbeAction, TicketCategory, IntegrationType, BUILTIN_PROBE_TOOL_NAMES, BUILTIN_PROBE_TOOLS } from '@bronco/shared-types';
 import { buildUtcCron } from '@bronco/shared-utils';
+import { resolveClientScope, scopeToWhere, getOperatorClientIds } from '../plugins/client-scope.js';
 
 const VALID_ACTIONS = new Set(Object.values(ProbeAction));
 const VALID_CATEGORIES = new Set(Object.values(TicketCategory));
@@ -95,6 +96,68 @@ export async function scheduledProbeRoutes(
   opts: ScheduledProbeOpts,
 ): Promise<void> {
   const { probeQueue } = opts;
+
+  // GET /api/search/scheduled-probes — lightweight search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/scheduled-probes',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      const clientWhere = scopeToWhere(scope);
+
+      const results = await fastify.db.scheduledProbe.findMany({
+        where: {
+          ...clientWhere,
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { description: { contains: rawQ, mode: 'insensitive' } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' } } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          clientId: true,
+          toolName: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        toolName: p.toolName,
+        isActive: p.isActive,
+      }));
+    },
+  );
 
   // List all probes, optionally filtered by clientId
   fastify.get<{

--- a/services/copilot-api/src/routes/users.ts
+++ b/services/copilot-api/src/routes/users.ts
@@ -24,6 +24,52 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
   });
 
   /**
+   * GET /api/search/users
+   * Lightweight search for the command palette. Admin gate inherited from preHandler.
+   */
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/users',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const results = await fastify.db.user.findMany({
+        where: {
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { email: { contains: rawQ, mode: 'insensitive' } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          isActive: true,
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit);
+    },
+  );
+
+  /**
    * GET /api/users
    * List all control panel users. Includes slackUserId from matching Operator record.
    */

--- a/services/copilot-api/src/routes/users.ts
+++ b/services/copilot-api/src/routes/users.ts
@@ -59,10 +59,19 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
       });
 
       const qLower = rawQ.toLowerCase();
+      const getRank = (user: { name: string; email: string }): number => {
+        const nameLower = user.name.toLowerCase();
+        const emailLower = user.email.toLowerCase();
+        if (emailLower === qLower) return 0;
+        if (nameLower.startsWith(qLower) || emailLower.startsWith(qLower)) return 1;
+        return 2;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        const rankDiff = getRank(a) - getRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        const nameDiff = a.name.localeCompare(b.name);
+        if (nameDiff !== 0) return nameDiff;
+        return a.email.localeCompare(b.email);
       });
 
       return results.slice(0, limit);


### PR DESCRIPTION
- Add GET /api/search/{clients,scheduled-probes,users,people}
  with min-q=2, limit<=50, scope filtering, lightweight projections
- Add matching MCP platform tools (search_clients, search_scheduled_probes,
  search_users, search_people) per Platform Server Sync convention
- Refactor CommandPaletteComponent: five debounced server-side
  Subject<string> streams replace the forkJoin upfront load
- Scoped-ops users skip the user-search call entirely;
  remaining sections scope-filter server-side
- UX change: empty palette now shows only Commands + Navigate
  (matches behavior documented in issue #275)

https://claude.ai/code/session_01GwcDDNfopnKoNZ3tgXHgjL