### PR TITLE
refactor: #219 Wave 2B — MCP platform tools on unified model

### DIFF
--- a/mcp-servers/platform/src/tools/operators.ts
+++ b/mcp-servers/platform/src/tools/operators.ts
@@ -1,81 +1,279 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
+import { OperatorRole } from '@bronco/shared-types';
 
-// TODO: #219 Wave 2B — rework against the unified Person + Operator model.
-// Wave 1 keeps the MCP surface working by joining Operator → Person for
-// the identity fields (name/email/isActive) and accepting name updates on
-// Person transparently.
+// Explicit Person select — never expose passwordHash or emailLower to MCP callers.
+const PERSON_SELECT = { id: true, name: true, email: true, phone: true, isActive: true } as const;
+
+const OPERATOR_SELECT = {
+  id: true,
+  personId: true,
+  clientId: true,
+  role: true,
+  notifyEmail: true,
+  notifySlack: true,
+  slackUserId: true,
+  createdAt: true,
+  updatedAt: true,
+  person: { select: PERSON_SELECT },
+} as const;
+
+function flattenOperator(op: {
+  id: string;
+  personId: string;
+  clientId: string | null;
+  role: string;
+  notifyEmail: boolean;
+  notifySlack: boolean;
+  slackUserId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  person: { id: string; name: string; email: string; phone: string | null; isActive: boolean };
+}) {
+  return {
+    id: op.id,
+    personId: op.personId,
+    name: op.person.name,
+    email: op.person.email,
+    phone: op.person.phone,
+    isActive: op.person.isActive,
+    role: op.role,
+    clientId: op.clientId,
+    notifyEmail: op.notifyEmail,
+    notifySlack: op.notifySlack,
+    slackUserId: op.slackUserId,
+    createdAt: op.createdAt,
+    updatedAt: op.updatedAt,
+  };
+}
+
 export function registerOperatorTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
     'list_operators',
     'List all operators with their notification preferences.',
