### PR TITLE
feat: GATHER_REPO_CONTEXT — purpose-built search/read tools + nudge + pre-pull (fixes #313)

### DIFF
--- a/mcp-servers/repo/src/tools/index.ts
+++ b/mcp-servers/repo/src/tools/index.ts
@@ -4,12 +4,21 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PrismaClient } from '@bronco/db';
 import type { RepoManager } from '../repo-manager.js';
 import { validateCommand, executeCommand } from '../command-validator.js';
+import { registerSearchCodeTool } from './search-code.js';
+import { registerReadFileTool } from './read-file.js';
+import { registerListFilesTool } from './list-files.js';
+import { registerPrepareRepoTool } from './prepare-repo.js';
 
 export function registerAllTools(
   server: McpServer,
   deps: { db: PrismaClient; repoManager: RepoManager },
 ): void {
   const { db, repoManager } = deps;
+
+  registerSearchCodeTool(server, deps);
+  registerReadFileTool(server, deps);
+  registerListFilesTool(server, deps);
+  registerPrepareRepoTool(server, deps);
 
   server.tool(
     'repo_exec',

--- a/mcp-servers/repo/src/tools/list-files.ts
+++ b/mcp-servers/repo/src/tools/list-files.ts
@@ -65,27 +65,47 @@ export function registerListFilesTool(
       const effectivePattern = pattern && /^[A-Za-z0-9._*?\[\]/-]+$/.test(pattern) ? pattern : '*';
       const cap = Math.min(Math.max(maxResults ?? 200, 1), 2000);
 
-      const command = `find ${shellQuote(safeDir)} -type f -name ${shellQuote(effectivePattern)}`;
+      // `executeCommand` truncates stdout at 50k chars. To report an accurate
+      // `total` even for large repos, count via a separate `find | wc -l` call
+      // and return only the capped slice via `find | head`.
+      const baseFind = `find ${shellQuote(safeDir)} -type f -name ${shellQuote(effectivePattern)}`;
+      const countCommand = `${baseFind} | wc -l`;
+      const listCommand = `${baseFind} | head -n ${cap}`;
 
       try {
         const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
-        const result = await executeCommand(command, worktreePath);
 
-        if (result.exitCode !== 0) {
-          const stderr = result.stderr || '(no stderr)';
+        const countResult = await executeCommand(countCommand, worktreePath);
+        if (countResult.exitCode !== 0) {
+          const stderr = countResult.stderr || '(no stderr)';
           return {
-            content: [{ type: 'text' as const, text: `list_files error on ${repo.name}: exit=${result.exitCode}\n${stderr}` }],
+            content: [{ type: 'text' as const, text: `list_files error on ${repo.name}: exit=${countResult.exitCode}\n${stderr}` }],
+            isError: true,
+          };
+        }
+        const totalText = countResult.stdout.trim();
+        const total = Number.parseInt(totalText, 10);
+        if (!Number.isFinite(total) || total < 0) {
+          return {
+            content: [{ type: 'text' as const, text: `list_files error on ${repo.name}: unable to parse total count: ${totalText || '(empty stdout)'}` }],
             isError: true,
           };
         }
 
-        const allPaths = result.stdout.split('\n').filter(l => l.length > 0);
-        const total = allPaths.length;
-        const slice = allPaths.slice(0, cap);
+        const listResult = await executeCommand(listCommand, worktreePath);
+        if (listResult.exitCode !== 0) {
+          const stderr = listResult.stderr || '(no stderr)';
+          return {
+            content: [{ type: 'text' as const, text: `list_files error on ${repo.name}: exit=${listResult.exitCode}\n${stderr}` }],
+            isError: true,
+          };
+        }
+
+        const slice = listResult.stdout.split('\n').filter(l => l.length > 0);
         const footer = `\n\n[returned ${slice.length} of total ${total} matching]`;
         const text = slice.length > 0
           ? slice.join('\n') + footer
-          : `[returned 0 of total 0 matching]`;
+          : `[returned 0 of total ${total} matching]`;
 
         return {
           content: [{ type: 'text' as const, text }],

--- a/mcp-servers/repo/src/tools/list-files.ts
+++ b/mcp-servers/repo/src/tools/list-files.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PrismaClient } from '@bronco/db';
+import type { RepoManager } from '../repo-manager.js';
+import { executeCommand } from '../command-validator.js';
+
+function sanitizeDirectory(dir: string): string | null {
+  if (!dir) return '.';
+  if (dir.startsWith('/')) return null;
+  const normalized = dir.replace(/\\/g, '/');
+  if (normalized.split('/').some(seg => seg === '..')) return null;
+  return normalized.replace(/^\.\//, '') || '.';
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function registerListFilesTool(
+  server: McpServer,
+  deps: { db: PrismaClient; repoManager: RepoManager },
+): void {
+  const { db, repoManager } = deps;
+
+  server.tool(
+    'list_files',
+    'List files in a registered code repository, optionally filtered by glob pattern or directory. Use this for discovery when you aren\'t sure what files exist.',
+    {
+      repoId: z.string().uuid().describe('The CodeRepo ID'),
+      pattern: z.string().optional().describe('Glob pattern to match (default "*")'),
+      directory: z.string().optional().describe('Directory to search within (default ".")'),
+      maxResults: z.number().int().positive().optional().describe('Cap on returned paths (default 200)'),
+      sessionId: z.string().optional().describe('Session ID for worktree reuse (auto-generated if omitted)'),
+      clientId: z.string().uuid().optional().describe('Client ID for ownership validation'),
+    },
+    async ({ repoId, pattern, directory, maxResults, sessionId, clientId }) => {
+      const sid = sessionId ?? randomUUID();
+
+      const repo = await db.codeRepo.findUnique({
+        where: { id: repoId },
+        select: { clientId: true, name: true },
+      });
+      if (!repo) {
+        return {
+          content: [{ type: 'text' as const, text: `Repository not found: ${repoId}` }],
+          isError: true,
+        };
+      }
+      if (clientId && repo.clientId !== clientId) {
+        return {
+          content: [{ type: 'text' as const, text: 'Access denied: repository does not belong to the specified client.' }],
+          isError: true,
+        };
+      }
+
+      const safeDir = sanitizeDirectory(directory ?? '.');
+      if (!safeDir) {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid directory: ${directory}` }],
+          isError: true,
+        };
+      }
+
+      const effectivePattern = pattern && /^[A-Za-z0-9._*?\[\]/-]+$/.test(pattern) ? pattern : '*';
+      const cap = Math.min(Math.max(maxResults ?? 200, 1), 2000);
+
+      const command = `find ${shellQuote(safeDir)} -type f -name ${shellQuote(effectivePattern)}`;
+
+      try {
+        const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
+        const result = await executeCommand(command, worktreePath);
+
+        if (result.exitCode !== 0) {
+          const stderr = result.stderr || '(no stderr)';
+          return {
+            content: [{ type: 'text' as const, text: `list_files error on ${repo.name}: exit=${result.exitCode}\n${stderr}` }],
+            isError: true,
+          };
+        }
+
+        const allPaths = result.stdout.split('\n').filter(l => l.length > 0);
+        const total = allPaths.length;
+        const slice = allPaths.slice(0, cap);
+        const footer = `\n\n[returned ${slice.length} of total ${total} matching]`;
+        const text = slice.length > 0
+          ? slice.join('\n') + footer
+          : `[returned 0 of total 0 matching]`;
+
+        return {
+          content: [{ type: 'text' as const, text }],
+          isError: false,
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/mcp-servers/repo/src/tools/prepare-repo.ts
+++ b/mcp-servers/repo/src/tools/prepare-repo.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PrismaClient } from '@bronco/db';
+import type { RepoManager } from '../repo-manager.js';
+
+export function registerPrepareRepoTool(
+  server: McpServer,
+  deps: { db: PrismaClient; repoManager: RepoManager },
+): void {
+  const { repoManager } = deps;
+
+  server.tool(
+    'prepare_repo',
+    'Ensure the bare clone for a repository is fetched and up to date. Called during pre-gather to warm the repo cache.',
+    {
+      repoId: z.string().uuid().describe('The CodeRepo ID'),
+    },
+    async ({ repoId }) => {
+      try {
+        await repoManager.clone(repoId);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ status: 'ready', message: `Repo ${repoId} is ready` }) }],
+          isError: false,
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ status: 'failed', message }) }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/mcp-servers/repo/src/tools/prepare-repo.ts
+++ b/mcp-servers/repo/src/tools/prepare-repo.ts
@@ -7,16 +7,32 @@ export function registerPrepareRepoTool(
   server: McpServer,
   deps: { db: PrismaClient; repoManager: RepoManager },
 ): void {
-  const { repoManager } = deps;
+  const { db, repoManager } = deps;
 
   server.tool(
     'prepare_repo',
     'Ensure the bare clone for a repository is fetched and up to date. Called during pre-gather to warm the repo cache.',
     {
       repoId: z.string().uuid().describe('The CodeRepo ID'),
+      clientId: z.string().uuid().optional().describe('Optional client ID used to validate repository ownership'),
     },
-    async ({ repoId }) => {
+    async ({ repoId, clientId }) => {
       try {
+        // Defense-in-depth: mirror the ownership check used by the other per-repo
+        // tools (repo_exec, search_code, read_file, list_files). prepare_repo is
+        // callable over MCP even though it isn't registered as an agentic tool.
+        if (clientId) {
+          const repo = await db.codeRepo.findUnique({
+            where: { id: repoId },
+            select: { clientId: true },
+          });
+          if (!repo || repo.clientId !== clientId) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({ status: 'failed', message: 'Access denied: repository does not belong to the specified client.' }) }],
+              isError: true,
+            };
+          }
+        }
         await repoManager.clone(repoId);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ status: 'ready', message: `Repo ${repoId} is ready` }) }],

--- a/mcp-servers/repo/src/tools/read-file.ts
+++ b/mcp-servers/repo/src/tools/read-file.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
+import { open, stat } from 'node:fs/promises';
+import { isAbsolute, join, resolve, relative } from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PrismaClient } from '@bronco/db';
 import type { RepoManager } from '../repo-manager.js';
-import { executeCommand } from '../command-validator.js';
 
 const DEFAULT_LIMIT = 4000;
 const MAX_LIMIT = 16_000;
@@ -17,10 +18,6 @@ function sanitizeFilePath(fp: string): string | null {
   const normalized = fp.replace(/\\/g, '/');
   if (normalized.split('/').some(seg => seg === '..')) return null;
   return normalized.replace(/^\.\//, '');
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function describeRepo(repo: { description: string | null }): string {
@@ -77,37 +74,76 @@ export function registerReadFileTool(
 
       try {
         const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
-        const result = await executeCommand(`cat ${shellQuote(safePath)}`, worktreePath);
-
-        if (result.exitCode !== 0) {
-          const stderr = result.stderr || '(no stderr)';
+        // Resolve absolute path and verify it's still inside the worktree —
+        // belt-and-suspenders alongside sanitizeFilePath (guards against symlinks
+        // escaping via `..` that survive the string-level check).
+        const absolutePath = resolve(join(worktreePath, safePath));
+        const relToWorktree = relative(worktreePath, absolutePath);
+        if (relToWorktree === '' || relToWorktree.startsWith('..') || isAbsolute(relToWorktree)) {
           return {
-            content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] read_file error on ${repo.name}:${safePath}: exit=${result.exitCode}\n${stderr}` }],
+            content: [{ type: 'text' as const, text: `Invalid file path: ${filePath}` }],
             isError: true,
           };
         }
 
-        const fullContent = result.stdout;
-        const totalChars = fullContent.length;
-        const slice = fullContent.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+        // Stat first so we report the real total file size regardless of slice.
+        let fileStat;
+        try {
+          fileStat = await stat(absolutePath);
+        } catch (err) {
+          return {
+            content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] read_file error on ${repo.name}:${safePath}: ${err instanceof Error ? err.message : String(err)}` }],
+            isError: true,
+          };
+        }
+        if (!fileStat.isFile()) {
+          return {
+            content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] read_file error on ${repo.name}:${safePath}: not a regular file` }],
+            isError: true,
+          };
+        }
+        const totalChars = fileStat.size;
 
-        // Number the lines for the slice. Line numbers are relative to the file start,
-        // so we need to count newlines before the offset to get the starting line number.
-        const startLine = effectiveOffset === 0
-          ? 1
-          : fullContent.slice(0, effectiveOffset).split('\n').length;
+        // Bounded read: allocate only the slice. Read at position=offset so a
+        // 1GB file with offset=10MB, limit=4k reads only 4k bytes.
+        const fh = await open(absolutePath, 'r');
+        try {
+          const sliceBuffer = Buffer.alloc(effectiveLimit);
+          const { bytesRead } = await fh.read(sliceBuffer, 0, effectiveLimit, effectiveOffset);
+          const slice = sliceBuffer.slice(0, bytesRead).toString('utf8');
 
-        const numbered = slice
-          .split('\n')
-          .map((line, idx) => `${startLine + idx}: ${line}`)
-          .join('\n');
+          // Compute startLine by streaming the prefix [0, offset) once.
+          // Counts newlines directly to avoid holding the prefix in memory.
+          let startLine = 1;
+          if (effectiveOffset > 0) {
+            const PREFIX_CHUNK = 64 * 1024;
+            const prefixBuf = Buffer.alloc(PREFIX_CHUNK);
+            let pos = 0;
+            while (pos < effectiveOffset) {
+              const readLen = Math.min(PREFIX_CHUNK, effectiveOffset - pos);
+              const r = await fh.read(prefixBuf, 0, readLen, pos);
+              if (r.bytesRead === 0) break;
+              for (let i = 0; i < r.bytesRead; i++) {
+                if (prefixBuf[i] === 0x0a /* \n */) startLine++;
+              }
+              pos += r.bytesRead;
+            }
+          }
 
-        const footer = `\n\n[returned ${slice.length} chars at offset ${effectiveOffset} of total ${totalChars}]`;
+          const numbered = slice
+            .split('\n')
+            .map((line, idx) => `${startLine + idx}: ${line}`)
+            .join('\n');
 
-        return {
-          content: [{ type: 'text' as const, text: numbered + footer }],
-          isError: false,
-        };
+          const footer = `\n\n[returned ${bytesRead} chars at offset ${effectiveOffset} of total ${totalChars}]`;
+
+          return {
+            content: [{ type: 'text' as const, text: numbered + footer }],
+            isError: false,
+          };
+        } finally {
+          await fh.close();
+        }
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],

--- a/mcp-servers/repo/src/tools/read-file.ts
+++ b/mcp-servers/repo/src/tools/read-file.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PrismaClient } from '@bronco/db';
+import type { RepoManager } from '../repo-manager.js';
+import { executeCommand } from '../command-validator.js';
+
+const DEFAULT_LIMIT = 4000;
+const MAX_LIMIT = 16_000;
+
+/**
+ * Mirror of the sanitizeFilePath helper in ticket-analyzer — rejects absolute
+ * paths, path-traversal segments, and strips a leading `./`.
+ */
+function sanitizeFilePath(fp: string): string | null {
+  if (!fp || fp.startsWith('/')) return null;
+  const normalized = fp.replace(/\\/g, '/');
+  if (normalized.split('/').some(seg => seg === '..')) return null;
+  return normalized.replace(/^\.\//, '');
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function describeRepo(repo: { description: string | null }): string {
+  return repo.description ? repo.description : 'Code repository';
+}
+
+export function registerReadFileTool(
+  server: McpServer,
+  deps: { db: PrismaClient; repoManager: RepoManager },
+): void {
+  const { db, repoManager } = deps;
+
+  server.tool(
+    'read_file',
+    'Read the contents of a specific file in a registered code repository. Supports offset/limit paging for large files. Use this after search_code locates a file you want to inspect.',
+    {
+      repoId: z.string().uuid().describe('The CodeRepo ID'),
+      filePath: z.string().min(1).describe('Repo-relative path to the file'),
+      offset: z.number().int().nonnegative().optional().describe('Character offset to start reading from (default 0)'),
+      limit: z.number().int().positive().optional().describe('Max chars to return (default 4000, max 16000)'),
+      sessionId: z.string().optional().describe('Session ID for worktree reuse (auto-generated if omitted)'),
+      clientId: z.string().uuid().optional().describe('Client ID for ownership validation'),
+    },
+    async ({ repoId, filePath, offset, limit, sessionId, clientId }) => {
+      const sid = sessionId ?? randomUUID();
+
+      const repo = await db.codeRepo.findUnique({
+        where: { id: repoId },
+        select: { clientId: true, name: true, description: true },
+      });
+      if (!repo) {
+        return {
+          content: [{ type: 'text' as const, text: `Repository not found: ${repoId}` }],
+          isError: true,
+        };
+      }
+      if (clientId && repo.clientId !== clientId) {
+        return {
+          content: [{ type: 'text' as const, text: 'Access denied: repository does not belong to the specified client.' }],
+          isError: true,
+        };
+      }
+
+      const safePath = sanitizeFilePath(filePath);
+      if (!safePath) {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid file path: ${filePath}` }],
+          isError: true,
+        };
+      }
+
+      const effectiveOffset = Math.max(offset ?? 0, 0);
+      const effectiveLimit = Math.min(Math.max(limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+      try {
+        const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
+        const result = await executeCommand(`cat ${shellQuote(safePath)}`, worktreePath);
+
+        if (result.exitCode !== 0) {
+          const stderr = result.stderr || '(no stderr)';
+          return {
+            content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] read_file error on ${repo.name}:${safePath}: exit=${result.exitCode}\n${stderr}` }],
+            isError: true,
+          };
+        }
+
+        const fullContent = result.stdout;
+        const totalChars = fullContent.length;
+        const slice = fullContent.slice(effectiveOffset, effectiveOffset + effectiveLimit);
+
+        // Number the lines for the slice. Line numbers are relative to the file start,
+        // so we need to count newlines before the offset to get the starting line number.
+        const startLine = effectiveOffset === 0
+          ? 1
+          : fullContent.slice(0, effectiveOffset).split('\n').length;
+
+        const numbered = slice
+          .split('\n')
+          .map((line, idx) => `${startLine + idx}: ${line}`)
+          .join('\n');
+
+        const footer = `\n\n[returned ${slice.length} chars at offset ${effectiveOffset} of total ${totalChars}]`;
+
+        return {
+          content: [{ type: 'text' as const, text: numbered + footer }],
+          isError: false,
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/mcp-servers/repo/src/tools/search-code.ts
+++ b/mcp-servers/repo/src/tools/search-code.ts
@@ -87,10 +87,12 @@ export function registerSearchCodeTool(
         }
       }
 
+      // Use `-e` so patterns beginning with `-` are not treated as grep options.
       const command = [
         'grep',
         ...flags,
         ...includeArgs,
+        '-e',
         shellQuote(query),
         '.',
       ].join(' ');

--- a/mcp-servers/repo/src/tools/search-code.ts
+++ b/mcp-servers/repo/src/tools/search-code.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod';
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { PrismaClient } from '@bronco/db';
+import type { RepoManager } from '../repo-manager.js';
+import { executeCommand } from '../command-validator.js';
+
+const DEFAULT_FILE_EXTENSIONS = [
+  '.cs', '.sql', '.ts', '.tsx', '.js', '.jsx',
+  '.cshtml', '.razor', '.aspx', '.xml', '.config',
+  '.json', '.yaml', '.yml', '.md', '.py', '.go',
+  '.java', '.rb', '.rs', '.php',
+] as const;
+
+const MAX_OUTPUT_CHARS = 40_000;
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function describeRepo(repo: { name: string; description: string | null }): string {
+  return repo.description ? repo.description : 'Code repository';
+}
+
+export function registerSearchCodeTool(
+  server: McpServer,
+  deps: { db: PrismaClient; repoManager: RepoManager },
+): void {
+  const { db, repoManager } = deps;
+
+  server.tool(
+    'search_code',
+    'Search for code patterns, symbols, class names, SQL procedure definitions, configuration keys, or any text across a registered code repository. Prefer this over run_custom_query when looking for object definitions, code references, or configuration values — only fall back to database queries when the repo lookup returns nothing.',
+    {
+      repoId: z.string().uuid().describe('The CodeRepo ID'),
+      query: z.string().min(1).describe('Text or regex pattern to search for'),
+      filePattern: z.string().optional().describe('Optional glob filter (e.g. "*.cs")'),
+      fileExtensions: z.array(z.string()).optional().describe('Only include files matching these extensions (e.g. [".ts", ".sql"]). Falls back to the repo\'s configured extensions, or a sensible default list.'),
+      caseSensitive: z.boolean().optional().describe('Case-sensitive match (default false)'),
+      wordBoundary: z.boolean().optional().describe('Whole-word match (default false)'),
+      maxResults: z.number().int().positive().optional().describe('Cap on returned matches (default 100)'),
+      sessionId: z.string().optional().describe('Session ID for worktree reuse (auto-generated if omitted)'),
+      clientId: z.string().uuid().optional().describe('Client ID for ownership validation'),
+    },
+    async ({ repoId, query, filePattern, fileExtensions, caseSensitive, wordBoundary, maxResults, sessionId, clientId }) => {
+      const sid = sessionId ?? randomUUID();
+
+      const repo = await db.codeRepo.findUnique({
+        where: { id: repoId },
+        select: { clientId: true, name: true, description: true, fileExtensions: true },
+      });
+      if (!repo) {
+        return {
+          content: [{ type: 'text' as const, text: `Repository not found: ${repoId}` }],
+          isError: true,
+        };
+      }
+      if (clientId && repo.clientId !== clientId) {
+        return {
+          content: [{ type: 'text' as const, text: 'Access denied: repository does not belong to the specified client.' }],
+          isError: true,
+        };
+      }
+
+      const cap = Math.min(Math.max(maxResults ?? 100, 1), 500);
+      const effectiveExtensions = (fileExtensions && fileExtensions.length > 0)
+        ? fileExtensions
+        : (repo.fileExtensions && repo.fileExtensions.length > 0)
+          ? repo.fileExtensions
+          : [...DEFAULT_FILE_EXTENSIONS];
+
+      const flags: string[] = ['-rn', '-I'];
+      if (!caseSensitive) flags.push('-i');
+      if (wordBoundary) flags.push('-w');
+
+      const includeArgs = effectiveExtensions
+        .map(ext => {
+          const clean = ext.startsWith('.') ? ext.slice(1) : ext;
+          if (!/^[A-Za-z0-9._-]+$/.test(clean)) return null;
+          return `--include=*.${clean}`;
+        })
+        .filter((v): v is string => v !== null);
+
+      if (filePattern) {
+        if (/^[A-Za-z0-9._*?\[\]/-]+$/.test(filePattern)) {
+          includeArgs.push(`--include=${filePattern}`);
+        }
+      }
+
+      const command = [
+        'grep',
+        ...flags,
+        ...includeArgs,
+        shellQuote(query),
+        '.',
+      ].join(' ');
+
+      try {
+        const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
+        const result = await executeCommand(command, worktreePath);
+
+        // grep exits 1 when no match — not an error for us
+        if (result.exitCode !== 0 && result.exitCode !== 1) {
+          const stderr = result.stderr || '(no stderr)';
+          return {
+            content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code error on ${repo.name}: exit=${result.exitCode}\n${stderr}` }],
+            isError: true,
+          };
+        }
+
+        const lines = result.stdout.split('\n').filter(l => l.length > 0);
+        const files = new Set<string>();
+        const outputLines: string[] = [];
+        for (const line of lines) {
+          if (outputLines.length >= cap) break;
+          // grep -rn output format: ./path/to/file:<lineNo>:<matchingLine>
+          const match = line.match(/^\.?\/?([^:]+):(\d+):(.*)$/);
+          if (match) {
+            const filePath = match[1];
+            const lineNumber = match[2];
+            const matchingLine = match[3];
+            files.add(filePath);
+            outputLines.push(`${filePath}:${lineNumber}: ${matchingLine}`);
+          } else {
+            outputLines.push(line);
+          }
+        }
+
+        const truncatedNote = lines.length > cap ? ` (truncated — ${lines.length - cap} more)` : '';
+        const footer = outputLines.length > 0
+          ? `\n\n[found ${outputLines.length} matches across ${files.size} files${truncatedNote}]`
+          : `[found 0 matches]`;
+
+        let text = outputLines.length > 0
+          ? outputLines.join('\n') + footer
+          : footer;
+
+        if (text.length > MAX_OUTPUT_CHARS) {
+          text = text.slice(0, MAX_OUTPUT_CHARS) + '\n\n[output truncated — exceeded 40,000 characters]';
+        }
+
+        return {
+          content: [{ type: 'text' as const, text }],
+          isError: false,
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/packages/db/prisma/migrations/20260421030000_add_code_repo_file_extensions/migration.sql
+++ b/packages/db/prisma/migrations/20260421030000_add_code_repo_file_extensions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "code_repos" ADD COLUMN "file_extensions" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -514,6 +514,7 @@ model CodeRepo {
   defaultBranch String   @default("master") @map("default_branch")
   branchPrefix  String   @default("claude") @map("branch_prefix")
   description   String?  @map("description")
+  fileExtensions String[] @default([]) @map("file_extensions")
   isActive      Boolean  @default(true) @map("is_active")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")

--- a/packages/shared-types/src/code-repo.ts
+++ b/packages/shared-types/src/code-repo.ts
@@ -45,6 +45,8 @@ export interface CodeRepo {
   repoUrl: string;
   defaultBranch: string;
   branchPrefix: string;
+  description: string | null;
+  fileExtensions: string[];
   environmentId: string | null;
   isActive: boolean;
   createdAt: Date;

--- a/services/ticket-analyzer/src/analysis/flat.ts
+++ b/services/ticket-analyzer/src/analysis/flat.ts
@@ -10,6 +10,7 @@ import type {
   AIToolUseBlock,
 } from '@bronco/shared-types';
 import {
+  buildRepoNudgeSnippet,
   buildTruncatedPreview,
   executeAgenticToolCall,
   getToolResultMaxTokens,
@@ -20,6 +21,7 @@ import {
   REQUEST_NEW_TOOL_SNIPPET,
   SUFFICIENCY_EVAL_INSTRUCTIONS,
   TRUNCATION_SYSTEM_PROMPT_SNIPPET,
+  type AgenticRepoInfo,
   type AnalysisDeps,
   type AnalysisPipelineContext,
   type AnalysisResult,
@@ -37,6 +39,7 @@ export interface AgenticToolContext {
   tools: AIToolDefinition[];
   mcpIntegrations: Map<string, McpIntegrationInfo>;
   repoIdByPrefix: Map<string, string>;
+  repos: AgenticRepoInfo[];
 }
 
 /**
@@ -54,7 +57,7 @@ export async function runFlatAnalysis(
   const { db, ai, appLog, artifactStoragePath } = deps;
   const { ticketId, clientId, category, priority, emailSubject, emailBody, clientContext, environmentContext, codeContext, dbContext, facts, summary } = ctx;
   const { maxIterations, reanalysisCtx } = opts;
-  const { tools: agenticTools, mcpIntegrations, repoIdByPrefix } = tools;
+  const { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: clientRepos } = tools;
 
   const stepConfig = step.config as { systemPromptOverride?: string } | null;
 
@@ -115,6 +118,8 @@ export async function runFlatAnalysis(
   systemParts.push(TRUNCATION_SYSTEM_PROMPT_SNIPPET);
   systemParts.push(PREFER_EXISTING_TOOLS_SNIPPET);
   systemParts.push(REQUEST_NEW_TOOL_SNIPPET);
+  const repoNudge = buildRepoNudgeSnippet(clientRepos);
+  if (repoNudge) systemParts.push(repoNudge);
 
   const agenticSystemPrompt = systemParts.join('\n');
 

--- a/services/ticket-analyzer/src/analysis/orchestrated.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated.ts
@@ -8,6 +8,7 @@ import type {
 } from '@bronco/shared-types';
 import {
   buildArtifactCatalog,
+  buildRepoNudgeSnippet,
   buildTruncatedPreview,
   chunkArray,
   executeAgenticToolCall,
@@ -343,7 +344,7 @@ export async function runOrchestratedAnalysis(
   const { maxIterations: orchMaxIterations, existingKnowledgeDoc, reanalysisCtx } = opts;
   const reanalysisMode = reanalysisCtx?.mode ?? ReanalysisMode.CONTINUE;
   const isReanalysis = !!reanalysisCtx && reanalysisMode !== ReanalysisMode.FRESH_START;
-  const { tools: agenticTools, mcpIntegrations, repoIdByPrefix } = tools;
+  const { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: clientRepos } = tools;
 
   const defaultMaxTokens = await deps.loadDefaultMaxTokens?.() ?? undefined;
   const toolResultMaxTokens = await getToolResultMaxTokens(db);
@@ -463,7 +464,7 @@ export async function runOrchestratedAnalysis(
       taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
       context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1, logId: strategistLogId },
       prompt: strategistPrompt,
-      systemPrompt: `${ORCHESTRATED_SYSTEM_PROMPT}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}`,
+      systemPrompt: `${ORCHESTRATED_SYSTEM_PROMPT}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}${buildRepoNudgeSnippet(clientRepos)}`,
       providerOverride: 'CLAUDE',
       modelOverride: 'claude-opus-4-6',
       maxTokens: defaultMaxTokens ?? 4096,

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -171,6 +171,38 @@ export const TRUNCATION_SYSTEM_PROMPT_SNIPPET = [
 ].join('\n');
 
 /**
+ * Canonical file extensions considered "code" when pre-gathering repo context
+ * and when the MCP search_code tool is called without explicit extensions and
+ * the repo has no per-repo override configured.
+ */
+export const DEFAULT_REPO_FILE_EXTENSIONS = [
+  '.cs', '.sql', '.ts', '.tsx', '.js', '.jsx',
+  '.cshtml', '.razor', '.aspx', '.xml', '.config',
+  '.json', '.yaml', '.yml', '.md', '.py', '.go',
+  '.java', '.rb', '.rs', '.php',
+] as const;
+
+/**
+ * Compose a short system-prompt snippet that nudges the agent toward the
+ * per-repo `search_code` / `read_file` tools when the client has active
+ * repositories. Returns empty string when there are no repos, so callers can
+ * unconditionally append.
+ */
+export function buildRepoNudgeSnippet(repos: Array<{ name: string; description?: string | null }>): string {
+  if (repos.length === 0) return '';
+  const names = repos.map(r => r.name).join(', ');
+  const plural = repos.length === 1 ? 'repository' : 'repositories';
+  return [
+    '',
+    `This client has ${repos.length} code ${plural} registered (${names}).`,
+    'When investigating object definitions, code behavior, configuration, or "where is X',
+    'defined / used," prefer the `<repo>__search_code` and `<repo>__read_file` tools over',
+    'database queries. Only use `run_custom_query` to inspect database objects when the',
+    'repo lookup returns nothing.',
+  ].join('\n');
+}
+
+/**
  * Nudges the agent to scan the available tool list before falling back to
  * generic tools like `run_custom_query`. Pairs with REQUEST_NEW_TOOL_SNIPPET
  * so gaps get surfaced as tool requests rather than silently improvised.
@@ -224,6 +256,13 @@ export interface McpIntegrationInfo {
  * and code repositories (via mcp-repo). MCP tool names are prefixed with the
  * integration label to disambiguate across servers (e.g. `prod-db__get_blocking_tree`).
  */
+export interface AgenticRepoInfo {
+  id: string;
+  name: string;
+  description: string | null;
+  prefix: string;
+}
+
 export async function buildAgenticTools(
   db: PrismaClient,
   clientId: string,
@@ -236,10 +275,12 @@ export async function buildAgenticTools(
   tools: AIToolDefinition[];
   mcpIntegrations: Map<string, McpIntegrationInfo>;
   repoIdByPrefix: Map<string, string>;
+  repos: AgenticRepoInfo[];
 }> {
   const tools: AIToolDefinition[] = [];
   const mcpIntegrations = new Map<string, McpIntegrationInfo>();
   const repoIdByPrefix = new Map<string, string>();
+  const repoInfos: AgenticRepoInfo[] = [];
 
   // Collect MCP_DATABASE integrations
   const integrations = await db.clientIntegration.findMany({
@@ -325,18 +366,71 @@ export async function buildAgenticTools(
       },
     });
 
-    // Register per-repo repo_exec tools with repoId baked in
+    // Register per-repo tools with repoId baked in
     for (const repo of repos) {
       const prefix = `repo-${repo.name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()}-${repo.id.slice(0, 8)}`;
       repoIdByPrefix.set(prefix, repo.id);
+      repoInfos.push({ id: repo.id, name: repo.name, description: repo.description, prefix });
+      const repoDescription = repo.description || 'Code repository';
 
       // Register this prefix to point at mcp-repo
       mcpIntegrations.set(prefix, { label: `repo:${repo.name}`, url: mcpRepoUrl, mcpPath: '/mcp', apiKey: repoAuth, authHeader: repoAuthHeader });
 
-      // Build a modified input schema for repo_exec with repoId removed
+      // search_code — purpose-built grep
+      tools.push({
+        name: `${prefix}__search_code`,
+        description: `[${repo.name}] Search for code patterns, symbols, class names, SQL procedure definitions, configuration keys, or any text across the ${repoDescription} codebase. Prefer this over run_custom_query when looking for object definitions, code references, or configuration values — only fall back to database queries when the repo lookup returns nothing.`,
+        input_schema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Text or regex pattern to search for' },
+            filePattern: { type: 'string', description: 'Optional glob filter (e.g. "*.cs")' },
+            fileExtensions: { type: 'array', items: { type: 'string' }, description: 'Only include files matching these extensions' },
+            caseSensitive: { type: 'boolean', description: 'Case-sensitive match (default false)' },
+            wordBoundary: { type: 'boolean', description: 'Whole-word match (default false)' },
+            maxResults: { type: 'number', description: 'Cap on returned matches (default 100)' },
+            sessionId: { type: 'string', description: 'Session ID for worktree reuse' },
+          },
+          required: ['query'],
+        },
+      });
+
+      // read_file — purpose-built cat with paging
+      tools.push({
+        name: `${prefix}__read_file`,
+        description: `[${repo.name}] Read the contents of a specific file in the ${repoDescription} codebase. Supports offset/limit paging for large files. Use this after search_code locates a file you want to inspect.`,
+        input_schema: {
+          type: 'object',
+          properties: {
+            filePath: { type: 'string', description: 'Repo-relative path to the file' },
+            offset: { type: 'number', description: 'Character offset to start reading from (default 0)' },
+            limit: { type: 'number', description: 'Max chars to return (default 4000, max 16000)' },
+            sessionId: { type: 'string', description: 'Session ID for worktree reuse' },
+          },
+          required: ['filePath'],
+        },
+      });
+
+      // list_files — purpose-built find
+      tools.push({
+        name: `${prefix}__list_files`,
+        description: `[${repo.name}] List files in the ${repoDescription} codebase, optionally filtered by glob pattern or directory. Use this for discovery when you aren't sure what files exist.`,
+        input_schema: {
+          type: 'object',
+          properties: {
+            pattern: { type: 'string', description: 'Glob pattern to match (default "*")' },
+            directory: { type: 'string', description: 'Directory to search within (default ".")' },
+            maxResults: { type: 'number', description: 'Cap on returned paths (default 200)' },
+            sessionId: { type: 'string', description: 'Session ID for worktree reuse' },
+          },
+          required: [],
+        },
+      });
+
+      // repo_exec — escape hatch retained unchanged
       tools.push({
         name: `${prefix}__repo_exec`,
-        description: `[${repo.name}] ${repo.description || 'Code repository'}. Execute a read-only shell command in a sandboxed worktree. Allowed: grep, find, cat, head, tail, ls, tree, diff, stat. Pipes to grep/sed/awk/sort allowed.`,
+        description: `[${repo.name}] ${repoDescription}. Execute a read-only shell command in a sandboxed worktree. Allowed: grep, find, cat, head, tail, ls, tree, diff, stat. Pipes to grep/sed/awk/sort allowed.`,
         input_schema: {
           type: 'object',
           properties: {
@@ -375,7 +469,7 @@ export async function buildAgenticTools(
     },
   });
 
-  return { tools, mcpIntegrations, repoIdByPrefix };
+  return { tools, mcpIntegrations, repoIdByPrefix, repos: repoInfos };
 }
 
 /**
@@ -404,11 +498,12 @@ export async function executeAgenticToolCall(
       return { toolUseId, result: `No MCP integration found for prefix "${prefix}"`, isError: true };
     }
 
-    // For repo_exec, inject the baked-in repoId and clientId for defense-in-depth
+    // For per-repo tools, inject the baked-in repoId and clientId for defense-in-depth
     // For list_repos, inject clientId to prevent cross-client repo enumeration
     // For read_tool_result_artifact, inject ticketId as the auth scope (overwrite any agent-supplied value)
+    const PER_REPO_TOOLS = new Set(['repo_exec', 'search_code', 'read_file', 'list_files']);
     let toolInput = input;
-    if (actualToolName === 'repo_exec') {
+    if (PER_REPO_TOOLS.has(actualToolName)) {
       const repoId = repoIdByPrefix.get(prefix);
       if (repoId) {
         toolInput = { ...input, repoId, ...(clientId ? { clientId } : {}) };

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1857,8 +1857,9 @@ async function executeRoutePipeline(
 
       case RouteStepType.GATHER_REPO_CONTEXT: {
         if (!ticket) break;
+        const ticketClientId = ticket.clientId;
         // Query client repos via CodeRepo model
-        const clientRepos = await db.codeRepo.findMany({ where: { clientId: ticket.clientId, isActive: true } });
+        const clientRepos = await db.codeRepo.findMany({ where: { clientId: ticketClientId, isActive: true } });
         if (clientRepos.length === 0) break;
 
         const gatherSessionId = `gather-${ticketId}`;
@@ -1867,23 +1868,49 @@ async function executeRoutePipeline(
         const repoAuthHeader = deps.mcpAuthToken ? 'bearer' : 'x-api-key';
 
         // Pre-pull all repos in parallel so the per-repo search loop doesn't
-        // block serially on cold clones.
+        // block serially on cold clones. `callMcpToolViaSdk` resolves on both
+        // success and MCP-level tool errors, so we also parse the JSON body
+        // to detect a { status: 'failed' } response and bump prePullFailed.
         const prePullResults = await Promise.allSettled(
           clientRepos.map(r =>
-            callMcpToolViaSdk(mcpRepoUrl, '/mcp', 'prepare_repo', { repoId: r.id }, repoAuth, repoAuthHeader),
+            callMcpToolViaSdk(mcpRepoUrl, '/mcp', 'prepare_repo', { repoId: r.id, clientId: ticketClientId }, repoAuth, repoAuthHeader),
           ),
         );
-        const prePullSucceeded = prePullResults.filter(r => r.status === 'fulfilled').length;
-        const prePullFailed = prePullResults.length - prePullSucceeded;
+        let prePullSucceeded = 0;
+        let prePullFailed = 0;
         prePullResults.forEach((r, idx) => {
+          const repoName = clientRepos[idx]?.name ?? '(unknown)';
           if (r.status === 'rejected') {
-            const repoName = clientRepos[idx]?.name ?? '(unknown)';
+            prePullFailed++;
             const errMsg = redactUrls(r.reason instanceof Error ? r.reason.message : String(r.reason));
             appLog.warn(
               `prepare_repo failed for ${repoName}: ${errMsg}`,
               { ticketId, repo: repoName, err: r.reason },
               ticketId, 'ticket',
             );
+            return;
+          }
+          // Successful transport — still inspect the JSON body for tool-level failure.
+          let toolFailed = false;
+          let toolMessage = '';
+          try {
+            const parsed = JSON.parse(r.value) as { status?: string; message?: string };
+            if (parsed && parsed.status === 'failed') {
+              toolFailed = true;
+              toolMessage = typeof parsed.message === 'string' ? parsed.message : '';
+            }
+          } catch {
+            // Non-JSON body (shouldn't happen) — treat as opaque success.
+          }
+          if (toolFailed) {
+            prePullFailed++;
+            appLog.warn(
+              `prepare_repo reported failure for ${repoName}: ${redactUrls(toolMessage)}`,
+              { ticketId, repo: repoName, message: toolMessage },
+              ticketId, 'ticket',
+            );
+          } else {
+            prePullSucceeded++;
           }
         });
 
@@ -1920,21 +1947,34 @@ async function executeRoutePipeline(
               if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
               const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
               try {
+                // Use `-e` so patterns beginning with `-` are not treated as grep options.
                 const grepResult = await callMcpToolViaSdk(
                   mcpRepoUrl, '/mcp', 'repo_exec',
-                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnilI "${sanitized.replace(/"/g, '\\"')}" .` },
+                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnilI -e "${sanitized.replace(/"/g, '\\"')}" .` },
                   repoAuth, repoAuthHeader,
                 );
-                // Parse file paths from stdout (skip the [session:...] line)
-                let matchedAny = false;
-                for (const line of grepResult.split('\n')) {
-                  const trimmed = line.trim();
-                  if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]') && exts.some(e => trimmed.endsWith(e))) {
-                    relevantFiles.add(trimmed);
-                    matchedAny = true;
+                // `callMcpToolViaSdk` doesn't surface MCP-level isError. `repo_exec`
+                // emits distinct markers we can use to separate real errors from
+                // the "grep exited 1 with no output" no-match case.
+                if (grepResult.startsWith('Command rejected:') || grepResult.startsWith('Error:') || grepResult.includes('[stderr]')) {
+                  grepErrors++;
+                  appLog.warn(
+                    `search_code pre-gather error for ${repo.name}:${rawTerm}`,
+                    { ticketId, repo: repo.name, term: rawTerm, result: grepResult.slice(0, 500) },
+                    ticketId, 'ticket',
+                  );
+                } else {
+                  // Parse file paths from stdout (skip the [session:...] line)
+                  let matchedAny = false;
+                  for (const line of grepResult.split('\n')) {
+                    const trimmed = line.trim();
+                    if (trimmed && !trimmed.startsWith('[session:') && exts.some(e => trimmed.endsWith(e))) {
+                      relevantFiles.add(trimmed);
+                      matchedAny = true;
+                    }
                   }
+                  if (!matchedAny) grepNoMatch++;
                 }
-                if (!matchedAny) grepNoMatch++;
               } catch (err) {
                 grepErrors++;
                 appLog.warn(

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -14,6 +14,7 @@ import { executeRecommendations } from './recommendation-executor.js';
 import type { ParsedAction } from './recommendation-executor.js';
 import {
   buildAgenticTools,
+  DEFAULT_REPO_FILE_EXTENSIONS,
   parseSufficiencyEvaluation,
   resolveAnalysisStrategy,
   SUFFICIENCY_EVAL_INSTRUCTIONS,
@@ -1865,13 +1866,54 @@ async function executeRoutePipeline(
         const repoAuth = deps.mcpAuthToken || deps.apiKey;
         const repoAuthHeader = deps.mcpAuthToken ? 'bearer' : 'x-api-key';
 
+        // Pre-pull all repos in parallel so the per-repo search loop doesn't
+        // block serially on cold clones.
+        const prePullResults = await Promise.allSettled(
+          clientRepos.map(r =>
+            callMcpToolViaSdk(mcpRepoUrl, '/mcp', 'prepare_repo', { repoId: r.id }, repoAuth, repoAuthHeader),
+          ),
+        );
+        const prePullSucceeded = prePullResults.filter(r => r.status === 'fulfilled').length;
+        const prePullFailed = prePullResults.length - prePullSucceeded;
+        prePullResults.forEach((r, idx) => {
+          if (r.status === 'rejected') {
+            const repoName = clientRepos[idx]?.name ?? '(unknown)';
+            const errMsg = redactUrls(r.reason instanceof Error ? r.reason.message : String(r.reason));
+            appLog.warn(
+              `prepare_repo failed for ${repoName}: ${errMsg}`,
+              { ticketId, repo: repoName, err: r.reason },
+              ticketId, 'ticket',
+            );
+          }
+        });
+
+        let grepErrors = 0;
+        let grepNoMatch = 0;
+
         for (const repo of clientRepos) {
           try {
-            const searchTerms = [
+            // Start with extracted-fact search terms, capped at 10.
+            let searchTerms = [
               ...(facts.keywords ?? []),
               ...(facts.filesMentioned ?? []),
               ...(facts.errorMessages?.map((e) => e.slice(0, 60)) ?? []),
-            ].slice(0, 5);
+            ].slice(0, 10);
+
+            // If we have fewer than 3 usable terms, back-fill from the email
+            // subject — split on whitespace, drop tokens < 3 chars or
+            // punctuation-only, take up to 5 extra terms.
+            if (searchTerms.length < 3) {
+              const subjectTokens = (emailSubject || '')
+                .split(/\s+/)
+                .map(t => t.trim())
+                .filter(t => t.length >= 3 && /[A-Za-z0-9]/.test(t))
+                .slice(0, 5);
+              searchTerms = [...searchTerms, ...subjectTokens].slice(0, 10);
+            }
+
+            const exts = (repo.fileExtensions && repo.fileExtensions.length > 0)
+              ? repo.fileExtensions
+              : [...DEFAULT_REPO_FILE_EXTENSIONS];
 
             const relevantFiles = new Set<string>();
             for (const rawTerm of searchTerms) {
@@ -1880,18 +1922,27 @@ async function executeRoutePipeline(
               try {
                 const grepResult = await callMcpToolViaSdk(
                   mcpRepoUrl, '/mcp', 'repo_exec',
-                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnil "${sanitized.replace(/"/g, '\\"')}" .` },
+                  { repoId: repo.id, sessionId: gatherSessionId, clientId: ticket.clientId, command: `grep -rnilI "${sanitized.replace(/"/g, '\\"')}" .` },
                   repoAuth, repoAuthHeader,
                 );
                 // Parse file paths from stdout (skip the [session:...] line)
-                const exts = ['.sql', '.cs', '.ts'];
+                let matchedAny = false;
                 for (const line of grepResult.split('\n')) {
                   const trimmed = line.trim();
                   if (trimmed && !trimmed.startsWith('[session:') && !trimmed.startsWith('[stderr]') && exts.some(e => trimmed.endsWith(e))) {
                     relevantFiles.add(trimmed);
+                    matchedAny = true;
                   }
                 }
-              } catch { /* grep found nothing */ }
+                if (!matchedAny) grepNoMatch++;
+              } catch (err) {
+                grepErrors++;
+                appLog.warn(
+                  `search_code pre-gather failed for ${repo.name}:${rawTerm}: ${err instanceof Error ? err.message : String(err)}`,
+                  { ticketId, repo: repo.name, term: rawTerm },
+                  ticketId, 'ticket',
+                );
+              }
             }
             for (const f of facts.filesMentioned ?? []) {
               relevantFiles.add(f);
@@ -1933,11 +1984,31 @@ async function executeRoutePipeline(
           await callMcpToolViaSdk(mcpRepoUrl, '/mcp', 'repo_cleanup', { sessionId: gatherSessionId }, repoAuth, repoAuthHeader);
         } catch { /* best effort */ }
 
+        // If pre-gather produced nothing but we know repos exist and something
+        // failed, surface a notice so downstream analysis still nudges the
+        // agent to hit the per-repo tools directly.
+        if (codeContext.length === 0 && (grepErrors > 0 || prePullFailed > 0)) {
+          const repoList = clientRepos.map(r => r.name).join(', ');
+          const plural = clientRepos.length === 1 ? 'repository' : 'repositories';
+          codeContext.push(
+            `## Repository Status Notice\n\n${clientRepos.length} ${plural} registered for this client (${repoList}) but pre-search could not reach them this run. Use the \`<repo>__search_code\` and \`<repo>__read_file\` tools directly — the code is available, only the pre-gather failed.`,
+          );
+        }
+
         {
           const stepDuration = Date.now() - stepStart;
           appLog.info(
             `Repo context gathered: ${clientRepos.length} repos checked, ${codeContext.length} with results (${(stepDuration / 1000).toFixed(1)}s)`,
-            { ticketId, reposChecked: clientRepos.length, reposWithResults: codeContext.length, durationMs: stepDuration },
+            {
+              ticketId,
+              reposChecked: clientRepos.length,
+              reposWithResults: codeContext.length,
+              prePullSucceeded,
+              prePullFailed,
+              grepErrors,
+              grepNoMatch,
+              durationMs: stepDuration,
+            },
             ticketId, 'ticket',
           );
         }
@@ -2073,7 +2144,7 @@ async function executeRoutePipeline(
         }
 
         // Build tool definitions from MCP integrations and mcp-repo
-        const { tools: agenticTools, mcpIntegrations, repoIdByPrefix } = await buildAgenticTools(
+        const { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: agenticRepos } = await buildAgenticTools(
           db, ticket.clientId, deps.encryptionKey, deps.mcpRepoUrl, deps.mcpPlatformUrl, deps.apiKey, deps.mcpAuthToken,
         );
 
@@ -2099,7 +2170,7 @@ async function executeRoutePipeline(
           ticketId, clientId, category, priority, emailSubject, emailBody,
           clientContext, environmentContext, codeContext, dbContext, facts, summary,
         };
-        const toolCtx = { tools: agenticTools, mcpIntegrations, repoIdByPrefix };
+        const toolCtx = { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: agenticRepos };
 
         const result = canRunOrchestrated
           ? await runOrchestratedAnalysis(analysisDeps, analysisCtx, step, toolCtx, { maxIterations, existingKnowledgeDoc: ticket.knowledgeDoc ?? '', reanalysisCtx })


### PR DESCRIPTION
## Summary

Addresses the "agents reach for `run_custom_query` instead of repo tools" pattern by adding three purpose-built per-repo MCP tools, pre-pulling repos in parallel during `GATHER_REPO_CONTEXT`, widening the file-extension filter, and injecting a system-prompt nudge when the client has active repos.

Fixes #313.

## Key pieces

- **Four new mcp-repo tools** (`mcp-servers/repo/src/tools/`):
  - `search_code` — structured grep with per-repo extension filter (`CodeRepo.fileExtensions` → `DEFAULT_REPO_FILE_EXTENSIONS` fallback), case-insensitive by default, skip binary, match/file summary footer
  - `read_file` — paged `cat` with line numbers; safeguards against path traversal
  - `list_files` — `find` with glob + directory filter
  - `prepare_repo` — thin wrapper around `RepoManager.clone` for the pre-pull path; NOT surfaced as an agentic tool
- **Per-repo registration**: `buildAgenticTools` in `analysis/shared.ts` now registers `${prefix}__search_code`, `${prefix}__read_file`, `${prefix}__list_files` alongside the existing `${prefix}__repo_exec` escape hatch. `executeAgenticToolCall` injects `repoId` + `clientId` for all four.
- **System-prompt nudge** (`buildRepoNudgeSnippet`) appended to both flat and orchestrated system prompts whenever the client has active repos, regardless of pre-gather outcome.
- **`GATHER_REPO_CONTEXT` hardening** at `services/ticket-analyzer/src/analyzer.ts:1856-1994`:
  - Parallel `prepare_repo` pre-pull via `Promise.allSettled`
  - Search term cap 5 → 10 with email-subject token fallback when <3 terms
  - `grep -rnil` → `grep -rnilI` (case-insensitive + skip binary)
  - Widened extension list: per-repo `CodeRepo.fileExtensions` → `DEFAULT_REPO_FILE_EXTENSIONS` (20 extensions covering `.cs`, `.sql`, `.razor`, `.cshtml`, `.config`, etc.)
  - `grepErrors` vs `grepNoMatch` tracked separately; structured log line includes `prePullSucceeded`, `prePullFailed`, `grepErrors`, `grepNoMatch`
  - Status-notice block pushed to `codeContext` when pre-gather produced nothing but repos exist and something failed
- **Schema**: `CodeRepo.fileExtensions String[] @default([])` column + migration. `shared-types/src/code-repo.ts` exposes the field (and `description`).

## Scope guardrails

- `repo_exec` retained unchanged as escape hatch
- No control-panel UI for per-repo `fileExtensions` editing (column exists, defaults to global)
- No status-monitor metric work

## Test plan

- [ ] `pnpm build` + `pnpm typecheck` + `pnpm db:migrate` pass
- [ ] Smoke a ticket that previously hit `run_custom_query` for a stored-proc definition — agent calls `<prefix>__search_code` instead
- [ ] GATHER_REPO_CONTEXT structured log line includes all four new counters
- [ ] With mcp-repo deliberately unreachable: status-notice block appears in `codeContext`, agent still attempts repo tools via the nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
