### PR TITLE
feat: gap requests — dedupe agent + create-GitHub-issue button (refs #307)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ System prompts for each task are registered in `packages/ai-provider/src/prompts
 - `CUSTOM_AI_QUERY` — Flexible configurable AI query within a route pipeline (task type and model overridable per step)
 - `ANALYZE_APP_HEALTH` — Scheduled platform health analysis — ticket patterns, AI usage trends, error logs, and codebase review
 - `DETECT_TOOL_GAPS` — Post-hoc review of a completed analysis to detect capability gaps; upserts tool requests into the registry (default: Claude Haiku for cheap review)
+- `ANALYZE_TOOL_REQUESTS` — Admin-triggered dedupe agent: compares a client's PROPOSED/APPROVED tool requests against each other and against the live MCP tool catalog (platform + repo + database + per-client integrations) and writes `suggestedDuplicateOf*` / `suggestedImprovesExisting*` fields on rows (default: Claude Sonnet)
 
 ### Task Type Discipline (CRITICAL)
 
@@ -368,9 +369,11 @@ pnpm dev:portal           # Start ticket portal (Angular, port 4201)
 | `services/copilot-api/src/routes/ticket-routes.ts` | Ticket route CRUD + step type registry for configurable analysis pipelines. |
 | `services/copilot-api/src/routes/tool-requests.ts` | Gap Requests CRUD API (admin-only): list/filter tool-request records, view rationale history, transition status (approve/reject/duplicate/implemented/reopen), delete. |
 | `services/copilot-api/src/services/tool-request-registry.ts` | Dedup upsert helper for tool-request records keyed on `(clientId, requestedName)`; appends rationale rows without clobbering operator edits. |
+| `services/copilot-api/src/services/tool-request-dedupe.ts` | Admin-triggered dedupe agent: discovers MCP catalog per-client + shared, calls Claude via `ANALYZE_TOOL_REQUESTS`, persists `suggestedDuplicateOf*` / `suggestedImprovesExisting*` suggestions transactionally. |
+| `packages/shared-utils/src/tool-request-github.ts` | Shared GitHub-issue helper for tool requests: reads encrypted token from `system-config-github`, repo from `tool-requests-github-default-repo` AppSetting (or override), POSTs via GitHub REST v3, persists `githubIssueUrl` + `implementedInIssue` on the row. |
 | `mcp-servers/platform/src/tools/request-tool.ts` | MCP `request_tool` that analyzers call when they hit a capability gap; enforces the per-run rate limit from AppSetting `tool-request-rate-limit-per-run`. |
-| `mcp-servers/platform/src/tools/tool-requests.ts` | MCP CRUD tools for tool requests (list/get/update/delete) used by the platform surface. |
-| `services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts` | Admin Tool Requests page: list + detail dialog with rationale history, linked tickets, and status transition controls. |
+| `mcp-servers/platform/src/tools/tool-requests.ts` | MCP CRUD tools for tool requests (list/get/update/delete) + `create_tool_request_github_issue` wrapper used by the platform surface. |
+| `services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts` | Admin Tool Requests page: list + detail dialog with rationale history, linked tickets, status transition controls, client filter + Run Dedupe button, AI suggestion pills with Accept/Dismiss, and Create GitHub Issue flow for approved requests. |
 | `services/copilot-api/src/routes/artifacts.ts` | MCP tool artifact storage and retrieval endpoints (`/api/artifacts`). |
 | `services/copilot-api/src/routes/release-notes.ts` | Release notes API: commit ingestion, AI summarization, GitHub backfill, service filtering. |
 | `services/copilot-api/src/routes/ingest.ts` | Ingestion API: queue endpoints for email/scheduled/manual payloads, plus `GET /api/ingest/runs` and `GET /api/ingest/runs/:id` for run history. |

--- a/mcp-servers/platform/src/tools/tool-requests.ts
+++ b/mcp-servers/platform/src/tools/tool-requests.ts
@@ -2,11 +2,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { Prisma } from '@bronco/db';
 import { ToolRequestStatus } from '@bronco/shared-types';
+import { createToolRequestGithubIssue } from '@bronco/shared-utils';
 import type { ServerDeps } from '../server.js';
 
 const STATUS_VALUES = Object.values(ToolRequestStatus) as [string, ...string[]];
 
-export function registerToolRequestTools(server: McpServer, { db }: ServerDeps): void {
+export function registerToolRequestTools(server: McpServer, { db, config }: ServerDeps): void {
   server.tool(
     'list_tool_requests',
     'List agent-flagged tool requests (missing capability registry). Filterable by client and status.',
@@ -114,6 +115,34 @@ export function registerToolRequestTools(server: McpServer, { db }: ServerDeps):
     async (params) => {
       await db.toolRequest.delete({ where: { id: params.id } });
       return { content: [{ type: 'text', text: JSON.stringify({ deleted: true, id: params.id }) }] };
+    },
+  );
+
+  server.tool(
+    'create_tool_request_github_issue',
+    'Create a GitHub issue for a tool request using the configured default repo (or override). Persists githubIssueUrl + implementedInIssue on the row.',
+    {
+      id: z.string().uuid().describe('Tool request ID'),
+      repoOwner: z.string().optional().describe('Override the default repo owner'),
+      repoName: z.string().optional().describe('Override the default repo name'),
+      labels: z.array(z.string()).optional().describe('GitHub labels (defaults to ["tool-request"])'),
+    },
+    async (params) => {
+      try {
+        const result = await createToolRequestGithubIssue(db, config.ENCRYPTION_KEY, {
+          toolRequestId: params.id,
+          repoOwner: params.repoOwner,
+          repoName: params.repoName,
+          labels: params.labels,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `ERROR: ${msg}` }],
+        };
+      }
     },
   );
 }

--- a/packages/ai-provider/src/prompts/analyze-tool-requests.ts
+++ b/packages/ai-provider/src/prompts/analyze-tool-requests.ts
@@ -1,0 +1,36 @@
+import type { PromptDefinition } from './types.js';
+
+export const ANALYZE_TOOL_REQUESTS_SYSTEM: PromptDefinition = {
+  key: 'analyze-tool-requests.system',
+  name: 'Analyze Tool Requests (Dedupe)',
+  description:
+    'Reviews pending ToolRequest records for a single client and identifies duplicate groups and "improves existing tool" candidates against the client\'s live MCP catalog.',
+  taskType: 'ANALYZE_TOOL_REQUESTS',
+  role: 'SYSTEM',
+  content:
+    'You review pending tool-request records for a single client and identify:\n\n' +
+    '1. Duplicate groups — multiple requests that describe the same capability, ' +
+    'just with different names or wording. Pick a canonical request (the clearest ' +
+    'or earliest) and list the others as duplicates.\n' +
+    '2. Requests that would be better served by improving an existing MCP tool ' +
+    'rather than adding a new one.\n\n' +
+    'Use the existing-tool catalog as the source of truth for what already exists. ' +
+    'Be conservative — only mark a duplicate if you are confident the requests ' +
+    'describe the same capability. Only flag "improves existing" if an existing ' +
+    'tool could reasonably be extended to serve the request.\n\n' +
+    'Output ONLY a JSON object with keys "duplicateGroups" and "improvesExisting" ' +
+    'as specified. No prose, no code fences.\n\n' +
+    'Shape:\n' +
+    '{\n' +
+    '  "duplicateGroups": [\n' +
+    '    { "canonicalId": "uuid", "duplicateIds": ["uuid", "uuid"], "reason": "short explanation" }\n' +
+    '  ],\n' +
+    '  "improvesExisting": [\n' +
+    '    { "requestId": "uuid", "existingToolName": "server.tool", "reason": "short explanation" }\n' +
+    '  ]\n' +
+    '}',
+  temperature: 0.2,
+  maxTokens: 4000,
+};
+
+export const ANALYZE_TOOL_REQUESTS_PROMPTS: PromptDefinition[] = [ANALYZE_TOOL_REQUESTS_SYSTEM];

--- a/packages/ai-provider/src/prompts/index.ts
+++ b/packages/ai-provider/src/prompts/index.ts
@@ -27,6 +27,9 @@ export * from './client-memory.js';
 export { DETECT_TOOL_GAPS_PROMPTS } from './detect-tool-gaps.js';
 export * from './detect-tool-gaps.js';
 
+export { ANALYZE_TOOL_REQUESTS_PROMPTS } from './analyze-tool-requests.js';
+export * from './analyze-tool-requests.js';
+
 // Re-export individual prompts for direct import convenience
 import { IMAP_PROMPTS } from './imap.js';
 import { DEVOPS_PROMPTS } from './devops.js';
@@ -37,6 +40,7 @@ import { RELEASE_NOTES_PROMPTS } from './release-notes.js';
 import { ROUTING_PROMPTS } from './routing.js';
 import { CLIENT_MEMORY_PROMPTS } from './client-memory.js';
 import { DETECT_TOOL_GAPS_PROMPTS } from './detect-tool-gaps.js';
+import { ANALYZE_TOOL_REQUESTS_PROMPTS } from './analyze-tool-requests.js';
 import type { PromptDefinition } from './types.js';
 
 /**
@@ -57,6 +61,7 @@ export const ALL_PROMPTS: PromptDefinition[] = [
   ...ROUTING_PROMPTS,
   ...CLIENT_MEMORY_PROMPTS,
   ...DETECT_TOOL_GAPS_PROMPTS,
+  ...ANALYZE_TOOL_REQUESTS_PROMPTS,
 ];
 
 /**

--- a/packages/ai-provider/src/task-capabilities.ts
+++ b/packages/ai-provider/src/task-capabilities.ts
@@ -25,6 +25,7 @@ export const TASK_CAPABILITY_REQUIREMENTS: Record<string, string> = {
   [TaskType.ANALYZE_WORK_ITEM]: CapabilityLevel.STANDARD,
   [TaskType.DRAFT_COMMENT]: CapabilityLevel.STANDARD,
   [TaskType.GENERATE_RELEASE_NOTE]: CapabilityLevel.STANDARD,
+  [TaskType.ANALYZE_TOOL_REQUESTS]: CapabilityLevel.STANDARD,
 
   // ADVANCED — large models (planning, SQL generation, code review)
   [TaskType.GENERATE_DEVOPS_PLAN]: CapabilityLevel.ADVANCED,

--- a/packages/db/prisma/migrations/20260421020000_tool_request_dedupe_suggestions/migration.sql
+++ b/packages/db/prisma/migrations/20260421020000_tool_request_dedupe_suggestions/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "tool_requests"
+  ADD COLUMN "suggested_duplicate_of_id" UUID,
+  ADD COLUMN "suggested_duplicate_reason" TEXT,
+  ADD COLUMN "suggested_improves_existing" TEXT,
+  ADD COLUMN "suggested_improves_reason" TEXT,
+  ADD COLUMN "dedupe_analysis_at" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1666,6 +1666,15 @@ model ToolRequest {
   implementedInIssue  String?           @map("implemented_in_issue")
   githubIssueUrl      String?           @map("github_issue_url")
 
+  // AI dedupe suggestions — populated by runToolRequestDedupe.
+  // Operators review via the admin UI; accepting transitions status/rejects,
+  // dismissing clears the suggestion fields.
+  suggestedDuplicateOfId    String?   @map("suggested_duplicate_of_id") @db.Uuid
+  suggestedDuplicateReason  String?   @db.Text @map("suggested_duplicate_reason")
+  suggestedImprovesExisting String?   @map("suggested_improves_existing")
+  suggestedImprovesReason   String?   @db.Text @map("suggested_improves_reason")
+  dedupeAnalysisAt          DateTime? @map("dedupe_analysis_at")
+
   rationales ToolRequestRationale[]
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @updatedAt @map("updated_at")

--- a/packages/shared-types/src/ai.ts
+++ b/packages/shared-types/src/ai.ts
@@ -45,6 +45,8 @@ export const TaskType = {
   ANALYZE_APP_HEALTH: 'ANALYZE_APP_HEALTH',
   // Post-hoc capability-gap detection (Claude Haiku — cheap review)
   DETECT_TOOL_GAPS: 'DETECT_TOOL_GAPS',
+  // Admin dedupe pass over pending ToolRequest rows (Claude Sonnet)
+  ANALYZE_TOOL_REQUESTS: 'ANALYZE_TOOL_REQUESTS',
 } as const;
 export type TaskType = (typeof TaskType)[keyof typeof TaskType];
 
@@ -116,6 +118,9 @@ export const TASK_APP_SCOPE: Record<TaskType, AppScope> = {
 
   // Post-hoc capability-gap detection
   [TaskType.DETECT_TOOL_GAPS]: AppScope.CORE,
+
+  // Admin dedupe pass
+  [TaskType.ANALYZE_TOOL_REQUESTS]: AppScope.CORE,
 
 } satisfies Record<TaskType, AppScope>;
 

--- a/packages/shared-types/src/tool-request.ts
+++ b/packages/shared-types/src/tool-request.ts
@@ -47,6 +47,11 @@ export interface ToolRequest {
   implementedInCommit: string | null;
   implementedInIssue: string | null;
   githubIssueUrl: string | null;
+  suggestedDuplicateOfId: string | null;
+  suggestedDuplicateReason: string | null;
+  suggestedImprovesExisting: string | null;
+  suggestedImprovesReason: string | null;
+  dedupeAnalysisAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -32,3 +32,5 @@ export { SlackClient } from './slack-client.js';
 export type { SlackClientOpts, SlackMessageResult, SlackBlockAction, SlackThreadMessage, SlackMentionEvent, SlackDirectMessageEvent, BlockActionHandler, ThreadMessageHandler, MentionHandler, DirectMessageHandler } from './slack-client.js';
 export { registerToolRequest, normalizeRequestedName } from './tool-request-registry.js';
 export type { RegisterToolRequestInput, RegisterToolRequestResult } from './tool-request-registry.js';
+export { createToolRequestGithubIssue, buildToolRequestIssueBody } from './tool-request-github.js';
+export type { CreateGithubIssueInput, CreateGithubIssueResult } from './tool-request-github.js';

--- a/packages/shared-utils/src/tool-request-github.ts
+++ b/packages/shared-utils/src/tool-request-github.ts
@@ -1,0 +1,171 @@
+import { PrismaClient } from '@bronco/db';
+import { createLogger } from './logger.js';
+import { decrypt, looksEncrypted } from './crypto.js';
+
+const logger = createLogger('tool-request-github');
+
+const SETTINGS_KEY_GITHUB = 'system-config-github';
+const SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO = 'tool-requests-github-default-repo';
+
+export interface CreateGithubIssueInput {
+  toolRequestId: string;
+  repoOwner?: string;
+  repoName?: string;
+  labels?: string[];
+}
+
+export interface CreateGithubIssueResult {
+  issueUrl: string;
+  issueNumber: number;
+}
+
+interface RationaleRow {
+  id: string;
+  rationale: string;
+  source: string;
+  createdAt: Date;
+  ticket: { id: string; ticketNumber: number; subject: string } | null;
+}
+
+interface ToolRequestRow {
+  id: string;
+  displayTitle: string;
+  description: string;
+  requestCount: number;
+  suggestedInputs: unknown;
+  exampleUsage: string | null;
+  rationales: RationaleRow[];
+  client: { id: string; name: string; shortCode: string | null };
+}
+
+/**
+ * Creates a GitHub issue from a ToolRequest row's content. Uses the
+ * `system-config-github` AppSetting for the PAT (encrypted) and the
+ * `tool-requests-github-default-repo` AppSetting for the target repo
+ * unless overridden by input.
+ *
+ * On success, persists `githubIssueUrl` and `implementedInIssue` on the row
+ * so the admin UI can show the link without refetching.
+ */
+export async function createToolRequestGithubIssue(
+  db: PrismaClient,
+  encryptionKey: string,
+  input: CreateGithubIssueInput,
+): Promise<CreateGithubIssueResult> {
+  const row = (await db.toolRequest.findUnique({
+    where: { id: input.toolRequestId },
+    include: {
+      rationales: {
+        orderBy: { createdAt: 'desc' },
+        include: {
+          ticket: { select: { id: true, ticketNumber: true, subject: true } },
+        },
+      },
+      client: { select: { id: true, name: true, shortCode: true } },
+    },
+  })) as ToolRequestRow | null;
+  if (!row) throw new Error('Tool request not found');
+
+  let owner = input.repoOwner?.trim();
+  let name = input.repoName?.trim();
+  if (!owner || !name) {
+    const def = await db.appSetting.findUnique({
+      where: { key: SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO },
+    });
+    if (def?.value && typeof def.value === 'object' && !Array.isArray(def.value)) {
+      const v = def.value as { owner?: string; name?: string };
+      owner = owner || (typeof v.owner === 'string' ? v.owner.trim() : '');
+      name = name || (typeof v.name === 'string' ? v.name.trim() : '');
+    }
+  }
+  if (!owner || !name) {
+    throw new Error('GitHub default repo not configured for tool requests');
+  }
+
+  const githubRow = await db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB } });
+  if (!githubRow) {
+    throw new Error('GitHub token not configured (system-config-github AppSetting missing)');
+  }
+  const cfg = githubRow.value as { token?: string } | null;
+  if (!cfg || typeof cfg.token !== 'string' || cfg.token.length === 0) {
+    throw new Error('GitHub token missing from system-config-github');
+  }
+  const token = looksEncrypted(cfg.token) ? decrypt(cfg.token, encryptionKey) : cfg.token;
+
+  const body = buildToolRequestIssueBody(row);
+  const title = `[tool-request] ${row.displayTitle}`;
+
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues`;
+  const labels = input.labels && input.labels.length > 0 ? input.labels : ['tool-request'];
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      'User-Agent': 'bronco',
+    },
+    body: JSON.stringify({ title, body, labels }),
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub API error ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const issue = (await res.json()) as { html_url?: string; number?: number };
+  if (!issue.html_url || typeof issue.number !== 'number') {
+    throw new Error('GitHub API returned unexpected payload (missing html_url or number)');
+  }
+
+  await db.toolRequest.update({
+    where: { id: row.id },
+    data: {
+      githubIssueUrl: issue.html_url,
+      implementedInIssue: String(issue.number),
+    },
+  });
+
+  logger.info(
+    { toolRequestId: row.id, repo: `${owner}/${name}`, issueNumber: issue.number },
+    'Created GitHub issue for tool request',
+  );
+
+  return { issueUrl: issue.html_url, issueNumber: issue.number };
+}
+
+export function buildToolRequestIssueBody(row: ToolRequestRow): string {
+  const lines: string[] = [];
+  lines.push(`## ${row.displayTitle}`);
+  lines.push('');
+  lines.push(row.description);
+  lines.push('');
+  if (row.suggestedInputs && typeof row.suggestedInputs === 'object') {
+    lines.push('### Suggested Inputs');
+    lines.push('```json');
+    lines.push(JSON.stringify(row.suggestedInputs, null, 2));
+    lines.push('```');
+    lines.push('');
+  }
+  if (row.exampleUsage) {
+    lines.push('### Example Usage');
+    lines.push(row.exampleUsage);
+    lines.push('');
+  }
+  lines.push(`### Rationale History (${row.rationales.length})`);
+  for (const r of row.rationales) {
+    const ticketLink = r.ticket ? ` — ticket #${r.ticket.ticketNumber} (${r.ticket.subject})` : '';
+    const dt = new Date(r.createdAt).toISOString().slice(0, 10);
+    lines.push(`- **[${r.source}]** ${dt}${ticketLink}: ${r.rationale}`);
+  }
+  const linkedCount = new Set(
+    row.rationales.filter((r) => r.ticket).map((r) => r.ticket!.id),
+  ).size;
+  lines.push('');
+  const shortCode = row.client.shortCode ?? '—';
+  lines.push(
+    `_Detected from ${linkedCount} ticket(s) · client: ${row.client.name} (${shortCode}) · requestCount: ${row.requestCount}_`,
+  );
+  return lines.join('\n');
+}

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -138,6 +138,11 @@ export interface ToolRequestRateLimitConfig {
   limit: number;
 }
 
