### PR TITLE
fix: table viewport overflow on System Issues + swept surfaces (fixes #339)

### DIFF
--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -237,10 +237,22 @@ import { ToastService } from '../../core/services/toast.service.js';
       box-shadow: var(--shadow-card);
       overflow: hidden;
     }
-    .from-cell { display: flex; flex-direction: column; }
-    .from-name { font-weight: 500; font-size: 13px; color: var(--text-primary); }
-    .from-address { font-size: 11px; color: var(--text-tertiary); }
+    .from-cell { display: flex; flex-direction: column; min-width: 0; }
+    .from-name {
+      font-weight: 500; font-size: 13px; color: var(--text-primary);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .from-address {
+      font-size: 11px; color: var(--text-tertiary);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
     .subject-text { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; color: var(--text-secondary); }
+
+    /* Respect column widths so From addresses and flex cells can't push
+     * downstream columns past the viewport. */
+    :host ::ng-deep app-data-table table {
+      table-layout: fixed;
+    }
     .time-cell { white-space: nowrap; font-size: 12px; color: var(--text-tertiary); font-family: var(--font-primary); }
     .muted { color: var(--text-tertiary); }
     .link { text-decoration: none; color: var(--accent-link); font-weight: 500; }

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -259,7 +259,11 @@ const ALL_QUEUES = [
       font-family: ui-monospace, monospace;
       white-space: nowrap;
     }
-    .job-name { font-weight: 500; color: var(--text-primary); font-size: 14px; }
+    .job-name {
+      font-weight: 500; color: var(--text-primary); font-size: 14px;
+      display: block; min-width: 0;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
     .job-id { font-size: 12px; color: var(--text-tertiary); font-family: ui-monospace, monospace; }
     .job-attempts { font-family: ui-monospace, monospace; font-size: 12px; color: var(--text-tertiary); }
     .job-time { font-size: 12px; color: var(--text-tertiary); white-space: nowrap; }
@@ -272,6 +276,12 @@ const ALL_QUEUES = [
       line-height: 1.4;
       word-break: break-word;
       white-space: pre-wrap;
+    }
+
+    /* Respect column widths so the flex Name column truncates long job names
+     * instead of pushing Time/Attempts/Actions off the viewport. */
+    :host ::ng-deep app-data-table table {
+      table-layout: fixed;
     }
 
     .job-detail { padding: 4px 0; }

--- a/services/control-panel/src/app/features/system-issues/system-issues.component.ts
+++ b/services/control-panel/src/app/features/system-issues/system-issues.component.ts
@@ -213,7 +213,7 @@ import {
 
                 <app-data-column key="message" header="Message" [sortable]="false" mobilePriority="primary">
                   <ng-template #cell let-row>
-                    <span class="col-message" [title]="row.error ?? ''">{{ row.message }}</span>
+                    <span class="col-message" [title]="row.message + (row.error ? ' — ' + row.error : '')">{{ row.message }}</span>
                   </ng-template>
                 </app-data-column>
 
@@ -362,10 +362,21 @@ import {
       font-size: 12px; font-family: monospace;
     }
     .col-message {
+      display: block;
+      max-width: 100%;
+      min-width: 0;
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
       color: var(--text-secondary);
     }
     .col-time { color: var(--text-tertiary); }
+
+    /* Force table cells to respect column widths so flex columns (no explicit
+     * width) can truncate with ellipsis rather than pushing the table past
+     * the viewport. Without this, a long .col-message grows its td and
+     * shoves Service/Time off-screen. */
+    :host ::ng-deep app-data-table table {
+      table-layout: fixed;
+    }
 
     .queue-failed-count {
       font-family: var(--font-primary); font-size: 16px;

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -203,6 +203,7 @@
   padding: 6px 10px;
   border-radius: var(--radius-sm);
   border-left: 3px solid transparent;
+  min-width: 0;
 }
 .log-entry-header {
   display: flex;
@@ -210,6 +211,7 @@
   gap: 8px;
   font-size: 12px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .log-time {
@@ -243,8 +245,10 @@
 }
 .log-message {
   color: var(--text-primary);
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .log-expand-btn { font-size: 11px; }
 .log-metadata {
@@ -265,6 +269,8 @@
   color: var(--color-error);
   margin-top: 4px;
   white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .logs-pagination {
   display: flex;

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -379,6 +379,11 @@ interface ActiveFilterChip {
       color: var(--accent);
       font-weight: 500;
       font-size: 13px;
+      display: block;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .subject-link:hover {
@@ -390,6 +395,17 @@ interface ActiveFilterChip {
       color: var(--text-tertiary);
       margin-top: 2px;
       line-height: 1.3;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Force the Subject column (the only auto-width column) to respect the
+     * column width so long subjects truncate instead of pushing Status/
+     * Category/Created off the right edge. */
+    :host ::ng-deep app-data-table table {
+      table-layout: fixed;
     }
 
     .code-chip {

--- a/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
+++ b/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
@@ -391,9 +391,21 @@ const STATUS_OPTIONS = [
     .status-pill.status-implemented { background: rgba(0,122,255,0.1); color: var(--accent); border: 1px solid rgba(0,122,255,0.25); }
     .status-pill.status-duplicate { background: rgba(142,142,147,0.15); color: var(--text-secondary); border: 1px solid rgba(142,142,147,0.3); }
 
-    .title-cell { display: flex; flex-direction: column; gap: 2px; }
-    .title { font-weight: 500; color: var(--text-primary); }
-    .requested-name { font-family: ui-monospace, monospace; font-size: 11px; color: var(--text-tertiary); }
+    .title-cell { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .title {
+      font-weight: 500; color: var(--text-primary);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .requested-name {
+      font-family: ui-monospace, monospace; font-size: 11px; color: var(--text-tertiary);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+
+    /* Respect column widths so the flex Title column truncates long tool
+     * names/titles instead of pushing Client/Count/Updated off the right. */
+    :host ::ng-deep app-data-table table {
+      table-layout: fixed;
+    }
     .client-name { font-size: 13px; color: var(--text-secondary); }
     .count-pill {
       display: inline-block;


### PR DESCRIPTION
## Summary

Fixes #339 — the System Issues → Unresolved Error Logs table was wider than the viewport; the Message cell forced horizontal scroll and shoved Service/Time off-screen. Same pattern swept across other list surfaces.

Root cause: `<app-data-table>` renders a `<table width: 100%>` with `table-layout: auto`. Columns without an explicit `width` grow to fit their content, so a long nowrap `.col-message` span pushed the whole table past the container.

## Fix pattern

- Scope `table-layout: fixed` to each consuming component via `:host ::ng-deep app-data-table table` (no changes to the shared `app-data-table` primitive).
- Apply `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0` to the flex column's cell content.

## Files touched + column fixed

| File | Column |
|------|--------|
| `services/control-panel/src/app/features/system-issues/system-issues.component.ts` | Message (+ tooltip bug: was `row.error ?? ''`, now shows `row.message` plus error suffix when present) |
| `services/control-panel/src/app/features/tickets/ticket-list.component.ts` | Subject (`.subject-link`, `.summary-preview`) |
| `services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts` | Name (`.job-name`) |
| `services/control-panel/src/app/features/email-logs/email-log.component.ts` | From (`.from-name`, `.from-address`) |
| `services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts` | Title (`.title`, `.requested-name`) |
| `services/control-panel/src/app/features/tickets/ticket-detail.component.css` | Analysis Trace Raw Logs — `.log-entry` / `.log-entry-header` get `min-width: 0`; `.log-message` and `.log-error-detail` get `overflow-wrap: anywhere` + `word-break: break-word` so long unbroken tokens (URLs, hashes) can't push the flex row past the viewport |

### Inspected but not modified

- **AI Usage** (`services/control-panel/src/app/features/ai-usage/`) — the Usage Summary and Model Costs tables hold short content (provider/model IDs, numeric cells). The Prompt Log's Context column is already pre-sliced to 50 chars with an ellipsis, and the table is inside a `.table-card` with `overflow: hidden`. No overflow pattern matching the bug.

## Test plan

- [x] `pnpm install` (lockfile in sync, no dep changes)
- [x] `pnpm build` — all packages
- [x] `pnpm typecheck` — all packages
- [ ] **UI not verified in a running browser** — remote sandbox has no browser. Please sanity-check the System Issues page + at least two swept surfaces at 1440 and 768 viewport widths before merging.
- [ ] Verify Service (160px) and Time (160px) columns remain fully visible on System Issues at 1920 / 1440 / 1024 / 768 / 400
- [ ] Verify tooltip on the Message cell shows the full message text (plus `— <error>` when `row.error` is set)
- [ ] Spot-check tickets list, failed-jobs, email-logs, tool-requests for horizontal scroll regressions

## Out of scope

- Virtualization / pagination
- Responsive column hiding
- Changes to the shared `app-data-table` primitive (`table-layout: fixed` is scoped per consumer)
- Backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
