### PR TITLE
feat: gap requests — schema + inline request_tool + CRUD + admin page (refs #305)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,11 @@ pnpm dev:portal           # Start ticket portal (Angular, port 4201)
 | `mcp-servers/platform/src/tools/people.ts` | MCP people tools (list, get, create, update, delete). |
 | `services/copilot-api/src/routes/client-memory.ts` | Client memory CRUD endpoints with resolver cache invalidation. |
 | `services/copilot-api/src/routes/ticket-routes.ts` | Ticket route CRUD + step type registry for configurable analysis pipelines. |
+| `services/copilot-api/src/routes/tool-requests.ts` | Gap Requests CRUD API (admin-only): list/filter tool-request records, view rationale history, transition status (approve/reject/duplicate/implemented/reopen), delete. |
+| `services/copilot-api/src/services/tool-request-registry.ts` | Dedup upsert helper for tool-request records keyed on `(clientId, requestedName)`; appends rationale rows without clobbering operator edits. |
+| `mcp-servers/platform/src/tools/request-tool.ts` | MCP `request_tool` that analyzers call when they hit a capability gap; enforces the per-run rate limit from AppSetting `tool-request-rate-limit-per-run`. |
+| `mcp-servers/platform/src/tools/tool-requests.ts` | MCP CRUD tools for tool requests (list/get/update/delete) used by the platform surface. |
+| `services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts` | Admin Tool Requests page: list + detail dialog with rationale history, linked tickets, and status transition controls. |
 | `services/copilot-api/src/routes/artifacts.ts` | MCP tool artifact storage and retrieval endpoints (`/api/artifacts`). |
 | `services/copilot-api/src/routes/release-notes.ts` | Release notes API: commit ingestion, AI summarization, GitHub backfill, service filtering. |
 | `services/copilot-api/src/routes/ingest.ts` | Ingestion API: queue endpoints for email/scheduled/manual payloads, plus `GET /api/ingest/runs` and `GET /api/ingest/runs/:id` for run history. |

--- a/mcp-servers/platform/src/shared/tool-request-registry.ts
+++ b/mcp-servers/platform/src/shared/tool-request-registry.ts
@@ -1,0 +1,84 @@
+import type { PrismaClient } from '@bronco/db';
+import { Prisma } from '@bronco/db';
+import { ToolRequestRationaleSource } from '@bronco/shared-types';
+
+// Keep in sync with services/copilot-api/src/services/tool-request-registry.ts.
+// Both services share behavior here; duplicated locally because mcp-platform
+// can't import from copilot-api.
+
+export interface RegisterToolRequestInput {
+  clientId: string;
+  ticketId?: string;
+  requestedName: string;
+  displayTitle: string;
+  description: string;
+  rationale: string;
+  suggestedInputs?: Record<string, unknown>;
+  exampleUsage?: string;
+  source: ToolRequestRationaleSource;
+}
+
+export interface RegisterToolRequestResult {
+  toolRequestId: string;
+  isNew: boolean;
+  normalizedName: string;
+}
+
+export function normalizeRequestedName(raw: string): string {
+  const normalized = raw
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+  if (normalized.length < 3 || normalized.length > 100) {
+    throw new Error(
+      `Invalid requestedName: normalized form must be 3–100 chars of [a-z0-9_], got "${normalized}"`,
+    );
+  }
+  return normalized;
+}
+
+export async function registerToolRequest(
+  db: PrismaClient,
+  input: RegisterToolRequestInput,
+): Promise<RegisterToolRequestResult> {
+  const normalizedName = normalizeRequestedName(input.requestedName);
+  return db.$transaction(async (tx) => {
+    const existing = await tx.toolRequest.findUnique({
+      where: {
+        clientId_requestedName: { clientId: input.clientId, requestedName: normalizedName },
+      },
+    });
+    let rowId: string;
+    let isNew = false;
+    if (!existing) {
+      const created = await tx.toolRequest.create({
+        data: {
+          clientId: input.clientId,
+          firstTicketId: input.ticketId,
+          requestedName: normalizedName,
+          displayTitle: input.displayTitle,
+          description: input.description,
+          suggestedInputs: (input.suggestedInputs ?? undefined) as Prisma.InputJsonValue | undefined,
+          exampleUsage: input.exampleUsage,
+        },
+      });
+      rowId = created.id;
+      isNew = true;
+    } else {
+      const updated = await tx.toolRequest.update({
+        where: { id: existing.id },
+        data: { requestCount: { increment: 1 } },
+      });
+      rowId = updated.id;
+    }
+    await tx.toolRequestRationale.create({
+      data: {
+        toolRequestId: rowId,
+        ticketId: input.ticketId,
+        rationale: input.rationale,
+        source: input.source,
+      },
+    });
+    return { toolRequestId: rowId, isNew, normalizedName };
+  });
+}

--- a/mcp-servers/platform/src/tools/index.ts
+++ b/mcp-servers/platform/src/tools/index.ts
@@ -15,6 +15,8 @@ import { registerSystemStatusTools } from './system-status.js';
 import { registerSlackConversationTools } from './slack-conversations.js';
 import { registerUserTools } from './users.js';
 import { registerArtifactTools } from './read-tool-result-artifact.js';
+import { registerRequestToolTool } from './request-tool.js';
+import { registerToolRequestTools } from './tool-requests.js';
 
 export function registerAllTools(server: McpServer, deps: ServerDeps): void {
   registerTicketTools(server, deps);
@@ -32,4 +34,6 @@ export function registerAllTools(server: McpServer, deps: ServerDeps): void {
   registerSystemStatusTools(server, deps);
   registerSlackConversationTools(server, deps);
   registerArtifactTools(server, deps);
+  registerRequestToolTool(server, deps);
+  registerToolRequestTools(server, deps);
 }

--- a/mcp-servers/platform/src/tools/request-tool.ts
+++ b/mcp-servers/platform/src/tools/request-tool.ts
@@ -1,0 +1,166 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { ToolRequestRationaleSource } from '@bronco/shared-types';
+import type { ServerDeps } from '../server.js';
+import { normalizeRequestedName, registerToolRequest } from '../shared/tool-request-registry.js';
+
+const SETTING_KEY = 'tool-request-rate-limit-per-run';
+const DEFAULT_LIMIT_PER_RUN = 5;
+/**
+ * #306 will introduce an explicit per-run tracker. Until then, we use the
+ * ticket's lastAnalyzedAt (or a 1h window) as a pragmatic run-start proxy.
+ */
+const FALLBACK_RUN_WINDOW_MS = 60 * 60 * 1000;
+
+function parseLimit(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) return Math.floor(raw);
+  if (raw && typeof raw === 'object' && 'limit' in raw) {
+    const v = (raw as { limit: unknown }).limit;
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) return Math.floor(v);
+  }
+  return DEFAULT_LIMIT_PER_RUN;
+}
+
+export function registerRequestToolTool(server: McpServer, { db }: ServerDeps): void {
+  server.tool(
+    'request_tool',
+    [
+      'Flag a missing tool capability discovered during analysis.',
+      'Call when no existing tool fits and you are about to improvise with a',
+      'generic tool or abandon a line of investigation. Describe the tool you',
+      'wish existed so an operator can evaluate and implement it.',
+    ].join(' '),
+    {
+      ticketId: z.string().uuid().describe('Ticket being analyzed when the gap was encountered'),
+      clientId: z.string().uuid().describe('Client the ticket belongs to'),
+      requestedName: z
+        .string()
+        .min(3)
+        .max(100)
+        .describe('Proposed snake_case tool name (e.g. "analyze_execution_plan")'),
+      displayTitle: z
+        .string()
+        .min(3)
+        .max(200)
+        .describe('Short human-readable title for the missing tool'),
+      description: z
+        .string()
+        .min(20)
+        .describe('What the tool should do, inputs, outputs, and expected shape'),
+      rationale: z
+        .string()
+        .min(20)
+        .describe('Why this tool was needed for THIS ticket — specific to current work'),
+      suggestedInputs: z
+        .record(z.unknown())
+        .optional()
+        .describe('Optional JSON sketch of input parameters'),
+      exampleUsage: z
+        .string()
+        .optional()
+        .describe('Optional example invocation or pseudo-code showing how the tool would be used'),
+    },
+    async (params) => {
+      const ticket = await db.ticket.findUnique({
+        where: { id: params.ticketId },
+        select: { id: true, lastAnalyzedAt: true },
+      });
+      if (!ticket) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text', text: `ERROR: ticket ${params.ticketId} not found` },
+          ],
+        };
+      }
+
+      const setting = await db.appSetting.findUnique({ where: { key: SETTING_KEY } });
+      const limit = parseLimit(setting?.value);
+
+      // Pragmatic run window: the current analysis run started no earlier than
+      // the ticket's lastAnalyzedAt; fall back to a 1h window if this is the
+      // first run. #306 will replace this with an explicit per-run tracker.
+      const runStart =
+        ticket.lastAnalyzedAt ?? new Date(Date.now() - FALLBACK_RUN_WINDOW_MS);
+
+      const priorInRun = await db.toolRequestRationale.findMany({
+        where: {
+          ticketId: params.ticketId,
+          source: ToolRequestRationaleSource.INLINE_AGENT_REQUEST,
+          createdAt: { gte: runStart },
+        },
+        select: { toolRequest: { select: { requestedName: true } } },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      if (priorInRun.length >= limit) {
+        const names = priorInRun
+          .map((r) => r.toolRequest?.requestedName)
+          .filter((n): n is string => !!n);
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text:
+                `ERROR: request_tool rate limit reached for this analysis run (limit=${limit}). ` +
+                `Already requested in this run: [${names.join(', ')}]. ` +
+                `Focus on the current question with existing tools, or stop and summarize findings.`,
+            },
+          ],
+        };
+      }
+
+      let normalizedName: string;
+      try {
+        normalizedName = normalizeRequestedName(params.requestedName);
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text', text: `ERROR: ${(err as Error).message}` },
+          ],
+        };
+      }
+
+      const result = await registerToolRequest(db, {
+        clientId: params.clientId,
+        ticketId: params.ticketId,
+        requestedName: params.requestedName,
+        displayTitle: params.displayTitle,
+        description: params.description,
+        rationale: params.rationale,
+        suggestedInputs: params.suggestedInputs,
+        exampleUsage: params.exampleUsage,
+        source: ToolRequestRationaleSource.INLINE_AGENT_REQUEST,
+      });
+
+      const existing = await db.toolRequest.findUnique({
+        where: { id: result.toolRequestId },
+        select: { requestCount: true, status: true },
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                toolRequestId: result.toolRequestId,
+                isNew: result.isNew,
+                normalizedName,
+                requestCount: existing?.requestCount ?? 1,
+                status: existing?.status ?? 'PROPOSED',
+                message: result.isNew
+                  ? 'Recorded new tool request. Continue analysis with available tools.'
+                  : 'Appended rationale to existing tool request. Continue analysis with available tools.',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/mcp-servers/platform/src/tools/tool-requests.ts
+++ b/mcp-servers/platform/src/tools/tool-requests.ts
@@ -1,0 +1,119 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { Prisma } from '@bronco/db';
+import { ToolRequestStatus } from '@bronco/shared-types';
+import type { ServerDeps } from '../server.js';
+
+const STATUS_VALUES = Object.values(ToolRequestStatus) as [string, ...string[]];
+
+export function registerToolRequestTools(server: McpServer, { db }: ServerDeps): void {
+  server.tool(
+    'list_tool_requests',
+    'List agent-flagged tool requests (missing capability registry). Filterable by client and status.',
+    {
+      clientId: z.string().uuid().optional().describe('Filter by client ID'),
+      status: z
+        .array(z.enum(STATUS_VALUES))
+        .optional()
+        .describe('Filter by status values'),
+    },
+    async (params) => {
+      const where: Prisma.ToolRequestWhereInput = {};
+      if (params.clientId) where.clientId = params.clientId;
+      if (params.status && params.status.length > 0) {
+        where.status = { in: params.status as ToolRequestStatus[] };
+      }
+
+      const rows = await db.toolRequest.findMany({
+        where,
+        orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+      });
+
+      return { content: [{ type: 'text', text: JSON.stringify(rows, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'get_tool_request',
+    'Get a single tool request with its rationale history and duplicates.',
+    {
+      id: z.string().uuid().describe('Tool request ID'),
+    },
+    async (params) => {
+      const row = await db.toolRequest.findUnique({
+        where: { id: params.id },
+        include: {
+          rationales: { orderBy: { createdAt: 'desc' } },
+          duplicates: { select: { id: true, requestedName: true, status: true } },
+        },
+      });
+      if (!row) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `ERROR: tool request ${params.id} not found` }],
+        };
+      }
+      return { content: [{ type: 'text', text: JSON.stringify(row, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'update_tool_request',
+    'Update a tool request. On PROPOSED → APPROVED the approvedAt timestamp is set automatically (approvedBy stays null from the MCP path — set via REST).',
+    {
+      id: z.string().uuid().describe('Tool request ID'),
+      status: z.enum(STATUS_VALUES).optional().describe('New status'),
+      rejectedReason: z.string().optional().describe('Required when setting status to REJECTED'),
+      duplicateOfId: z
+        .string()
+        .uuid()
+        .optional()
+        .describe('Required when setting status to DUPLICATE — the canonical ToolRequest ID'),
+      implementedInCommit: z.string().optional().describe('Git commit SHA that implemented the tool'),
+      implementedInIssue: z.string().optional().describe('GitHub issue number that tracked the work'),
+      githubIssueUrl: z.string().url().optional().describe('Full URL to the GitHub issue'),
+    },
+    async (params) => {
+      const existing = await db.toolRequest.findUnique({
+        where: { id: params.id },
+        select: { status: true },
+      });
+      if (!existing) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `ERROR: tool request ${params.id} not found` }],
+        };
+      }
+
+      const data: Prisma.ToolRequestUpdateInput = {};
+      if (params.status) {
+        data.status = params.status as ToolRequestStatus;
+        if (params.status === ToolRequestStatus.APPROVED && existing.status === ToolRequestStatus.PROPOSED) {
+          data.approvedAt = new Date();
+        }
+      }
+      if (params.rejectedReason !== undefined) data.rejectedReason = params.rejectedReason;
+      if (params.duplicateOfId !== undefined) {
+        data.duplicateOf = { connect: { id: params.duplicateOfId } };
+      }
+      if (params.implementedInCommit !== undefined) data.implementedInCommit = params.implementedInCommit;
+      if (params.implementedInIssue !== undefined) data.implementedInIssue = params.implementedInIssue;
+      if (params.githubIssueUrl !== undefined) data.githubIssueUrl = params.githubIssueUrl;
+
+      const updated = await db.toolRequest.update({ where: { id: params.id }, data });
+      return { content: [{ type: 'text', text: JSON.stringify(updated, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'delete_tool_request',
+    'Hard-delete a tool request (including its rationale history via cascade).',
+    {
+      id: z.string().uuid().describe('Tool request ID'),
+    },
+    async (params) => {
+      await db.toolRequest.delete({ where: { id: params.id } });
+      return { content: [{ type: 'text', text: JSON.stringify({ deleted: true, id: params.id }) }] };
+    },
+  );
+}

--- a/packages/db/prisma/migrations/20260421000000_tool_requests/migration.sql
+++ b/packages/db/prisma/migrations/20260421000000_tool_requests/migration.sql
@@ -1,0 +1,66 @@
+-- CreateEnum
+CREATE TYPE "tool_request_status" AS ENUM ('PROPOSED', 'APPROVED', 'REJECTED', 'IMPLEMENTED', 'DUPLICATE');
+
+-- CreateEnum
+CREATE TYPE "tool_request_rationale_source" AS ENUM ('INLINE_AGENT_REQUEST', 'POST_HOC_DETECTION', 'MANUAL');
+
+-- CreateTable
+CREATE TABLE "tool_requests" (
+    "id" UUID NOT NULL,
+    "client_id" UUID NOT NULL,
+    "first_ticket_id" UUID,
+    "requested_name" TEXT NOT NULL,
+    "display_title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "suggested_inputs" JSONB,
+    "example_usage" TEXT,
+    "status" "tool_request_status" NOT NULL DEFAULT 'PROPOSED',
+    "request_count" INTEGER NOT NULL DEFAULT 1,
+    "approved_at" TIMESTAMP(3),
+    "approved_by" TEXT,
+    "rejected_reason" TEXT,
+    "duplicate_of_id" UUID,
+    "implemented_in_commit" TEXT,
+    "implemented_in_issue" TEXT,
+    "github_issue_url" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tool_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tool_request_rationales" (
+    "id" UUID NOT NULL,
+    "tool_request_id" UUID NOT NULL,
+    "ticket_id" UUID,
+    "rationale" TEXT NOT NULL,
+    "source" "tool_request_rationale_source" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tool_request_rationales_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tool_requests_client_id_requested_name_key" ON "tool_requests"("client_id", "requested_name");
+
+-- CreateIndex
+CREATE INDEX "tool_requests_status_created_at_idx" ON "tool_requests"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "tool_request_rationales_tool_request_id_created_at_idx" ON "tool_request_rationales"("tool_request_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "tool_requests" ADD CONSTRAINT "tool_requests_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "clients"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tool_requests" ADD CONSTRAINT "tool_requests_first_ticket_id_fkey" FOREIGN KEY ("first_ticket_id") REFERENCES "tickets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tool_requests" ADD CONSTRAINT "tool_requests_duplicate_of_id_fkey" FOREIGN KEY ("duplicate_of_id") REFERENCES "tool_requests"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tool_request_rationales" ADD CONSTRAINT "tool_request_rationales_tool_request_id_fkey" FOREIGN KEY ("tool_request_id") REFERENCES "tool_requests"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tool_request_rationales" ADD CONSTRAINT "tool_request_rationales_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "tickets"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -171,6 +171,7 @@ model Client {
   emailProcessingLogs EmailProcessingLog[]
   slackConversations  SlackConversationLog[]
   operatorAssignments OperatorClient[]
+  toolRequests        ToolRequest[]
 
   @@map("clients")
 }
@@ -317,6 +318,8 @@ model Ticket {
   ingestionRuns       IngestionRun[]
   emailProcessingLogs EmailProcessingLog[]
   pendingActions      PendingAction[]
+  toolRequests          ToolRequest[]           @relation("FirstTicketRequests")
+  toolRequestRationales ToolRequestRationale[]
 
   @@unique([clientId, ticketNumber])
   @@index([clientId, status])
@@ -1614,4 +1617,73 @@ model AppSetting {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("app_settings")
+}
+
+// --- Tool Requests (agent-flagged missing tool capabilities) ---
+// Agents call `request_tool` (MCP) mid-analysis to register a gap.
+// The same requested tool across multiple tickets is deduped via
+// (clientId, requestedName) and each call appends a rationale entry.
+
+enum ToolRequestStatus {
+  PROPOSED
+  APPROVED
+  REJECTED
+  IMPLEMENTED
+  DUPLICATE
+
+  @@map("tool_request_status")
+}
+
+enum ToolRequestRationaleSource {
+  INLINE_AGENT_REQUEST
+  POST_HOC_DETECTION
+  MANUAL
+
+  @@map("tool_request_rationale_source")
+}
+
+model ToolRequest {
+  id                  String            @id @default(uuid()) @db.Uuid
+  clientId            String            @map("client_id") @db.Uuid
+  client              Client            @relation(fields: [clientId], references: [id])
+  firstTicketId       String?           @map("first_ticket_id") @db.Uuid
+  firstTicket         Ticket?           @relation("FirstTicketRequests", fields: [firstTicketId], references: [id])
+  requestedName       String            @map("requested_name")
+  displayTitle        String            @map("display_title")
+  description         String            @db.Text
+  suggestedInputs     Json?             @map("suggested_inputs")
+  exampleUsage        String?           @db.Text @map("example_usage")
+  status              ToolRequestStatus @default(PROPOSED)
+  requestCount        Int               @default(1) @map("request_count")
+  approvedAt          DateTime?         @map("approved_at")
+  approvedBy          String?           @map("approved_by")
+  rejectedReason      String?           @map("rejected_reason")
+  duplicateOfId       String?           @map("duplicate_of_id") @db.Uuid
+  duplicateOf         ToolRequest?      @relation("ToolRequestDuplicates", fields: [duplicateOfId], references: [id])
+  duplicates          ToolRequest[]     @relation("ToolRequestDuplicates")
+  implementedInCommit String?           @map("implemented_in_commit")
+  implementedInIssue  String?           @map("implemented_in_issue")
+  githubIssueUrl      String?           @map("github_issue_url")
+
+  rationales ToolRequestRationale[]
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  @@unique([clientId, requestedName])
+  @@index([status, createdAt])
+  @@map("tool_requests")
+}
+
+model ToolRequestRationale {
+  id            String                     @id @default(uuid()) @db.Uuid
+  toolRequestId String                     @map("tool_request_id") @db.Uuid
+  toolRequest   ToolRequest                @relation(fields: [toolRequestId], references: [id], onDelete: Cascade)
+  ticketId      String?                    @map("ticket_id") @db.Uuid
+  ticket        Ticket?                    @relation(fields: [ticketId], references: [id])
+  rationale     String                     @db.Text
+  source        ToolRequestRationaleSource
+  createdAt     DateTime                   @default(now()) @map("created_at")
+
+  @@index([toolRequestId, createdAt])
+  @@map("tool_request_rationales")
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -17,6 +17,7 @@ export * from './operational-task.js';
 export * from './ticket-route.js';
 export * from './ingestion.js';
 export * from './client-memory.js';
+export * from './tool-request.js';
 export * from './client-user.js';
 export * from './client-environment.js';
 export * from './scheduled-probe.js';

--- a/packages/shared-types/src/tool-request.ts
+++ b/packages/shared-types/src/tool-request.ts
@@ -1,0 +1,63 @@
+// --- Tool Request Status (lifecycle of an agent-flagged tool gap) ---
+
+export const ToolRequestStatus = {
+  /** Agent flagged the gap; awaiting operator triage. */
+  PROPOSED: 'PROPOSED',
+  /** Operator accepted the request; ready for implementation. */
+  APPROVED: 'APPROVED',
+  /** Operator declined the request. */
+  REJECTED: 'REJECTED',
+  /** Tool has been implemented and shipped. */
+  IMPLEMENTED: 'IMPLEMENTED',
+  /** Consolidated into another ToolRequest via duplicateOfId. */
+  DUPLICATE: 'DUPLICATE',
+} as const;
+export type ToolRequestStatus = (typeof ToolRequestStatus)[keyof typeof ToolRequestStatus];
+
+// --- Tool Request Rationale Source (how this rationale entry was recorded) ---
+
+export const ToolRequestRationaleSource = {
+  /** Agent called `request_tool` MCP during analysis. */
+  INLINE_AGENT_REQUEST: 'INLINE_AGENT_REQUEST',
+  /** Post-hoc detection step mined the transcript after analysis finished. */
+  POST_HOC_DETECTION: 'POST_HOC_DETECTION',
+  /** Operator added the rationale manually via the admin UI/API. */
+  MANUAL: 'MANUAL',
+} as const;
+export type ToolRequestRationaleSource =
+  (typeof ToolRequestRationaleSource)[keyof typeof ToolRequestRationaleSource];
+
+// --- Tool Request (dedup'd per-client missing-tool entry) ---
+
+export interface ToolRequest {
+  id: string;
+  clientId: string;
+  firstTicketId: string | null;
+  requestedName: string;
+  displayTitle: string;
+  description: string;
+  suggestedInputs: Record<string, unknown> | null;
+  exampleUsage: string | null;
+  status: ToolRequestStatus;
+  requestCount: number;
+  approvedAt: Date | null;
+  approvedBy: string | null;
+  rejectedReason: string | null;
+  duplicateOfId: string | null;
+  implementedInCommit: string | null;
+  implementedInIssue: string | null;
+  githubIssueUrl: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// --- Tool Request Rationale (one entry per agent/operator call) ---
+
+export interface ToolRequestRationale {
+  id: string;
+  toolRequestId: string;
+  ticketId: string | null;
+  rationale: string;
+  source: ToolRequestRationaleSource;
+  createdAt: Date;
+}

--- a/services/control-panel/src/app/app.routes.ts
+++ b/services/control-panel/src/app/app.routes.ts
@@ -141,6 +141,11 @@ export const routes: Routes = [
         loadComponent: () => import('./features/ticket-routes/ticket-route-list.component.js').then(m => m.TicketRouteListComponent),
       },
       {
+        path: 'tool-requests',
+        canActivate: [scopedOpsGuard],
+        loadComponent: () => import('./features/tool-requests/tool-request-list.component.js').then(m => m.ToolRequestListComponent),
+      },
+      {
         path: 'ingestion-jobs',
         canActivate: [scopedOpsGuard],
         loadComponent: () => import('./features/ingestion-jobs/ingestion-job-list.component.js').then(m => m.IngestionJobListComponent),

--- a/services/control-panel/src/app/core/nav/nav-routes.ts
+++ b/services/control-panel/src/app/core/nav/nav-routes.ts
@@ -43,6 +43,7 @@ export const NAV_ROUTES: readonly NavRoute[] = [
   { route: '/ai-providers', label: 'AI Providers', icon: 'robot', section: 'ai' },
   { route: '/ai-usage', label: 'AI Usage', icon: 'bolt', section: 'ai' },
   { route: '/ticket-routes', label: 'Ticket Routes', icon: 'tag', section: 'ai' },
+  { route: '/tool-requests', label: 'Tool Requests', icon: 'sparkles', section: 'ai' },
   { route: '/system-analysis', label: 'System Analysis', icon: 'search', section: 'ai' },
   { route: '/system-issues', label: 'System Issues', icon: 'warning', section: 'ai' },
 

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -134,6 +134,10 @@ export interface PromptRetentionConfig {
   summaryRetentionDays: number;
 }
 
+export interface ToolRequestRateLimitConfig {
+  limit: number;
+}
+
 export interface ActionSafetyConfig {
   actions: Record<string, 'auto' | 'approval'>;
 }
@@ -268,6 +272,14 @@ export class SettingsService {
   }
   savePromptRetention(config: PromptRetentionConfig): Observable<PromptRetentionConfig> {
     return this.api.put<PromptRetentionConfig>('/settings/prompt-retention', config);
+  }
+
+  // --- Tool Request Rate Limit ---
+  getToolRequestRateLimit(): Observable<ToolRequestRateLimitConfig> {
+    return this.api.get<ToolRequestRateLimitConfig>('/settings/tool-request-rate-limit');
+  }
+  saveToolRequestRateLimit(config: ToolRequestRateLimitConfig): Observable<ToolRequestRateLimitConfig> {
+    return this.api.put<ToolRequestRateLimitConfig>('/settings/tool-request-rate-limit', config);
   }
 
   // --- Action Safety ---

--- a/services/control-panel/src/app/core/services/tool-request.service.ts
+++ b/services/control-panel/src/app/core/services/tool-request.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service.js';
+
+// Keep in sync with packages/shared-types/src/tool-request.ts.
+// Control panel does not depend on @bronco/shared-types directly; these
+// literal unions mirror the enum values used by the REST API.
+export const ToolRequestStatus = {
+  PROPOSED: 'PROPOSED',
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
+  IMPLEMENTED: 'IMPLEMENTED',
+  DUPLICATE: 'DUPLICATE',
+} as const;
+export type ToolRequestStatus = (typeof ToolRequestStatus)[keyof typeof ToolRequestStatus];
+
+export const ToolRequestRationaleSource = {
+  INLINE_AGENT_REQUEST: 'INLINE_AGENT_REQUEST',
+  POST_HOC_DETECTION: 'POST_HOC_DETECTION',
+  MANUAL: 'MANUAL',
+} as const;
+export type ToolRequestRationaleSource =
+  (typeof ToolRequestRationaleSource)[keyof typeof ToolRequestRationaleSource];
+
+export interface ToolRequestClientSummary {
+  id: string;
+  name: string;
+  shortCode: string | null;
+}
+
+export interface ToolRequestTicketSummary {
+  id: string;
+  ticketNumber: number;
+  subject: string;
+  status: string;
+}
+
+export interface ToolRequestListItem {
+  id: string;
+  clientId: string;
+  firstTicketId: string | null;
+  requestedName: string;
+  displayTitle: string;
+  description: string;
+  suggestedInputs: Record<string, unknown> | null;
+  exampleUsage: string | null;
+  status: ToolRequestStatus;
+  requestCount: number;
+  approvedAt: string | null;
+  approvedBy: string | null;
+  rejectedReason: string | null;
+  duplicateOfId: string | null;
+  implementedInCommit: string | null;
+  implementedInIssue: string | null;
+  githubIssueUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+  client: ToolRequestClientSummary;
+  _count: { rationales: number };
+}
+
+export interface ToolRequestRationaleItem {
+  id: string;
+  toolRequestId: string;
+  ticketId: string | null;
+  rationale: string;
+  source: ToolRequestRationaleSource;
+  createdAt: string;
+  ticket: ToolRequestTicketSummary | null;
+}
+
+export interface ToolRequestDetail extends ToolRequestListItem {
+  rationales: ToolRequestRationaleItem[];
+  duplicates: Array<{
+    id: string;
+    requestedName: string;
+    displayTitle: string;
+    status: ToolRequestStatus;
+    requestCount: number;
+  }>;
+  duplicateOf: {
+    id: string;
+    requestedName: string;
+    displayTitle: string;
+    status: ToolRequestStatus;
+  } | null;
+  firstTicket: ToolRequestTicketSummary | null;
+  linkedTickets: ToolRequestTicketSummary[];
+}
+
+export interface ToolRequestListResponse {
+  items: ToolRequestListItem[];
+  total: number;
+}
+
+export interface ToolRequestListFilters {
+  status?: ToolRequestStatus | ToolRequestStatus[];
+  clientId?: string;
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface UpdateToolRequestBody {
+  status?: ToolRequestStatus;
+  rejectedReason?: string;
+  duplicateOfId?: string | null;
+  implementedInCommit?: string;
+  implementedInIssue?: string;
+  githubIssueUrl?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToolRequestService {
+  private api = inject(ApiService);
+
+  list(filters?: ToolRequestListFilters): Observable<ToolRequestListResponse> {
+    const params: Record<string, string | number> = {};
+    if (filters?.clientId) params['clientId'] = filters.clientId;
+    if (filters?.search) params['search'] = filters.search;
+    if (filters?.limit != null) params['limit'] = filters.limit;
+    if (filters?.offset != null) params['offset'] = filters.offset;
+    if (filters?.status) {
+      const arr = Array.isArray(filters.status) ? filters.status : [filters.status];
+      // ApiService joins via URLSearchParams; send comma-separated then split on server? Server schema accepts array or single.
+      // Use single status when only one; use first value otherwise (multi-status kept to a single call each in UI).
+      if (arr.length === 1) params['status'] = arr[0];
+    }
+    return this.api.get<ToolRequestListResponse>('/tool-requests', params);
+  }
+
+  get(id: string): Observable<ToolRequestDetail> {
+    return this.api.get<ToolRequestDetail>(`/tool-requests/${id}`);
+  }
+
+  update(id: string, body: UpdateToolRequestBody): Observable<ToolRequestListItem> {
+    return this.api.patch<ToolRequestListItem>(`/tool-requests/${id}`, body);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/tool-requests/${id}`);
+  }
+}

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -17,6 +17,7 @@ import {
   ImapSystemConfig,
   SlackSystemConfig,
   PromptRetentionConfig,
+  ToolRequestRateLimitConfig,
 } from '../../core/services/settings.service.js';
 import { ExternalServiceDialogComponent } from './external-service-dialog.component.js';
 import { StatusConfigDialogComponent } from './status-config-dialog.component.js';
@@ -38,7 +39,7 @@ import {
 } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
-const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis Strategy', 'Self Analysis', 'SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention'] as const;
+const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis Strategy', 'Self Analysis', 'SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention', 'Tool Requests'] as const;
 
 @Component({
   standalone: true,
@@ -561,6 +562,22 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               </div>
               <div class="card-actions">
                 <app-bronco-button variant="primary" (click)="savePromptRetention()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
+              </div>
+            </app-card>
+          </div>
+        </app-tab>
+
+        <!-- Tool Requests Tab -->
+        <app-tab label="Tool Requests">
+          <div class="tab-content">
+            <app-card>
+              <h2 class="section-title">Tool Request Rate Limit</h2>
+              <p class="hint">Caps how often the analyzer can call <code>request_tool</code> within a single analysis run. Prevents runaway requests when an agent loops on missing capabilities.</p>
+              <div class="form-grid">
+                <app-form-field label="Maximum request_tool calls per analysis run"><input class="text-input" type="number" [(ngModel)]="toolRequestRateLimit.limit" min="1" max="100" placeholder="5"></app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveToolRequestRateLimit()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
               </div>
             </app-card>
           </div>
@@ -1223,6 +1240,7 @@ export class SettingsComponent implements OnInit {
   imapConfig: ImapSystemConfig = { host: '', port: 993, user: '', password: '', pollIntervalSeconds: 60 };
   slackConfig: SlackSystemConfig = { botToken: '', appToken: '', defaultChannelId: '', enabled: false };
   promptRetention: PromptRetentionConfig = { fullRetentionDays: 30, summaryRetentionDays: 90 };
+  toolRequestRateLimit: ToolRequestRateLimitConfig = { limit: 5 };
 
   private loadSystemConfigs(): void {
     this.settingsSvc.getSmtpConfig().subscribe({ next: (c) => { if (c) this.smtp = { ...this.smtp, ...c }; } });
@@ -1231,6 +1249,7 @@ export class SettingsComponent implements OnInit {
     this.settingsSvc.getImapConfig().subscribe({ next: (c) => { if (c) this.imapConfig = { ...this.imapConfig, ...c }; } });
     this.settingsSvc.getSlackConfig().subscribe({ next: (c) => { if (c) this.slackConfig = { ...this.slackConfig, ...c }; } });
     this.settingsSvc.getPromptRetention().subscribe({ next: (c) => { if (c) this.promptRetention = { ...this.promptRetention, ...c }; } });
+    this.settingsSvc.getToolRequestRateLimit().subscribe({ next: (c) => { if (c) this.toolRequestRateLimit = { ...this.toolRequestRateLimit, ...c }; } });
   }
 
   saveSmtp(): void { this.sysConfigSaving.set(true); this.settingsSvc.updateSmtpConfig(this.smtp).subscribe({ next: (c) => { this.smtp = { ...this.smtp, ...c }; this.toast.success('SMTP config saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
@@ -1249,4 +1268,6 @@ export class SettingsComponent implements OnInit {
   testSlackConfig(): void { this.sysConfigTesting.set(true); this.settingsSvc.testSlackConnection().subscribe({ next: (r) => { r.success ? this.toast.success(r.message || 'Success') : this.toast.error(r.error || 'Test failed'); this.sysConfigTesting.set(false); }, error: () => { this.toast.error('Test failed'); this.sysConfigTesting.set(false); } }); }
 
   savePromptRetention(): void { this.sysConfigSaving.set(true); this.settingsSvc.savePromptRetention(this.promptRetention).subscribe({ next: (c: PromptRetentionConfig) => { this.promptRetention = { ...this.promptRetention, ...c }; this.toast.success('Prompt retention saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
+
+  saveToolRequestRateLimit(): void { this.sysConfigSaving.set(true); this.settingsSvc.saveToolRequestRateLimit(this.toolRequestRateLimit).subscribe({ next: (c: ToolRequestRateLimitConfig) => { this.toolRequestRateLimit = { ...this.toolRequestRateLimit, ...c }; this.toast.success('Tool request rate limit saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
 }

--- a/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
+++ b/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
@@ -1,0 +1,523 @@
+import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe, JsonPipe, NgClass } from '@angular/common';
+import {
+  ToolRequestService,
+  ToolRequestStatus,
+  type ToolRequestListItem,
+  type ToolRequestDetail,
+  type UpdateToolRequestBody,
+} from '../../core/services/tool-request.service.js';
+import { ToastService } from '../../core/services/toast.service.js';
+import {
+  BroncoButtonComponent,
+  CardComponent,
+  FormFieldComponent,
+  SelectComponent,
+  TextInputComponent,
+  ToolbarComponent,
+  DataTableComponent,
+  DataTableColumnComponent,
+  DialogComponent,
+} from '../../shared/components/index.js';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All Statuses' },
+  { value: ToolRequestStatus.PROPOSED, label: 'Proposed' },
+  { value: ToolRequestStatus.APPROVED, label: 'Approved' },
+  { value: ToolRequestStatus.REJECTED, label: 'Rejected' },
+  { value: ToolRequestStatus.IMPLEMENTED, label: 'Implemented' },
+  { value: ToolRequestStatus.DUPLICATE, label: 'Duplicate' },
+];
+
+@Component({
+  standalone: true,
+  imports: [
+    FormsModule,
+    DatePipe,
+    JsonPipe,
+    NgClass,
+    BroncoButtonComponent,
+    CardComponent,
+    FormFieldComponent,
+    SelectComponent,
+    TextInputComponent,
+    ToolbarComponent,
+    DataTableComponent,
+    DataTableColumnComponent,
+    DialogComponent,
+  ],
+  template: `
+    <div class="page-header">
+      <h1>Tool Requests</h1>
+      <div class="header-actions">
+        <app-bronco-button variant="secondary" size="sm" (click)="refresh()" [disabled]="loading()">
+          ↻ Refresh
+        </app-bronco-button>
+      </div>
+    </div>
+
+    <p class="page-hint">
+      Agent-flagged capability gaps. Each row represents a missing tool the analyzer wished it had, deduplicated by
+      <code>(client, requested_name)</code> with rationale history.
+    </p>
+
+    <app-toolbar>
+      <app-select
+        [value]="statusFilter()"
+        [options]="statusOptions"
+        (valueChange)="onStatusFilter($event)" />
+      <app-text-input
+        type="text"
+        [value]="searchInput()"
+        placeholder="Search name or title..."
+        (valueChange)="onSearchChange($event)" />
+    </app-toolbar>
+
+    @if (loading() && items().length === 0) {
+      <div class="loading-state">Loading tool requests...</div>
+    }
+
+    @if (!loading() && items().length === 0) {
+      <app-card>
+        <div class="empty-state">
+          <p>No tool requests{{ statusFilter() ? ' with status ' + statusFilter() : '' }}.</p>
+          <p class="empty-hint">When the analyzer identifies a missing capability it will post a <code>request_tool</code> call and surface it here.</p>
+        </div>
+      </app-card>
+    }
+
+    @if (items().length > 0) {
+      <app-data-table [data]="items()" [trackBy]="trackById" (rowClick)="openDetail($event)">
+        <app-data-column key="status" header="Status" width="120px" [sortable]="false">
+          <ng-template #cell let-row>
+            <span class="status-pill" [ngClass]="statusClass(row.status)">{{ row.status }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="displayTitle" header="Title" [sortable]="false">
+          <ng-template #cell let-row>
+            <div class="title-cell">
+              <span class="title">{{ row.displayTitle }}</span>
+              <span class="requested-name">{{ row.requestedName }}</span>
+            </div>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="client" header="Client" width="180px" [sortable]="false">
+          <ng-template #cell let-row>
+            <span class="client-name">{{ row.client.name }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="requestCount" header="Count" width="80px" [sortable]="false">
+          <ng-template #cell let-row>
+            <span class="count-pill">{{ row.requestCount }}</span>
+          </ng-template>
+        </app-data-column>
+
+        <app-data-column key="updatedAt" header="Last Updated" width="160px" [sortable]="false">
+          <ng-template #cell let-row>
+            <span class="time">{{ row.updatedAt | date:'short' }}</span>
+          </ng-template>
+        </app-data-column>
+      </app-data-table>
+
+      @if (total() > items().length) {
+        <div class="load-more">
+          <app-bronco-button variant="secondary" (click)="loadMore()" [disabled]="loading()">
+            Load More ({{ items().length }} of {{ total() }})
+          </app-bronco-button>
+        </div>
+      }
+    }
+
+    @if (detail(); as d) {
+      <app-dialog [open]="true" [title]="d.displayTitle" maxWidth="720px" (openChange)="closeDetail()">
+        <div class="detail">
+          <div class="detail-header">
+            <span class="status-pill" [ngClass]="statusClass(d.status)">{{ d.status }}</span>
+            <span class="requested-name-big">{{ d.requestedName }}</span>
+            <span class="count-pill">requests: {{ d.requestCount }}</span>
+          </div>
+
+          <section>
+            <h3>Description</h3>
+            <p class="body-text">{{ d.description }}</p>
+          </section>
+
+          @if (d.exampleUsage) {
+            <section>
+              <h3>Example Usage</h3>
+              <pre class="code-block">{{ d.exampleUsage }}</pre>
+            </section>
+          }
+
+          @if (d.suggestedInputs) {
+            <section>
+              <h3>Suggested Inputs</h3>
+              <pre class="code-block">{{ d.suggestedInputs | json }}</pre>
+            </section>
+          }
+
+          <section>
+            <h3>Rationale History ({{ d.rationales.length }})</h3>
+            @for (r of d.rationales; track r.id) {
+              <div class="rationale">
+                <div class="rationale-meta">
+                  <span class="source-tag">{{ r.source }}</span>
+                  @if (r.ticket) {
+                    <span class="ticket-ref">#{{ r.ticket.ticketNumber }} · {{ r.ticket.subject }}</span>
+                  }
+                  <span class="time">{{ r.createdAt | date:'short' }}</span>
+                </div>
+                <div class="rationale-text">{{ r.rationale }}</div>
+              </div>
+            }
+          </section>
+
+          @if (d.linkedTickets.length > 0) {
+            <section>
+              <h3>Linked Tickets</h3>
+              <ul class="ticket-list">
+                @for (t of d.linkedTickets; track t.id) {
+                  <li>#{{ t.ticketNumber }} — {{ t.subject }} <span class="muted">({{ t.status }})</span></li>
+                }
+              </ul>
+            </section>
+          }
+
+          @if (d.duplicateOf) {
+            <section>
+              <h3>Duplicate Of</h3>
+              <p>{{ d.duplicateOf.displayTitle }} ({{ d.duplicateOf.requestedName }}) — {{ d.duplicateOf.status }}</p>
+            </section>
+          }
+
+          @if (d.duplicates.length > 0) {
+            <section>
+              <h3>Duplicates Pointing Here</h3>
+              <ul class="dup-list">
+                @for (dup of d.duplicates; track dup.id) {
+                  <li>{{ dup.displayTitle }} ({{ dup.requestedName }}) — {{ dup.status }} · {{ dup.requestCount }}</li>
+                }
+              </ul>
+            </section>
+          }
+
+          <section class="transition-section">
+            <h3>Change Status</h3>
+
+            @if (d.status === 'PROPOSED') {
+              <div class="action-row">
+                <app-bronco-button variant="primary" (click)="approve(d)" [disabled]="saving()">Approve</app-bronco-button>
+                <app-bronco-button variant="secondary" (click)="showRejectForm.set(true)" [disabled]="saving()">Reject</app-bronco-button>
+                <app-bronco-button variant="secondary" (click)="showDuplicateForm.set(true)" [disabled]="saving()">Mark Duplicate</app-bronco-button>
+              </div>
+            }
+            @if (d.status === 'APPROVED') {
+              <div class="action-row">
+                <app-bronco-button variant="primary" (click)="showImplementedForm.set(true)" [disabled]="saving()">Mark Implemented</app-bronco-button>
+                <app-bronco-button variant="secondary" (click)="reopen(d)" [disabled]="saving()">Reopen (→ Proposed)</app-bronco-button>
+              </div>
+            }
+            @if (d.status === 'REJECTED' || d.status === 'DUPLICATE' || d.status === 'IMPLEMENTED') {
+              <div class="action-row">
+                <app-bronco-button variant="secondary" (click)="reopen(d)" [disabled]="saving()">Reopen (→ Proposed)</app-bronco-button>
+              </div>
+            }
+
+            @if (showRejectForm()) {
+              <div class="form-block">
+                <app-form-field label="Reason for rejection">
+                  <textarea class="text-input" [(ngModel)]="rejectReason" rows="3" placeholder="Why this request is being declined..."></textarea>
+                </app-form-field>
+                <div class="action-row">
+                  <app-bronco-button variant="destructive" (click)="reject(d)" [disabled]="saving() || !rejectReason.trim()">Confirm Reject</app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="showRejectForm.set(false)">Cancel</app-bronco-button>
+                </div>
+              </div>
+            }
+
+            @if (showDuplicateForm()) {
+              <div class="form-block">
+                <app-form-field label="Canonical tool request ID">
+                  <input class="text-input" [(ngModel)]="duplicateOfId" placeholder="UUID of existing request" />
+                </app-form-field>
+                <div class="action-row">
+                  <app-bronco-button variant="primary" (click)="markDuplicate(d)" [disabled]="saving() || !duplicateOfId.trim()">Confirm Duplicate</app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="showDuplicateForm.set(false)">Cancel</app-bronco-button>
+                </div>
+              </div>
+            }
+
+            @if (showImplementedForm()) {
+              <div class="form-block">
+                <app-form-field label="Commit SHA (optional)">
+                  <input class="text-input" [(ngModel)]="implementedInCommit" placeholder="abc1234" />
+                </app-form-field>
+                <app-form-field label="GitHub Issue URL (optional)">
+                  <input class="text-input" [(ngModel)]="githubIssueUrl" placeholder="https://github.com/owner/repo/issues/123" />
+                </app-form-field>
+                <div class="action-row">
+                  <app-bronco-button variant="primary" (click)="markImplemented(d)" [disabled]="saving()">Mark Implemented</app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="showImplementedForm.set(false)">Cancel</app-bronco-button>
+                </div>
+              </div>
+            }
+          </section>
+
+          <section class="danger-section">
+            <app-bronco-button variant="destructive" (click)="remove(d)" [disabled]="saving()">Delete Tool Request</app-bronco-button>
+          </section>
+        </div>
+      </app-dialog>
+    }
+  `,
+  styles: [`
+    .page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+    .page-header h1 { margin: 0; font-size: 21px; font-weight: 600; color: var(--text-primary); }
+    .page-hint { color: var(--text-tertiary); font-size: 13px; margin: 0 0 16px; }
+    .page-hint code { background: var(--bg-muted); padding: 1px 6px; border-radius: 4px; font-size: 12px; }
+
+    .loading-state, .empty-state { padding: 48px; text-align: center; color: var(--text-tertiary); }
+    .empty-hint { font-size: 12px; margin-top: 8px; }
+    .empty-hint code { background: var(--bg-muted); padding: 1px 5px; border-radius: 4px; }
+
+    .status-pill {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+    .status-pill.status-proposed { background: rgba(255,204,0,0.15); color: #b58900; border: 1px solid rgba(255,204,0,0.3); }
+    .status-pill.status-approved { background: rgba(52,199,89,0.12); color: var(--color-success); border: 1px solid rgba(52,199,89,0.25); }
+    .status-pill.status-rejected { background: rgba(255,59,48,0.1); color: var(--color-error); border: 1px solid rgba(255,59,48,0.25); }
+    .status-pill.status-implemented { background: rgba(0,122,255,0.1); color: var(--accent); border: 1px solid rgba(0,122,255,0.25); }
+    .status-pill.status-duplicate { background: rgba(142,142,147,0.15); color: var(--text-secondary); border: 1px solid rgba(142,142,147,0.3); }
+
+    .title-cell { display: flex; flex-direction: column; gap: 2px; }
+    .title { font-weight: 500; color: var(--text-primary); }
+    .requested-name { font-family: ui-monospace, monospace; font-size: 11px; color: var(--text-tertiary); }
+    .client-name { font-size: 13px; color: var(--text-secondary); }
+    .count-pill {
+      display: inline-block;
+      padding: 1px 8px;
+      font-size: 12px;
+      background: var(--bg-muted);
+      color: var(--text-secondary);
+      border-radius: var(--radius-pill);
+      font-family: ui-monospace, monospace;
+    }
+    .time { font-size: 12px; color: var(--text-tertiary); }
+    .load-more { display: flex; justify-content: center; margin-top: 16px; }
+
+    .detail { display: flex; flex-direction: column; gap: 16px; }
+    .detail-header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .requested-name-big { font-family: ui-monospace, monospace; font-size: 14px; color: var(--text-secondary); }
+    .detail section h3 { margin: 0 0 6px; font-size: 13px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px; }
+    .body-text { margin: 0; line-height: 1.5; color: var(--text-primary); white-space: pre-wrap; }
+    .code-block {
+      background: var(--bg-muted);
+      padding: 10px 12px;
+      border-radius: var(--radius-md);
+      font-size: 12px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .rationale {
+      border-left: 2px solid var(--border-light);
+      padding: 4px 12px;
+      margin-bottom: 10px;
+    }
+    .rationale-meta { display: flex; gap: 12px; font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px; flex-wrap: wrap; }
+    .source-tag { background: var(--bg-active); color: var(--accent); padding: 1px 6px; border-radius: 3px; font-family: ui-monospace, monospace; font-size: 10px; }
+    .ticket-ref { color: var(--text-secondary); }
+    .rationale-text { font-size: 13px; color: var(--text-primary); white-space: pre-wrap; }
+
+    .ticket-list, .dup-list { margin: 0; padding-left: 20px; }
+    .ticket-list li, .dup-list li { font-size: 13px; margin-bottom: 4px; }
+    .muted { color: var(--text-tertiary); font-size: 11px; }
+
+    .transition-section { border-top: 1px solid var(--border-light); padding-top: 12px; }
+    .action-row { display: flex; gap: 8px; flex-wrap: wrap; }
+    .form-block { margin-top: 12px; padding: 12px; background: var(--bg-muted); border-radius: var(--radius-md); display: flex; flex-direction: column; gap: 10px; }
+    .danger-section { border-top: 1px solid var(--border-light); padding-top: 12px; }
+  `],
+})
+export class ToolRequestListComponent implements OnInit {
+  private svc = inject(ToolRequestService);
+  private toast = inject(ToastService);
+
+  readonly statusOptions = STATUS_OPTIONS;
+  loading = signal(false);
+  saving = signal(false);
+  items = signal<ToolRequestListItem[]>([]);
+  total = signal(0);
+  statusFilter = signal<string>('');
+  searchInput = signal<string>('');
+  offset = signal(0);
+  readonly pageSize = 50;
+
+  detail = signal<ToolRequestDetail | null>(null);
+  showRejectForm = signal(false);
+  showDuplicateForm = signal(false);
+  showImplementedForm = signal(false);
+  rejectReason = '';
+  duplicateOfId = '';
+  implementedInCommit = '';
+  githubIssueUrl = '';
+
+  private searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  hasMore = computed(() => this.total() > this.items().length);
+
+  trackById = (row: ToolRequestListItem) => row.id;
+
+  ngOnInit(): void {
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.offset.set(0);
+    this.fetch(false);
+  }
+
+  loadMore(): void {
+    this.offset.set(this.items().length);
+    this.fetch(true);
+  }
+
+  private fetch(append: boolean): void {
+    this.loading.set(true);
+    const status = this.statusFilter();
+    this.svc
+      .list({
+        status: status ? (status as ToolRequestStatus) : undefined,
+        search: this.searchInput() || undefined,
+        limit: this.pageSize,
+        offset: this.offset(),
+      })
+      .subscribe({
+        next: (res) => {
+          this.items.set(append ? [...this.items(), ...res.items] : res.items);
+          this.total.set(res.total);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.toast.error('Failed to load tool requests');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  onStatusFilter(value: string): void {
+    this.statusFilter.set(value);
+    this.refresh();
+  }
+
+  onSearchChange(value: string): void {
+    this.searchInput.set(value);
+    if (this.searchDebounce) clearTimeout(this.searchDebounce);
+    this.searchDebounce = setTimeout(() => this.refresh(), 250);
+  }
+
+  statusClass(status: string): string {
+    return `status-${status.toLowerCase()}`;
+  }
+
+  openDetail(row: ToolRequestListItem): void {
+    this.svc.get(row.id).subscribe({
+      next: (d) => {
+        this.resetForms();
+        this.detail.set(d);
+      },
+      error: () => this.toast.error('Failed to load tool request detail'),
+    });
+  }
+
+  closeDetail(): void {
+    this.detail.set(null);
+    this.resetForms();
+  }
+
+  private resetForms(): void {
+    this.showRejectForm.set(false);
+    this.showDuplicateForm.set(false);
+    this.showImplementedForm.set(false);
+    this.rejectReason = '';
+    this.duplicateOfId = '';
+    this.implementedInCommit = '';
+    this.githubIssueUrl = '';
+  }
+
+  private applyUpdate(id: string, body: UpdateToolRequestBody, successMsg: string): void {
+    this.saving.set(true);
+    this.svc.update(id, body).subscribe({
+      next: () => {
+        this.toast.success(successMsg);
+        this.saving.set(false);
+        // Reload both the detail and the list row
+        this.svc.get(id).subscribe({ next: (d) => this.detail.set(d) });
+        this.fetch(false);
+      },
+      error: (err) => {
+        const msg = err?.error?.message ?? 'Failed to update tool request';
+        this.toast.error(msg);
+        this.saving.set(false);
+      },
+    });
+  }
+
+  approve(d: ToolRequestDetail): void {
+    this.applyUpdate(d.id, { status: ToolRequestStatus.APPROVED }, 'Tool request approved');
+  }
+
+  reject(d: ToolRequestDetail): void {
+    this.applyUpdate(
+      d.id,
+      { status: ToolRequestStatus.REJECTED, rejectedReason: this.rejectReason.trim() },
+      'Tool request rejected',
+    );
+  }
+
+  markDuplicate(d: ToolRequestDetail): void {
+    this.applyUpdate(
+      d.id,
+      { status: ToolRequestStatus.DUPLICATE, duplicateOfId: this.duplicateOfId.trim() },
+      'Marked as duplicate',
+    );
+  }
+
+  markImplemented(d: ToolRequestDetail): void {
+    const body: UpdateToolRequestBody = { status: ToolRequestStatus.IMPLEMENTED };
+    if (this.implementedInCommit.trim()) body.implementedInCommit = this.implementedInCommit.trim();
+    if (this.githubIssueUrl.trim()) body.githubIssueUrl = this.githubIssueUrl.trim();
+    this.applyUpdate(d.id, body, 'Marked implemented');
+  }
+
+  reopen(d: ToolRequestDetail): void {
+    this.applyUpdate(d.id, { status: ToolRequestStatus.PROPOSED }, 'Tool request reopened');
+  }
+
+  remove(d: ToolRequestDetail): void {
+    if (!confirm(`Delete tool request "${d.displayTitle}"? This removes its rationale history.`)) return;
+    this.saving.set(true);
+    this.svc.delete(d.id).subscribe({
+      next: () => {
+        this.toast.success('Tool request deleted');
+        this.saving.set(false);
+        this.detail.set(null);
+        this.fetch(false);
+      },
+      error: () => {
+        this.toast.error('Failed to delete tool request');
+        this.saving.set(false);
+      },
+    });
+  }
+}

--- a/services/copilot-api/src/routes/index.ts
+++ b/services/copilot-api/src/routes/index.ts
@@ -48,6 +48,7 @@ import { operatorRoutes } from './operators.js';
 import { notificationPreferenceRoutes } from './notification-preferences.js';
 import { pendingActionRoutes } from './pending-actions.js';
 import { slackConversationRoutes } from './slack-conversations.js';
+import { toolRequestRoutes } from './tool-requests.js';
 
 interface RouteOpts {
   config: Config;
@@ -132,5 +133,15 @@ export async function registerRoutes(fastify: FastifyInstance, opts: RouteOpts):
     await scoped.register(operatorRoutes);
     await scoped.register(notificationPreferenceRoutes);
     await scoped.register(slackConversationRoutes);
+  });
+
+  // Admin-only routes — restricted to platform ADMIN operators. Client-scoped
+  // operators and STANDARD operators are rejected.
+  const adminOnlyGuard = requireRole(OperatorRole.ADMIN);
+
+  await fastify.register(async (scoped) => {
+    scoped.addHook('preHandler', adminOnlyGuard);
+
+    await scoped.register(toolRequestRoutes);
   });
 }

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -43,6 +43,7 @@ const SETTINGS_KEY_PROMPT_RETENTION = 'system-config-prompt-retention';
 const SETTINGS_KEY_ACTION_SAFETY = 'system-config-action-safety';
 const SETTINGS_KEY_ANALYSIS_STRATEGY = 'system-config-analysis-strategy';
 const SETTINGS_KEY_SELF_ANALYSIS = 'self_analysis_config';
+const SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT = 'tool-request-rate-limit-per-run';
 
 const REDACTED = '••••••••';
 
@@ -881,6 +882,46 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
       });
 
       return row.value as unknown as { fullRetentionDays: number; summaryRetentionDays: number };
+    },
+  );
+
+  // ─── Tool Request Rate Limit ───
+
+  const toolRequestRateLimitSchema = z.object({
+    limit: z.number().int().min(1).max(100).default(5),
+  });
+
+  const DEFAULT_TOOL_REQUEST_RATE_LIMIT = { limit: 5 };
+
+  // GET /api/settings/tool-request-rate-limit — max `request_tool` calls per analysis run
+  fastify.get('/api/settings/tool-request-rate-limit', async () => {
+    const row = await fastify.db.appSetting.findUnique({
+      where: { key: SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT },
+    });
+    if (!row) return DEFAULT_TOOL_REQUEST_RATE_LIMIT;
+    const parsed = toolRequestRateLimitSchema.safeParse(row.value);
+    return parsed.success ? parsed.data : DEFAULT_TOOL_REQUEST_RATE_LIMIT;
+  });
+
+  // PUT /api/settings/tool-request-rate-limit — update limit
+  fastify.put<{ Body: { limit?: number } }>(
+    '/api/settings/tool-request-rate-limit',
+    async (request) => {
+      const parsed = toolRequestRateLimitSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+        return fastify.httpErrors.badRequest(`Invalid tool request rate limit: ${issues}`);
+      }
+
+      const config = parsed.data;
+
+      const row = await fastify.db.appSetting.upsert({
+        where: { key: SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT },
+        update: { value: config as unknown as object },
+        create: { key: SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT, value: config as unknown as object },
+      });
+
+      return row.value as unknown as { limit: number };
     },
   );
 

--- a/services/copilot-api/src/routes/tool-requests.ts
+++ b/services/copilot-api/src/routes/tool-requests.ts
@@ -1,0 +1,205 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { Prisma } from '@bronco/db';
+import { ToolRequestStatus } from '@bronco/shared-types';
+
+const STATUS_VALUES = Object.values(ToolRequestStatus) as [string, ...string[]];
+
+const listQuerySchema = z.object({
+  status: z
+    .union([z.enum(STATUS_VALUES), z.array(z.enum(STATUS_VALUES))])
+    .optional(),
+  clientId: z.string().uuid().optional(),
+  search: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+const updateBodySchema = z.object({
+  status: z.enum(STATUS_VALUES).optional(),
+  rejectedReason: z.string().optional(),
+  duplicateOfId: z.string().uuid().nullable().optional(),
+  implementedInCommit: z.string().optional(),
+  implementedInIssue: z.string().optional(),
+  githubIssueUrl: z.string().url().optional(),
+});
+
+function isPrismaError(err: unknown, code: string): boolean {
+  return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
+}
+
+export async function toolRequestRoutes(fastify: FastifyInstance): Promise<void> {
+  // List tool requests with filters
+  fastify.get('/api/tool-requests', async (request) => {
+    const parsed = listQuerySchema.safeParse(request.query);
+    if (!parsed.success) {
+      return fastify.httpErrors.badRequest(
+        parsed.error.errors[0]?.message ?? 'Invalid query parameters',
+      );
+    }
+    const { status, clientId, search, limit, offset } = parsed.data;
+
+    const where: Prisma.ToolRequestWhereInput = {};
+    if (status) {
+      const statuses = Array.isArray(status) ? status : [status];
+      where.status = { in: statuses as ToolRequestStatus[] };
+    }
+    if (clientId) where.clientId = clientId;
+    if (search) {
+      where.OR = [
+        { requestedName: { contains: search, mode: 'insensitive' } },
+        { displayTitle: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      fastify.db.toolRequest.findMany({
+        where,
+        orderBy: [{ status: 'asc' }, { createdAt: 'desc' }],
+        include: {
+          client: { select: { id: true, name: true, shortCode: true } },
+          _count: { select: { rationales: true } },
+        },
+        take: limit ?? 50,
+        skip: offset ?? 0,
+      }),
+      fastify.db.toolRequest.count({ where }),
+    ]);
+
+    return { items, total };
+  });
+
+  // Get single tool request with rationales, duplicates, and linked tickets
+  fastify.get<{ Params: { id: string } }>('/api/tool-requests/:id', async (request) => {
+    const row = await fastify.db.toolRequest.findUnique({
+      where: { id: request.params.id },
+      include: {
+        client: { select: { id: true, name: true, shortCode: true } },
+        rationales: {
+          orderBy: { createdAt: 'desc' },
+          include: {
+            ticket: {
+              select: { id: true, ticketNumber: true, subject: true, status: true },
+            },
+          },
+        },
+        duplicates: {
+          select: {
+            id: true,
+            requestedName: true,
+            displayTitle: true,
+            status: true,
+            requestCount: true,
+          },
+        },
+        duplicateOf: {
+          select: {
+            id: true,
+            requestedName: true,
+            displayTitle: true,
+            status: true,
+          },
+        },
+        firstTicket: {
+          select: { id: true, ticketNumber: true, subject: true, status: true },
+        },
+      },
+    });
+    if (!row) return fastify.httpErrors.notFound('Tool request not found');
+
+    // Derive distinct linked tickets from rationale history
+    const seen = new Set<string>();
+    const linkedTickets: Array<{
+      id: string;
+      ticketNumber: number;
+      subject: string;
+      status: string;
+    }> = [];
+    for (const r of row.rationales) {
+      if (r.ticket && !seen.has(r.ticket.id)) {
+        seen.add(r.ticket.id);
+        linkedTickets.push(r.ticket);
+      }
+    }
+
+    return { ...row, linkedTickets };
+  });
+
+  // Update tool request (status transitions, reasons, implementation refs)
+  fastify.patch<{ Params: { id: string } }>('/api/tool-requests/:id', async (request) => {
+    const parsed = updateBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return fastify.httpErrors.badRequest(
+        parsed.error.errors[0]?.message ?? 'Invalid request body',
+      );
+    }
+
+    const existing = await fastify.db.toolRequest.findUnique({
+      where: { id: request.params.id },
+      select: { status: true },
+    });
+    if (!existing) return fastify.httpErrors.notFound('Tool request not found');
+
+    const body = parsed.data;
+    const data: Prisma.ToolRequestUpdateInput = {};
+
+    if (body.status) {
+      data.status = body.status as ToolRequestStatus;
+      if (
+        body.status === ToolRequestStatus.APPROVED &&
+        existing.status === ToolRequestStatus.PROPOSED
+      ) {
+        data.approvedAt = new Date();
+        data.approvedBy = request.user?.personId ?? null;
+      }
+      if (body.status === ToolRequestStatus.REJECTED && !body.rejectedReason) {
+        return fastify.httpErrors.badRequest('rejectedReason is required when rejecting');
+      }
+      if (body.status === ToolRequestStatus.DUPLICATE && !body.duplicateOfId) {
+        return fastify.httpErrors.badRequest('duplicateOfId is required when marking duplicate');
+      }
+    }
+    if (body.rejectedReason !== undefined) data.rejectedReason = body.rejectedReason;
+    if (body.duplicateOfId !== undefined) {
+      data.duplicateOf =
+        body.duplicateOfId === null
+          ? { disconnect: true }
+          : { connect: { id: body.duplicateOfId } };
+    }
+    if (body.implementedInCommit !== undefined) data.implementedInCommit = body.implementedInCommit;
+    if (body.implementedInIssue !== undefined) data.implementedInIssue = body.implementedInIssue;
+    if (body.githubIssueUrl !== undefined) data.githubIssueUrl = body.githubIssueUrl;
+
+    try {
+      return await fastify.db.toolRequest.update({
+        where: { id: request.params.id },
+        data,
+        include: {
+          client: { select: { id: true, name: true, shortCode: true } },
+          _count: { select: { rationales: true } },
+        },
+      });
+    } catch (err) {
+      if (isPrismaError(err, 'P2025')) {
+        return fastify.httpErrors.notFound('Tool request not found');
+      }
+      throw err;
+    }
+  });
+
+  // Delete tool request (cascades to rationales)
+  fastify.delete<{ Params: { id: string } }>(
+    '/api/tool-requests/:id',
+    async (request, reply) => {
+      try {
+        await fastify.db.toolRequest.delete({ where: { id: request.params.id } });
+      } catch (err) {
+        if (isPrismaError(err, 'P2025')) {
+          return fastify.httpErrors.notFound('Tool request not found');
+        }
+        throw err;
+      }
+      reply.code(204).send();
+    },
+  );
+}

--- a/services/copilot-api/src/services/tool-request-registry.ts
+++ b/services/copilot-api/src/services/tool-request-registry.ts
@@ -1,0 +1,92 @@
+import type { PrismaClient } from '@bronco/db';
+import { Prisma } from '@bronco/db';
+import { ToolRequestRationaleSource } from '@bronco/shared-types';
+
+export interface RegisterToolRequestInput {
+  clientId: string;
+  ticketId?: string;
+  /** Raw snake_case tool name proposed by the agent (normalized on write). */
+  requestedName: string;
+  displayTitle: string;
+  description: string;
+  rationale: string;
+  suggestedInputs?: Record<string, unknown>;
+  exampleUsage?: string;
+  source: ToolRequestRationaleSource;
+}
+
+export interface RegisterToolRequestResult {
+  toolRequestId: string;
+  /** True when this call created a new ToolRequest row (vs. appending to an existing one). */
+  isNew: boolean;
+  normalizedName: string;
+}
+
+/**
+ * Normalize an agent-proposed tool name to lowercase snake_case with
+ * only [a-z0-9_] characters. Throws if the result would be <3 or >100 chars.
+ */
+export function normalizeRequestedName(raw: string): string {
+  const normalized = raw
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+  if (normalized.length < 3 || normalized.length > 100) {
+    throw new Error(
+      `Invalid requestedName: normalized form must be 3–100 chars of [a-z0-9_], got "${normalized}"`,
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Upsert a ToolRequest by (clientId, normalizedName) and always append a new
+ * rationale row. When a matching ToolRequest already exists we only bump its
+ * requestCount — core fields (displayTitle, description, suggestedInputs,
+ * exampleUsage) stay as originally recorded so operator edits aren't clobbered.
+ */
+export async function registerToolRequest(
+  db: PrismaClient,
+  input: RegisterToolRequestInput,
+): Promise<RegisterToolRequestResult> {
+  const normalizedName = normalizeRequestedName(input.requestedName);
+  return db.$transaction(async (tx) => {
+    const existing = await tx.toolRequest.findUnique({
+      where: {
+        clientId_requestedName: { clientId: input.clientId, requestedName: normalizedName },
+      },
+    });
+    let rowId: string;
+    let isNew = false;
+    if (!existing) {
+      const created = await tx.toolRequest.create({
+        data: {
+          clientId: input.clientId,
+          firstTicketId: input.ticketId,
+          requestedName: normalizedName,
+          displayTitle: input.displayTitle,
+          description: input.description,
+          suggestedInputs: (input.suggestedInputs ?? undefined) as Prisma.InputJsonValue | undefined,
+          exampleUsage: input.exampleUsage,
+        },
+      });
+      rowId = created.id;
+      isNew = true;
+    } else {
+      const updated = await tx.toolRequest.update({
+        where: { id: existing.id },
+        data: { requestCount: { increment: 1 } },
+      });
+      rowId = updated.id;
+    }
+    await tx.toolRequestRationale.create({
+      data: {
+        toolRequestId: rowId,
+        ticketId: input.ticketId,
+        rationale: input.rationale,
+        source: input.source,
+      },
+    });
+    return { toolRequestId: rowId, isNew, normalizedName };
+  });
+}

--- a/services/ticket-analyzer/src/analysis/flat.ts
+++ b/services/ticket-analyzer/src/analysis/flat.ts
@@ -16,6 +16,8 @@ import {
   parseSufficiencyEvaluation,
   saveMcpToolArtifact,
   shouldTruncate,
+  PREFER_EXISTING_TOOLS_SNIPPET,
+  REQUEST_NEW_TOOL_SNIPPET,
   SUFFICIENCY_EVAL_INSTRUCTIONS,
   TRUNCATION_SYSTEM_PROMPT_SNIPPET,
   type AnalysisDeps,
@@ -111,6 +113,8 @@ export async function runFlatAnalysis(
   if (stepConfig?.systemPromptOverride) systemParts.push('', stepConfig.systemPromptOverride);
   systemParts.push(SUFFICIENCY_EVAL_INSTRUCTIONS);
   systemParts.push(TRUNCATION_SYSTEM_PROMPT_SNIPPET);
+  systemParts.push(PREFER_EXISTING_TOOLS_SNIPPET);
+  systemParts.push(REQUEST_NEW_TOOL_SNIPPET);
 
   const agenticSystemPrompt = systemParts.join('\n');
 

--- a/services/ticket-analyzer/src/analysis/orchestrated.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated.ts
@@ -16,7 +16,9 @@ import {
   ORCHESTRATED_SYSTEM_PROMPT,
   parseStrategistResponse,
   parseSufficiencyEvaluation,
+  PREFER_EXISTING_TOOLS_SNIPPET,
   ReanalysisMode,
+  REQUEST_NEW_TOOL_SNIPPET,
   resolveMaxParallelTasks,
   resolveOrchestratedModelMap,
   resolveTaskTools,
@@ -85,8 +87,8 @@ async function executeOrchestratedSubTask(
     ? `\n\n## Prior Artifacts You May Need\nThese artifact IDs from prior runs may be relevant. Read them via \`platform__read_tool_result_artifact\` before re-querying:\n${task.priorArtifactIds.map(id => `- ${id}`).join('\n')}`
     : '';
   const subTaskSystemPrompt = combinedContext
-    ? `${subTaskInstructions}\n\n${combinedContext}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`
-    : `${subTaskInstructions}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`;
+    ? `${subTaskInstructions}\n\n${combinedContext}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}${priorArtifactsHint}`
+    : `${subTaskInstructions}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}${priorArtifactsHint}`;
 
   // Resolve tools using ranked matching (exact → base name → substring → fuzzy)
   const resolution = task.tools.length > 0
@@ -461,7 +463,7 @@ export async function runOrchestratedAnalysis(
       taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
       context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1, logId: strategistLogId },
       prompt: strategistPrompt,
-      systemPrompt: `${ORCHESTRATED_SYSTEM_PROMPT}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}`,
+      systemPrompt: `${ORCHESTRATED_SYSTEM_PROMPT}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}`,
       providerOverride: 'CLAUDE',
       modelOverride: 'claude-opus-4-6',
       maxTokens: defaultMaxTokens ?? 4096,

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -170,6 +170,43 @@ export const TRUNCATION_SYSTEM_PROMPT_SNIPPET = [
   'specific patterns.',
 ].join('\n');
 
+/**
+ * Nudges the agent to scan the available tool list before falling back to
+ * generic tools like `run_custom_query`. Pairs with REQUEST_NEW_TOOL_SNIPPET
+ * so gaps get surfaced as tool requests rather than silently improvised.
+ */
+export const PREFER_EXISTING_TOOLS_SNIPPET = [
+  '',
+  '## Using Tools Effectively',
+  'Before working around a missing capability, scan the available tools. Use',
+  'specific tools when they fit; only fall back to generic tools like',
+  '`run_custom_query` when no specific tool applies to your question.',
+].join('\n');
+
+/**
+ * Teaches the agent to call `request_tool` when no existing tool fits —
+ * surfacing capability gaps to operators rather than improvising silently.
+ */
+export const REQUEST_NEW_TOOL_SNIPPET = [
+  '',
+  '## Requesting New Tools',
+  'If no existing tool fits the job and you are about to improvise with a',
+  'generic tool or give up on a line of investigation, call `request_tool`',
+  'with a specific name, description, suggested inputs, and why it was',
+  'needed for this ticket.',
+  '',
+  'Good examples of when to call:',
+  '- You inspected a stored procedure definition via `run_custom_query` that',
+  '  a `describe_schema_object` tool would serve better',
+  '- You parsed an execution plan XML by hand because there is no',
+  '  `analyze_execution_plan` tool',
+  '- You re-queried deadlock history because there is no',
+  '  `get_deadlock_history` tool returning structured results',
+  '',
+  'Do not request vague capabilities like "a better tool" or "an easier way."',
+  'Each request should be specific enough that someone could implement it.',
+].join('\n');
+
 // ---------------------------------------------------------------------------
 // Agentic tool builder / executor
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First session in the Gap Requests series (coordinator #308). Introduces a first-class missing-tool registry so agents can explicitly flag capability gaps instead of silently improvising.

- New Prisma models: `ToolRequest` + `ToolRequestRationale` with dedupe on `(clientId, requestedName)` and rationale-history append-only log
- Shared registry helper with snake_case normalization and upsert-with-increment semantics (duplicated between copilot-api and mcp-platform with "keep in sync" comment — candidate for shared workspace package in #306)
- Platform MCP tool `request_tool` rate-limited via `tool-request-rate-limit-per-run` AppSetting (default 5/run); uses `ticket.lastAnalyzedAt` as run-window proxy until #306 adds an explicit run tracker
- Admin-only `/api/tool-requests` CRUD with transition validation (rejected requires reason, duplicate requires duplicateOfId, PROPOSED→APPROVED stamps approvedAt/By)
- MCP CRUD tools: `list_tool_requests`, `get_tool_request`, `update_tool_request`, `delete_tool_request`
- Agentic system prompts (flat + orchestrated strategist + orchestrated sub-task) now include `PREFER_EXISTING_TOOLS_SNIPPET` + `REQUEST_NEW_TOOL_SNIPPET`
- Control panel `/tool-requests` admin page with status/search/client filters and a detail dialog (description, rationale history, linked tickets, duplicates, status transitions)
- Settings tab exposes the rate-limit control

Documented deviation: `Client.toolRequestRationales` reverse relation was skipped — rationales have no direct `clientId` FK (only through `toolRequest.clientId`), so there is nothing to reverse-relate.

## Test plan

- [ ] `pnpm db:migrate` applies cleanly on a fresh env
- [ ] Invoke `request_tool` via mcp-inspector with a test ticketId/clientId — row appears with rationale
- [ ] Repeat identical call — `requestCount` increments, second rationale row appended
- [ ] Invoke 6 times in a single run — 6th returns rate-limit error with list of prior names
- [ ] Non-ADMIN STANDARD operator hits `/api/tool-requests` — receives 403
- [ ] Control panel `/tool-requests` page lists, filters, detail dialog opens, status transitions persist

Refs #305.

Part of Gap Requests series (coordinator #308). Bundles to `staging` after #306 + #307.
