### PR TITLE
fix: move haptic.success() into subscribe callbacks (gap analysis PR #285)

### DIFF
--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -103,7 +103,6 @@ export class UserDialogComponent {
   }
 
   save(): void {
-    this.haptic.success();
     const u = this.user();
     if (!u && this.password.length < 8) {
       this.toast.error('Password must be at least 8 characters');
@@ -118,6 +117,7 @@ export class UserDialogComponent {
         ...(this.slackUserId !== undefined && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
+          this.haptic.success();
           this.toast.success('User updated');
           this.saved.emit(true);
         },
@@ -132,6 +132,7 @@ export class UserDialogComponent {
         ...(this.slackUserId && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
+          this.haptic.success();
           this.toast.success('User created');
           this.saved.emit(true);
         },


### PR DESCRIPTION
Gap-analysis fix for PR #285 release.

Before: `save()` in user-dialog fired `haptic.success()` up front, before the password length guard — a failed validation produced a success haptic followed by an error toast.

After: `haptic.success()` moved into each `.subscribe({ next: ... })` callback so it only fires on server-confirmed success.