### PR TITLE
fix: probe result — full content on expand, line/byte size chip

### DIFF
--- a/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
@@ -232,7 +232,7 @@ import { ToastService } from '../../core/services/toast.service.js';
                           <div class="step-result-block">
                             <div class="result-toolbar">
                               <span class="result-label">Result</span>
-                              <span class="result-size">{{ getLineCount(step.detail) }} lines · {{ formatBytes(getByteSize(step.detail)) }}</span>
+                              <span class="result-size">{{ getLineCount(step.id) }} lines · {{ formatBytes(getByteSize(step.id)) }}</span>
                               <app-bronco-button
                                 variant="icon"
                                 size="sm"
@@ -247,7 +247,8 @@ import { ToastService } from '../../core/services/toast.service.js';
                                 Show full result
                               </app-bronco-button>
                             } @else {
-                              <pre class="detail-pre detail-pre-expanded" [class.detail-pre-json]="getFormattedJson(step.id) !== null">{{ getFormattedJson(step.id) !== null ? getFormattedJson(step.id) : step.detail }}</pre>
+                              @let formattedJson = getFormattedJson(step.id);
+                              <pre class="detail-pre detail-pre-expanded" [class.detail-pre-json]="formattedJson !== null">{{ formattedJson ?? step.detail }}</pre>
                               @if (step.detail.length > 500) {
                                 <app-bronco-button variant="ghost" size="sm" (click)="toggleStepExpand(step.id); $event.stopPropagation()">
                                   Collapse
@@ -294,7 +295,7 @@ import { ToastService } from '../../core/services/toast.service.js';
                         <details class="detail-step-output">
                           <summary>
                             Output
-                            <span class="result-size">{{ getLineCount(step.detail) }} lines · {{ formatBytes(getByteSize(step.detail)) }}</span>
+                            <span class="result-size">{{ getLineCount(step.id) }} lines · {{ formatBytes(getByteSize(step.id)) }}</span>
                           </summary>
                           <div class="result-toolbar">
                             <span></span>
@@ -682,6 +683,10 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
   expandedStepIds = new Set<string>();
   /** Precomputed formatted JSON per step id; null means content is not JSON. */
   private formattedJsonCache = new Map<string, string | null>();
+  /** Precomputed line count per step id. */
+  private lineCountCache = new Map<string, number>();
+  /** Precomputed byte size per step id. */
+  private byteSizeCache = new Map<string, number>();
 
   filterStatus = '';
   page = 0;
@@ -759,6 +764,8 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
     this.expandedRun.set(null);
     this.expandedStepIds.clear();
     this.formattedJsonCache.clear();
+    this.lineCountCache.clear();
+    this.byteSizeCache.clear();
   }
 
   toggleExpand(run: ProbeRun): void {
@@ -773,12 +780,18 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
     this.probeService.getRun(this.probeId, run.id).subscribe({
       next: (r) => {
         this.formattedJsonCache.clear();
+        this.lineCountCache.clear();
+        this.byteSizeCache.clear();
         for (const step of r.steps ?? []) {
           if (step.detail) {
             const parsed = this.tryParseJson(step.detail.trim());
             this.formattedJsonCache.set(step.id, parsed !== null ? JSON.stringify(parsed, null, 2) : null);
+            this.lineCountCache.set(step.id, step.detail.split('\n').length);
+            this.byteSizeCache.set(step.id, new Blob([step.detail]).size);
           } else {
             this.formattedJsonCache.set(step.id, null);
+            this.lineCountCache.set(step.id, 0);
+            this.byteSizeCache.set(step.id, 0);
           }
         }
         if (this.expandedRunId() === run.id) this.expandedRun.set(r);
@@ -880,14 +893,12 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
     }
   }
 
-  getLineCount(text: string | null | undefined): number {
-    if (!text) return 0;
-    return text.split('\n').length;
+  getLineCount(stepId: string): number {
+    return this.lineCountCache.get(stepId) ?? 0;
   }
 
-  getByteSize(text: string | null | undefined): number {
-    if (!text) return 0;
-    return new Blob([text]).size;
+  getByteSize(stepId: string): number {
+    return this.byteSizeCache.get(stepId) ?? 0;
   }
 
   formatBytes(n: number): string {

--- a/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-runs.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, OnDestroy, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
-import { DatePipe, DecimalPipe, SlicePipe } from '@angular/common';
+import { DatePipe, SlicePipe } from '@angular/common';
 import {
   BroncoButtonComponent,
   CardComponent,
@@ -28,7 +28,6 @@ import { ToastService } from '../../core/services/toast.service.js';
     RouterLink,
     ClipboardModule,
     DatePipe,
-    DecimalPipe,
     SlicePipe,
     BroncoButtonComponent,
     CardComponent,
@@ -233,6 +232,7 @@ import { ToastService } from '../../core/services/toast.service.js';
                           <div class="step-result-block">
                             <div class="result-toolbar">
                               <span class="result-label">Result</span>
+                              <span class="result-size">{{ getLineCount(step.detail) }} lines · {{ formatBytes(getByteSize(step.detail)) }}</span>
                               <app-bronco-button
                                 variant="icon"
                                 size="sm"
@@ -244,14 +244,10 @@ import { ToastService } from '../../core/services/toast.service.js';
                             @if (step.detail.length > 500 && !isStepExpanded(step.id)) {
                               <pre class="detail-pre">{{ step.detail.slice(0, 500) }}…</pre>
                               <app-bronco-button variant="ghost" size="sm" (click)="toggleStepExpand(step.id); $event.stopPropagation()">
-                                Show full result ({{ step.detail.length | number }} chars)
+                                Show full result
                               </app-bronco-button>
                             } @else {
-                              @if (getFormattedJson(step.id) !== null) {
-                                <pre class="detail-pre detail-pre-json">{{ getFormattedJson(step.id) }}</pre>
-                              } @else {
-                                <pre class="detail-pre">{{ step.detail }}</pre>
-                              }
+                              <pre class="detail-pre detail-pre-expanded" [class.detail-pre-json]="getFormattedJson(step.id) !== null">{{ getFormattedJson(step.id) !== null ? getFormattedJson(step.id) : step.detail }}</pre>
                               @if (step.detail.length > 500) {
                                 <app-bronco-button variant="ghost" size="sm" (click)="toggleStepExpand(step.id); $event.stopPropagation()">
                                   Collapse
@@ -296,7 +292,10 @@ import { ToastService } from '../../core/services/toast.service.js';
                         </div>
                       } @else {
                         <details class="detail-step-output">
-                          <summary>Output</summary>
+                          <summary>
+                            Output
+                            <span class="result-size">{{ getLineCount(step.detail) }} lines · {{ formatBytes(getByteSize(step.detail)) }}</span>
+                          </summary>
                           <div class="result-toolbar">
                             <span></span>
                             <app-bronco-button
@@ -310,10 +309,10 @@ import { ToastService } from '../../core/services/toast.service.js';
                           @if (step.detail.length > 500 && !isStepExpanded(step.id)) {
                             <pre class="detail-pre">{{ step.detail.slice(0, 500) }}…</pre>
                             <app-bronco-button variant="ghost" size="sm" (click)="toggleStepExpand(step.id); $event.stopPropagation()">
-                              Show full output ({{ step.detail.length | number }} chars)
+                              Show full output
                             </app-bronco-button>
                           } @else {
-                            <pre class="detail-pre">{{ step.detail }}</pre>
+                            <pre class="detail-pre detail-pre-expanded">{{ step.detail }}</pre>
                             @if (step.detail.length > 500) {
                               <app-bronco-button variant="ghost" size="sm" (click)="toggleStepExpand(step.id); $event.stopPropagation()">
                                 Collapse
@@ -597,11 +596,15 @@ import { ToastService } from '../../core/services/toast.service.js';
       border-radius: var(--radius-sm);
       font-size: 12px;
       overflow-x: auto;
-      max-height: 400px;
+      overflow-y: auto;
+      max-height: 200px;
       white-space: pre-wrap;
       word-break: break-word;
       margin: 0;
       font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    }
+    .detail-pre-expanded {
+      max-height: 60vh;
     }
     .detail-pre-json { color: var(--color-success); }
 
@@ -647,6 +650,12 @@ import { ToastService } from '../../core/services/toast.service.js';
       font-weight: 500;
       color: var(--text-tertiary);
       font-family: var(--font-primary);
+    }
+    .result-size {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      margin-left: 6px;
     }
 
     .eval-result {
@@ -869,6 +878,22 @@ export class ProbeRunsComponent implements OnInit, OnDestroy {
     } else {
       this.toast.error('Failed to copy to clipboard');
     }
+  }
+
+  getLineCount(text: string | null | undefined): number {
+    if (!text) return 0;
+    return text.split('\n').length;
+  }
+
+  getByteSize(text: string | null | undefined): number {
+    if (!text) return 0;
+    return new Blob([text]).size;
+  }
+
+  formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(2)} MB`;
   }
 
   private tryParseJson(text: string): unknown {


### PR DESCRIPTION
## Summary

- Added a **line count + byte size chip** (`42 lines · 1.3 KB`) to the tool-result toolbar and the generic output `<details>` summary — visible whether the result is collapsed or expanded
- Fixed **visual truncation on expand**: added `.detail-pre-expanded` CSS class (`max-height: 60vh; overflow-y: auto`) applied only in the expanded branch so large results scroll instead of disappearing off-screen
- Preserved the **500-char collapsed preview** and simplified the expand/collapse button labels (char count moved to the toolbar chip)
- Cleaned up: removed unused `DecimalPipe` import/binding; collapsed the dual JSON/plain `<pre>` pair into a single `<pre>` with a `[class.detail-pre-json]` binding
- Same changes applied to both the **tool-result block** (lines ~233–258) and the **generic output `<details>` block** (lines ~295–328)
- `copyToClipboard(step.detail!)` already uses full content regardless of expand state — no change needed

## Test plan

- [ ] Small result (~5 lines): collapsed shows 500-char preview + chip; expanded shows full content without height clipping
- [ ] Large result (>400 lines / >50 KB): expanded renders scrollable block; copy pastes full content
- [ ] Generic non-tool-result step: `<details>` summary shows chip; expanded pre scrolls
- [ ] JSON result: green text + formatted JSON in expanded view

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)