### PR TITLE
fix(mcp-repo): add openssh-client so git-over-SSH clones work (fixes #332)

### DIFF
--- a/mcp-servers/repo/Dockerfile
+++ b/mcp-servers/repo/Dockerfile
@@ -21,7 +21,7 @@ RUN pnpm --filter @bronco/shared-utils run build
 RUN pnpm --filter @bronco/mcp-repo run build
 
 FROM base AS production
-RUN apk add --no-cache git tree file
+RUN apk add --no-cache git openssh-client tree file
 COPY --from=build /app /app
 RUN pnpm prune --prod
 RUN mkdir -p /var/lib/mcp-repo/repos \


### PR DESCRIPTION
## Summary

Adds `openssh-client` to the mcp-repo container so `git clone` over SSH works. Without it, every `search_code` / `read_file` / `list_files` call on a repo with a `git@github.com:` URL fails instantly with `error: cannot run ssh: No such file or directory`.

One-line change in `mcp-servers/repo/Dockerfile` production stage.

## Test plan

- [ ] `pnpm typecheck` and `pnpm build` pass locally (confirmed by session)
- [ ] After deploy, `docker exec bronco-mcp-repo-1 which ssh` returns a path
- [ ] Re-run a ticket that previously failed with the SSH error; `search_code` succeeds
- [ ] SSH key mounting + HTTPS-with-PAT fallback tracked as follow-ups (out of scope here)

Fixes #332.