### PR TITLE
fix: authenticated artifact downloads + JSON-error save guard (#340)

### DIFF
--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -198,6 +198,24 @@ export interface TicketArtifact {
   createdAt: string;
 }
 
+/** Parse Content-Disposition filename, preferring RFC 5987 filename*= over plain filename=". */
+function parseContentDispositionFilename(disposition: string): string | null {
+  const star = /filename\*=(?:UTF-8'')?([^;]+)/i.exec(disposition);
+  if (star && star[1]) {
+    try { return decodeURIComponent(star[1].trim()); } catch { /* fallthrough */ }
+  }
+  const plain = /filename="?([^";]+)"?/i.exec(disposition);
+  return plain ? plain[1].trim() : null;
+}
+
+/** Strip path separators, control characters, and leading dots; cap at 255 chars. */
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[\\/\x00-\x1f\x7f]/g, '_')
+    .replace(/^\.+/, '_')
+    .slice(0, 255) || 'artifact';
+}
+
 @Injectable({ providedIn: 'root' })
 export class TicketService {
   private api = inject(ApiService);
@@ -300,29 +318,42 @@ export class TicketService {
   }
 
   async downloadArtifact(artifactId: string): Promise<void> {
-    const res = await fetch(`/api/artifacts/${artifactId}/download`, {
-      headers: { Authorization: `Bearer ${this.auth.accessToken ?? ''}` },
-      credentials: 'include',
-    });
-    if (!res.ok) {
-      let msg = `Download failed (HTTP ${res.status})`;
-      try {
-        const body = await res.json() as { error?: string };
-        if (body.error) msg = body.error;
-      } catch { /* ignore */ }
-      this.toast.error(msg);
-      return;
+    try {
+      const token = this.auth.accessToken;
+      const headers: Record<string, string> = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch(`/api/artifacts/${artifactId}/download`, {
+        headers,
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        let msg = `Download failed (HTTP ${res.status})`;
+        try {
+          const body = await res.json() as { error?: string };
+          if (body.error) msg = body.error;
+        } catch { /* ignore */ }
+        this.toast.error(msg);
+        return;
+      }
+      const blob = await res.blob();
+      const disposition = res.headers.get('Content-Disposition') ?? '';
+      const raw = parseContentDispositionFilename(disposition) ?? `artifact-${artifactId}`;
+      const filename = sanitizeFilename(raw);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(() => {
+        a.remove();
+        URL.revokeObjectURL(url);
+      }, 0);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Download failed';
+      this.toast.error(`Download failed: ${message}`);
     }
-    const blob = await res.blob();
-    const disposition = res.headers.get('Content-Disposition') ?? '';
-    const match = /filename="([^"]+)"/.exec(disposition);
-    const filename = match ? match[1] : `artifact-${artifactId}`;
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
   }
 }
 

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { ApiService } from './api.service.js';
+import { AuthService } from './auth.service.js';
+import { ToastService } from './toast.service.js';
 
 /** Comma-separated active status values for API queries. Single source of truth for the UI. */
 export const ACTIVE_STATUS_FILTER = 'OPEN,IN_PROGRESS,WAITING';
@@ -199,6 +201,8 @@ export interface TicketArtifact {
 @Injectable({ providedIn: 'root' })
 export class TicketService {
   private api = inject(ApiService);
+  private auth = inject(AuthService);
+  private toast = inject(ToastService);
 
   private static readonly ACTIVE_STATUSES = ACTIVE_STATUS_FILTER.split(',');
 
@@ -295,8 +299,30 @@ export class TicketService {
     return this.api.get<TicketSearchResult[]>('/search/tickets', { q, limit });
   }
 
-  getArtifactDownloadUrl(artifactId: string): string {
-    return `/api/artifacts/${artifactId}/download`;
+  async downloadArtifact(artifactId: string): Promise<void> {
+    const res = await fetch(`/api/artifacts/${artifactId}/download`, {
+      headers: { Authorization: `Bearer ${this.auth.accessToken ?? ''}` },
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      let msg = `Download failed (HTTP ${res.status})`;
+      try {
+        const body = await res.json() as { error?: string };
+        if (body.error) msg = body.error;
+      } catch { /* ignore */ }
+      this.toast.error(msg);
+      return;
+    }
+    const blob = await res.blob();
+    const disposition = res.headers.get('Content-Disposition') ?? '';
+    const match = /filename="([^"]+)"/.exec(disposition);
+    const filename = match ? match[1] : `artifact-${artifactId}`;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
   }
 }
 

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
@@ -148,7 +148,7 @@ export interface ExpandPayload {
           }
 
           @if (p.artifactId) {
-            <a class="artifact-download" [href]="ticketService.getArtifactDownloadUrl(p.artifactId)" download>
+            <a class="artifact-download" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact(p.artifactId)">
               <app-icon name="download" size="sm" /> Download full output artifact
             </a>
           }

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
@@ -148,9 +148,9 @@ export interface ExpandPayload {
           }
 
           @if (p.artifactId) {
-            <a class="artifact-download" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact(p.artifactId)">
+            <button type="button" class="artifact-download" (click)="ticketService.downloadArtifact(p.artifactId)">
               <app-icon name="download" size="sm" /> Download full output artifact
-            </a>
+            </button>
           }
         </div>
       }
