### PR TITLE
feat: mobile UX batch — zoom fix, body scroll, haptics, pull-to-refresh, sidebar cleanup (fixes #239, fixes #273, fixes #249, fixes #248, fixes #282)

### DIFF
--- a/services/control-panel/src/app/core/config/app-constants.ts
+++ b/services/control-panel/src/app/core/config/app-constants.ts
@@ -1,0 +1,3 @@
+export const APP_CONSTANTS = {
+  projectName: 'Bronco',
+} as const;

--- a/services/control-panel/src/app/core/services/haptic.service.ts
+++ b/services/control-panel/src/app/core/services/haptic.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class HapticService {
+  tap(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate(10);
+  }
+
+  success(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate([10, 30, 10]);
+  }
+
+  warn(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate(30);
+  }
+}

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -17,6 +17,7 @@ import {
   PriorityPillComponent,
   IconComponent,
 } from '../../shared/components/index.js';
+import { PullToRefreshDirective } from '../../shared/directives/pull-to-refresh.directive.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
 interface StatusPill {
@@ -85,9 +86,10 @@ interface ActiveFilterChip {
     TicketQuickActionsDialogComponent,
     TicketFilterDialogComponent,
     IconComponent,
+    PullToRefreshDirective,
   ],
   template: `
-    <div class="ticket-list-page">
+    <div class="ticket-list-page" appPullToRefresh (refresh)="load()">
       <div class="page-header">
         <h1 class="page-title">Tickets</h1>
         <app-bronco-button variant="primary" (click)="showCreateDialog.set(true)">+ Create Ticket</app-bronco-button>

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, effect, inject, input, output, untracked } from '@angular/core';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
+import { HapticService } from '../../core/services/haptic.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
@@ -50,6 +51,7 @@ import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchCo
 })
 export class UserDialogComponent {
   private userService = inject(UserService);
+  private haptic = inject(HapticService);
   private toast = inject(ToastService);
 
   user = input<ControlPanelUser | undefined>(undefined);
@@ -101,6 +103,7 @@ export class UserDialogComponent {
   }
 
   save(): void {
+    this.haptic.success();
     const u = this.user();
     if (!u && this.password.length < 8) {
       this.toast.error('Password must be at least 8 characters');

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { AuthService } from '../../core/services/auth.service.js';
+import { HapticService } from '../../core/services/haptic.service.js';
 import { UserDialogComponent } from './user-dialog.component.js';
 import {
   BroncoButtonComponent,
@@ -299,6 +300,7 @@ import { ToastService } from '../../core/services/toast.service.js';
 export class UserListComponent implements OnInit {
   private userService = inject(UserService);
   private authService = inject(AuthService);
+  private haptic = inject(HapticService);
   private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -416,6 +418,7 @@ export class UserListComponent implements OnInit {
   }
 
   deactivate(user: ControlPanelUser): void {
+    this.haptic.warn();
     this.userService.deleteUser(user.id).subscribe({
       next: () => {
         this.toast.success('User deactivated');

--- a/services/control-panel/src/app/shared/components/text-input.component.ts
+++ b/services/control-panel/src/app/shared/components/text-input.component.ts
@@ -47,6 +47,10 @@ let standaloneInputCounter = 0;
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    @media (max-width: 767.98px) {
+      .text-input { font-size: 16px; }
+    }
   `],
 })
 export class TextInputComponent {

--- a/services/control-panel/src/app/shared/components/textarea.component.ts
+++ b/services/control-panel/src/app/shared/components/textarea.component.ts
@@ -48,6 +48,10 @@ let standaloneTextareaCounter = 0;
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    @media (max-width: 767.98px) {
+      .textarea-input { font-size: 16px; }
+    }
   `],
 })
 export class TextareaComponent {

--- a/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
+++ b/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
@@ -1,11 +1,11 @@
-import { Directive, HostListener, Renderer2, inject, output } from '@angular/core';
+import { Directive, HostListener, OnDestroy, Renderer2, inject, output } from '@angular/core';
 
 @Directive({
   selector: '[appPullToRefresh]',
   standalone: true,
   host: { style: 'overscroll-behavior: contain' },
 })
-export class PullToRefreshDirective {
+export class PullToRefreshDirective implements OnDestroy {
   private renderer = inject(Renderer2);
 
   readonly refresh = output<void>();
@@ -41,6 +41,20 @@ export class PullToRefreshDirective {
     const delta = this.currentDelta;
     this.reset();
     if (delta >= this.threshold) this.refresh.emit();
+  }
+
+  // Clean up the spinner if the gesture is interrupted (e.g. a phone call,
+  // system dialog, or the browser cancelling touches). Without this, the
+  // spinner can be left attached to document.body.
+  @HostListener('touchcancel')
+  onTouchCancel(): void {
+    this.reset();
+  }
+
+  // Also clean up if the directive is destroyed mid-gesture (e.g. the user
+  // navigates away while holding). Angular won't fire touchend for us.
+  ngOnDestroy(): void {
+    this.reset();
   }
 
   private showSpinner(progress: number): void {

--- a/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
+++ b/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
@@ -1,0 +1,63 @@
+import { Directive, HostListener, Renderer2, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[appPullToRefresh]',
+  standalone: true,
+  host: { style: 'overscroll-behavior: contain' },
+})
+export class PullToRefreshDirective {
+  private renderer = inject(Renderer2);
+
+  readonly refresh = output<void>();
+
+  private startY = 0;
+  private currentDelta = 0;
+  private pulling = false;
+  private spinner: HTMLElement | null = null;
+  private readonly threshold = 60;
+
+  @HostListener('touchstart', ['$event'])
+  onTouchStart(e: TouchEvent): void {
+    if (!('ontouchstart' in window)) return;
+    if (window.scrollY > 0) return;
+    this.startY = e.touches[0].clientY;
+    this.currentDelta = 0;
+    this.pulling = true;
+  }
+
+  @HostListener('touchmove', ['$event'])
+  onTouchMove(e: TouchEvent): void {
+    if (!this.pulling) return;
+    if (window.scrollY > 0) { this.reset(); return; }
+    const delta = e.touches[0].clientY - this.startY;
+    if (delta <= 0) { this.reset(); return; }
+    this.currentDelta = delta;
+    this.showSpinner(Math.min(delta, this.threshold));
+  }
+
+  @HostListener('touchend')
+  onTouchEnd(): void {
+    if (!this.pulling) return;
+    const delta = this.currentDelta;
+    this.reset();
+    if (delta >= this.threshold) this.refresh.emit();
+  }
+
+  private showSpinner(progress: number): void {
+    if (!this.spinner) {
+      this.spinner = this.renderer.createElement('div');
+      this.renderer.addClass(this.spinner, 'pull-to-refresh-spinner');
+      this.renderer.appendChild(document.body, this.spinner);
+    }
+    this.renderer.setStyle(this.spinner, 'opacity', String(Math.min(progress / this.threshold, 1)));
+  }
+
+  private reset(): void {
+    this.pulling = false;
+    this.currentDelta = 0;
+    if (this.spinner) {
+      this.renderer.removeChild(document.body, this.spinner);
+      this.spinner = null;
+    }
+  }
+}

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -89,10 +89,14 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
       padding: 24px;
     }
     @media (max-width: 767.98px) {
+      .shell { height: auto; overflow: visible; min-height: 100dvh; }
+      .shell-main { overflow: visible; }
       .shell-content {
+        overflow: visible;
         padding: 12px;
         padding-bottom: max(12px, env(safe-area-inset-bottom));
       }
+      app-header-bar { position: sticky; top: 0; z-index: 5; }
     }
   `],
 })

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -6,6 +6,7 @@ import { ThemeService } from '../core/services/theme.service.js';
 import { VersionService } from '../core/services/version.service.js';
 import { TicketService } from '../core/services/ticket.service.js';
 import { FailedJobsService } from '../core/services/failed-jobs.service.js';
