### PR TITLE
merge: staging → master

### DIFF
--- a/mcp-servers/platform/src/tools/clients.ts
+++ b/mcp-servers/platform/src/tools/clients.ts
@@ -29,12 +29,21 @@ export function registerClientTools(server: McpServer, { db }: ServerDeps): void
           isActive: true,
         },
         take: limit * 2,
+        orderBy: { name: 'asc' },
       });
 
+      const getRank = (name: string, shortCode: string): number => {
+        const nameLower = name.toLowerCase();
+        const shortCodeLower = shortCode.toLowerCase();
+        if (shortCodeLower === qLower) return 0;
+        if (shortCodeLower.startsWith(qLower)) return 1;
+        if (nameLower === qLower) return 2;
+        if (nameLower.startsWith(qLower)) return 3;
+        return 4;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        if (aStarts !== bStarts) return aStarts - bStarts;
+        const rankDiff = getRank(a.name, a.shortCode) - getRank(b.name, b.shortCode);
+        if (rankDiff !== 0) return rankDiff;
         return a.name.localeCompare(b.name);
       });
 

--- a/mcp-servers/platform/src/tools/clients.ts
+++ b/mcp-servers/platform/src/tools/clients.ts
@@ -4,6 +4,45 @@ import type { ServerDeps } from '../server.js';
 
 export function registerClientTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_clients',