@@ -173,7 +173,7 @@ export interface ExpandPayload {
     .artifact-download {
       display: inline-flex; align-items: center; gap: 6px;
       padding: 6px 10px; border: 1px solid var(--color-info); color: var(--color-info);
-      border-radius: 4px; font-size: 13px; text-decoration: none; align-self: flex-start;
+      border-radius: 4px; font-size: 13px; background: none; cursor: pointer; font: inherit; align-self: flex-start;
     }
     .artifact-download:hover { background: var(--color-info-subtle); }
   `],

--- a/services/control-panel/src/app/features/tickets/chat/chat-tool-summary.component.ts
+++ b/services/control-panel/src/app/features/tickets/chat/chat-tool-summary.component.ts
@@ -1,6 +1,7 @@
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { CommonModule, DecimalPipe } from '@angular/common';
 import { IconComponent } from '../../../shared/components/index.js';
+import { TicketService } from '../../../core/services/ticket.service.js';
 import type { ChatRunToolSummary } from './chat.types.js';
 
 @Component({
@@ -23,8 +24,8 @@ import type { ChatRunToolSummary } from './chat.types.js';
             }
             @if (t.artifactId) {
               <a class="tool-pill-download"
-                 [href]="artifactUrl(t.artifactId)"
-                 download
+                 href="#"
+                 (click)="$event.preventDefault(); ticketService.downloadArtifact(t.artifactId)"
                  title="Download raw result artifact">
                 <app-icon name="download" size="xs" />
               </a>
@@ -74,11 +75,8 @@ import type { ChatRunToolSummary } from './chat.types.js';
   `],
 })
 export class ChatToolSummaryComponent {
+  readonly ticketService = inject(TicketService);
   tools = input<ChatRunToolSummary[]>([]);
-
-  artifactUrl(id: string): string {
-    return `/api/artifacts/${id}/download`;
-  }
 
   formatSize(bytes: number): string {
     if (bytes < 1024) return `${bytes}B`;

--- a/services/control-panel/src/app/features/tickets/chat/chat-tool-summary.component.ts
+++ b/services/control-panel/src/app/features/tickets/chat/chat-tool-summary.component.ts
@@ -23,12 +23,11 @@ import type { ChatRunToolSummary } from './chat.types.js';
               <span class="tool-pill-meta">{{ formatSize(t.resultSize) }}</span>
             }
             @if (t.artifactId) {
-              <a class="tool-pill-download"
-                 href="#"
-                 (click)="$event.preventDefault(); ticketService.downloadArtifact(t.artifactId)"
+              <button type="button" class="tool-pill-download"
+                 (click)="ticketService.downloadArtifact(t.artifactId)"
                  title="Download raw result artifact">
                 <app-icon name="download" size="xs" />
-              </a>
+              </button>
             }
           </span>
         }
