### PR TITLE
feat: split TicketStatus — NEW (pre-analysis) and OPEN (post-analysis) (#345)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,19 @@ AZDO_POLL_INTERVAL_SECONDS=120
 | `services/devops-worker/src/poller.ts` | Incremental work item polling |
 | `services/devops-worker/src/config.ts` | Zod config schema |
 
+## Ticket Statuses
+
+| Status | Class | Description |
+|--------|-------|-------------|
+| `NEW` | open | Pre-analysis: ticket was just created and the analyzer pipeline has not yet run. All ingestion paths set this. |
+| `OPEN` | open | Post-analysis: analysis complete, ticket is active and awaiting operator action or external response. The analyzer auto-transitions `NEW → OPEN` at end-of-run (unless the ticket was set to `WAITING` by the sufficiency check). |
+| `IN_PROGRESS` | open | Actively being worked on by the operator. |
+| `WAITING` | open | Awaiting external input or response. Set by the analyzer when sufficiency eval returns `NEEDS_USER_INPUT`. |
+| `RESOLVED` | closed | Issue has been resolved. |
+| `CLOSED` | closed | Ticket is closed. |
+
+`NEW`, `OPEN`, `IN_PROGRESS`, and `WAITING` are all in `OPEN_STATUSES` and are treated as "active" tickets throughout the codebase (filters, notifications, MCP queries).
+
 ## Ticket Categories
 
 Tickets span multiple domains, not just DBA work:

--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -180,6 +180,7 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
           clientId: params.clientId,
           subject: params.subject,
           ticketNumber,
+          status: 'NEW',
           ...(params.description && { description: params.description }),
           ...(params.priority && { priority: params.priority as never }),
           ...(params.category && { category: params.category as never }),

--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -95,7 +95,7 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
     'List tickets with optional filters. Returns summary array with id, ticketNumber, subject, status, priority, category, client name, createdAt, and analysisStatus.',
     {
       clientId: z.string().uuid().optional().describe('Filter by client ID'),
-      status: z.string().optional().describe('Filter by ticket status (OPEN, IN_PROGRESS, WAITING, RESOLVED, CLOSED)'),
+      status: z.string().optional().describe('Filter by ticket status (NEW, OPEN, IN_PROGRESS, WAITING, RESOLVED, CLOSED)'),
       priority: z.string().optional().describe('Filter by priority (LOW, MEDIUM, HIGH, CRITICAL)'),
       category: z.string().optional().describe('Filter by category (DATABASE_PERF, BUG_FIX, FEATURE_REQUEST, SCHEMA_CHANGE, CODE_REVIEW, ARCHITECTURE, GENERAL)'),
       assignedOperatorId: z.string().uuid().optional().describe('Filter by assigned operator ID'),

--- a/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
+++ b/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
@@ -1,7 +1,7 @@
 -- AlterEnum
 ALTER TYPE "ticket_status" ADD VALUE 'NEW';
 
--- Backfill: OPEN tickets with no completed AI_ANALYSIS event → NEW
+-- Backfill: OPEN tickets with no AI_ANALYSIS event recorded (i.e., pre-analysis) → NEW
 UPDATE tickets
 SET status = 'NEW'
 WHERE status = 'OPEN'

--- a/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
+++ b/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
@@ -1,0 +1,12 @@
+-- AlterEnum
+ALTER TYPE "ticket_status" ADD VALUE 'NEW';
+
+-- Backfill: OPEN tickets with no completed AI_ANALYSIS event → NEW
+UPDATE tickets
+SET status = 'NEW'
+WHERE status = 'OPEN'
+  AND NOT EXISTS (
+    SELECT 1 FROM ticket_events
+    WHERE ticket_events.ticket_id = tickets.id
+      AND event_type = 'AI_ANALYSIS'
+  );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -986,6 +986,7 @@ enum Environment {
 }
 
 enum TicketStatus {
+  NEW
   OPEN
   IN_PROGRESS
   WAITING

--- a/packages/shared-types/src/ticket.ts
+++ b/packages/shared-types/src/ticket.ts
@@ -1,4 +1,5 @@
 export const TicketStatus = {
+  NEW: 'NEW',
   OPEN: 'OPEN',
   IN_PROGRESS: 'IN_PROGRESS',
   WAITING: 'WAITING',
@@ -63,6 +64,7 @@ export const TicketEventType = {
 export type TicketEventType = (typeof TicketEventType)[keyof typeof TicketEventType];
 
 export type OpenTicketStatus =
+  | typeof TicketStatus.NEW
   | typeof TicketStatus.OPEN
   | typeof TicketStatus.IN_PROGRESS
   | typeof TicketStatus.WAITING;
@@ -73,6 +75,7 @@ export type ClosedTicketStatus =
 
 /** Statuses that represent an active/open ticket. */
 export const OPEN_STATUSES = Object.freeze([
+  TicketStatus.NEW,
   TicketStatus.OPEN,
   TicketStatus.IN_PROGRESS,
   TicketStatus.WAITING,

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -5,7 +5,7 @@ import { AuthService } from './auth.service.js';
 import { ToastService } from './toast.service.js';
 
 /** Comma-separated active status values for API queries. Single source of truth for the UI. */
-export const ACTIVE_STATUS_FILTER = 'OPEN,IN_PROGRESS,WAITING';
+export const ACTIVE_STATUS_FILTER = 'NEW,OPEN,IN_PROGRESS,WAITING';
 
 export interface TicketFollower {
   id: string;

--- a/services/control-panel/src/app/features/tickets/ticket-list.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-list.component.ts
@@ -28,6 +28,7 @@ interface StatusPill {
 const STATUS_PILLS: StatusPill[] = [
   { label: 'All', value: '' },
   { label: 'Active', value: ACTIVE_STATUS_FILTER },
+  { label: 'New', value: 'NEW' },
   { label: 'Open', value: 'OPEN' },
   { label: 'In Progress', value: 'IN_PROGRESS' },
   { label: 'Resolved', value: 'RESOLVED' },

--- a/services/copilot-api/src/routes/pending-actions.ts
+++ b/services/copilot-api/src/routes/pending-actions.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@bronco/shared-utils';
 
 const logger = createLogger('pending-actions');
 
-const VALID_STATUSES = new Set(['OPEN', 'IN_PROGRESS', 'WAITING', 'RESOLVED', 'CLOSED']);
+const VALID_STATUSES = new Set(['NEW', 'OPEN', 'IN_PROGRESS', 'WAITING', 'RESOLVED', 'CLOSED']);
 const VALID_PRIORITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
 const VALID_CATEGORIES = new Set([
   'DATABASE_PERF', 'BUG_FIX', 'FEATURE_REQUEST', 'SCHEMA_CHANGE',
@@ -35,7 +35,7 @@ async function executePendingAction(
       await db.ticket.update({
         where: { id: ticketId },
         data: {
-          status: value as 'OPEN' | 'IN_PROGRESS' | 'WAITING' | 'RESOLVED' | 'CLOSED',
+          status: value as 'NEW' | 'OPEN' | 'IN_PROGRESS' | 'WAITING' | 'RESOLVED' | 'CLOSED',
           resolvedAt: isClosedStatus(value) ? new Date() : null,
         },
       });

--- a/services/copilot-api/src/routes/portal-tickets.ts
+++ b/services/copilot-api/src/routes/portal-tickets.ts
@@ -259,6 +259,7 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
               clientId: portalUser.clientId,
               subject: subject.trim(),
               description: description?.trim() || null,
+              status: 'NEW',
               priority: (priority as Priority) ?? 'MEDIUM',
               source: 'MANUAL',
               ticketNumber: portalTicketNumber,

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -9,11 +9,12 @@ const settingsLogger = createLogger('settings');
 
 /** Default configs seeded lazily if the DB tables are empty. */
 const DEFAULT_STATUS_CONFIGS = [
-  { value: TicketStatus.OPEN, displayName: 'Open', description: 'Newly created ticket awaiting triage', color: '#2196f3', sortOrder: 0, statusClass: 'open' },
-  { value: TicketStatus.IN_PROGRESS, displayName: 'In Progress', description: 'Actively being worked on', color: '#ff9800', sortOrder: 1, statusClass: 'open' },
-  { value: TicketStatus.WAITING, displayName: 'Waiting', description: 'Waiting for external input or response', color: '#9c27b0', sortOrder: 2, statusClass: 'open' },
-  { value: TicketStatus.RESOLVED, displayName: 'Resolved', description: 'Issue has been resolved', color: '#4caf50', sortOrder: 3, statusClass: 'closed' },
-  { value: TicketStatus.CLOSED, displayName: 'Closed', description: 'Ticket is closed', color: '#757575', sortOrder: 4, statusClass: 'closed' },
+  { value: TicketStatus.NEW, displayName: 'New', description: 'Newly created ticket awaiting analysis', color: '#60a5fa', sortOrder: 0, statusClass: 'open' },
+  { value: TicketStatus.OPEN, displayName: 'Open', description: 'Active ticket — analysis complete, awaiting operator action or external response', color: '#2196f3', sortOrder: 1, statusClass: 'open' },
+  { value: TicketStatus.IN_PROGRESS, displayName: 'In Progress', description: 'Actively being worked on', color: '#ff9800', sortOrder: 2, statusClass: 'open' },
+  { value: TicketStatus.WAITING, displayName: 'Waiting', description: 'Waiting for external input or response', color: '#9c27b0', sortOrder: 3, statusClass: 'open' },
+  { value: TicketStatus.RESOLVED, displayName: 'Resolved', description: 'Issue has been resolved', color: '#4caf50', sortOrder: 4, statusClass: 'closed' },
+  { value: TicketStatus.CLOSED, displayName: 'Closed', description: 'Ticket is closed', color: '#757575', sortOrder: 5, statusClass: 'closed' },
 ];
 
 const DEFAULT_CATEGORY_CONFIGS = [
@@ -145,12 +146,14 @@ interface SettingsRouteOpts {
 export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRouteOpts): Promise<void> {
   // ─── Ticket Statuses ───
 
-  // GET /api/settings/statuses — list all status configs (auto-seed if empty)
+  // GET /api/settings/statuses — list all status configs (auto-seed missing defaults)
   fastify.get('/api/settings/statuses', async () => {
     let configs = await fastify.db.ticketStatusConfig.findMany({ orderBy: { sortOrder: 'asc' } });
 
-    if (configs.length === 0) {
-      await fastify.db.ticketStatusConfig.createMany({ data: DEFAULT_STATUS_CONFIGS, skipDuplicates: true });
+    const existingValues = new Set(configs.map((c) => c.value));
+    const missing = DEFAULT_STATUS_CONFIGS.filter((d) => !existingValues.has(d.value));
+    if (missing.length > 0) {
+      await fastify.db.ticketStatusConfig.createMany({ data: missing, skipDuplicates: true });
       configs = await fastify.db.ticketStatusConfig.findMany({ orderBy: { sortOrder: 'asc' } });
     }
 

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -154,6 +154,25 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     const missing = DEFAULT_STATUS_CONFIGS.filter((d) => !existingValues.has(d.value));
     if (missing.length > 0) {
       await fastify.db.ticketStatusConfig.createMany({ data: missing, skipDuplicates: true });
+    }
+
+    // For existing deployments where the OPEN row was seeded before the NEW status was
+    // introduced, it may still carry the old pre-PR defaults (sortOrder=0, old description).
+    // Apply the targeted update only when the row still matches those exact pre-PR values so
+    // that operator customizations are left untouched.
+    const PRE_PR_OPEN_DESCRIPTION = 'Newly created ticket awaiting triage';
+    const openRow = configs.find((c) => c.value === 'OPEN');
+    if (openRow && openRow.sortOrder === 0 && openRow.description === PRE_PR_OPEN_DESCRIPTION) {
+      await fastify.db.ticketStatusConfig.update({
+        where: { value: 'OPEN' },
+        data: {
+          sortOrder: 1,
+          description: 'Active ticket — analysis complete, awaiting operator action or external response',
+        },
+      });
+    }
+
+    if (missing.length > 0 || (openRow && openRow.sortOrder === 0 && openRow.description === PRE_PR_OPEN_DESCRIPTION)) {
       configs = await fastify.db.ticketStatusConfig.findMany({ orderBy: { sortOrder: 'asc' } });
     }
 

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -395,6 +395,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
             description,
             systemId,
             environmentId: environmentId ?? undefined,
+            status: 'NEW',
             priority: priority as Priority,
             source: source as TicketSource,
             category: category as TicketCategory,

--- a/services/probe-worker/src/probe-worker.ts
+++ b/services/probe-worker/src/probe-worker.ts
@@ -736,6 +736,7 @@ async function createTicketFromProbe(
           clientId: probe.clientId,
           subject: title ?? `[Probe] ${probe.name}: ${probe.toolName}`,
           description,
+          status: 'NEW',
           source: 'SCHEDULED',
           category: (probe.category || null) as TicketCategory | null,
           ticketNumber,

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -5,9 +5,9 @@ import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
 import { Prisma } from '@bronco/db';
 import type { PrismaClient } from '@bronco/db';
-import type { TicketCategory, Priority, TicketStatus, TicketSource, AnalysisJob } from '@bronco/shared-types';
+import type { TicketCategory, Priority, TicketSource, AnalysisJob } from '@bronco/shared-types';
 import { AIRouter } from '@bronco/ai-provider';
-import { TaskType, RouteStepType, isClosedStatus, AnalysisStatus, SufficiencyStatus, NotificationMode, ToolRequestRationaleSource } from '@bronco/shared-types';
+import { TicketStatus, TaskType, RouteStepType, isClosedStatus, AnalysisStatus, SufficiencyStatus, NotificationMode, ToolRequestRationaleSource } from '@bronco/shared-types';
 import { createLogger, AppLogger, createPrismaLogWriter, MCP_TOOL_TIMEOUT_MS, mcpUrl, callMcpToolViaSdk, notifyOperators as notifyOperatorsFn, notifyClientOperators as notifyClientOperatorsFn, getActiveOperatorRecords, getSelfAnalysisConfig, registerToolRequest } from '@bronco/shared-utils';
 import type { Mailer, ReplyOptions } from '@bronco/shared-utils';
 import { executeRecommendations } from './recommendation-executor.js';
@@ -3520,6 +3520,11 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
       await deps.db.ticket.update({
         where: { id: ticketId },
         data: { analysisStatus: AnalysisStatus.COMPLETED, analysisError: null, lastAnalyzedAt: new Date() },
+      });
+      // Auto-transition NEW → OPEN now that analysis is complete (leave WAITING/IN_PROGRESS untouched)
+      await deps.db.ticket.updateMany({
+        where: { id: ticketId, status: TicketStatus.NEW },
+        data: { status: TicketStatus.OPEN },
       });
       appLog.info(
         `Ticket analysis pipeline completed successfully (${route ? 'route-driven' : 'default fallback'})`,

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -665,6 +665,7 @@ async function executeIngestionPipeline(
                 subject: subject.slice(0, 200),
                 description: description || null,
                 summary: ctx.summary || null,
+                status: 'NEW',
                 source: source as never,
                 category: ctx.category as TicketCategory | null,
                 priority: ctx.priority as Priority,


### PR DESCRIPTION
Fixes #345. Splits the ambiguous OPEN status into NEW (pre-analysis) and OPEN (post-analysis) to restore pipeline-consistency trust.

## What's in

- `TicketStatus.NEW` added to shared-types const-object, `OpenTicketStatus` union, and `OPEN_STATUSES` array; Prisma enum extended; migration backfills existing OPEN-with-no-AI_ANALYSIS rows → NEW.
- `DEFAULT_STATUS_CONFIGS` seed includes NEW (color `#60a5fa`, order 0); OPEN's description updated; seed upgraded from 'only if empty' to 'fill missing rows' so existing deployments pick up NEW on next boot.
- ticket-analyzer end-of-run: `updateMany` guarded on `status: 'NEW'` transitions to OPEN (other statuses untouched).
- All 4 `db.ticket.create` sites (analyzer ingestion, API manual create, portal create, probe-worker) now set `status: 'NEW'` explicitly.
- Control-panel filter chips: New added before Open; Active / All include NEW via `ACTIVE_STATUS_FILTER`. MCP `list_tickets` status filter doc updated.
- `pending-actions.ts` `VALID_STATUSES` includes NEW so operators can manually set it.

## Review notes

- Migration is NOT wrapped in a single BEGIN/COMMIT because PostgreSQL disallows wrapping `ALTER TYPE ... ADD VALUE` in a transaction. The spec's 'single transaction' language can't apply literally; the migration runner's idempotency covers the safety case.
- End-of-run transition uses a separate `updateMany` rather than embedding in the existing `ticket.update` — functionally equivalent with one extra round trip; clean to read.

## Test plan
- [ ] `pnpm db:migrate` applies cleanly
- [ ] New ticket via POST /api/tickets → `status: 'NEW'`
- [ ] Analyzer run on a NEW ticket → transitions to `OPEN` at completion
- [ ] Settings → Ticket Statuses: NEW + OPEN both visible with correct descriptions and distinct colors
- [ ] Tickets list filter chips: New / Open behave independently; Active + All include both
- [ ] Existing OPEN-with-AI_ANALYSIS tickets unchanged after migration