+import { APP_CONSTANTS } from '../core/config/app-constants.js';
 
 @Component({
   selector: 'app-sidebar',
@@ -36,6 +37,7 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
           <div class="nav-section">
             <span class="section-label">Account</span>
             <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
+            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
           </div>
         } @else {
           <div class="nav-section">
@@ -82,17 +84,18 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
             <span class="section-label">Account</span>
             <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
             <a routerLink="/notification-preferences" routerLinkActive="nav-active" class="nav-item">Notifications</a>
+            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
           </div>
         }
-      </div>
 
-      <div class="sidebar-footer">
-        <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
         <a routerLink="/profile" class="theme-indicator">
           <span class="theme-dot" [style.background]="themeService.currentTheme().accentColor"></span>
           <span>{{ themeService.currentTheme().name }}</span>
         </a>
-        <span class="version-label">v{{ version() }}</span>
+      </div>
+
+      <div class="sidebar-footer">
+        <span class="version-label">Project {{ projectName }} {{ version() }}</span>
       </div>
     </nav>
   `,
@@ -181,7 +184,6 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
       padding: 8px 0 4px;
     }
     .logout-btn {
-      width: calc(100% - 16px);
       text-align: left;
       background: none;
       border: none;
@@ -261,6 +263,7 @@ export class SidebarComponent {
   private readonly ticketService = inject(TicketService);
   private readonly failedJobsService = inject(FailedJobsService);
 
+  readonly projectName = APP_CONSTANTS.projectName;
   readonly version = toSignal(this.versionService.getVersion(), { initialValue: '' });
   readonly ticketBadge = this.ticketService.activeCount;
   readonly failedJobsBadge = this.failedJobsService.totalCount;

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -82,7 +82,10 @@ app-dialog .dialog-body [dialogFooter] {
 }
 .pull-to-refresh-spinner {
   position: fixed;
-  top: 60px;
+  // Position below the sticky header, respecting the iOS safe-area inset so
+  // the spinner clears Safari's status-bar region. Tracks --header-height so
+  // future header resizes propagate automatically.
+  top: calc(var(--header-height) + env(safe-area-inset-top) + 8px);
   left: 50%;
   transform: translateX(-50%);
   width: 28px;
@@ -90,7 +93,9 @@ app-dialog .dialog-body [dialogFooter] {
   border-radius: 50%;
   border: 2.5px solid var(--border-medium);
   border-top-color: var(--accent);
-  z-index: 9999;
+  // Sits above normal content but below dialogs/menus (z-index: 1000) and
+  // toasts (10000), so refresh gestures never obscure active modal UI.
+  z-index: 100;
   pointer-events: none;
   opacity: 0;
   animation: ptr-spin 0.8s linear infinite;

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -55,22 +55,17 @@ app-dialog .dialog-body [dialogFooter] {
 }
 
 /*
- * iOS Safari auto-zooms on focus when an input has font-size < 16px. The
- * native-element selectors alone aren't enough: the primitives set their
- * own 14px via view-encapsulated attribute selectors (e.g.
- * `.text-input[_ngcontent-xxx]`), which have higher specificity than the
- * global `input { ... }` rule. So the mobile override targets both the
- * native elements AND the primitive classes by name, guaranteeing the 16px
- * wins on small screens. Desktop keeps the 14px default for density.
+ * iOS Safari auto-zooms on focus when an input has font-size < 16px.
+ * Primitives (app-text-input, app-textarea) set their mobile 16px inside
+ * their own component styles so view-encapsulation source order guarantees
+ * the rule wins. This global block covers raw native inputs (e.g. <input>
+ * with .date-input) that aren't wrapped by a primitive, as a safety net.
  * Form-field tap targets also get bumped to a 44px minimum height.
  */
 @media (max-width: 767.98px) {
   input,
   textarea,
   select,
-  app-text-input .text-input,
-  app-textarea .textarea-input,
-  app-select .select-input,
   .date-input {
     font-size: 16px;
   }
@@ -80,6 +75,25 @@ app-dialog .dialog-body [dialogFooter] {
   app-select .select-input {
     min-height: 44px;
   }
+}
+
+@keyframes ptr-spin {
+  to { transform: translateX(-50%) rotate(360deg); }
+}
+.pull-to-refresh-spinner {
+  position: fixed;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2.5px solid var(--border-medium);
+  border-top-color: var(--accent);
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0;
+  animation: ptr-spin 0.8s linear infinite;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
- #239: move iOS 16px font-size rule into app-text-input and
  app-textarea component styles so view-encapsulation specificity
  wins; simplify global rule in styles.scss
- #273: mobile body-level scroll + sticky header so iOS Safari
  URL pill auto-collapses on document-flow scrolling
- #249: HapticService (tap/success/warn) with one destructive and
  one save call site wired up; graceful no-op on unsupported browsers
- #248: pull-to-refresh directive applied to tickets list;
  threshold + spinner + overscroll-behavior contain
- #282: sidebar cleanup — Logout under Account in both scoped and
  operator layouts; theme indicator at end of scrollable list;
  single-line "Project Bronco v0.1.7" footer; APP_CONSTANTS.projectName
  as the Angular-scoped source of truth

https://claude.ai/code/session_01TTfxajePczaAEqrAxKNEC3