@@ -70,7 +69,11 @@ import type { ChatRunToolSummary } from './chat.types.js';
       display: inline-flex;
       align-items: center;
       color: var(--color-primary, #0969da);
-      text-decoration: none;
+      background: none;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      font: inherit;
     }
   `],
 })

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -813,9 +813,12 @@
   flex-shrink: 0;
   font-size: 12px;
   color: var(--accent);
-  text-decoration: none;
+  background: none;
+  border: none;
   padding: 4px 8px;
   border-radius: var(--radius-sm);
+  cursor: pointer;
+  font: inherit;
   transition: background 120ms ease;
 }
 .artifact-dl:hover { background: var(--bg-muted); }
@@ -833,7 +836,11 @@
 .artifact-link {
   font-size: 11px;
   color: var(--accent);
-  text-decoration: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
   margin-left: 8px;
 }
 .artifact-link:hover { text-decoration: underline; }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -290,7 +290,7 @@ interface ConvTreeNode {
                       @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                       <span class="log-message">{{ entry.message }}</span>
                       @if (entry.context?.['artifactId']) {
-                        <a class="artifact-link" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</a>
+                        <button type="button" class="artifact-link" (click)="ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</button>
                       }
                     </div>
                     @if (entry.context && hasKeys(entry.context)) {
@@ -355,7 +355,7 @@ interface ConvTreeNode {
                                 @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                                 <span class="log-message">{{ entry.message }}</span>
                                 @if (entry.context?.['artifactId']) {
-                                  <a class="artifact-link" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</a>
+                                  <button type="button" class="artifact-link" (click)="ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</button>
                                 }
                               }
                             </div>
@@ -665,9 +665,9 @@ interface ConvTreeNode {
                         <span class="artifact-desc">{{ a.description }}</span>
                       }
                     </div>
-                    <a class="artifact-dl" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact(a.id)">
+                    <button type="button" class="artifact-dl" (click)="ticketService.downloadArtifact(a.id)">
                       <app-icon name="download" size="sm" /> Download
-                    </a>
+                    </button>
                   </div>
                 }
               </div>

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -290,7 +290,7 @@ interface ConvTreeNode {
                       @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                       <span class="log-message">{{ entry.message }}</span>
                       @if (entry.context?.['artifactId']) {
-                        <a class="artifact-link" [href]="ticketService.getArtifactDownloadUrl('' + entry.context!['artifactId'])" download><app-icon name="download" size="xs" /> Full output</a>
+                        <a class="artifact-link" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</a>
                       }
                     </div>
                     @if (entry.context && hasKeys(entry.context)) {
@@ -355,7 +355,7 @@ interface ConvTreeNode {
                                 @if (entry.service) { <span class="log-service">{{ entry.service }}</span> }
                                 <span class="log-message">{{ entry.message }}</span>
                                 @if (entry.context?.['artifactId']) {
-                                  <a class="artifact-link" [href]="ticketService.getArtifactDownloadUrl('' + entry.context!['artifactId'])" download><app-icon name="download" size="xs" /> Full output</a>
+                                  <a class="artifact-link" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact('' + entry.context!['artifactId'])"><app-icon name="download" size="xs" /> Full output</a>
                                 }
                               }
                             </div>
@@ -665,7 +665,7 @@ interface ConvTreeNode {
                         <span class="artifact-desc">{{ a.description }}</span>
                       }
                     </div>
-                    <a class="artifact-dl" [href]="ticketService.getArtifactDownloadUrl(a.id)" download>
+                    <a class="artifact-dl" href="#" (click)="$event.preventDefault(); ticketService.downloadArtifact(a.id)">
                       <app-icon name="download" size="sm" /> Download
                     </a>
                   </div>


### PR DESCRIPTION
## Summary

- **Root cause**: Bare `<a [href]="..." download>` anchors don't carry the app's JWT `Authorization` header, so `/api/artifacts/:id/download` returns 401. On Desktop Chrome the download aborts; on iPhone Safari the JSON error body (`{"error":"unauthorized"}`) gets saved to disk as the "file".
- Added `TicketService.downloadArtifact(artifactId)` — fetches with `Authorization: Bearer <token>`, saves a blob on success, shows a toast error on failure (never writes a file).
- Replaced all 5 bare-anchor download sites with `(click)` handlers that call the new method.
- Server-side: no changes needed — the global `onRequest` hook in `auth.ts` already gates `/api/artifacts/:id/download`.

## Changed files

| File | What changed |
|---|---|
| `services/control-panel/src/app/core/services/ticket.service.ts` | Replaced `getArtifactDownloadUrl()` with `downloadArtifact()` (authenticated fetch → blob save or toast error) |
| `services/control-panel/src/app/features/tickets/ticket-detail.component.ts` | 3 bare anchor sites → click handlers |
| `services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts` | 1 bare anchor site → click handler |
| `services/control-panel/src/app/features/tickets/chat/chat-tool-summary.component.ts` | Injected `TicketService`, removed `artifactUrl()` helper, 1 bare anchor → click handler |

## Test plan

- [ ] Desktop Chrome (logged in): click Download from Artifacts tab → file saves with correct filename and content
- [ ] Desktop Chrome (logged out): click Download → toast shows "Unauthorized" (or HTTP 401 message), nothing saved
- [ ] iPhone Safari (logged in): file saves correctly
- [ ] iPhone Safari (logged out): toast shown, no JSON blob saved to disk

> UI not manually testable from this remote coding session; build and typecheck pass clean.

Closes #340