+export interface ToolRequestsDefaultRepoConfig {
+  owner: string;
+  name: string;
+}
+
 export interface ActionSafetyConfig {
   actions: Record<string, 'auto' | 'approval'>;
 }
@@ -280,6 +285,21 @@ export class SettingsService {
   }
   saveToolRequestRateLimit(config: ToolRequestRateLimitConfig): Observable<ToolRequestRateLimitConfig> {
     return this.api.put<ToolRequestRateLimitConfig>('/settings/tool-request-rate-limit', config);
+  }
+
+  // --- Tool Requests GitHub Default Repo ---
+  getToolRequestsDefaultRepo(): Observable<ToolRequestsDefaultRepoConfig | null> {
+    return this.api.get<ToolRequestsDefaultRepoConfig | null>(
+      '/settings/tool-requests-github-default-repo',
+    );
+  }
+  saveToolRequestsDefaultRepo(
+    config: ToolRequestsDefaultRepoConfig,
+  ): Observable<ToolRequestsDefaultRepoConfig> {
+    return this.api.put<ToolRequestsDefaultRepoConfig>(
+      '/settings/tool-requests-github-default-repo',
+      config,
+    );
   }
 
   // --- Action Safety ---

--- a/services/control-panel/src/app/core/services/tool-request.service.ts
+++ b/services/control-panel/src/app/core/services/tool-request.service.ts
@@ -53,6 +53,11 @@ export interface ToolRequestListItem {
   implementedInCommit: string | null;
   implementedInIssue: string | null;
   githubIssueUrl: string | null;
+  suggestedDuplicateOfId: string | null;
+  suggestedDuplicateReason: string | null;
+  suggestedImprovesExisting: string | null;
+  suggestedImprovesReason: string | null;
+  dedupeAnalysisAt: string | null;
   createdAt: string;
   updatedAt: string;
   client: ToolRequestClientSummary;
@@ -84,8 +89,35 @@ export interface ToolRequestDetail extends ToolRequestListItem {
     displayTitle: string;
     status: ToolRequestStatus;
   } | null;
+  suggestedDuplicateOf: {
+    id: string;
+    requestedName: string;
+    displayTitle: string;
+    status: ToolRequestStatus;
+  } | null;
   firstTicket: ToolRequestTicketSummary | null;
   linkedTickets: ToolRequestTicketSummary[];
+}
+
+export interface DedupeResult {
+  duplicateGroupsCount: number;
+  improvesExistingCount: number;
+  requestsAnalyzed: number;
+  warnings: string[];
+  raw?: unknown;
+}
+
+export type SuggestionKind = 'duplicate' | 'improves_existing';
+
+export interface CreateGithubIssueOptions {
+  repoOwner?: string;
+  repoName?: string;
+  labels?: string[];
+}
+
+export interface CreateGithubIssueResponse {
+  issueUrl: string;
+  issueNumber: number;
 }
 
 export interface ToolRequestListResponse {
@@ -139,5 +171,27 @@ export class ToolRequestService {
 
   delete(id: string): Observable<void> {
     return this.api.delete<void>(`/tool-requests/${id}`);
+  }
+
+  runDedupeAnalysis(clientId: string): Observable<DedupeResult> {
+    return this.api.post<DedupeResult>('/tool-requests/dedupe-analyses', { clientId });
+  }
+
+  acceptSuggestion(id: string, kind: SuggestionKind): Observable<ToolRequestDetail> {
+    return this.api.post<ToolRequestDetail>(`/tool-requests/${id}/accept-suggestion`, { kind });
+  }
+
+  dismissSuggestion(id: string, kind: SuggestionKind): Observable<ToolRequestDetail> {
+    return this.api.post<ToolRequestDetail>(`/tool-requests/${id}/dismiss-suggestion`, { kind });
+  }
+
+  createGithubIssue(
+    id: string,
+    opts?: CreateGithubIssueOptions,
+  ): Observable<CreateGithubIssueResponse> {
+    return this.api.post<CreateGithubIssueResponse>(
+      `/tool-requests/${id}/create-github-issue`,
+      opts ?? {},
+    );
   }
 }

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -18,6 +18,7 @@ import {
   SlackSystemConfig,
   PromptRetentionConfig,
   ToolRequestRateLimitConfig,
+  ToolRequestsDefaultRepoConfig,
 } from '../../core/services/settings.service.js';
 import { ExternalServiceDialogComponent } from './external-service-dialog.component.js';
 import { StatusConfigDialogComponent } from './status-config-dialog.component.js';
@@ -578,6 +579,18 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               </div>
               <div class="card-actions">
                 <app-bronco-button variant="primary" (click)="saveToolRequestRateLimit()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
+              </div>
+            </app-card>
+
+            <app-card>
+              <h2 class="section-title">GitHub Default Repo</h2>
+              <p class="hint">Target repository when an operator clicks "Create GitHub Issue" on an approved tool request. Uses the token from the GitHub tab.</p>
+              <div class="form-grid">
+                <app-form-field label="Owner"><input class="text-input" type="text" [(ngModel)]="toolRequestsDefaultRepo.owner" placeholder="e.g. siir"></app-form-field>
+                <app-form-field label="Repo name"><input class="text-input" type="text" [(ngModel)]="toolRequestsDefaultRepo.name" placeholder="e.g. bronco"></app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveToolRequestsDefaultRepo()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
               </div>
             </app-card>
           </div>
@@ -1241,6 +1254,7 @@ export class SettingsComponent implements OnInit {
   slackConfig: SlackSystemConfig = { botToken: '', appToken: '', defaultChannelId: '', enabled: false };
   promptRetention: PromptRetentionConfig = { fullRetentionDays: 30, summaryRetentionDays: 90 };
   toolRequestRateLimit: ToolRequestRateLimitConfig = { limit: 5 };
+  toolRequestsDefaultRepo: ToolRequestsDefaultRepoConfig = { owner: '', name: '' };
 
   private loadSystemConfigs(): void {
     this.settingsSvc.getSmtpConfig().subscribe({ next: (c) => { if (c) this.smtp = { ...this.smtp, ...c }; } });
@@ -1250,6 +1264,7 @@ export class SettingsComponent implements OnInit {
     this.settingsSvc.getSlackConfig().subscribe({ next: (c) => { if (c) this.slackConfig = { ...this.slackConfig, ...c }; } });
     this.settingsSvc.getPromptRetention().subscribe({ next: (c) => { if (c) this.promptRetention = { ...this.promptRetention, ...c }; } });
     this.settingsSvc.getToolRequestRateLimit().subscribe({ next: (c) => { if (c) this.toolRequestRateLimit = { ...this.toolRequestRateLimit, ...c }; } });
+    this.settingsSvc.getToolRequestsDefaultRepo().subscribe({ next: (c) => { if (c) this.toolRequestsDefaultRepo = { ...this.toolRequestsDefaultRepo, ...c }; } });
   }
 
   saveSmtp(): void { this.sysConfigSaving.set(true); this.settingsSvc.updateSmtpConfig(this.smtp).subscribe({ next: (c) => { this.smtp = { ...this.smtp, ...c }; this.toast.success('SMTP config saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
@@ -1270,4 +1285,15 @@ export class SettingsComponent implements OnInit {
   savePromptRetention(): void { this.sysConfigSaving.set(true); this.settingsSvc.savePromptRetention(this.promptRetention).subscribe({ next: (c: PromptRetentionConfig) => { this.promptRetention = { ...this.promptRetention, ...c }; this.toast.success('Prompt retention saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
 
   saveToolRequestRateLimit(): void { this.sysConfigSaving.set(true); this.settingsSvc.saveToolRequestRateLimit(this.toolRequestRateLimit).subscribe({ next: (c: ToolRequestRateLimitConfig) => { this.toolRequestRateLimit = { ...this.toolRequestRateLimit, ...c }; this.toast.success('Tool request rate limit saved'); this.sysConfigSaving.set(false); }, error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); } }); }
+
+  saveToolRequestsDefaultRepo(): void {
+    const owner = this.toolRequestsDefaultRepo.owner.trim();
+    const name = this.toolRequestsDefaultRepo.name.trim();
+    if (!owner || !name) { this.toast.error('Both owner and repo name are required'); return; }
+    this.sysConfigSaving.set(true);
+    this.settingsSvc.saveToolRequestsDefaultRepo({ owner, name }).subscribe({
+      next: (c: ToolRequestsDefaultRepoConfig) => { this.toolRequestsDefaultRepo = { ...this.toolRequestsDefaultRepo, ...c }; this.toast.success('Default repo saved'); this.sysConfigSaving.set(false); },
+      error: () => { this.toast.error('Failed to save'); this.sysConfigSaving.set(false); },
+    });
+  }
 }

--- a/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
+++ b/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
@@ -7,7 +7,9 @@ import {
   type ToolRequestListItem,
   type ToolRequestDetail,
   type UpdateToolRequestBody,
+  type SuggestionKind,
 } from '../../core/services/tool-request.service.js';
+import { ClientService, type Client } from '../../core/services/client.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
 import {
   BroncoButtonComponent,
@@ -51,6 +53,13 @@ const STATUS_OPTIONS = [
     <div class="page-header">
       <h1>Tool Requests</h1>
       <div class="header-actions">
+        <app-bronco-button
+          variant="primary"
+          size="sm"
+          (click)="runDedupe()"
+          [disabled]="dedupeRunning() || !clientFilter()">
+          {{ dedupeRunning() ? 'Analyzing…' : '⎇ Run Dedupe' }}
+        </app-bronco-button>
         <app-bronco-button variant="secondary" size="sm" (click)="refresh()" [disabled]="loading()">
           ↻ Refresh
         </app-bronco-button>
@@ -59,10 +68,14 @@ const STATUS_OPTIONS = [
 
     <p class="page-hint">
       Agent-flagged capability gaps. Each row represents a missing tool the analyzer wished it had, deduplicated by
-      <code>(client, requested_name)</code> with rationale history.
+      <code>(client, requested_name)</code> with rationale history. Select a client and click Run Dedupe to have Claude propose duplicate/improves-existing suggestions for its PROPOSED/APPROVED requests.
     </p>
 
     <app-toolbar>
+      <app-select
+        [value]="clientFilter()"
+        [options]="clientOptions()"
+        (valueChange)="onClientFilter($event)" />
       <app-select
         [value]="statusFilter()"
         [options]="statusOptions"
@@ -100,6 +113,12 @@ const STATUS_OPTIONS = [
             <div class="title-cell">
               <span class="title">{{ row.displayTitle }}</span>
               <span class="requested-name">{{ row.requestedName }}</span>
+              @if (row.suggestedDuplicateOfId) {
+                <span class="suggestion-pill suggestion-duplicate" title="AI dedupe flagged this as a duplicate">⚠ Suggested duplicate</span>
+              }
+              @if (row.suggestedImprovesExisting) {
+                <span class="suggestion-pill suggestion-improves" title="AI dedupe flagged this as improving an existing tool">↗ Improves: {{ row.suggestedImprovesExisting }}</span>
+              }
             </div>
           </ng-template>
         </app-data-column>
@@ -202,6 +221,79 @@ const STATUS_OPTIONS = [
                   <li>{{ dup.displayTitle }} ({{ dup.requestedName }}) — {{ dup.status }} · {{ dup.requestCount }}</li>
                 }
               </ul>
+            </section>
+          }
+
+          @if (d.suggestedDuplicateOfId || d.suggestedImprovesExisting) {
+            <section class="suggestion-section">
+              <h3>AI Dedupe Suggestions</h3>
+              @if (d.dedupeAnalysisAt) {
+                <p class="muted suggestion-when">Last analyzed {{ d.dedupeAnalysisAt | date:'short' }}</p>
+              }
+
+              @if (d.suggestedDuplicateOfId) {
+                <div class="suggestion-card suggestion-card-duplicate">
+                  <div class="suggestion-header">
+                    <span class="suggestion-pill suggestion-duplicate">⚠ Suggested duplicate</span>
+                    @if (d.suggestedDuplicateOf) {
+                      <span class="muted">of {{ d.suggestedDuplicateOf.displayTitle }} ({{ d.suggestedDuplicateOf.requestedName }})</span>
+                    }
+                  </div>
+                  @if (d.suggestedDuplicateReason) {
+                    <p class="suggestion-reason">{{ d.suggestedDuplicateReason }}</p>
+                  }
+                  <div class="action-row">
+                    <app-bronco-button variant="primary" size="sm" (click)="acceptSuggestion(d, 'duplicate')" [disabled]="saving()">Accept (→ Duplicate)</app-bronco-button>
+                    <app-bronco-button variant="secondary" size="sm" (click)="dismissSuggestion(d, 'duplicate')" [disabled]="saving()">Dismiss</app-bronco-button>
+                  </div>
+                </div>
+              }
+
+              @if (d.suggestedImprovesExisting) {
+                <div class="suggestion-card suggestion-card-improves">
+                  <div class="suggestion-header">
+                    <span class="suggestion-pill suggestion-improves">↗ Improves existing</span>
+                    <span class="muted">{{ d.suggestedImprovesExisting }}</span>
+                  </div>
+                  @if (d.suggestedImprovesReason) {
+                    <p class="suggestion-reason">{{ d.suggestedImprovesReason }}</p>
+                  }
+                  <div class="action-row">
+                    <app-bronco-button variant="primary" size="sm" (click)="acceptSuggestion(d, 'improves_existing')" [disabled]="saving()">Accept (→ Rejected)</app-bronco-button>
+                    <app-bronco-button variant="secondary" size="sm" (click)="dismissSuggestion(d, 'improves_existing')" [disabled]="saving()">Dismiss</app-bronco-button>
+                  </div>
+                </div>
+              }
+            </section>
+          }
+
+          @if (d.status === 'APPROVED' && !d.githubIssueUrl) {
+            <section class="github-section">
+              <h3>Create GitHub Issue</h3>
+              <p class="muted">Opens an issue in the configured default repo (or override below) and saves the link on this request.</p>
+              <div class="form-block">
+                <app-form-field label="Repo owner (optional override)">
+                  <input class="text-input" [(ngModel)]="ghRepoOwner" placeholder="e.g. siir" />
+                </app-form-field>
+                <app-form-field label="Repo name (optional override)">
+                  <input class="text-input" [(ngModel)]="ghRepoName" placeholder="e.g. bronco" />
+                </app-form-field>
+                <app-form-field label="Labels (comma-separated, optional)">
+                  <input class="text-input" [(ngModel)]="ghLabels" placeholder="tool-request, enhancement" />
+                </app-form-field>
+                <div class="action-row">
+                  <app-bronco-button variant="primary" (click)="createGithubIssue(d)" [disabled]="ghCreating()">
+                    {{ ghCreating() ? 'Creating…' : 'Create GitHub Issue' }}
+                  </app-bronco-button>
+                </div>
+              </div>
+            </section>
+          }
+
+          @if (d.githubIssueUrl) {
+            <section class="github-section">
+              <h3>GitHub Issue</h3>
+              <p><a [href]="d.githubIssueUrl" target="_blank" rel="noopener">{{ d.githubIssueUrl }}</a></p>
             </section>
           }
 
@@ -347,10 +439,39 @@ const STATUS_OPTIONS = [
     .action-row { display: flex; gap: 8px; flex-wrap: wrap; }
     .form-block { margin-top: 12px; padding: 12px; background: var(--bg-muted); border-radius: var(--radius-md); display: flex; flex-direction: column; gap: 10px; }
     .danger-section { border-top: 1px solid var(--border-light); padding-top: 12px; }
+
+    .suggestion-pill {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+      font-size: 11px;
+      font-weight: 600;
+      margin-left: 4px;
+      white-space: nowrap;
+    }
+    .suggestion-pill.suggestion-duplicate { background: rgba(255,204,0,0.15); color: #b58900; border: 1px solid rgba(255,204,0,0.35); }
+    .suggestion-pill.suggestion-improves { background: rgba(0,122,255,0.12); color: var(--accent); border: 1px solid rgba(0,122,255,0.25); }
+
+    .suggestion-section { border-top: 1px solid var(--border-light); padding-top: 12px; }
+    .suggestion-when { margin: -4px 0 8px; font-size: 11px; }
+    .suggestion-card {
+      padding: 10px 12px;
+      border-radius: var(--radius-md);
+      margin-bottom: 10px;
+      border: 1px solid var(--border-light);
+    }
+    .suggestion-card-duplicate { background: rgba(255,204,0,0.04); border-color: rgba(255,204,0,0.2); }
+    .suggestion-card-improves { background: rgba(0,122,255,0.03); border-color: rgba(0,122,255,0.2); }
+    .suggestion-header { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 6px; }
+    .suggestion-reason { margin: 4px 0 8px; font-size: 13px; color: var(--text-primary); white-space: pre-wrap; }
+
+    .github-section { border-top: 1px solid var(--border-light); padding-top: 12px; }
+    .github-section a { color: var(--accent); word-break: break-all; }
   `],
 })
 export class ToolRequestListComponent implements OnInit {
   private svc = inject(ToolRequestService);
+  private clientSvc = inject(ClientService);
   private toast = inject(ToastService);
 
   readonly statusOptions = STATUS_OPTIONS;
@@ -359,9 +480,18 @@ export class ToolRequestListComponent implements OnInit {
   items = signal<ToolRequestListItem[]>([]);
   total = signal(0);
   statusFilter = signal<string>('');
+  clientFilter = signal<string>('');
   searchInput = signal<string>('');
   offset = signal(0);
   readonly pageSize = 50;
+
+  clients = signal<Client[]>([]);
+  clientOptions = computed(() => [
+    { value: '', label: 'All Clients' },
+    ...this.clients().map((c) => ({ value: c.id, label: `${c.name} (${c.shortCode})` })),
+  ]);
+
+  dedupeRunning = signal(false);
 
   detail = signal<ToolRequestDetail | null>(null);
   showRejectForm = signal(false);
@@ -372,6 +502,11 @@ export class ToolRequestListComponent implements OnInit {
   implementedInCommit = '';
   githubIssueUrl = '';
 
+  ghRepoOwner = '';
+  ghRepoName = '';
+  ghLabels = '';
+  ghCreating = signal(false);
+
   private searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
   hasMore = computed(() => this.total() > this.items().length);
@@ -379,6 +514,12 @@ export class ToolRequestListComponent implements OnInit {
   trackById = (row: ToolRequestListItem) => row.id;
 
   ngOnInit(): void {
+    this.clientSvc.getClients().subscribe({
+      next: (list) => this.clients.set(list),
+      error: () => {
+        /* non-fatal — client filter stays empty */
+      },
+    });
     this.refresh();
   }
 
@@ -398,6 +539,7 @@ export class ToolRequestListComponent implements OnInit {
     this.svc
       .list({
         status: status ? (status as ToolRequestStatus) : undefined,
+        clientId: this.clientFilter() || undefined,
         search: this.searchInput() || undefined,
         limit: this.pageSize,
         offset: this.offset(),
@@ -418,6 +560,35 @@ export class ToolRequestListComponent implements OnInit {
   onStatusFilter(value: string): void {
     this.statusFilter.set(value);
     this.refresh();
+  }
+
+  onClientFilter(value: string): void {
+    this.clientFilter.set(value);
+    this.refresh();
+  }
+
+  runDedupe(): void {
+    const clientId = this.clientFilter();
+    if (!clientId) {
+      this.toast.error('Select a client first');
+      return;
+    }
+    this.dedupeRunning.set(true);
+    this.svc.runDedupeAnalysis(clientId).subscribe({
+      next: (res) => {
+        this.dedupeRunning.set(false);
+        const warn = res.warnings?.length ? ` (${res.warnings.length} warning${res.warnings.length === 1 ? '' : 's'})` : '';
+        this.toast.success(
+          `Dedupe complete: ${res.duplicateGroupsCount} duplicate group(s), ${res.improvesExistingCount} improves-existing across ${res.requestsAnalyzed} request(s)${warn}`,
+        );
+        this.refresh();
+      },
+      error: (err) => {
+        this.dedupeRunning.set(false);
+        const msg = err?.error?.message ?? 'Dedupe analysis failed';
+        this.toast.error(msg);
+      },
+    });
   }
 
   onSearchChange(value: string): void {
@@ -453,6 +624,9 @@ export class ToolRequestListComponent implements OnInit {
     this.duplicateOfId = '';
     this.implementedInCommit = '';
     this.githubIssueUrl = '';
+    this.ghRepoOwner = '';
+    this.ghRepoName = '';
+    this.ghLabels = '';
   }
 
   private applyUpdate(id: string, body: UpdateToolRequestBody, successMsg: string): void {
@@ -517,6 +691,66 @@ export class ToolRequestListComponent implements OnInit {
       error: () => {
         this.toast.error('Failed to delete tool request');
         this.saving.set(false);
+      },
+    });
+  }
+
+  acceptSuggestion(d: ToolRequestDetail, kind: SuggestionKind): void {
+    this.saving.set(true);
+    this.svc.acceptSuggestion(d.id, kind).subscribe({
+      next: (updated) => {
+        this.saving.set(false);
+        this.detail.set(updated);
+        this.toast.success(kind === 'duplicate' ? 'Accepted — marked as duplicate' : 'Accepted — marked rejected (improves existing)');
+        this.fetch(false);
+      },
+      error: (err) => {
+        this.saving.set(false);
+        const msg = err?.error?.message ?? 'Failed to accept suggestion';
+        this.toast.error(msg);
+      },
+    });
+  }
+
+  dismissSuggestion(d: ToolRequestDetail, kind: SuggestionKind): void {
+    this.saving.set(true);
+    this.svc.dismissSuggestion(d.id, kind).subscribe({
+      next: (updated) => {
+        this.saving.set(false);
+        this.detail.set(updated);
+        this.toast.success('Suggestion dismissed');
+        this.fetch(false);
+      },
+      error: (err) => {
+        this.saving.set(false);
+        const msg = err?.error?.message ?? 'Failed to dismiss suggestion';
+        this.toast.error(msg);
+      },
+    });
+  }
+
+  createGithubIssue(d: ToolRequestDetail): void {
+    this.ghCreating.set(true);
+    const opts: { repoOwner?: string; repoName?: string; labels?: string[] } = {};
+    if (this.ghRepoOwner.trim()) opts.repoOwner = this.ghRepoOwner.trim();
+    if (this.ghRepoName.trim()) opts.repoName = this.ghRepoName.trim();
+    const labels = this.ghLabels
+      .split(',')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (labels.length > 0) opts.labels = labels;
+
+    this.svc.createGithubIssue(d.id, opts).subscribe({
+      next: (res) => {
+        this.ghCreating.set(false);
+        this.toast.success(`Created GitHub issue #${res.issueNumber}`);
+        this.svc.get(d.id).subscribe({ next: (refreshed) => this.detail.set(refreshed) });
+        this.fetch(false);
+      },
+      error: (err) => {
+        this.ghCreating.set(false);
+        const msg = err?.error?.message ?? 'Failed to create GitHub issue';
+        this.toast.error(msg);
       },
     });
   }

--- a/services/copilot-api/src/routes/index.ts
+++ b/services/copilot-api/src/routes/index.ts
@@ -142,6 +142,13 @@ export async function registerRoutes(fastify: FastifyInstance, opts: RouteOpts):
   await fastify.register(async (scoped) => {
     scoped.addHook('preHandler', adminOnlyGuard);
 
-    await scoped.register(toolRequestRoutes);
+    await scoped.register(toolRequestRoutes, {
+      ai: opts.ai,
+      encryptionKey: opts.config.ENCRYPTION_KEY,
+      mcpPlatformUrl: opts.config.MCP_PLATFORM_HEALTH_URL,
+      mcpRepoUrl: opts.config.MCP_REPO_HEALTH_URL,
+      mcpDatabaseUrl: opts.config.MCP_DATABASE_HEALTH_URL,
+      platformApiKey: opts.config.API_KEY,
+    });
   });
 }

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -44,6 +44,7 @@ const SETTINGS_KEY_ACTION_SAFETY = 'system-config-action-safety';
 const SETTINGS_KEY_ANALYSIS_STRATEGY = 'system-config-analysis-strategy';
 const SETTINGS_KEY_SELF_ANALYSIS = 'self_analysis_config';
 const SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT = 'tool-request-rate-limit-per-run';
+const SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO = 'tool-requests-github-default-repo';
 
 const REDACTED = '••••••••';
 
@@ -922,6 +923,47 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
       });
 
       return row.value as unknown as { limit: number };
+    },
+  );
+
+  // ─── Tool Requests: default GitHub repo ───
+
+  const toolRequestsDefaultRepoSchema = z.object({
+    owner: z.string().trim().min(1),
+    name: z.string().trim().min(1),
+  });
+
+  type ToolRequestsDefaultRepo = z.output<typeof toolRequestsDefaultRepoSchema>;
+
+  // GET /api/settings/tool-requests-github-default-repo
+  fastify.get('/api/settings/tool-requests-github-default-repo', async () => {
+    const row = await fastify.db.appSetting.findUnique({
+      where: { key: SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO },
+    });
+    if (!row) return null;
+    const parsed = toolRequestsDefaultRepoSchema.safeParse(row.value);
+    return parsed.success ? parsed.data : null;
+  });
+
+  // PUT /api/settings/tool-requests-github-default-repo
+  fastify.put<{ Body: ToolRequestsDefaultRepo }>(
+    '/api/settings/tool-requests-github-default-repo',
+    async (request) => {
+      const parsed = toolRequestsDefaultRepoSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+        return fastify.httpErrors.badRequest(`Invalid default repo config: ${msg}`);
+      }
+
+      const config = parsed.data;
+
+      const row = await fastify.db.appSetting.upsert({
+        where: { key: SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO },
+        update: { value: config as unknown as object },
+        create: { key: SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO, value: config as unknown as object },
+      });
+
+      return row.value as unknown as ToolRequestsDefaultRepo;
     },
   );
 

--- a/services/copilot-api/src/routes/tool-requests.ts
+++ b/services/copilot-api/src/routes/tool-requests.ts
@@ -2,6 +2,9 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { Prisma } from '@bronco/db';
 import { ToolRequestStatus } from '@bronco/shared-types';
+import type { AIRouter } from '@bronco/ai-provider';
+import { runToolRequestDedupe } from '../services/tool-request-dedupe.js';
+import { createToolRequestGithubIssue } from '../services/tool-request-github.js';
 
 const STATUS_VALUES = Object.values(ToolRequestStatus) as [string, ...string[]];
 
@@ -24,11 +27,37 @@ const updateBodySchema = z.object({
   githubIssueUrl: z.string().url().optional(),
 });
 
+const dedupeBodySchema = z.object({
+  clientId: z.string().uuid(),
+});
+
+const suggestionBodySchema = z.object({
+  kind: z.enum(['duplicate', 'improves_existing']),
+});
+
+const createGithubIssueBodySchema = z.object({
+  repoOwner: z.string().min(1).optional(),
+  repoName: z.string().min(1).optional(),
+  labels: z.array(z.string().min(1)).optional(),
+});
+
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
 }
 
-export async function toolRequestRoutes(fastify: FastifyInstance): Promise<void> {
+export interface ToolRequestRouteOpts {
+  ai: AIRouter;
+  encryptionKey: string;
+  mcpPlatformUrl?: string;
+  mcpRepoUrl?: string;
+  mcpDatabaseUrl?: string;
+  platformApiKey?: string;
+}
+
+export async function toolRequestRoutes(
+  fastify: FastifyInstance,
+  opts: ToolRequestRouteOpts,
+): Promise<void> {
   // List tool requests with filters
   fastify.get('/api/tool-requests', async (request) => {
     const parsed = listQuerySchema.safeParse(request.query);
@@ -122,7 +151,22 @@ export async function toolRequestRoutes(fastify: FastifyInstance): Promise<void>
       }
     }
 
-    return { ...row, linkedTickets };
+    // Resolve a short preview of the suggested canonical duplicate when present
+    let suggestedDuplicateOf: {
+      id: string;
+      requestedName: string;
+      displayTitle: string;
+      status: string;
+    } | null = null;
+    if (row.suggestedDuplicateOfId) {
+      const canonical = await fastify.db.toolRequest.findUnique({
+        where: { id: row.suggestedDuplicateOfId },
+        select: { id: true, requestedName: true, displayTitle: true, status: true },
+      });
+      suggestedDuplicateOf = canonical;
+    }
+
+    return { ...row, linkedTickets, suggestedDuplicateOf };
   });
 
   // Update tool request (status transitions, reasons, implementation refs)
@@ -202,4 +246,172 @@ export async function toolRequestRoutes(fastify: FastifyInstance): Promise<void>
       reply.code(204).send();
     },
   );
+
+  // Run dedupe analysis for a client — populates suggestion fields on
+  // PROPOSED/APPROVED rows. Idempotent; each run overwrites prior suggestions.
+  fastify.post<{ Body: { clientId: string } }>(
+    '/api/tool-requests/dedupe-analyses',
+    async (request, reply) => {
+      const parsed = dedupeBodySchema.safeParse(request.body);
+      if (!parsed.success) {
+        return fastify.httpErrors.badRequest(
+          parsed.error.errors[0]?.message ?? 'clientId is required',
+        );
+      }
+      const client = await fastify.db.client.findUnique({
+        where: { id: parsed.data.clientId },
+        select: { id: true },
+      });
+      if (!client) return fastify.httpErrors.notFound('Client not found');
+
+      try {
+        return await runToolRequestDedupe(
+          fastify.db,
+          opts.ai,
+          parsed.data.clientId,
+          opts.encryptionKey,
+          {
+            mcpPlatformUrl: opts.mcpPlatformUrl,
+            mcpRepoUrl: opts.mcpRepoUrl,
+            mcpDatabaseUrl: opts.mcpDatabaseUrl,
+            platformApiKey: opts.platformApiKey,
+          },
+        );
+      } catch (err) {
+        reply.code(500);
+        const error = err as Error & { debugContent?: string };
+        return { error: error.message, debugContent: error.debugContent };
+      }
+    },
+  );
+
+  // Accept an AI-suggested transition (duplicate or improves-existing).
+  fastify.post<{
+    Params: { id: string };
+    Body: { kind: 'duplicate' | 'improves_existing' };
+  }>('/api/tool-requests/:id/accept-suggestion', async (request) => {
+    const parsed = suggestionBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return fastify.httpErrors.badRequest(
+        parsed.error.errors[0]?.message ?? 'kind must be "duplicate" or "improves_existing"',
+      );
+    }
+    const { kind } = parsed.data;
+
+    const row = await fastify.db.toolRequest.findUnique({
+      where: { id: request.params.id },
+      select: {
+        id: true,
+        suggestedDuplicateOfId: true,
+        suggestedImprovesExisting: true,
+      },
+    });
+    if (!row) return fastify.httpErrors.notFound('Tool request not found');
+
+    if (kind === 'duplicate') {
+      if (!row.suggestedDuplicateOfId) {
+        return fastify.httpErrors.badRequest('No duplicate suggestion on this request');
+      }
+      return fastify.db.toolRequest.update({
+        where: { id: row.id },
+        data: {
+          status: ToolRequestStatus.DUPLICATE,
+          duplicateOf: { connect: { id: row.suggestedDuplicateOfId } },
+          suggestedDuplicateOfId: null,
+          suggestedDuplicateReason: null,
+        },
+        include: {
+          client: { select: { id: true, name: true, shortCode: true } },
+          _count: { select: { rationales: true } },
+        },
+      });
+    }
+
+    // improves_existing
+    if (!row.suggestedImprovesExisting) {
+      return fastify.httpErrors.badRequest('No improves-existing suggestion on this request');
+    }
+    return fastify.db.toolRequest.update({
+      where: { id: row.id },
+      data: {
+        status: ToolRequestStatus.REJECTED,
+        rejectedReason: `Improves existing tool: ${row.suggestedImprovesExisting}`,
+        suggestedImprovesExisting: null,
+        suggestedImprovesReason: null,
+      },
+      include: {
+        client: { select: { id: true, name: true, shortCode: true } },
+        _count: { select: { rationales: true } },
+      },
+    });
+  });
+
+  // Dismiss an AI-suggested transition — clears suggestion fields, no status change.
+  fastify.post<{
+    Params: { id: string };
+    Body: { kind: 'duplicate' | 'improves_existing' };
+  }>('/api/tool-requests/:id/dismiss-suggestion', async (request) => {
+    const parsed = suggestionBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return fastify.httpErrors.badRequest(
+        parsed.error.errors[0]?.message ?? 'kind must be "duplicate" or "improves_existing"',
+      );
+    }
+    const { kind } = parsed.data;
+
+    const data: Prisma.ToolRequestUpdateInput =
+      kind === 'duplicate'
+        ? { suggestedDuplicateOfId: null, suggestedDuplicateReason: null }
+        : { suggestedImprovesExisting: null, suggestedImprovesReason: null };
+
+    try {
+      return await fastify.db.toolRequest.update({
+        where: { id: request.params.id },
+        data,
+        include: {
+          client: { select: { id: true, name: true, shortCode: true } },
+          _count: { select: { rationales: true } },
+        },
+      });
+    } catch (err) {
+      if (isPrismaError(err, 'P2025')) {
+        return fastify.httpErrors.notFound('Tool request not found');
+      }
+      throw err;
+    }
+  });
+
+  // Create a GitHub issue for this tool request. Uses the configured default
+  // repo (SETTINGS_KEY_TOOL_REQUESTS_DEFAULT_REPO) unless overridden.
+  fastify.post<{
+    Params: { id: string };
+    Body: { repoOwner?: string; repoName?: string; labels?: string[] };
+  }>('/api/tool-requests/:id/create-github-issue', async (request, reply) => {
+    const parsed = createGithubIssueBodySchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      return fastify.httpErrors.badRequest(
+        parsed.error.errors[0]?.message ?? 'Invalid request body',
+      );
+    }
+    try {
+      return await createToolRequestGithubIssue(fastify.db, opts.encryptionKey, {
+        toolRequestId: request.params.id,
+        repoOwner: parsed.data.repoOwner,
+        repoName: parsed.data.repoName,
+        labels: parsed.data.labels,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('not configured') || msg.includes('not found') || msg.includes('missing')) {
+        reply.code(400);
+        return { error: msg };
+      }
+      if (msg.startsWith('GitHub API error')) {
+        reply.code(502);
+        return { error: msg };
+      }
+      reply.code(500);
+      return { error: msg };
+    }
+  });
 }