-    {},
-    async () => {
+    {
+      includeInactive: z.boolean().optional().describe('Include inactive operators (default false)'),
+    },
+    async (params) => {
+      const { includeInactive = false } = params;
       const operators = await db.operator.findMany({
-        include: { person: { select: { email: true, name: true, isActive: true } } },
+        where: includeInactive ? {} : { person: { isActive: true } },
+        select: OPERATOR_SELECT,
         orderBy: { person: { name: 'asc' } },
       });
-      const out = operators.map((op) => ({
-        id: op.id,
-        email: op.person.email,
-        name: op.person.name,
-        isActive: op.person.isActive,
-        notifyEmail: op.notifyEmail,
-        notifySlack: op.notifySlack,
-        slackUserId: op.slackUserId,
-        role: op.role,
-        clientId: op.clientId,
-        createdAt: op.createdAt,
-      }));
-      return { content: [{ type: 'text', text: JSON.stringify(out, null, 2) }] };
+      return { content: [{ type: 'text', text: JSON.stringify(operators.map(flattenOperator), null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'search_operators',
+    'Search operators by name or email. Returns a lightweight projection for UI pickers.',
+    {
+      q: z.string().min(2).describe('Search query (name or email). Must be at least 2 characters.'),
+      limit: z.number().int().min(1).max(50).optional().describe('Max results to return (default 20)'),
+    },
+    async (params) => {
+      const { q, limit = 20 } = params;
+      const qLower = q.toLowerCase();
+
+      const operators = await db.operator.findMany({
+        where: {
+          person: {
+            OR: [
+              { name: { contains: q, mode: 'insensitive' as const } },
+              { email: { contains: q, mode: 'insensitive' as const } },
+            ],
+          },
+        },
+        select: OPERATOR_SELECT,
+        take: limit,
+        orderBy: { person: { name: 'asc' } },
+      });
+
+      const results = operators.map(flattenOperator).sort((a, b) => {
+        const getRank = (u: { name: string; email: string }) => {
+          const nameLower = u.name.toLowerCase();
+          const emailLower = u.email.toLowerCase();
+          if (emailLower === qLower) return 0;
+          if (nameLower.startsWith(qLower) || emailLower.startsWith(qLower)) return 1;
+          return 2;
+        };
+        const rankDiff = getRank(a) - getRank(b);
+        if (rankDiff !== 0) return rankDiff;
+        return a.name.localeCompare(b.name);
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(results.slice(0, limit), null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_operator',
+    'Get a single operator by their Operator ID.',
+    {
+      operatorId: z.string().uuid().describe('Operator ID'),
+    },
+    async (params) => {
+      const operator = await db.operator.findUnique({
+        where: { id: params.operatorId },
+        select: OPERATOR_SELECT,
+      });
+      if (!operator) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Operator not found' }, null, 2) }] };
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(flattenOperator(operator), null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'create_operator',
+    'Create a new operator. If a Person with the given email already exists it is reactivated and promoted; ' +
+      'if they already have an Operator record a conflict error is returned.',
+    {
+      name: z.string().min(1).describe('Full name'),
+      email: z.string().email().describe('Email address'),
+      role: z.enum([OperatorRole.ADMIN, OperatorRole.STANDARD]).optional().describe('Operator role (default STANDARD)'),
+      clientId: z.string().uuid().optional().describe('Scope this operator to a specific client'),
+      notifyEmail: z.boolean().optional().describe('Enable email notifications (default true)'),
+      notifySlack: z.boolean().optional().describe('Enable Slack notifications (default false)'),
+      slackUserId: z.string().optional().describe('Slack user ID'),
+    },
+    async (params) => {
+      const { name, email, role, clientId, notifyEmail, notifySlack, slackUserId } = params;
+      const emailLower = email.trim().toLowerCase();
+
+      const existingPerson = await db.person.findUnique({
+        where: { emailLower },
+        select: { id: true, operator: { select: { id: true } } },
+      });
+
+      if (existingPerson?.operator) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: 'An operator with this email already exists.' }, null, 2) }],
+        };
+      }
+
+      const trimmedSlackUserId = slackUserId !== undefined ? slackUserId.trim() || null : undefined;
+
+      const operator = await db.$transaction(async (tx) => {
+        const person = existingPerson
+          ? await tx.person.update({
+              where: { id: existingPerson.id },
+              // Reactivate Person on promotion — isActive is the master auth switch.
+              data: { name: name.trim(), isActive: true },
+            })
+          : await tx.person.create({
+              data: { email: email.trim(), emailLower, name: name.trim() },
+            });
+
+        return tx.operator.create({
+          data: {
+            personId: person.id,
+            ...(role !== undefined && { role }),
+            ...(clientId !== undefined && { clientId }),
+            ...(notifyEmail !== undefined && { notifyEmail }),
+            ...(notifySlack !== undefined && { notifySlack }),
+            ...(trimmedSlackUserId !== undefined && { slackUserId: trimmedSlackUserId }),
+          },
+          select: OPERATOR_SELECT,
+        });
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(flattenOperator(operator), null, 2) }] };
     },
   );
 
   server.tool(
     'update_operator',
-    'Update operator fields such as name, Slack user ID, or notification preferences.',
+    'Update operator fields: name, role, clientId, Slack user ID, or notification preferences.',
     {
-      operatorId: z.string().uuid().describe('The operator ID'),
+      operatorId: z.string().uuid().describe('Operator ID'),
       name: z.string().optional().describe('New name'),
-      slackUserId: z.string().optional().describe('Slack user ID'),
+      role: z.enum([OperatorRole.ADMIN, OperatorRole.STANDARD]).optional().describe('New role'),
+      clientId: z.string().uuid().nullable().optional().describe('Assign or clear client scope (null to clear)'),
+      slackUserId: z.string().nullable().optional().describe('Slack user ID (null to clear)'),
       notifyEmail: z.boolean().optional().describe('Enable email notifications'),
       notifySlack: z.boolean().optional().describe('Enable Slack notifications'),
     },
     async (params) => {
-      const { operatorId, name, slackUserId, notifyEmail, notifySlack } = params;
+      const { operatorId, name, role, clientId, slackUserId, notifyEmail, notifySlack } = params;
+
+      const target = await db.operator.findUnique({
+        where: { id: operatorId },
+        select: { personId: true },
+      });
+      if (!target) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Operator not found' }, null, 2) }] };
+      }
+
+      const trimmedSlackUserId =
+        slackUserId !== undefined
+          ? typeof slackUserId === 'string'
+            ? slackUserId.trim() || null
+            : null
+          : undefined;
 
       const result = await db.$transaction(async (tx) => {
-        const target = await tx.operator.findUnique({ where: { id: operatorId } });
-        if (!target) throw new Error(`Operator ${operatorId} not found`);
-
         if (name !== undefined) {
-          await tx.person.update({ where: { id: target.personId }, data: { name } });
+          await tx.person.update({ where: { id: target.personId }, data: { name: name.trim() } });
         }
 
         return tx.operator.update({
           where: { id: operatorId },
           data: {
-            ...(slackUserId !== undefined && { slackUserId }),
+            ...(role !== undefined && { role }),
+            ...(clientId !== undefined && { clientId }),
+            ...(trimmedSlackUserId !== undefined && { slackUserId: trimmedSlackUserId }),
             ...(notifyEmail !== undefined && { notifyEmail }),
             ...(notifySlack !== undefined && { notifySlack }),
           },
-          include: { person: { select: { email: true, name: true, isActive: true } } },
+          select: OPERATOR_SELECT,
         });
       });
 
-      const out = {
-        id: result.id,
-        email: result.person.email,
-        name: result.person.name,
-        isActive: result.person.isActive,
-        notifyEmail: result.notifyEmail,
-        notifySlack: result.notifySlack,
-        slackUserId: result.slackUserId,
-        role: result.role,
-        clientId: result.clientId,
-      };
-      return { content: [{ type: 'text', text: JSON.stringify(out, null, 2) }] };
+      return { content: [{ type: 'text', text: JSON.stringify(flattenOperator(result), null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_operator',
+    'Remove operator access. If the Person has no remaining ClientUser associations they are also deactivated.',
+    {
+      operatorId: z.string().uuid().describe('Operator ID'),
+    },
+    async (params) => {
+      const { operatorId } = params;
+
+      const target = await db.operator.findUnique({
+        where: { id: operatorId },
+        select: { personId: true },
+      });
+      if (!target) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Operator not found' }, null, 2) }] };
+      }
+
+      await db.$transaction(async (tx) => {
+        await tx.operator.delete({ where: { id: operatorId } });
+
+        // Revoke operator refresh tokens so existing sessions are invalidated.
+        await tx.personRefreshToken.updateMany({
+          where: { personId: target.personId, accessType: 'OPERATOR', revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+
+        // If the Person has no remaining ClientUser records they have no way to
+        // authenticate — deactivate them so isActive is accurate.
+        const remaining = await tx.person.findUnique({
+          where: { id: target.personId },
+          select: { _count: { select: { clientUsers: true } } },
+        });
+        if (remaining && remaining._count.clientUsers === 0) {
+          await tx.person.update({ where: { id: target.personId }, data: { isActive: false } });
+        }
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify({ message: 'Operator deleted.' }, null, 2) }] };
     },
   );
 }

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -249,7 +249,7 @@ export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void
 
         let clientUser = null;
         if (clientId && (userType !== undefined || isPrimary !== undefined)) {
-          const cu = await db.clientUser.findUnique({
+          const cu = await tx.clientUser.findUnique({
             where: { personId_clientId: { personId, clientId } },
           });
           if (cu) {

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -1,11 +1,21 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
+import { ClientUserType } from '@bronco/shared-types';
 
-// TODO: #219 Wave 2B — rewrite the people tools for the unified
-// Person + ClientUser model. Wave 1 keeps read-only discovery working via
-// joins through ClientUser; create/update return a 501-style message so
-// callers learn that write operations are temporarily disabled.
+// Explicit Person select — never expose passwordHash or emailLower to MCP callers.
+const PERSON_SELECT = { id: true, name: true, email: true, phone: true, isActive: true } as const;
+
+const CLIENT_USER_SELECT = {
+  id: true,
+  clientId: true,
+  userType: true,
+  isPrimary: true,
+  lastLoginAt: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
 export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
     'search_people',
@@ -71,27 +81,11 @@ export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void
       clientId: z.string().uuid().optional().describe('Filter by client ID'),
     },
     async (params) => {
-      // Explicit select — never spread Person directly. `passwordHash` and
-      // `emailLower` must not leak to MCP tool callers.
       const clientUsers = await db.clientUser.findMany({
         where: params.clientId ? { clientId: params.clientId } : {},
         select: {
-          id: true,
-          clientId: true,
-          userType: true,
-          isPrimary: true,
-          lastLoginAt: true,
-          createdAt: true,
-          updatedAt: true,
-          person: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              phone: true,
-              isActive: true,
-            },
-          },
+          ...CLIENT_USER_SELECT,
+          person: { select: PERSON_SELECT },
           client: { select: { name: true } },
         },
         orderBy: { person: { name: 'asc' } },
@@ -101,34 +95,234 @@ export function registerPeopleTools(server: McpServer, { db }: ServerDeps): void
     },
   );
 
-  const writeDisabled = async () => ({
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(
-          {
-            error:
-              'People create/update via MCP is temporarily disabled while #219 Wave 2B rewrites it for the unified Person + ClientUser model.',
-            todo: '#219 Wave 2B',
+  server.tool(
+    'get_person',
+    'Get a person by their Person ID. Returns all ClientUser associations for the person.',
+    {
+      personId: z.string().uuid().describe('Person ID'),
+    },
+    async (params) => {
+      const person = await db.person.findUnique({
+        where: { id: params.personId },
+        select: {
+          ...PERSON_SELECT,
+          createdAt: true,
+          updatedAt: true,
+          clientUsers: {
+            select: {
+              ...CLIENT_USER_SELECT,
+              client: { select: { name: true, shortCode: true } },
+            },
+            // Deterministic: primary first, then oldest.
+            orderBy: [{ isPrimary: 'desc' }, { createdAt: 'asc' }],
           },
-          null,
-          2,
-        ),
-      },
-    ],
-  });
+        },
+      });
+
+      if (!person) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Person not found' }, null, 2) }] };
+      }
+
+      return { content: [{ type: 'text', text: JSON.stringify(person, null, 2) }] };
+    },
+  );
 
   server.tool(
     'create_person',
-    'Create a new person (disabled during #219 Wave 2B migration).',
-    { clientId: z.string().uuid(), name: z.string(), email: z.string().email() },
-    writeDisabled,
+    'Create a new person, optionally attaching them to a client as a ClientUser in a single transaction. ' +
+      'If a Person with the given email already exists and clientId is supplied, a new ClientUser is added for that client.',
+    {
+      name: z.string().min(1).describe('Full name'),
+      email: z.string().email().describe('Email address'),
+      phone: z.string().optional().describe('Phone number'),
+      clientId: z.string().uuid().optional().describe('Client to attach the person to'),
+      userType: z.enum([ClientUserType.ADMIN, ClientUserType.USER]).optional().describe('ClientUser type (default USER)'),
+      isPrimary: z.boolean().optional().describe('Mark as primary contact for the client'),
+    },
+    async (params) => {
+      const { name, email, phone, clientId, userType, isPrimary } = params;
+      const emailLower = email.trim().toLowerCase();
+
+      const existingPerson = await db.person.findUnique({
+        where: { emailLower },
+        select: { id: true },
+      });
+
+      if (existingPerson) {
+        if (!clientId) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'A person with this email already exists.' }, null, 2) }],
+          };
+        }
+        const existingCu = await db.clientUser.findUnique({
+          where: { personId_clientId: { personId: existingPerson.id, clientId } },
+        });
+        if (existingCu) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'This person is already linked to that client.' }, null, 2) }],
+          };
+        }
+      }
+
+      const result = await db.$transaction(async (tx) => {
+        const person = existingPerson
+          ? await tx.person.update({
+              where: { id: existingPerson.id },
+              data: { name: name.trim(), isActive: true },
+              select: { ...PERSON_SELECT, createdAt: true, updatedAt: true },
+            })
+          : await tx.person.create({
+              data: {
+                email: email.trim(),
+                emailLower,
+                name: name.trim(),
+                ...(phone !== undefined && { phone: phone.trim() || null }),
+              },
+              select: { ...PERSON_SELECT, createdAt: true, updatedAt: true },
+            });
+
+        let clientUser = null;
+        if (clientId) {
+          clientUser = await tx.clientUser.create({
+            data: {
+              personId: person.id,
+              clientId,
+              userType: (userType as ClientUserType) ?? ClientUserType.USER,
+              ...(isPrimary !== undefined && { isPrimary }),
+            },
+            select: CLIENT_USER_SELECT,
+          });
+        }
+
+        return { person, clientUser };
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
   );
 
   server.tool(
     'update_person',
-    'Update an existing person (disabled during #219 Wave 2B migration).',
-    { personId: z.string().uuid() },
-    writeDisabled,
+    'Update a person\'s fields and optionally their ClientUser association for a specific client.',
+    {
+      personId: z.string().uuid().describe('Person ID to update'),
+      name: z.string().optional().describe('New name'),
+      phone: z.string().nullable().optional().describe('New phone number (null to clear)'),
+      isActive: z.boolean().optional().describe('Activate or deactivate the person'),
+      clientId: z.string().uuid().optional().describe('Client context for updating ClientUser fields (validates tenant membership)'),
+      userType: z.enum([ClientUserType.ADMIN, ClientUserType.USER]).optional().describe('New ClientUser type (requires clientId)'),
+      isPrimary: z.boolean().optional().describe('Set as primary contact for the client (requires clientId)'),
+    },
+    async (params) => {
+      const { personId, name, phone, isActive, clientId, userType, isPrimary } = params;
+
+      const existing = await db.person.findUnique({
+        where: { id: personId },
+        select: { id: true },
+      });
+      if (!existing) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Person not found' }, null, 2) }] };
+      }
+
+      // Tenant validation: if clientId is given, confirm the person belongs to that client.
+      if (clientId) {
+        const cu = await db.clientUser.findUnique({
+          where: { personId_clientId: { personId, clientId } },
+        });
+        if (!cu) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Person is not linked to the specified client.' }, null, 2) }],
+          };
+        }
+      }
+
+      const result = await db.$transaction(async (tx) => {
+        const person = await tx.person.update({
+          where: { id: personId },
+          data: {
+            ...(name !== undefined && { name: name.trim() }),
+            ...(phone !== undefined && { phone: phone ? phone.trim() : null }),
+            ...(isActive !== undefined && { isActive }),
+          },
+          select: { ...PERSON_SELECT, createdAt: true, updatedAt: true },
+        });
+
+        let clientUser = null;
+        if (clientId && (userType !== undefined || isPrimary !== undefined)) {
+          const cu = await db.clientUser.findUnique({
+            where: { personId_clientId: { personId, clientId } },
+          });
+          if (cu) {
+            clientUser = await tx.clientUser.update({
+              where: { id: cu.id },
+              data: {
+                ...(userType !== undefined && { userType: userType as ClientUserType }),
+                ...(isPrimary !== undefined && { isPrimary }),
+              },
+              select: CLIENT_USER_SELECT,
+            });
+          }
+        }
+
+        return { person, clientUser };
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_person',
+    'Soft-delete a person (set isActive=false), or when clientId is provided remove only that ClientUser association. ' +
+      'After removing a ClientUser, if the person has no remaining access records they are also deactivated.',
+    {
+      personId: z.string().uuid().describe('Person ID'),
+      clientId: z.string().uuid().optional().describe('If provided, removes only the ClientUser for this client instead of deactivating the person globally.'),
+    },
+    async (params) => {
+      const { personId, clientId } = params;
+
+      const person = await db.person.findUnique({
+        where: { id: personId },
+        select: { id: true },
+      });
+      if (!person) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Person not found' }, null, 2) }] };
+      }
+
+      if (clientId) {
+        const cu = await db.clientUser.findUnique({
+          where: { personId_clientId: { personId, clientId } },
+        });
+        if (!cu) {
+          return {
+            content: [{ type: 'text', text: JSON.stringify({ error: 'Person is not linked to the specified client.' }, null, 2) }],
+          };
+        }
+
+        await db.$transaction(async (tx) => {
+          await tx.clientUser.delete({ where: { id: cu.id } });
+
+          // If Person has no remaining ClientUser rows and no Operator record,
+          // they can't authenticate at all — deactivate them.
+          const remaining = await tx.person.findUnique({
+            where: { id: personId },
+            select: {
+              operator: { select: { id: true } },
+              _count: { select: { clientUsers: true } },
+            },
+          });
+          if (remaining && !remaining.operator && remaining._count.clientUsers === 0) {
+            await tx.person.update({ where: { id: personId }, data: { isActive: false } });
+          }
+        });
+
+        return { content: [{ type: 'text', text: JSON.stringify({ message: 'ClientUser association removed.' }, null, 2) }] };
+      }
+
+      // Global soft delete — deactivate the person across all access.
+      await db.person.update({ where: { id: personId }, data: { isActive: false } });
+      return { content: [{ type: 'text', text: JSON.stringify({ message: 'Person deactivated.' }, null, 2) }] };
+    },
   );
 }