+    'Search clients by name or short code. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name or short code). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.client.findMany({
+        where: {
+          isInternal: false,
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { shortCode: { contains: q, mode: 'insensitive' as const } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          shortCode: true,
+          isActive: true,
+        },
+        take: limit * 2,
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.name.localeCompare(b.name);
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_clients',
     'List all clients with system count and ticket count.',
     {},

--- a/mcp-servers/platform/src/tools/index.ts
+++ b/mcp-servers/platform/src/tools/index.ts
@@ -13,11 +13,13 @@ import { registerClientMemoryTools } from './client-memory.js';
 import { registerSettingsTools } from './settings.js';
 import { registerSystemStatusTools } from './system-status.js';
 import { registerSlackConversationTools } from './slack-conversations.js';
+import { registerUserTools } from './users.js';
 
 export function registerAllTools(server: McpServer, deps: ServerDeps): void {
   registerTicketTools(server, deps);
   registerPeopleTools(server, deps);
   registerClientTools(server, deps);
+  registerUserTools(server, deps);
   registerSystemTools(server, deps);
   registerProbeTools(server, deps);
   registerIssueJobTools(server, deps);

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -4,6 +4,60 @@ import type { ServerDeps } from '../server.js';
 
 export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
+    'search_people',
+    'Search people (unified contacts + portal users) by name, email, or client. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name, email, or client). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.person.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { email: { contains: q, mode: 'insensitive' as const } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          clientId: true,
+          role: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      const result = results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        email: p.email,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        role: p.role,
+        isActive: p.isActive,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_people',
     'List people (unified contacts + portal users), optionally filtered by client.',
     {

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -37,9 +37,18 @@ export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void
       });
 
       results.sort((a, b) => {
+        const aEmailExact = a.email.toLowerCase() === qLower ? 0 : 1;
+        const bEmailExact = b.email.toLowerCase() === qLower ? 0 : 1;
+        if (aEmailExact !== bEmailExact) return aEmailExact - bEmailExact;
+
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const nameCompare = a.name.localeCompare(b.name);
+        if (nameCompare !== 0) return nameCompare;
+
+        return a.email.localeCompare(b.email);
       });
 
       const result = results.slice(0, limit).map(p => ({

--- a/mcp-servers/platform/src/tools/probes.ts
+++ b/mcp-servers/platform/src/tools/probes.ts
@@ -4,6 +4,58 @@ import type { ServerDeps } from '../server.js';
 
 export function registerProbeTools(server: McpServer, { db, probeQueue }: ServerDeps): void {
   server.tool(
+    'search_scheduled_probes',
+    'Search scheduled probes by name, description, or client. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name, description, or client). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.scheduledProbe.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { description: { contains: q, mode: 'insensitive' as const } },
+            { client: { name: { contains: q, mode: 'insensitive' as const } } },
+            { client: { shortCode: { contains: q, mode: 'insensitive' as const } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          clientId: true,
+          toolName: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      const result = results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        toolName: p.toolName,
+        isActive: p.isActive,
+      }));
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
     'list_probes',
     'List scheduled probes with last run info. Optionally filter by client.',
     {

--- a/mcp-servers/platform/src/tools/probes.ts
+++ b/mcp-servers/platform/src/tools/probes.ts
@@ -26,19 +26,25 @@ export function registerProbeTools(server: McpServer, { db, probeQueue }: Server
         select: {
           id: true,
           name: true,
+          createdAt: true,
           clientId: true,
           toolName: true,
           isActive: true,
           client: { select: { name: true, shortCode: true } },
         },
         take: limit,
-        orderBy: { name: 'asc' },
+        orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
       });
 
       results.sort((a, b) => {
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+        if (createdAtDiff !== 0) return createdAtDiff;
+
+        return a.name.localeCompare(b.name);
       });
 
       const result = results.slice(0, limit).map(p => ({

--- a/mcp-servers/platform/src/tools/users.ts
+++ b/mcp-servers/platform/src/tools/users.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ServerDeps } from '../server.js';
+
+export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
+  server.tool(
+    'search_users',
+    'Search control panel users by name or email. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name or email). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const results = await db.user.findMany({
+        where: {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' as const } },
+            { email: { contains: q, mode: 'insensitive' as const } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          isActive: true,
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };
+    },
+  );
+}

--- a/mcp-servers/platform/src/tools/users.ts
+++ b/mcp-servers/platform/src/tools/users.ts
@@ -32,10 +32,19 @@ export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
         orderBy: { name: 'asc' },
       });
 
+      const getRank = (user: { name: string; email: string }): number => {
+        const nameLower = user.name.toLowerCase();
+        const emailLower = user.email.toLowerCase();
+        if (emailLower === qLower) return 0;
+        if (nameLower.startsWith(qLower) || emailLower.startsWith(qLower)) return 1;
+        return 2;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        const rankDiff = getRank(a) - getRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        const nameDiff = a.name.localeCompare(b.name);
+        if (nameDiff !== 0) return nameDiff;
+        return a.email.localeCompare(b.email);
       });
 
       return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };

--- a/services/control-panel/package.json
+++ b/services/control-panel/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.json",
     "dev": "ng serve --proxy-config proxy.conf.json",
+    "prebuild": "node scripts/check-theme-colors.mjs",
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "typecheck": "ng build --configuration production",

--- a/services/control-panel/scripts/check-theme-colors.mjs
+++ b/services/control-panel/scripts/check-theme-colors.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Drift-check: asserts that the inline THEME_COLORS map in src/index.html
- * matches the canonical map exported from theme-colors.ts.
+ * matches the canonical map exported from theme-colors.ts, AND that the
+ * static <meta name="theme-color"> tag matches THEME_COLORS[DEFAULT_THEME].
  *
  * Runs as a prebuild step so CI fails immediately on divergence rather than
  * silently shipping mismatched pre-boot colors.
@@ -13,6 +14,34 @@ import { join, dirname } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 
+/**
+ * Parse a block of `key: '#value',` lines into an object.
+ * Fails if no entries parsed or if the count of key/value pairs in the
+ * source doesn't match the parsed count (guards against silent regex drift
+ * if the source formatting ever changes — e.g. double quotes, quoted keys).
+ */
+function parseColorBlock(block, label) {
+  const parsed = {};
+  const lines = block.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+    if (m) parsed[m[1]] = m[2];
+  }
+  // Count lines that look like a key/value entry (a colon followed by a value
+  // that doesn't start with `{` or `[`), so we can detect silent parse skips.
+  const entryLines = lines.filter(l => /^\s*\S+\s*:\s*[^{[]/.test(l));
+  const parsedCount = Object.keys(parsed).length;
+  if (parsedCount === 0) {
+    console.error(`ERROR: parsed 0 entries from ${label} THEME_COLORS block; regex likely out of sync with source format.`);
+    process.exit(1);
+  }
+  if (parsedCount !== entryLines.length) {
+    console.error(`ERROR: ${label} THEME_COLORS has ${entryLines.length} entry lines but only ${parsedCount} parsed; regex likely out of sync with source format.`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
 // --- Load the canonical source of truth ---
 const tsSource = readFileSync(join(root, 'src/app/core/services/theme-colors.ts'), 'utf8');
 
@@ -22,11 +51,7 @@ if (!tsColorsMatch) {
   console.error('ERROR: Could not parse THEME_COLORS from theme-colors.ts');
   process.exit(1);
 }
-const tsColors = {};
-for (const line of tsColorsMatch[1].split('\n')) {
-  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
-  if (m) tsColors[m[1]] = m[2];
-}
+const tsColors = parseColorBlock(tsColorsMatch[1], 'theme-colors.ts');
 
 // Parse DEFAULT_THEME from the TS source
 const tsDefaultMatch = tsSource.match(/export const DEFAULT_THEME[^=]*=\s*'(\w+)'/);
@@ -44,11 +69,7 @@ if (!htmlColorsMatch) {
   console.error('ERROR: Could not parse var THEME_COLORS from index.html');
   process.exit(1);
 }
-const htmlColors = {};
-for (const line of htmlColorsMatch[1].split('\n')) {
-  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
-  if (m) htmlColors[m[1]] = m[2];
-}
+const htmlColors = parseColorBlock(htmlColorsMatch[1], 'index.html');
 
 const htmlDefaultMatch = html.match(/var DEFAULT_THEME\s*=\s*'(\w+)'/);
 if (!htmlDefaultMatch) {
@@ -56,6 +77,15 @@ if (!htmlDefaultMatch) {
   process.exit(1);
 }
 const htmlDefault = htmlDefaultMatch[1];
+
+// Parse the static <meta name="theme-color" content="..."> tag — the color
+// Safari samples on first paint before the inline script runs.
+const metaMatch = html.match(/<meta\s+name=["']theme-color["']\s+content=["'](#[0-9a-fA-F]{3,8})["']/);
+if (!metaMatch) {
+  console.error('ERROR: Could not find <meta name="theme-color" content="..."> tag in index.html');
+  process.exit(1);
+}
+const metaColor = metaMatch[1];
 
 // --- Compare ---
 let failed = false;
@@ -79,8 +109,17 @@ if (tsDefault !== htmlDefault) {
   failed = true;
 }
 
+// The static <meta> tag Safari samples on first paint MUST equal the color
+// that THEME_COLORS[DEFAULT_THEME] resolves to — otherwise the default theme
+// flashes the wrong color before the inline script can update it.
+const expectedMetaColor = tsColors[tsDefault];
+if (expectedMetaColor && metaColor.toLowerCase() !== expectedMetaColor.toLowerCase()) {
+  console.error(`DRIFT: <meta name="theme-color"> content='${metaColor}' but THEME_COLORS[DEFAULT_THEME='${tsDefault}']='${expectedMetaColor}'`);
+  failed = true;
+}
+
 if (failed) {
-  console.error('\nFix: update index.html inline script to match theme-colors.ts (the single source of truth).');
+  console.error('\nFix: update index.html inline script and <meta name="theme-color"> tag to match theme-colors.ts (the single source of truth).');
   process.exit(1);
 }
 

--- a/services/control-panel/scripts/check-theme-colors.mjs
+++ b/services/control-panel/scripts/check-theme-colors.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Drift-check: asserts that the inline THEME_COLORS map in src/index.html
+ * matches the canonical map exported from theme-colors.ts.
+ *
+ * Runs as a prebuild step so CI fails immediately on divergence rather than
+ * silently shipping mismatched pre-boot colors.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// --- Load the canonical source of truth ---
+const tsSource = readFileSync(join(root, 'src/app/core/services/theme-colors.ts'), 'utf8');
+
+// Parse THEME_COLORS object entries from the TS source
+const tsColorsMatch = tsSource.match(/export const THEME_COLORS\s*=\s*\{([^}]+)\}/s);
+if (!tsColorsMatch) {
+  console.error('ERROR: Could not parse THEME_COLORS from theme-colors.ts');
+  process.exit(1);
+}
+const tsColors = {};
+for (const line of tsColorsMatch[1].split('\n')) {
+  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+  if (m) tsColors[m[1]] = m[2];
+}
+
+// Parse DEFAULT_THEME from the TS source
+const tsDefaultMatch = tsSource.match(/export const DEFAULT_THEME[^=]*=\s*'(\w+)'/);
+if (!tsDefaultMatch) {
+  console.error('ERROR: Could not parse DEFAULT_THEME from theme-colors.ts');
+  process.exit(1);
+}
+const tsDefault = tsDefaultMatch[1];
+
+// --- Load the inline script in index.html ---
+const html = readFileSync(join(root, 'src/index.html'), 'utf8');
+
+const htmlColorsMatch = html.match(/var THEME_COLORS\s*=\s*\{([^}]+)\}/s);
+if (!htmlColorsMatch) {
+  console.error('ERROR: Could not parse var THEME_COLORS from index.html');
+  process.exit(1);
+}
+const htmlColors = {};
+for (const line of htmlColorsMatch[1].split('\n')) {
+  const m = line.match(/^\s*(\w+):\s*'(#[0-9a-fA-F]{3,8})'/);
+  if (m) htmlColors[m[1]] = m[2];
+}
+
+const htmlDefaultMatch = html.match(/var DEFAULT_THEME\s*=\s*'(\w+)'/);
+if (!htmlDefaultMatch) {
+  console.error('ERROR: Could not parse var DEFAULT_THEME from index.html');
+  process.exit(1);
+}
+const htmlDefault = htmlDefaultMatch[1];
+
+// --- Compare ---
+let failed = false;
+
+const tsKeys = Object.keys(tsColors).sort();
+const htmlKeys = Object.keys(htmlColors).sort();
+if (JSON.stringify(tsKeys) !== JSON.stringify(htmlKeys)) {
+  console.error(`DRIFT: key sets differ.\n  theme-colors.ts: ${tsKeys.join(', ')}\n  index.html:      ${htmlKeys.join(', ')}`);
+  failed = true;
+}
+
+for (const key of tsKeys) {
+  if (tsColors[key] !== htmlColors[key]) {
+    console.error(`DRIFT: ${key}: theme-colors.ts='${tsColors[key]}' vs index.html='${htmlColors[key]}'`);
+    failed = true;
+  }
+}
+
+if (tsDefault !== htmlDefault) {
+  console.error(`DRIFT: DEFAULT_THEME: theme-colors.ts='${tsDefault}' vs index.html='${htmlDefault}'`);
+  failed = true;
+}
+
+if (failed) {
+  console.error('\nFix: update index.html inline script to match theme-colors.ts (the single source of truth).');
+  process.exit(1);
+}
+
+console.log('theme-colors check passed: index.html and theme-colors.ts are in sync.');

--- a/services/control-panel/src/app/core/config/app-constants.ts
+++ b/services/control-panel/src/app/core/config/app-constants.ts
@@ -1,0 +1,3 @@
+export const APP_CONSTANTS = {
+  projectName: 'Bronco',
+} as const;

--- a/services/control-panel/src/app/core/nav/nav-routes.ts
+++ b/services/control-panel/src/app/core/nav/nav-routes.ts
@@ -1,0 +1,61 @@
+import type { IconName } from '../../shared/components/icon-registry.js';
+
+export const NAV_SECTIONS = ['main', 'client', 'operations', 'ai', 'integrations', 'system', 'account'] as const;
+export type NavSection = (typeof NAV_SECTIONS)[number];
+
+export interface NavRoute {
+  /** Canonical route path, e.g. '/tickets'. */
+  route: string;
+  /** Display label used by the sidebar and (with "Go to " prefix) the palette. */
+  label: string;
+  /** Icon registry name. */
+  icon: IconName;
+  /** Which sidebar section this route belongs to. */
+  section: NavSection;
+}
+
+export const NAV_SECTION_LABELS: Record<NavSection, string> = {
+  main: 'Main',
+  client: 'Client',
+  operations: 'Operations',
+  ai: 'AI',
+  integrations: 'Integrations',
+  system: 'System',
+  account: 'Account',
+};
+
+export const NAV_ROUTES: readonly NavRoute[] = [
+  // Main
+  { route: '/dashboard', label: 'Dashboard', icon: 'home', section: 'main' },
+  { route: '/tickets', label: 'Tickets', icon: 'ticket', section: 'main' },
+  { route: '/activity', label: 'Activity Feed', icon: 'bell', section: 'main' },
+  { route: '/clients', label: 'Clients', icon: 'building', section: 'main' },
+
+  // Operations
+  { route: '/scheduled-probes', label: 'Scheduled Probes', icon: 'clock', section: 'operations' },
+  { route: '/ingestion-jobs', label: 'Ingestion Jobs', icon: 'play', section: 'operations' },
+  { route: '/failed-jobs', label: 'Failed Jobs', icon: 'warning', section: 'operations' },
+  { route: '/logs', label: 'Logs', icon: 'file', section: 'operations' },
+  { route: '/email-logs', label: 'Email Log', icon: 'email', section: 'operations' },
+
+  // AI
+  { route: '/prompts', label: 'AI Prompts', icon: 'sparkles', section: 'ai' },
+  { route: '/ai-providers', label: 'AI Providers', icon: 'robot', section: 'ai' },
+  { route: '/ai-usage', label: 'AI Usage', icon: 'bolt', section: 'ai' },
+  { route: '/ticket-routes', label: 'Ticket Routes', icon: 'tag', section: 'ai' },
+  { route: '/system-analysis', label: 'System Analysis', icon: 'search', section: 'ai' },
+  { route: '/system-issues', label: 'System Issues', icon: 'warning', section: 'ai' },
+
+  // Integrations
+  { route: '/slack-conversations', label: 'Slack Conversations', icon: 'comment', section: 'integrations' },
+  { route: '/release-notes', label: 'Release Notes', icon: 'book', section: 'integrations' },
+
+  // System
+  { route: '/system-status', label: 'Status', icon: 'server', section: 'system' },
+  { route: '/settings', label: 'Settings', icon: 'gear', section: 'system' },
+  { route: '/users', label: 'User Maint', icon: 'user', section: 'system' },
+
+  // Account
+  { route: '/profile', label: 'Profile', icon: 'user', section: 'account' },
+  { route: '/notification-preferences', label: 'Notifications', icon: 'bell', section: 'account' },
+];

--- a/services/control-panel/src/app/core/services/client.service.ts
+++ b/services/control-panel/src/app/core/services/client.service.ts
@@ -81,4 +81,15 @@ export class ClientService {
   updateClient(id: string, data: Partial<Client>): Observable<Client> {
     return this.api.patch<Client>(`/clients/${id}`, data);
   }
+
+  searchClients(q: string, limit = 20): Observable<ClientSearchResult[]> {
+    return this.api.get<ClientSearchResult[]>('/search/clients', { q, limit });
+  }
+}
+
+export interface ClientSearchResult {
+  id: string;
+  name: string;
+  shortCode: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/haptic.service.ts
+++ b/services/control-panel/src/app/core/services/haptic.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class HapticService {
+  tap(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate(10);
+  }
+
+  success(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate([10, 30, 10]);
+  }
+
+  warn(): void {
+    if (!('vibrate' in navigator)) return;
+    navigator.vibrate(30);
+  }
+}

--- a/services/control-panel/src/app/core/services/person.service.ts
+++ b/services/control-panel/src/app/core/services/person.service.ts
@@ -48,4 +48,19 @@ export class PersonService {
   resetPassword(id: string, password: string): Observable<{ message: string }> {
     return this.api.post<{ message: string }>(`/people/${id}/reset-password`, { password });
   }
+
+  searchPeople(q: string, limit = 20): Observable<PersonSearchResult[]> {
+    return this.api.get<PersonSearchResult[]>('/search/people', { q, limit });
+  }
+}
+
+export interface PersonSearchResult {
+  id: string;
+  name: string;
+  email: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
+  role: string | null;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/scheduled-probe.service.ts
+++ b/services/control-panel/src/app/core/services/scheduled-probe.service.ts
@@ -143,4 +143,18 @@ export class ScheduledProbeService {
   getBuiltinTools(): Observable<Array<{ name: string; description: string; inputSchema?: Record<string, unknown> }>> {
     return this.api.get('/scheduled-probes/builtin-tools');
   }
+
+  searchProbes(q: string, limit = 20): Observable<ProbeSearchResult[]> {
+    return this.api.get<ProbeSearchResult[]>('/search/scheduled-probes', { q, limit });
+  }
+}
+
+export interface ProbeSearchResult {
+  id: string;
+  name: string;
+  clientId: string;
+  clientName: string;
+  clientShortCode: string;
+  toolName: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/core/services/theme-colors.ts
+++ b/services/control-panel/src/app/core/services/theme-colors.ts
@@ -1,0 +1,12 @@
+export const THEME_COLORS = {
+  apple: '#f5f5f7',
+  linear: '#08090a',
+  sentry: '#1f1633',
+  supabase: '#171717',
+  nvidia: '#000000',
+  vercel: '#ffffff',
+} as const;
+
+export type ThemeId = keyof typeof THEME_COLORS;
+
+export const DEFAULT_THEME: ThemeId = 'apple';

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -2,9 +2,10 @@ import { Injectable, effect, inject, signal } from '@angular/core';
 import { AuthService } from './auth.service.js';
 import { ApiService } from './api.service.js';
 import { ToastService } from './toast.service.js';
+import { THEME_COLORS, DEFAULT_THEME, type ThemeId } from './theme-colors.js';
 
 export interface ThemeOption {
-  id: string;
+  id: ThemeId;
   name: string;
   bodyClass: string;
   description: string;
@@ -109,7 +110,9 @@ export class ThemeService {
   private applyThemeColorMeta(): void {
     const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
     if (!meta) return;
-    const color = getComputedStyle(document.body).getPropertyValue('--bg-page').trim() || '#08090a';
+    const theme = this.currentTheme();
+    const computed = getComputedStyle(document.body).getPropertyValue('--bg-page').trim();
+    const color = computed || THEME_COLORS[theme.id] || THEME_COLORS[DEFAULT_THEME];
     meta.content = color;
     // Clear the inline background style set by the pre-boot script in
     // index.html. That inline style exists only to cover first-paint on iOS

--- a/services/control-panel/src/app/core/services/theme.service.ts
+++ b/services/control-panel/src/app/core/services/theme.service.ts
@@ -126,6 +126,13 @@ export class ThemeService {
 
   private resolveInitial(): ThemeOption {
     const saved = localStorage.getItem(STORAGE_KEY);
-    return THEMES.find(t => t.id === saved) ?? THEMES[0];
+    // Fall back to DEFAULT_THEME (single source of truth in theme-colors.ts)
+    // rather than THEMES[0], so changing the default doesn't require reordering
+    // the array. THEMES[0] remains only as a last-resort safety net.
+    return (
+      THEMES.find(t => t.id === saved) ??
+      THEMES.find(t => t.id === DEFAULT_THEME) ??
+      THEMES[0]
+    );
   }
 }

--- a/services/control-panel/src/app/core/services/user.service.ts
+++ b/services/control-panel/src/app/core/services/user.service.ts
@@ -37,4 +37,16 @@ export class UserService {
   resetPassword(id: string, password: string): Observable<{ message: string }> {
     return this.api.post<{ message: string }>(`/users/${id}/reset-password`, { password });
   }
+
+  searchUsers(q: string, limit = 20): Observable<UserSearchResult[]> {
+    return this.api.get<UserSearchResult[]>('/search/users', { q, limit });
+  }
+}
+
+export interface UserSearchResult {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  isActive: boolean;
 }

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -17,6 +17,7 @@ import {
   PriorityPillComponent,
   IconComponent,
 } from '../../shared/components/index.js';
+import { PullToRefreshDirective } from '../../shared/directives/pull-to-refresh.directive.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
 interface StatusPill {
@@ -85,9 +86,10 @@ interface ActiveFilterChip {
     TicketQuickActionsDialogComponent,
     TicketFilterDialogComponent,
     IconComponent,
+    PullToRefreshDirective,
   ],
   template: `
-    <div class="ticket-list-page">
+    <div class="ticket-list-page" appPullToRefresh (refresh)="load()">
       <div class="page-header">
         <h1 class="page-title">Tickets</h1>
         <app-bronco-button variant="primary" (click)="showCreateDialog.set(true)">+ Create Ticket</app-bronco-button>

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, effect, inject, input, output, untracked } from '@angular/core';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
+import { HapticService } from '../../core/services/haptic.service.js';
 import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchComponent, BroncoButtonComponent } from '../../shared/components/index.js';
 
 @Component({
@@ -50,6 +51,7 @@ import { FormFieldComponent, TextInputComponent, SelectComponent, ToggleSwitchCo
 })
 export class UserDialogComponent {
   private userService = inject(UserService);
+  private haptic = inject(HapticService);
   private toast = inject(ToastService);
 
   user = input<ControlPanelUser | undefined>(undefined);
@@ -101,6 +103,7 @@ export class UserDialogComponent {
   }
 
   save(): void {
+    this.haptic.success();
     const u = this.user();
     if (!u && this.password.length < 8) {
       this.toast.error('Password must be at least 8 characters');

--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -103,7 +103,6 @@ export class UserDialogComponent {
   }
 
   save(): void {
-    this.haptic.success();
     const u = this.user();
     if (!u && this.password.length < 8) {
       this.toast.error('Password must be at least 8 characters');
@@ -118,6 +117,7 @@ export class UserDialogComponent {
         ...(this.slackUserId !== undefined && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
+          this.haptic.success();
           this.toast.success('User updated');
           this.saved.emit(true);
         },
@@ -132,6 +132,7 @@ export class UserDialogComponent {
         ...(this.slackUserId && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
+          this.haptic.success();
           this.toast.success('User created');
           this.saved.emit(true);
         },

--- a/services/control-panel/src/app/features/users/user-list.component.ts
+++ b/services/control-panel/src/app/features/users/user-list.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
 import { AuthService } from '../../core/services/auth.service.js';
+import { HapticService } from '../../core/services/haptic.service.js';
 import { UserDialogComponent } from './user-dialog.component.js';
 import {
   BroncoButtonComponent,
@@ -299,6 +300,7 @@ import { ToastService } from '../../core/services/toast.service.js';
 export class UserListComponent implements OnInit {
   private userService = inject(UserService);
   private authService = inject(AuthService);
+  private haptic = inject(HapticService);
   private toast = inject(ToastService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -416,6 +418,7 @@ export class UserListComponent implements OnInit {
   }
 
   deactivate(user: ControlPanelUser): void {
+    this.haptic.warn();
     this.userService.deleteUser(user.id).subscribe({
       next: () => {
         this.toast.success('User deactivated');

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -11,17 +11,17 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { debounceTime, distinctUntilChanged, forkJoin, of, Subject, switchMap } from 'rxjs';
-import { catchError, map, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, of, Subject, switchMap } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { DialogComponent } from './dialog.component.js';
 import { IconComponent } from './icon.component.js';
 import type { IconName } from './icon-registry.js';
 import { CommandPaletteService } from '../../core/services/command-palette.service.js';
 import { AuthService } from '../../core/services/auth.service.js';
-import { ClientService, type Client } from '../../core/services/client.service.js';
-import { ScheduledProbeService, type ScheduledProbe } from '../../core/services/scheduled-probe.service.js';
-import { UserService, type ControlPanelUser } from '../../core/services/user.service.js';
-import { PersonService, type Person } from '../../core/services/person.service.js';
+import { ClientService, type ClientSearchResult } from '../../core/services/client.service.js';
+import { ScheduledProbeService, type ProbeSearchResult } from '../../core/services/scheduled-probe.service.js';
+import { UserService, type UserSearchResult } from '../../core/services/user.service.js';
+import { PersonService, type PersonSearchResult } from '../../core/services/person.service.js';
 import { TicketService, type TicketSearchResult } from '../../core/services/ticket.service.js';
 import { ThemeService } from '../../core/services/theme.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
@@ -273,14 +273,32 @@ export class CommandPaletteComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
-  private readonly cancelLoad$ = new Subject<void>();
   private readonly ticketSearch$ = new Subject<string>();
+  private readonly clientSearch$ = new Subject<string>();
+  private readonly probeSearch$ = new Subject<string>();
+  private readonly userSearch$ = new Subject<string>();
+  private readonly personSearch$ = new Subject<string>();
+  private readonly isScoped = computed(() => {
+    const user = this.auth.currentUser();
+    return user?.isPortalOpsUser === true && !!user?.clientId;
+  });
 
   readonly query = signal('');
   readonly items = signal<PaletteItem[]>([]);
   readonly ticketItems = signal<PaletteItem[]>([]);
-  readonly loading = signal(false);
+  readonly clientItems = signal<PaletteItem[]>([]);
+  readonly probeItems = signal<PaletteItem[]>([]);
+  readonly userItems = signal<PaletteItem[]>([]);
+  readonly personItems = signal<PaletteItem[]>([]);
   readonly ticketsLoading = signal(false);
+  readonly clientsLoading = signal(false);
+  readonly probesLoading = signal(false);
+  readonly usersLoading = signal(false);
+  readonly peopleLoading = signal(false);
+  readonly loading = computed(() =>
+    this.ticketsLoading() || this.clientsLoading() || this.probesLoading() ||
+    this.usersLoading() || this.peopleLoading()
+  );
   readonly selectedIndex = signal(0);
 
   readonly filteredItems = computed(() => {
@@ -305,12 +323,26 @@ export class CommandPaletteComponent {
       itemMap.set(item.section, bucket);
     }
 
-    // Ticket items are pre-filtered server-side; merge them separately.
+    // Server-side search sections — merge results independently of filteredItems().
+    const clients = this.clientItems();
+    const isClientsLoading = this.clientsLoading();
+    if (clients.length > 0 || isClientsLoading) itemMap.set('clients', clients);
+
     const tickets = this.ticketItems();
     const isTicketsLoading = this.ticketsLoading();
-    if (tickets.length > 0 || isTicketsLoading) {
-      itemMap.set('tickets', tickets);
-    }
+    if (tickets.length > 0 || isTicketsLoading) itemMap.set('tickets', tickets);
+
+    const probes = this.probeItems();
+    const isProbesLoading = this.probesLoading();
+    if (probes.length > 0 || isProbesLoading) itemMap.set('probes', probes);
+
+    const users = this.userItems();
+    const isUsersLoading = this.usersLoading();
+    if (users.length > 0 || isUsersLoading) itemMap.set('users', users);
+
+    const people = this.personItems();
+    const isPeopleLoading = this.peopleLoading();
+    if (people.length > 0 || isPeopleLoading) itemMap.set('people', people);
 
     return SECTION_ORDER
       .filter(s => itemMap.has(s))
@@ -318,7 +350,11 @@ export class CommandPaletteComponent {
         section: s,
         label: SECTION_LABELS[s],
         items: itemMap.get(s)!,
-        loading: s === 'tickets' && isTicketsLoading,
+        loading: (s === 'clients' && isClientsLoading)
+               || (s === 'tickets' && isTicketsLoading)
+               || (s === 'probes' && isProbesLoading)
+               || (s === 'users' && isUsersLoading)
+               || (s === 'people' && isPeopleLoading),
       }));
   });
 
@@ -335,13 +371,19 @@ export class CommandPaletteComponent {
     // Palette open/close lifecycle: fetch data on open, reset on close.
     effect((onCleanup) => {
       if (!this.paletteService.isOpen()) {
-        this.cancelLoad$.next();
         untracked(() => {
           this.query.set('');
           this.items.set([]);
           this.ticketItems.set([]);
-          this.loading.set(false);
+          this.clientItems.set([]);
+          this.probeItems.set([]);
+          this.userItems.set([]);
+          this.personItems.set([]);
           this.ticketsLoading.set(false);
+          this.clientsLoading.set(false);
+          this.probesLoading.set(false);
+          this.usersLoading.set(false);
+          this.peopleLoading.set(false);
           this.selectedIndex.set(0);
         });
         return;
@@ -362,10 +404,16 @@ export class CommandPaletteComponent {
       untracked(() => this.selectedIndex.set(0));
     });
 
-    // Drive the debounced ticket search from the query signal.
+    // Fan out the query to all server-side search streams.
     effect(() => {
       const q = this.query().trim();
-      untracked(() => this.ticketSearch$.next(q));
+      untracked(() => {
+        this.ticketSearch$.next(q);
+        this.clientSearch$.next(q);
+        this.probeSearch$.next(q);
+        this.userSearch$.next(q);
+        this.personSearch$.next(q);
+      });
     });
 
     this.ticketSearch$
@@ -398,7 +446,126 @@ export class CommandPaletteComponent {
         })));
       });
 
-    this.destroyRef.onDestroy(() => this.cancelLoad$.complete());
+    this.clientSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.clientsLoading.set(false);
+            this.clientItems.set([]);
+            return of([] as ClientSearchResult[]);
+          }
+          this.clientsLoading.set(true);
+          return this.clientService.searchClients(q, 20).pipe(
+            catchError(() => of([] as ClientSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.clientsLoading.set(false);
+        this.clientItems.set(results.map(c => ({
+          id: `client:${c.id}`,
+          label: c.name,
+          secondary: c.shortCode,
+          icon: 'building' as IconName,
+          route: ['/clients', c.id] as const,
+          section: 'clients' as const,
+          searchText: `${c.name} ${c.shortCode}`.toLowerCase(),
+        })));
+      });
+
+    this.probeSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.probesLoading.set(false);
+            this.probeItems.set([]);
+            return of([] as ProbeSearchResult[]);
+          }
+          this.probesLoading.set(true);
+          return this.probeService.searchProbes(q, 20).pipe(
+            catchError(() => of([] as ProbeSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.probesLoading.set(false);
+        this.probeItems.set(results.map(p => ({
+          id: `probe:${p.id}`,
+          label: p.name,
+          secondary: p.clientName,
+          icon: 'clock' as IconName,
+          route: ['/scheduled-probes', p.id, 'runs'] as const,
+          section: 'probes' as const,
+          searchText: `${p.name} ${p.clientName}`.toLowerCase(),
+        })));
+      });
+
+    this.userSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (untracked(() => this.isScoped()) || q.length < 2) {
+            this.usersLoading.set(false);
+            this.userItems.set([]);
+            return of([] as UserSearchResult[]);
+          }
+          this.usersLoading.set(true);
+          return this.userService.searchUsers(q, 20).pipe(
+            catchError(() => of([] as UserSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.usersLoading.set(false);
+        this.userItems.set(results.map(u => ({
+          id: `user:${u.id}`,
+          label: u.name,
+          secondary: u.email,
+          icon: 'user' as IconName,
+          route: ['/users'] as const,
+          queryParams: { edit: u.id },
+          section: 'users' as const,
+          searchText: `${u.name} ${u.email} ${u.role}`.toLowerCase(),
+        })));
+      });
+
+    this.personSearch$
+      .pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(q => {
+          if (q.length < 2) {
+            this.peopleLoading.set(false);
+            this.personItems.set([]);
+            return of([] as PersonSearchResult[]);
+          }
+          this.peopleLoading.set(true);
+          return this.personService.searchPeople(q, 20).pipe(
+            catchError(() => of([] as PersonSearchResult[])),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => {
+        this.peopleLoading.set(false);
+        this.personItems.set(results.map(p => ({
+          id: `person:${p.id}`,
+          label: p.name,
+          secondary: p.clientName,
+          icon: 'user' as IconName,
+          route: ['/clients', p.clientId] as const,
+          section: 'people' as const,
+          searchText: `${p.name} ${p.email} ${p.clientName}`.toLowerCase(),
+        })));
+      });
   }
 
   onOpenChange(open: boolean): void {
@@ -453,170 +620,77 @@ export class CommandPaletteComponent {
 
   private loadItems(): void {
     const user = this.auth.currentUser();
-    const isScoped = user?.isPortalOpsUser === true && !!user.clientId;
-    const clientId = user?.clientId ?? null;
+    const isScoped = user?.isPortalOpsUser === true && !!user?.clientId;
 
-    this.loading.set(true);
+    const newItems: PaletteItem[] = [];
 
-    const clients$ = isScoped && clientId
-      ? this.clientService.getClient(clientId).pipe(map(c => [c] as Client[]))
-      : this.clientService.getClients();
-
-    const probes$ = this.probeService.getProbes(
-      isScoped && clientId ? { clientId } : undefined,
-    );
-
-    // Scoped ops users cannot access /users (operator accounts).
-    const users$ = isScoped
-      ? of([] as ControlPanelUser[])
-      : this.userService.getUsers();
-
-    // PersonService.getPeople requires a clientId. For full operators without a
-    // client scope, the people section is omitted. A dedicated all-people search
-    // endpoint would be needed to support it (tracked for Phase B).
-    const people$ = clientId
-      ? this.personService.getPeople(clientId)
-      : of([] as Person[]);
-
-    forkJoin({
-      clients: clients$.pipe(catchError(() => of([] as Client[]))),
-      probes: probes$.pipe(catchError(() => of([] as ScheduledProbe[]))),
-      users: users$.pipe(catchError(() => of([] as ControlPanelUser[]))),
-      people: people$.pipe(catchError(() => of([] as Person[]))),
-    })
-      .pipe(
-        takeUntil(this.cancelLoad$),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: ({ clients, probes, users, people }) => {
-          const newItems: PaletteItem[] = [];
-
-          for (const c of clients) {
-            newItems.push({
-              id: `client:${c.id}`,
-              label: c.name,
-              secondary: c.shortCode,
-              icon: 'building',
-              route: ['/clients', c.id],
-              section: 'clients',
-              searchText: `${c.name} ${c.shortCode}`.toLowerCase(),
-            });
-          }
-
-          for (const p of probes) {
-            newItems.push({
-              id: `probe:${p.id}`,
-              label: p.name,
-              secondary: p.client?.name,
-              icon: 'clock',
-              route: ['/scheduled-probes', p.id, 'runs'],
-              section: 'probes',
-              searchText: `${p.name} ${p.client?.name ?? ''}`.toLowerCase(),
-            });
-          }
-
-          for (const u of users) {
-            newItems.push({
-              id: `user:${u.id}`,
-              label: u.name,
-              // Email disambiguates multiple users with the same display name —
-              // role (ADMIN / OPERATOR) doesn't.
-              secondary: u.email,
-              icon: 'user',
-              route: ['/users'],
-              // user-list reads ?edit=<id> and auto-opens the edit dialog.
-              queryParams: { edit: u.id },
-              section: 'users',
-              searchText: `${u.name} ${u.email} ${u.role}`.toLowerCase(),
-            });
-          }
-
-          for (const p of people) {
-            newItems.push({
-              id: `person:${p.id}`,
-              label: p.name,
-              secondary: p.client?.name,
-              icon: 'user',
-              route: ['/clients', p.clientId],
-              section: 'people',
-              searchText: `${p.name} ${p.email} ${p.client?.name ?? ''}`.toLowerCase(),
-            });
-          }
-
-          // Commands — static actions; Create commands hidden for scoped users.
-          if (!isScoped) {
-            newItems.push({
-              id: 'cmd:create-ticket',
-              label: 'Create Ticket',
-              icon: 'add',
-              route: ['/tickets'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create ticket',
-            });
-            newItems.push({
-              id: 'cmd:create-client',
-              label: 'Create Client',
-              icon: 'add',
-              route: ['/clients'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create client',
-            });
-            newItems.push({
-              id: 'cmd:create-probe',
-              label: 'Create Scheduled Probe',
-              icon: 'add',
-              route: ['/scheduled-probes'],
-              queryParams: { create: '1' },
-              section: 'commands',
-              searchText: 'create scheduled probe',
-            });
-          }
-
-          newItems.push({
-            id: 'cmd:switch-theme',
-            label: 'Switch Theme',
-            icon: 'sparkles',
-            action: () => {
-              const next = this.theme.cycleToNext();
-              this.toast.info(`Theme: ${next.name}`);
-            },
-            section: 'commands',
-            searchText: 'switch theme',
-          });
-
-          newItems.push({
-            id: 'cmd:logout',
-            label: 'Logout',
-            icon: 'close',
-            action: () => this.auth.logout(),
-            section: 'commands',
-            searchText: 'logout',
-          });
-
-          const navRoutes = isScoped
-            ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
-            : ALL_NAV_ROUTES;
-
-          for (const r of navRoutes) {
-            newItems.push({
-              id: `nav:${r.route}`,
-              label: `Go to ${r.label}`,
-              icon: r.icon,
-              route: [r.route],
-              section: 'navigate',
-              searchText: `go to ${r.label}`.toLowerCase(),
-            });
-          }
-
-          this.items.set(newItems);
-          this.loading.set(false);
-        },
-        error: () => {
-          this.loading.set(false);
-        },
+    // Commands — static actions; Create commands hidden for scoped users.
+    if (!isScoped) {
+      newItems.push({
+        id: 'cmd:create-ticket',
+        label: 'Create Ticket',
+        icon: 'add',
+        route: ['/tickets'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create ticket',
       });
+      newItems.push({
+        id: 'cmd:create-client',
+        label: 'Create Client',
+        icon: 'add',
+        route: ['/clients'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create client',
+      });
+      newItems.push({
+        id: 'cmd:create-probe',
+        label: 'Create Scheduled Probe',
+        icon: 'add',
+        route: ['/scheduled-probes'],
+        queryParams: { create: '1' },
+        section: 'commands',
+        searchText: 'create scheduled probe',
+      });
+    }
+
+    newItems.push({
+      id: 'cmd:switch-theme',
+      label: 'Switch Theme',
+      icon: 'sparkles',
+      action: () => {
+        const next = this.theme.cycleToNext();
+        this.toast.info(`Theme: ${next.name}`);
+      },
+      section: 'commands',
+      searchText: 'switch theme',
+    });
+
+    newItems.push({
+      id: 'cmd:logout',
+      label: 'Logout',
+      icon: 'close',
+      action: () => this.auth.logout(),
+      section: 'commands',
+      searchText: 'logout',
+    });
+
+    const navRoutes = isScoped
+      ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
+      : ALL_NAV_ROUTES;
+
+    for (const r of navRoutes) {
+      newItems.push({
+        id: `nav:${r.route}`,
+        label: `Go to ${r.label}`,
+        icon: r.icon,
+        route: [r.route],
+        section: 'navigate',
+        searchText: `go to ${r.label}`.toLowerCase(),
+      });
+    }
+
+    this.items.set(newItems);
   }
 }

--- a/services/control-panel/src/app/shared/components/command-palette.component.ts
+++ b/services/control-panel/src/app/shared/components/command-palette.component.ts
@@ -26,6 +26,7 @@ import { TicketService, type TicketSearchResult } from '../../core/services/tick
 import { ThemeService } from '../../core/services/theme.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
 import { isScopedOpsAllowedPath } from '../../core/guards/scoped-ops-allowlist.js';
+import { NAV_ROUTES } from '../../core/nav/nav-routes.js';
 
 interface PaletteItem {
   id: string;
@@ -61,37 +62,6 @@ const SECTION_LABELS: Record<PaletteSection, string> = {
   commands: 'Commands',
   navigate: 'Navigate',
 };
-
-interface NavRoute {
-  label: string;
-  route: string;
-  icon: IconName;
-}
-
-const ALL_NAV_ROUTES: NavRoute[] = [
-  { label: 'Dashboard', route: '/dashboard', icon: 'home' },
-  { label: 'Tickets', route: '/tickets', icon: 'ticket' },
-  { label: 'Activity Feed', route: '/activity', icon: 'bell' },
-  { label: 'Clients', route: '/clients', icon: 'building' },
-  { label: 'Scheduled Probes', route: '/scheduled-probes', icon: 'clock' },
-  { label: 'Ingestion Jobs', route: '/ingestion-jobs', icon: 'play' },
-  { label: 'Failed Jobs', route: '/failed-jobs', icon: 'warning' },
-  { label: 'Logs', route: '/logs', icon: 'file' },
-  { label: 'Email Log', route: '/email-logs', icon: 'email' },
-  { label: 'AI Prompts', route: '/prompts', icon: 'sparkles' },
-  { label: 'AI Providers', route: '/ai-providers', icon: 'robot' },
-  { label: 'AI Usage', route: '/ai-usage', icon: 'bolt' },
-  { label: 'Ticket Routes', route: '/ticket-routes', icon: 'tag' },
-  { label: 'System Analysis', route: '/system-analysis', icon: 'search' },
-  { label: 'System Issues', route: '/system-issues', icon: 'warning' },
-  { label: 'Slack Conversations', route: '/slack-conversations', icon: 'comment' },
-  { label: 'Release Notes', route: '/release-notes', icon: 'book' },
-  { label: 'System Status', route: '/system-status', icon: 'server' },
-  { label: 'Settings', route: '/settings', icon: 'gear' },
-  { label: 'User Maintenance', route: '/users', icon: 'user' },
-  { label: 'Profile', route: '/profile', icon: 'user' },
-  { label: 'Notifications', route: '/notification-preferences', icon: 'bell' },
-];
 
 @Component({
   selector: 'app-command-palette',
@@ -677,8 +647,8 @@ export class CommandPaletteComponent {
     });
 
     const navRoutes = isScoped
-      ? ALL_NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
-      : ALL_NAV_ROUTES;
+      ? NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route))
+      : NAV_ROUTES;
 
     for (const r of navRoutes) {
       newItems.push({

--- a/services/control-panel/src/app/shared/components/text-input.component.ts
+++ b/services/control-panel/src/app/shared/components/text-input.component.ts
@@ -47,6 +47,10 @@ let standaloneInputCounter = 0;
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    @media (max-width: 767.98px) {
+      .text-input { font-size: 16px; }
+    }
   `],
 })
 export class TextInputComponent {

--- a/services/control-panel/src/app/shared/components/textarea.component.ts
+++ b/services/control-panel/src/app/shared/components/textarea.component.ts
@@ -48,6 +48,10 @@ let standaloneTextareaCounter = 0;
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    @media (max-width: 767.98px) {
+      .textarea-input { font-size: 16px; }
+    }
   `],
 })
 export class TextareaComponent {

--- a/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
+++ b/services/control-panel/src/app/shared/directives/pull-to-refresh.directive.ts
@@ -1,0 +1,77 @@
+import { Directive, HostListener, OnDestroy, Renderer2, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[appPullToRefresh]',
+  standalone: true,
+  host: { style: 'overscroll-behavior: contain' },
+})
+export class PullToRefreshDirective implements OnDestroy {
+  private renderer = inject(Renderer2);
+
+  readonly refresh = output<void>();
+
+  private startY = 0;
+  private currentDelta = 0;
+  private pulling = false;
+  private spinner: HTMLElement | null = null;
+  private readonly threshold = 60;
+
+  @HostListener('touchstart', ['$event'])
+  onTouchStart(e: TouchEvent): void {
+    if (!('ontouchstart' in window)) return;
+    if (window.scrollY > 0) return;
+    this.startY = e.touches[0].clientY;
+    this.currentDelta = 0;
+    this.pulling = true;
+  }
+
+  @HostListener('touchmove', ['$event'])
+  onTouchMove(e: TouchEvent): void {
+    if (!this.pulling) return;
+    if (window.scrollY > 0) { this.reset(); return; }
+    const delta = e.touches[0].clientY - this.startY;
+    if (delta <= 0) { this.reset(); return; }
+    this.currentDelta = delta;
+    this.showSpinner(Math.min(delta, this.threshold));
+  }
+
+  @HostListener('touchend')
+  onTouchEnd(): void {
+    if (!this.pulling) return;
+    const delta = this.currentDelta;
+    this.reset();
+    if (delta >= this.threshold) this.refresh.emit();
+  }
+
+  // Clean up the spinner if the gesture is interrupted (e.g. a phone call,
+  // system dialog, or the browser cancelling touches). Without this, the
+  // spinner can be left attached to document.body.
+  @HostListener('touchcancel')
+  onTouchCancel(): void {
+    this.reset();
+  }
+
+  // Also clean up if the directive is destroyed mid-gesture (e.g. the user
+  // navigates away while holding). Angular won't fire touchend for us.
+  ngOnDestroy(): void {
+    this.reset();
+  }
+
+  private showSpinner(progress: number): void {
+    if (!this.spinner) {
+      this.spinner = this.renderer.createElement('div');
+      this.renderer.addClass(this.spinner, 'pull-to-refresh-spinner');
+      this.renderer.appendChild(document.body, this.spinner);
+    }
+    this.renderer.setStyle(this.spinner, 'opacity', String(Math.min(progress / this.threshold, 1)));
+  }
+
+  private reset(): void {
+    this.pulling = false;
+    this.currentDelta = 0;
+    if (this.spinner) {
+      this.renderer.removeChild(document.body, this.spinner);
+      this.spinner = null;
+    }
+  }
+}

--- a/services/control-panel/src/app/shell/app-shell.component.ts
+++ b/services/control-panel/src/app/shell/app-shell.component.ts
@@ -89,10 +89,14 @@ const ROUTE_TITLE_MAP: Record<string, string> = {
       padding: 24px;
     }
     @media (max-width: 767.98px) {
+      .shell { height: auto; overflow: visible; min-height: 100dvh; }
+      .shell-main { overflow: visible; }
       .shell-content {
+        overflow: visible;
         padding: 12px;
         padding-bottom: max(12px, env(safe-area-inset-bottom));
       }
+      app-header-bar { position: sticky; top: 0; z-index: 5; }
     }
   `],
 })

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -7,6 +7,8 @@ import { VersionService } from '../core/services/version.service.js';
 import { TicketService } from '../core/services/ticket.service.js';
 import { FailedJobsService } from '../core/services/failed-jobs.service.js';
 import { APP_CONSTANTS } from '../core/config/app-constants.js';
+import { NAV_ROUTES, NAV_SECTIONS, NAV_SECTION_LABELS, type NavRoute, type NavSection } from '../core/nav/nav-routes.js';
+import { isScopedOpsAllowedPath } from '../core/guards/scoped-ops-allowlist.js';
 
 @Component({
   selector: 'app-sidebar',
@@ -23,69 +25,28 @@ import { APP_CONSTANTS } from '../core/config/app-constants.js';
       </div>
 
       <div class="nav-sections">
-        @if (isScoped()) {
+        @for (group of navGroups(); track group.section) {
           <div class="nav-section">
-            <span class="section-label">Main</span>
-            <a routerLink="/tickets" routerLinkActive="nav-active" class="nav-item">Tickets @if (ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }</a>
+            <span class="section-label">{{ group.label }}</span>
+            @for (r of group.routes; track r.route) {
+              <a [routerLink]="r.route" routerLinkActive="nav-active" class="nav-item">
+                {{ r.label }}
+                @if (r.route === '/tickets' && ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }
+                @if (r.route === '/failed-jobs' && failedJobsBadge() > 0) { <span class="badge">{{ failedJobsBadge() }}</span> }
+              </a>
+            }
+            @if (group.section === 'account') {
+              <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
+            }
           </div>
-          @if (scopedClientLink(); as clientLink) {
-            <div class="nav-section">
-              <span class="section-label">Client</span>
-              <a [routerLink]="clientLink" routerLinkActive="nav-active" class="nav-item">Client Details</a>
-            </div>
+          @if (group.section === 'main' && isScoped()) {
+            @if (scopedClientLink(); as clientLink) {
+              <div class="nav-section">
+                <span class="section-label">Client</span>
+                <a [routerLink]="clientLink" routerLinkActive="nav-active" class="nav-item">Client Details</a>
+              </div>
+            }
           }
-          <div class="nav-section">
-            <span class="section-label">Account</span>
-            <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
-            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
-          </div>
-        } @else {
-          <div class="nav-section">
-            <span class="section-label">Main</span>
-            <a routerLink="/dashboard" routerLinkActive="nav-active" class="nav-item">Dashboard</a>
-            <a routerLink="/tickets" routerLinkActive="nav-active" class="nav-item">Tickets @if (ticketBadge() > 0) { <span class="badge">{{ ticketBadge() }}</span> }</a>
-            <a routerLink="/activity" routerLinkActive="nav-active" class="nav-item">Activity Feed</a>
-            <a routerLink="/clients" routerLinkActive="nav-active" class="nav-item">Clients</a>
-          </div>
-
-          <div class="nav-section">
-            <span class="section-label">Operations</span>
-            <a routerLink="/scheduled-probes" routerLinkActive="nav-active" class="nav-item">Scheduled Probes</a>
-            <a routerLink="/ingestion-jobs" routerLinkActive="nav-active" class="nav-item">Ingestion Jobs</a>
-            <a routerLink="/failed-jobs" routerLinkActive="nav-active" class="nav-item">Failed Jobs @if (failedJobsBadge() > 0) { <span class="badge">{{ failedJobsBadge() }}</span> }</a>
-            <a routerLink="/logs" routerLinkActive="nav-active" class="nav-item">Logs</a>
-            <a routerLink="/email-logs" routerLinkActive="nav-active" class="nav-item">Email Log</a>
-          </div>
-
-          <div class="nav-section">
-            <span class="section-label">AI</span>
-            <a routerLink="/prompts" routerLinkActive="nav-active" class="nav-item">AI Prompts</a>
-            <a routerLink="/ai-providers" routerLinkActive="nav-active" class="nav-item">AI Providers</a>
-            <a routerLink="/ai-usage" routerLinkActive="nav-active" class="nav-item">AI Usage</a>
-            <a routerLink="/ticket-routes" routerLinkActive="nav-active" class="nav-item">Ticket Routes</a>
-            <a routerLink="/system-analysis" routerLinkActive="nav-active" class="nav-item">System Analysis</a>
-            <a routerLink="/system-issues" routerLinkActive="nav-active" class="nav-item">System Issues</a>
-          </div>
-
-          <div class="nav-section">
-            <span class="section-label">Integrations</span>
-            <a routerLink="/slack-conversations" routerLinkActive="nav-active" class="nav-item">Slack Conversations</a>
-            <a routerLink="/release-notes" routerLinkActive="nav-active" class="nav-item">Release Notes</a>
-          </div>
-
-          <div class="nav-section">
-            <span class="section-label">System</span>
-            <a routerLink="/system-status" routerLinkActive="nav-active" class="nav-item">Status</a>
-            <a routerLink="/settings" routerLinkActive="nav-active" class="nav-item">Settings</a>
-            <a routerLink="/users" routerLinkActive="nav-active" class="nav-item">User Maint</a>
-          </div>
-
-          <div class="nav-section">
-            <span class="section-label">Account</span>
-            <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
-            <a routerLink="/notification-preferences" routerLinkActive="nav-active" class="nav-item">Notifications</a>
-            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
-          </div>
         }
 
         <a routerLink="/profile" class="theme-indicator">
@@ -282,4 +243,24 @@ export class SidebarComponent {
     return ['/clients', user.clientId];
   });
 
+  /** Nav sections with their routes, filtered and grouped for the current user. */
+  readonly navGroups = computed(() => {
+    const scoped = this.isScoped();
+    // For scoped users: filter to allowed routes, excluding /dashboard which
+    // auto-redirects to client detail (shown separately as Client Details).
+    const routes = scoped
+      ? NAV_ROUTES.filter(r => isScopedOpsAllowedPath(r.route) && r.route !== '/dashboard')
+      : NAV_ROUTES;
+
+    const grouped = new Map<NavSection, NavRoute[]>();
+    for (const r of routes) {
+      const bucket = grouped.get(r.section) ?? [];
+      bucket.push(r);
+      grouped.set(r.section, bucket);
+    }
+
+    return NAV_SECTIONS
+      .filter(s => grouped.has(s))
+      .map(s => ({ section: s as NavSection, label: NAV_SECTION_LABELS[s], routes: grouped.get(s)! }));
+  });
 }

--- a/services/control-panel/src/app/shell/sidebar.component.ts
+++ b/services/control-panel/src/app/shell/sidebar.component.ts
@@ -6,6 +6,7 @@ import { ThemeService } from '../core/services/theme.service.js';
 import { VersionService } from '../core/services/version.service.js';
 import { TicketService } from '../core/services/ticket.service.js';
 import { FailedJobsService } from '../core/services/failed-jobs.service.js';
+import { APP_CONSTANTS } from '../core/config/app-constants.js';
 
 @Component({
   selector: 'app-sidebar',
@@ -36,6 +37,7 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
           <div class="nav-section">
             <span class="section-label">Account</span>
             <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
+            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
           </div>
         } @else {
           <div class="nav-section">
@@ -82,17 +84,18 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
             <span class="section-label">Account</span>
             <a routerLink="/profile" routerLinkActive="nav-active" class="nav-item">Profile</a>
             <a routerLink="/notification-preferences" routerLinkActive="nav-active" class="nav-item">Notifications</a>
+            <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
           </div>
         }
-      </div>
 
-      <div class="sidebar-footer">
-        <button class="nav-item logout-btn" (click)="authService.logout()">Logout</button>
         <a routerLink="/profile" class="theme-indicator">
           <span class="theme-dot" [style.background]="themeService.currentTheme().accentColor"></span>
           <span>{{ themeService.currentTheme().name }}</span>
         </a>
-        <span class="version-label">v{{ version() }}</span>
+      </div>
+
+      <div class="sidebar-footer">
+        <span class="version-label">Project {{ projectName }} {{ version() }}</span>
       </div>
     </nav>
   `,
@@ -181,7 +184,6 @@ import { FailedJobsService } from '../core/services/failed-jobs.service.js';
       padding: 8px 0 4px;
     }
     .logout-btn {
-      width: calc(100% - 16px);
       text-align: left;
       background: none;
       border: none;
@@ -261,6 +263,7 @@ export class SidebarComponent {
   private readonly ticketService = inject(TicketService);
   private readonly failedJobsService = inject(FailedJobsService);
 
+  readonly projectName = APP_CONSTANTS.projectName;
   readonly version = toSignal(this.versionService.getVersion(), { initialValue: '' });
   readonly ticketBadge = this.ticketService.activeCount;
   readonly failedJobsBadge = this.failedJobsService.totalCount;

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -5,10 +5,9 @@
   <title>iTrack 3 — Control Panel</title>
   <base href="/cp/">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <!-- Initial theme-color matches the default Apple theme (--bg-page: #f5f5f7).
-       The inline script below updates this before Safari samples it if the
-       user has a different theme saved in localStorage. Kept in sync with
-       THEMES[0] in services/control-panel/src/app/core/services/theme.service.ts. -->
+  <!-- Initial theme-color matches THEME_COLORS[DEFAULT_THEME] from theme-colors.ts
+       (currently #f5f5f7 for Apple). The inline script below updates this before
+       Safari samples it if the user has a different theme saved in localStorage. -->
   <meta name="theme-color" content="#f5f5f7">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -38,9 +37,11 @@
      * applies the correct body class on boot, and the inline <html> background
      * + <meta> cover the gap.
      *
-     * Kept in sync with the THEMES list in
-     * services/control-panel/src/app/core/services/theme.service.ts.
-     * If a theme is added or renamed there, update the map here.
+     * Single source of truth: theme-colors.ts
+     * (services/control-panel/src/app/core/services/theme-colors.ts)
+     * The map below MUST match THEME_COLORS exported from that file.
+     * The prebuild script (scripts/check-theme-colors.mjs) enforces this and
+     * will fail CI if the two maps diverge.
      */
     (function () {
       var THEME_COLORS = {

--- a/services/control-panel/src/index.html
+++ b/services/control-panel/src/index.html
@@ -52,8 +52,9 @@
         nvidia: '#000000',
         vercel: '#ffffff'
       };
-      // Default matches THEMES[0] in theme.service.ts. Used when localStorage
-      // is empty (first-time visitor) or holds an unknown theme id.
+      // Must match DEFAULT_THEME from theme-colors.ts. Used when localStorage
+      // is empty (first-time visitor) or holds an unknown theme id. The
+      // prebuild drift-check enforces this stays in sync.
       var DEFAULT_THEME = 'apple';
       var saved;
       try {

--- a/services/control-panel/src/styles.scss
+++ b/services/control-panel/src/styles.scss
@@ -55,22 +55,17 @@ app-dialog .dialog-body [dialogFooter] {
 }
 
 /*
- * iOS Safari auto-zooms on focus when an input has font-size < 16px. The
- * native-element selectors alone aren't enough: the primitives set their
- * own 14px via view-encapsulated attribute selectors (e.g.
- * `.text-input[_ngcontent-xxx]`), which have higher specificity than the
- * global `input { ... }` rule. So the mobile override targets both the
- * native elements AND the primitive classes by name, guaranteeing the 16px
- * wins on small screens. Desktop keeps the 14px default for density.
+ * iOS Safari auto-zooms on focus when an input has font-size < 16px.
+ * Primitives (app-text-input, app-textarea) set their mobile 16px inside
+ * their own component styles so view-encapsulation source order guarantees
+ * the rule wins. This global block covers raw native inputs (e.g. <input>
+ * with .date-input) that aren't wrapped by a primitive, as a safety net.
  * Form-field tap targets also get bumped to a 44px minimum height.
  */
 @media (max-width: 767.98px) {
   input,
   textarea,
   select,
-  app-text-input .text-input,
-  app-textarea .textarea-input,
-  app-select .select-input,
   .date-input {
     font-size: 16px;
   }
@@ -80,6 +75,30 @@ app-dialog .dialog-body [dialogFooter] {
   app-select .select-input {
     min-height: 44px;
   }
+}
+
+@keyframes ptr-spin {
+  to { transform: translateX(-50%) rotate(360deg); }
+}
+.pull-to-refresh-spinner {
+  position: fixed;
+  // Position below the sticky header, respecting the iOS safe-area inset so
+  // the spinner clears Safari's status-bar region. Tracks --header-height so
+  // future header resizes propagate automatically.
+  top: calc(var(--header-height) + env(safe-area-inset-top) + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2.5px solid var(--border-medium);
+  border-top-color: var(--accent);
+  // Sits above normal content but below dialogs/menus (z-index: 1000) and
+  // toasts (10000), so refresh gestures never obscure active modal UI.
+  z-index: 100;
+  pointer-events: none;
+  opacity: 0;
+  animation: ptr-spin 0.8s linear infinite;
 }
 
 @media (max-width: 767px) {

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -18,6 +18,59 @@ function validateDomainMappings(domains: string[] | undefined): string[] | undef
 }
 
 export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
+  // GET /api/search/clients — lightweight search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/clients',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      // Translate clientId scope to id filter (clients are queried by their own id).
+      const scopeWhere = scopeToWhere(scope);
+      const idFilter = scopeWhere.clientId !== undefined ? { id: scopeWhere.clientId } : {};
+
+      const results = await fastify.db.client.findMany({
+        where: {
+          isInternal: false,
+          ...idFilter,
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { shortCode: { contains: rawQ, mode: 'insensitive' } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          shortCode: true,
+          isActive: true,
+        },
+        take: limit * 2,
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.name.localeCompare(b.name);
+      });
+
+      return results.slice(0, limit);
+    },
+  );
+
   fastify.get('/api/clients', async (request) => {
     const scope = await resolveClientScope(request, (operatorId) =>
       getOperatorClientIds(fastify.db, operatorId),

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -57,13 +57,22 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
           isActive: true,
         },
         take: limit * 2,
+        orderBy: { name: 'asc' },
       });
 
       const qLower = rawQ.toLowerCase();
+      const getRank = (name: string, shortCode: string): number => {
+        const nameLower = name.toLowerCase();
+        const shortCodeLower = shortCode.toLowerCase();
+        if (shortCodeLower === qLower) return 0;
+        if (shortCodeLower.startsWith(qLower)) return 1;
+        if (nameLower === qLower) return 2;
+        if (nameLower.startsWith(qLower)) return 3;
+        return 4;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        if (aStarts !== bStarts) return aStarts - bStarts;
+        const rankDiff = getRank(a.name, a.shortCode) - getRank(b.name, b.shortCode);
+        if (rankDiff !== 0) return rankDiff;
         return a.name.localeCompare(b.name);
       });
 

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -49,6 +49,78 @@ function canManagePeople(request: FastifyRequest): boolean {
 
 export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
   /**
+   * GET /api/search/people
+   * Lightweight search for the command palette. Mirrors scope branching from GET /api/people.
+   */
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/people',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+
+      let scopedClientIdFilter: string | { in: string[] } | undefined;
+      if (scope.type === 'assigned') {
+        if (scope.clientIds.length === 0) return [];
+        scopedClientIdFilter = { in: scope.clientIds };
+      } else if (scope.type === 'single') {
+        scopedClientIdFilter = scope.clientId;
+      }
+
+      const results = await fastify.db.person.findMany({
+        where: {
+          ...(scopedClientIdFilter !== undefined && { clientId: scopedClientIdFilter }),
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { email: { contains: rawQ, mode: 'insensitive' } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' } } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          clientId: true,
+          role: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        email: p.email,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        role: p.role,
+        isActive: p.isActive,
+      }));
+    },
+  );
+
+  /**
    * GET /api/people?clientId=X
    * List people for a client, ordered by name.
    */

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -102,9 +102,18 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
 
       const qLower = rawQ.toLowerCase();
       results.sort((a, b) => {
+        const aEmailExact = a.email.toLowerCase() === qLower ? 0 : 1;
+        const bEmailExact = b.email.toLowerCase() === qLower ? 0 : 1;
+        if (aEmailExact !== bEmailExact) return aEmailExact - bEmailExact;
+
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const nameCompare = a.name.localeCompare(b.name);
+        if (nameCompare !== 0) return nameCompare;
+
+        return a.email.localeCompare(b.email);
       });
 
       return results.slice(0, limit).map(p => ({

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -131,20 +131,26 @@ export async function scheduledProbeRoutes(
         select: {
           id: true,
           name: true,
+          createdAt: true,
           clientId: true,
           toolName: true,
           isActive: true,
           client: { select: { name: true, shortCode: true } },
         },
         take: limit,
-        orderBy: { name: 'asc' },
+        orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
       });
 
       const qLower = rawQ.toLowerCase();
       results.sort((a, b) => {
         const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
         const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+
+        const createdAtDiff = b.createdAt.getTime() - a.createdAt.getTime();
+        if (createdAtDiff !== 0) return createdAtDiff;
+
+        return a.name.localeCompare(b.name);
       });
 
       return results.slice(0, limit).map(p => ({

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -6,6 +6,7 @@ import cronParser from 'cron-parser';
 const { parseExpression } = cronParser;
 import { ProbeAction, TicketCategory, IntegrationType, BUILTIN_PROBE_TOOL_NAMES, BUILTIN_PROBE_TOOLS } from '@bronco/shared-types';
 import { buildUtcCron } from '@bronco/shared-utils';
+import { resolveClientScope, scopeToWhere, getOperatorClientIds } from '../plugins/client-scope.js';
 
 const VALID_ACTIONS = new Set(Object.values(ProbeAction));
 const VALID_CATEGORIES = new Set(Object.values(TicketCategory));
@@ -95,6 +96,68 @@ export async function scheduledProbeRoutes(
   opts: ScheduledProbeOpts,
 ): Promise<void> {
   const { probeQueue } = opts;
+
+  // GET /api/search/scheduled-probes — lightweight search for the command palette
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/scheduled-probes',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const scope = await resolveClientScope(request, (operatorId) =>
+        getOperatorClientIds(fastify.db, operatorId),
+      );
+      if (scope.type === 'assigned' && scope.clientIds.length === 0) return [];
+
+      const clientWhere = scopeToWhere(scope);
+
+      const results = await fastify.db.scheduledProbe.findMany({
+        where: {
+          ...clientWhere,
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { description: { contains: rawQ, mode: 'insensitive' } },
+            { client: { name: { contains: rawQ, mode: 'insensitive' } } },
+            { client: { shortCode: { contains: rawQ, mode: 'insensitive' } } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          clientId: true,
+          toolName: true,
+          isActive: true,
+          client: { select: { name: true, shortCode: true } },
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit).map(p => ({
+        id: p.id,
+        name: p.name,
+        clientId: p.clientId,
+        clientName: p.client.name,
+        clientShortCode: p.client.shortCode,
+        toolName: p.toolName,
+        isActive: p.isActive,
+      }));
+    },
+  );
 
   // List all probes, optionally filtered by clientId
   fastify.get<{

--- a/services/copilot-api/src/routes/users.ts
+++ b/services/copilot-api/src/routes/users.ts
@@ -24,6 +24,52 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
   });
 
   /**
+   * GET /api/search/users
+   * Lightweight search for the command palette. Admin gate inherited from preHandler.
+   */
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/api/search/users',
+    async (request) => {
+      const rawQ = (request.query.q ?? '').trim();
+      if (!rawQ) return fastify.httpErrors.badRequest('q is required');
+      if (rawQ.length < 2) return fastify.httpErrors.badRequest('q must be at least 2 characters');
+
+      const rawLimit = request.query.limit ?? '20';
+      const limit = Math.trunc(Number(rawLimit));
+      if (!Number.isFinite(limit) || limit < 1 || limit > 50) {
+        return fastify.httpErrors.badRequest('limit must be between 1 and 50');
+      }
+
+      const results = await fastify.db.user.findMany({
+        where: {
+          OR: [
+            { name: { contains: rawQ, mode: 'insensitive' } },
+            { email: { contains: rawQ, mode: 'insensitive' } },
+          ],
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          isActive: true,
+        },
+        take: limit,
+        orderBy: { name: 'asc' },
+      });
+
+      const qLower = rawQ.toLowerCase();
+      results.sort((a, b) => {
+        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
+        return aStarts - bStarts;
+      });
+
+      return results.slice(0, limit);
+    },
+  );
+
+  /**
    * GET /api/users
    * List all control panel users. Includes slackUserId from matching Operator record.
    */

--- a/services/copilot-api/src/routes/users.ts
+++ b/services/copilot-api/src/routes/users.ts
@@ -59,10 +59,19 @@ export async function userRoutes(fastify: FastifyInstance): Promise<void> {
       });
 
       const qLower = rawQ.toLowerCase();
+      const getRank = (user: { name: string; email: string }): number => {
+        const nameLower = user.name.toLowerCase();
+        const emailLower = user.email.toLowerCase();
+        if (emailLower === qLower) return 0;
+        if (nameLower.startsWith(qLower) || emailLower.startsWith(qLower)) return 1;
+        return 2;
+      };
       results.sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(qLower) ? 0 : 1;
-        return aStarts - bStarts;
+        const rankDiff = getRank(a) - getRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        const nameDiff = a.name.localeCompare(b.name);
+        if (nameDiff !== 0) return nameDiff;
+        return a.email.localeCompare(b.email);
       });
 
       return results.slice(0, limit);


### PR DESCRIPTION
Promotes staging to master for production deploy.

## Highlights

### Command palette & server-side search
- **#281** — Palette server-side search for clients, probes, users, people (closes #275). Scoped API endpoints + matching MCP platform tools; debounced in-palette streams replace the upfront forkJoin load.
- **#281 followup** — Search ranking: deterministic `orderBy`, exact-email/shortCode matches rank first, `createdAt` tiebreaker for probes.
- **#284** — Shared nav registry (`NAV_ROUTES`) feeding both the sidebar and the command palette (closes #268).

### Theme / iOS Safari first-paint
- **#280** — Single source of truth for theme → color map: `theme-colors.ts` exports `THEME_COLORS` + `DEFAULT_THEME`, consumed by `ThemeService` and mirrored in `index.html`. A prebuild drift-check asserts the inline map, `DEFAULT_THEME`, and the static `<meta name="theme-color">` tag all stay in sync with the TS source (closes #277, #278).
- **#280 followup** — Parser robustness in the drift-check; `resolveInitial()` falls back through `DEFAULT_THEME` so changing the default no longer requires reordering `THEMES`.

### Mobile UX batch
- **#283** — iOS 16px font-size baked into `app-text-input` / `app-textarea` component styles (closes #239); mobile body-level scroll + sticky header so Safari's URL pill auto-collapses (closes #273); `HapticService` with tap / success / warn wired into one destructive + one save call site (closes #249); pull-to-refresh directive on the tickets list with spinner + overscroll-contain (closes #248); sidebar cleanup — Logout under Account, theme indicator at end of scrollable list, single-line `Project Bronco v0.1.7` footer, `APP_CONSTANTS.projectName` as Angular-scoped source of truth (closes #282).
- **#283 followup** — Pull-to-refresh cleanup hardened (touchcancel + ngOnDestroy); spinner positions via `calc(var(--header-height) + env(safe-area-inset-top))` and drops z-index from 9999 to 100 so it sits below dialogs/toasts.