--- a/services/copilot-api/src/services/tool-request-dedupe.ts
+++ b/services/copilot-api/src/services/tool-request-dedupe.ts
@@ -1,0 +1,236 @@
+import { PrismaClient } from '@bronco/db';
+import type { AIRouter } from '@bronco/ai-provider';
+import { TaskType, ToolRequestStatus, IntegrationType } from '@bronco/shared-types';
+import { createLogger, decrypt, looksEncrypted } from '@bronco/shared-utils';
+import { discoverMcpServer } from './mcp-discovery.js';
+
+const logger = createLogger('tool-request-dedupe');
+
+interface SharedMcpServer {
+  name: string;
+  url: string;
+}
+
+export interface DedupeOptions {
+  mcpPlatformUrl?: string;
+  mcpRepoUrl?: string;
+  mcpDatabaseUrl?: string;
+  platformApiKey?: string;
+}
+
+export interface DedupeResult {
+  duplicateGroupsCount: number;
+  improvesExistingCount: number;
+  requestsAnalyzed: number;
+  warnings: string[];
+  raw: unknown;
+}
+
+interface DuplicateGroup {
+  canonicalId: string;
+  duplicateIds: string[];
+  reason: string;
+}
+
+interface ImprovesExistingEntry {
+  requestId: string;
+  existingToolName: string;
+  reason: string;
+}
+
+interface DedupeModelOutput {
+  duplicateGroups?: DuplicateGroup[];
+  improvesExisting?: ImprovesExistingEntry[];
+}
+
+export async function runToolRequestDedupe(
+  db: PrismaClient,
+  ai: AIRouter,
+  clientId: string,
+  encryptionKey: string,
+  opts: DedupeOptions,
+): Promise<DedupeResult> {
+  const requests = await db.toolRequest.findMany({
+    where: {
+      clientId,
+      status: { in: [ToolRequestStatus.PROPOSED, ToolRequestStatus.APPROVED] },
+    },
+    include: {
+      rationales: { take: 5, orderBy: { createdAt: 'desc' } },
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (requests.length === 0) {
+    return {
+      duplicateGroupsCount: 0,
+      improvesExistingCount: 0,
+      requestsAnalyzed: 0,
+      warnings: [],
+      raw: { duplicateGroups: [], improvesExisting: [] },
+    };
+  }
+
+  const warnings: string[] = [];
+  const existingTools: Array<{ serverName: string; toolName: string; description: string }> = [];
+
+  const integrations = await db.clientIntegration.findMany({
+    where: {
+      clientId,
+      type: IntegrationType.MCP_DATABASE,
+      isActive: true,
+    },
+    select: { id: true, label: true, config: true },
+  });
+
+  const integrationDiscoveries = await Promise.all(
+    integrations.map(async (integ) => {
+      const cfg = typeof integ.config === 'object' && integ.config !== null && !Array.isArray(integ.config)
+        ? (integ.config as Record<string, unknown>)
+        : {};
+      const url = typeof cfg.url === 'string' ? cfg.url : undefined;
+      if (!url) {
+        warnings.push(`Integration ${integ.label ?? integ.id} missing url — skipped`);
+        return null;
+      }
+      let apiKey: string | undefined;
+      if (typeof cfg.apiKey === 'string' && cfg.apiKey.length > 0) {
+        try {
+          apiKey = looksEncrypted(cfg.apiKey) ? decrypt(cfg.apiKey, encryptionKey) : cfg.apiKey;
+        } catch (err) {
+          warnings.push(`Failed to decrypt apiKey for integration ${integ.label ?? integ.id}`);
+          logger.warn({ err, integrationId: integ.id }, 'decrypt failed');
+          return null;
+        }
+      }
+      const authHeader = cfg.authHeader === 'x-api-key' ? 'x-api-key' : 'bearer';
+      const mcpPath = typeof cfg.mcpPath === 'string' ? cfg.mcpPath : undefined;
+      try {
+        const result = await discoverMcpServer({ url, mcpPath, apiKey, authHeader });
+        return { serverName: integ.label ?? result.serverName ?? 'mcp-integration', tools: result.tools };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warnings.push(`Discovery failed for integration ${integ.label ?? integ.id}: ${msg}`);
+        logger.warn({ err, integrationId: integ.id }, 'MCP integration discovery failed');
+        return null;
+      }
+    }),
+  );
+
+  for (const d of integrationDiscoveries) {
+    if (!d) continue;
+    for (const t of d.tools) {
+      existingTools.push({ serverName: d.serverName, toolName: t.name, description: t.description });
+    }
+  }
+
+  const sharedServers: SharedMcpServer[] = [];
+  if (opts.mcpPlatformUrl) sharedServers.push({ name: 'platform', url: opts.mcpPlatformUrl });
+  if (opts.mcpRepoUrl) sharedServers.push({ name: 'repo', url: opts.mcpRepoUrl });
+  if (opts.mcpDatabaseUrl) sharedServers.push({ name: 'database', url: opts.mcpDatabaseUrl });
+
+  const sharedDiscoveries = await Promise.all(
+    sharedServers.map(async (server) => {
+      try {
+        const result = await discoverMcpServer({
+          url: server.url,
+          apiKey: opts.platformApiKey,
+          authHeader: 'x-api-key',
+        });
+        return { serverName: server.name, tools: result.tools };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        warnings.push(`Discovery failed for shared ${server.name} server: ${msg}`);
+        logger.warn({ err, server: server.name }, 'Shared MCP discovery failed');
+        return null;
+      }
+    }),
+  );
+
+  for (const d of sharedDiscoveries) {
+    if (!d) continue;
+    for (const t of d.tools) {
+      existingTools.push({ serverName: d.serverName, toolName: t.name, description: t.description });
+    }
+  }
+
+  const userPayload = {
+    existingTools,
+    pendingRequests: requests.map((r) => ({
+      id: r.id,
+      requestedName: r.requestedName,
+      displayTitle: r.displayTitle,
+      description: r.description,
+      rationales: r.rationales.map((ra) => ra.rationale),
+    })),
+  };
+  const userPrompt = JSON.stringify(userPayload, null, 2);
+
+  const result = await ai.generate({
+    taskType: TaskType.ANALYZE_TOOL_REQUESTS,
+    context: { clientId, entityId: clientId, entityType: 'client' },
+    prompt: userPrompt,
+    promptKey: 'analyze-tool-requests.system',
+  });
+
+  const cleaned = result.content
+    .trim()
+    .replace(/^```(?:json)?\n?/i, '')
+    .replace(/\n?```$/i, '')
+    .trim();
+
+  let parsed: DedupeModelOutput;
+  try {
+    parsed = JSON.parse(cleaned) as DedupeModelOutput;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error = new Error(`Dedupe analysis returned non-JSON output: ${message}`) as Error & {
+      debugContent?: string;
+    };
+    error.debugContent = result.content;
+    throw error;
+  }
+
+  const duplicateGroups = Array.isArray(parsed.duplicateGroups) ? parsed.duplicateGroups : [];
+  const improvesExisting = Array.isArray(parsed.improvesExisting) ? parsed.improvesExisting : [];
+  const validIds = new Set(requests.map((r) => r.id));
+
+  await db.$transaction(async (tx) => {
+    const now = new Date();
+    for (const group of duplicateGroups) {
+      if (!group || !validIds.has(group.canonicalId)) continue;
+      const dupIds = Array.isArray(group.duplicateIds) ? group.duplicateIds : [];
+      for (const dupId of dupIds) {
+        if (!validIds.has(dupId) || dupId === group.canonicalId) continue;
+        await tx.toolRequest.update({
+          where: { id: dupId },
+          data: {
+            suggestedDuplicateOfId: group.canonicalId,
+            suggestedDuplicateReason: group.reason ?? null,
+            dedupeAnalysisAt: now,
+          },
+        });
+      }
+    }
+    for (const entry of improvesExisting) {
+      if (!entry || !validIds.has(entry.requestId)) continue;
+      if (!entry.existingToolName) continue;
+      await tx.toolRequest.update({
+        where: { id: entry.requestId },
+        data: {
+          suggestedImprovesExisting: entry.existingToolName,
+          suggestedImprovesReason: entry.reason ?? null,
+          dedupeAnalysisAt: now,
+        },
+      });
+    }
+  });
+
+  return {
+    duplicateGroupsCount: duplicateGroups.length,
+    improvesExistingCount: improvesExisting.length,
+    requestsAnalyzed: requests.length,
+    warnings,
+    raw: parsed,
+  };
+}

--- a/services/copilot-api/src/services/tool-request-github.ts
+++ b/services/copilot-api/src/services/tool-request-github.ts
@@ -1,0 +1,8 @@
+export {
+  createToolRequestGithubIssue,
+  buildToolRequestIssueBody,
+} from '@bronco/shared-utils';
+export type {
+  CreateGithubIssueInput,
+  CreateGithubIssueResult,
+} from '@bronco/shared-utils';


### PR DESCRIPTION
## Summary

Third and final child session in the Gap Requests series (coordinator #308). Adds the admin dedupe agent and the Create-GitHub-Issue button on top of the ToolRequest registry. After this merges, the integration branch is ready for the bundle PR to `staging`.

**Schema & types**
- 5 new nullable `ToolRequest` fields: `suggestedDuplicateOfId`, `suggestedDuplicateReason`, `suggestedImprovesExisting`, `suggestedImprovesReason`, `dedupeAnalysisAt` (migration `20260421020000_tool_request_dedupe_suggestions`)
- New `TaskType.ANALYZE_TOOL_REQUESTS` (Sonnet default, STANDARD capability) + `analyze-tool-requests.system` prompt

**Backend**
- `services/copilot-api/src/services/tool-request-dedupe.ts` — discovers per-client MCP integrations (type `MCP_DATABASE`) + shared platform/repo/database servers via `discoverMcpServer`, composes the catalog + pending-requests payload, calls Claude, applies suggestions transactionally with id-set validation
- `packages/shared-utils/src/tool-request-github.ts` — raw-fetch GitHub REST v3; uses the existing `system-config-github` AppSetting PAT (encrypted) and the new `tool-requests-github-default-repo` AppSetting; persists `githubIssueUrl` + `implementedInIssue` on success
- New REST endpoints: `POST /api/tool-requests/dedupe-analyses`, `POST /:id/accept-suggestion`, `POST /:id/dismiss-suggestion`, `POST /:id/create-github-issue`, `GET/PUT /api/settings/tool-requests-github-default-repo` — all under the existing `requireRole(ADMIN)` scope
- MCP platform gains `create_tool_request_github_issue`. **Dedupe MCP wrapper deferred** — `AIRouter` and `mcp-discovery` aren't in the mcp-platform dep graph; noted in the commit body and acceptable given the admin UI is the primary surface

**Control panel**
- Run Dedupe button (client-scoped; requires a selected client) with toast summary
- Yellow "Suggested duplicate" + blue "Improves: X" pills with Accept/Dismiss actions on each row
- Create GitHub Issue flow on APPROVED rows with default-repo fallback; `View on GitHub` link replaces the button once the issue exists
- Settings tab gains a default-repo card

## Test plan

- [ ] `pnpm db:migrate` applies cleanly
- [ ] Seed 5+ `ToolRequest` rows with overlapping names on a test client; click Run Dedupe; verify suggestion fields populate and pills render
- [ ] Accept duplicate pill → row transitions to DUPLICATE with `duplicateOfId` set, pill clears
- [ ] Dismiss → suggestion fields clear, pill clears
- [ ] On an APPROVED request, Create GitHub Issue → verify issue lands in the configured repo with title `[tool-request] <displayTitle>` and `githubIssueUrl` persists
- [ ] Non-ADMIN STANDARD operator → 403 on all new endpoints
- [ ] Malformed AI output → dedupe endpoint returns 500 with `debugContent` for diagnosis

Refs #307. Closes the Gap Requests child series (#305 ✓ · #306 ✓ · #307 pending → bundle PR to `staging` next).