--- a/mcp-servers/platform/src/tools/users.ts
+++ b/mcp-servers/platform/src/tools/users.ts
@@ -2,10 +2,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
 
-// TODO: #219 Wave 2B — refresh this tool for the unified Person + Operator
-// model. Wave 1 rewrites the query against Person joined to Operator so the
-// command palette keeps working; Wave 2B may rename the tool to
-// `search_operators`.
+// #219 Wave 2B — search_users operates on Operator joined to Person.
+// Tool name kept as `search_users` for backward compat; Wave 2C migrates consumers.
+// Role is returned from Operator.role directly (STANDARD | ADMIN) — no legacy slug mapping.
 export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
     'search_users',
@@ -41,7 +40,7 @@ export function registerUserTools(server: McpServer, { db }: ServerDeps): void {
         id: p.id,
         name: p.name,
         email: p.email,
-        role: p.operator?.role ?? 'STANDARD',
+        role: p.operator!.role,
         isActive: p.isActive,
       }));
 


### PR DESCRIPTION
- New Person shape (one identity per human, global email uniqueness)
- Operator extension table: personId, clientId?, role ADMIN|STANDARD,
  notification prefs, themePreference, passwordHash moved to Person
- ClientUser extension table: personId, clientId, userType, isPrimary
  moved from Person
- Unified person_refresh_tokens keyed by personId + accessType
- Auth routes rewritten: /api/auth/* checks Operator existence;
  /api/portal/auth/* checks ClientUser existence. No more hasOpsAccess
  fallback — clean record-based access gating
- Dropped: User table, RefreshToken table, Person.hasPortalAccess,
  Person.hasOpsAccess, Person.userType, Person.passwordHash (moved),
  requireOpsAccess helper
- Canonical API response shapes + JWT payloads published in
  shared-types for Waves 2A/2B/2C to consume
- Stubs/shims across routes, services, MCP tools, and frontend marked
  with // TODO: #219 Wave 2X — kept the build green while the parallel
  waves pick up their pieces