### PR TITLE
feat: reuse Scheduled Probes scheduler on Self Analysis tab (#338)

### DIFF
--- a/packages/shared-utils/src/self-analysis-config.ts
+++ b/packages/shared-utils/src/self-analysis-config.ts
@@ -10,6 +10,12 @@ export interface SelfAnalysisConfig {
   scheduledEnabled: boolean;
   scheduledCron: string;
   repoUrl: string;
+  /** 'time' = use scheduleHour/Minute/DaysOfWeek/Timezone; 'cron' = use scheduledCron directly. */
+  scheduleType: 'time' | 'cron';
+  scheduleHour: number | null;
+  scheduleMinute: number | null;
+  scheduleDaysOfWeek: string | null;
+  scheduleTimezone: string;
 }
 
 const DEFAULT_SELF_ANALYSIS_CONFIG: SelfAnalysisConfig = {
@@ -18,6 +24,11 @@ const DEFAULT_SELF_ANALYSIS_CONFIG: SelfAnalysisConfig = {
   scheduledEnabled: false,
   scheduledCron: '0 9 * * 1',
   repoUrl: 'https://github.com/siir/bronco',
+  scheduleType: 'cron',
+  scheduleHour: null,
+  scheduleMinute: null,
+  scheduleDaysOfWeek: null,
+  scheduleTimezone: 'America/Chicago',
 };
 
 const SETTINGS_KEY = 'self_analysis_config';
@@ -35,12 +46,18 @@ export async function getSelfAnalysisConfig(
       return DEFAULT_SELF_ANALYSIS_CONFIG;
     }
     const val = row.value as Record<string, unknown>;
+    const rawScheduleType = val['scheduleType'];
     return {
       postAnalysisTrigger: typeof val['postAnalysisTrigger'] === 'boolean' ? val['postAnalysisTrigger'] : DEFAULT_SELF_ANALYSIS_CONFIG.postAnalysisTrigger,
       ticketCloseTrigger: typeof val['ticketCloseTrigger'] === 'boolean' ? val['ticketCloseTrigger'] : DEFAULT_SELF_ANALYSIS_CONFIG.ticketCloseTrigger,
       scheduledEnabled: typeof val['scheduledEnabled'] === 'boolean' ? val['scheduledEnabled'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduledEnabled,
       scheduledCron: typeof val['scheduledCron'] === 'string' ? val['scheduledCron'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduledCron,
       repoUrl: typeof val['repoUrl'] === 'string' ? val['repoUrl'] : DEFAULT_SELF_ANALYSIS_CONFIG.repoUrl,
+      scheduleType: rawScheduleType === 'time' || rawScheduleType === 'cron' ? rawScheduleType : DEFAULT_SELF_ANALYSIS_CONFIG.scheduleType,
+      scheduleHour: typeof val['scheduleHour'] === 'number' ? val['scheduleHour'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduleHour,
+      scheduleMinute: typeof val['scheduleMinute'] === 'number' ? val['scheduleMinute'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduleMinute,
+      scheduleDaysOfWeek: typeof val['scheduleDaysOfWeek'] === 'string' ? val['scheduleDaysOfWeek'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduleDaysOfWeek,
+      scheduleTimezone: typeof val['scheduleTimezone'] === 'string' ? val['scheduleTimezone'] : DEFAULT_SELF_ANALYSIS_CONFIG.scheduleTimezone,
     };
   } catch {
     return DEFAULT_SELF_ANALYSIS_CONFIG;

--- a/packages/shared-utils/src/self-analysis-config.ts
+++ b/packages/shared-utils/src/self-analysis-config.ts
@@ -28,7 +28,7 @@ const DEFAULT_SELF_ANALYSIS_CONFIG: SelfAnalysisConfig = {
   scheduleHour: null,
   scheduleMinute: null,
   scheduleDaysOfWeek: null,
-  scheduleTimezone: 'America/Chicago',
+  scheduleTimezone: 'UTC',
 };
 
 const SETTINGS_KEY = 'self_analysis_config';

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -158,6 +158,11 @@ export interface SelfAnalysisConfig {
   scheduledEnabled: boolean;
   scheduledCron: string;
   repoUrl: string;
+  scheduleType: 'time' | 'cron';
+  scheduleHour: number | null;
+  scheduleMinute: number | null;
+  scheduleDaysOfWeek: string | null;
+  scheduleTimezone: string;
 }
 
 export interface TestResult {

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent } from '../../shared/components/index.js';
+import { FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent, CronSchedulerComponent } from '../../shared/components/index.js';
+import type { CronSchedulerValue } from '../../shared/components/index.js';
 import { ScheduledProbeService, ScheduledProbe, CreateProbeRequest, UpdateProbeRequest } from '../../core/services/scheduled-probe.service.js';
 import { IntegrationService, ClientIntegration } from '../../core/services/integration.service.js';
 import { Client } from '../../core/services/client.service.js';
@@ -18,37 +19,10 @@ const ACTIONS = [
   { value: 'silent', label: 'Silent (ticket only if actionable)' },
 ];
 
-const CRON_PRESETS = [
-  { label: 'Every hour', value: '0 * * * *' },
-  { label: 'Every 6 hours', value: '0 */6 * * *' },
-  { label: 'Daily at 2 AM', value: '0 2 * * *' },
-  { label: 'Daily at 8 AM', value: '0 8 * * *' },
-  { label: 'Every Monday at 9 AM', value: '0 9 * * 1' },
-  { label: 'Custom', value: '' },
-];
-
-const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) => {
-  const h12 = i === 0 ? 12 : i > 12 ? i - 12 : i;
-  const ampm = i < 12 ? 'AM' : 'PM';
-  return { value: i, label: `${h12}:00 ${ampm}` };
-});
-
-const MINUTE_OPTIONS = [0, 15, 30, 45].map((m) => ({ value: m, label: m.toString().padStart(2, '0') }));
-
-const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-const COMMON_TIMEZONES = [
-  { value: 'America/New_York', label: 'America/New_York (Eastern)' },
-  { value: 'America/Chicago', label: 'America/Chicago (Central)' },
-  { value: 'America/Denver', label: 'America/Denver (Mountain)' },
-  { value: 'America/Los_Angeles', label: 'America/Los_Angeles (Pacific)' },
-  { value: 'UTC', label: 'UTC' },
-];
-
 @Component({
   selector: 'app-probe-dialog-content',
   standalone: true,
-  imports: [FormsModule, FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent],
+  imports: [FormsModule, FormFieldComponent, TextInputComponent, TextareaComponent, SelectComponent, BroncoButtonComponent, CronSchedulerComponent],
   template: `
     <div class="dialog-content">
       <div class="form-grid">
@@ -91,49 +65,15 @@ const COMMON_TIMEZONES = [
           </div>
         }
 
-        <app-form-field label="Schedule Type">
-          <app-select [value]="scheduleType" [options]="scheduleTypeOptions" (valueChange)="scheduleType = $event === 'cron' ? 'cron' : 'time'; onScheduleTypeChange()"></app-select>
-        </app-form-field>
-
-        @if (scheduleType === 'time') {
-          <div class="time-row">
-            <app-form-field label="Hour">
-              <app-select [value]="scheduleHour.toString()" [options]="hourSelectOptions" (valueChange)="scheduleHour = +$event"></app-select>
-            </app-form-field>
-            <app-form-field label="Minute">
-              <app-select [value]="scheduleMinute.toString()" [options]="minuteSelectOptions" (valueChange)="scheduleMinute = +$event"></app-select>
-            </app-form-field>
-          </div>
-
-          <div class="days-section">
-            <label class="days-label">Days</label>
-            <div class="days-row">
-              @for (day of dayNames; track $index) {
-                <label class="checkbox-item">
-                  <input type="checkbox" class="form-checkbox" [(ngModel)]="selectedDays[$index]">
-                  {{ day }}
-                </label>
-              }
-            </div>
-            <span class="days-hint">Leave all unchecked for every day</span>
-          </div>
-
-          <app-form-field label="Timezone">
-            <app-select [value]="scheduleTimezone" [options]="commonTimezones" (valueChange)="scheduleTimezone = $event"></app-select>
-          </app-form-field>
-
-          <div class="utc-hint">Next run: {{ computedUtcTime }} UTC</div>
-        }
-
-        @if (scheduleType === 'cron') {
-          <app-form-field label="Schedule Preset">
-            <app-select [value]="cronPreset" [options]="cronPresets" (valueChange)="cronPreset = $event; onPresetChange()"></app-select>
-          </app-form-field>
-
-          <app-form-field label="Cron Expression" [hint]="cronHumanReadable">
-            <app-text-input [value]="cronExpression" (valueChange)="cronExpression = $event" placeholder="0 * * * *"></app-text-input>
-          </app-form-field>
-        }
+        <app-cron-scheduler
+          [initialScheduleType]="scheduleType"
+          [initialHour]="scheduleHour"
+          [initialMinute]="scheduleMinute"
+          [initialDays]="selectedDays"
+          [initialTimezone]="scheduleTimezone"
+          [initialCronExpression]="cronExpression"
+          (valueChange)="onScheduleChange($event)"
+        />
 
         <app-form-field label="Action">
           <app-select [value]="action" [options]="actions" (valueChange)="action = $event"></app-select>
@@ -192,26 +132,16 @@ const COMMON_TIMEZONES = [
     .form-grid { display: flex; flex-direction: column; gap: 12px; }
     .params-section { margin-bottom: 8px; }
     .params-section h4 { margin: 0 0 8px; font-size: 14px; color: var(--text-tertiary); }
-    .time-row { display: flex; gap: 12px; }
-    .time-row app-form-field { flex: 1; }
-    .days-section { margin-bottom: 16px; }
-    .days-label { font-size: 12px; color: var(--text-tertiary); display: block; margin-bottom: 4px; }
-    .days-row { display: flex; gap: 4px; flex-wrap: wrap; }
-    .days-hint { font-size: 11px; color: var(--text-tertiary); display: block; margin-top: 2px; }
-    .utc-hint { font-size: 12px; color: var(--color-info); margin-bottom: 12px; padding: 4px 8px; background: var(--color-info-subtle); border-radius: 4px; }
     .retention-section { margin-top: 8px; }
     .retention-section h4 { margin: 0 0 8px; font-size: 14px; color: var(--text-tertiary); }
     .retention-row { display: flex; gap: 12px; }
     .retention-field { flex: 1; }
     .retention-field app-form-field { flex: 1; }
     .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
-    .checkbox-item { display: flex; align-items: center; gap: 6px; font-size: 13px; cursor: pointer; }
-    .form-checkbox { width: 15px; height: 15px; cursor: pointer; accent-color: var(--accent); }
 
     @media (max-width: 767.98px) {
       .dialog-content { min-width: 0; }
-      .time-row, .retention-row { flex-direction: column; gap: 12px; }
-      .checkbox-item, .form-checkbox { min-height: 44px; }
+      .retention-row { flex-direction: column; gap: 12px; }
     }
   `],
 })
@@ -235,7 +165,6 @@ export class ProbeDialogComponent implements OnInit {
   toolName = '';
   toolParams: Record<string, unknown> = {};
   cronExpression = '0 * * * *';
-  cronPreset = '';
   category: string | null = null;
   action = 'create_ticket';
   operatorEmail = '';
@@ -252,11 +181,6 @@ export class ProbeDialogComponent implements OnInit {
   selectedDays: boolean[] = [false, false, false, false, false, false, false];
 
   actions = ACTIONS;
-  cronPresets = CRON_PRESETS;
-  hourOptions = HOUR_OPTIONS;
-  minuteOptions = MINUTE_OPTIONS;
-  dayNames = DAY_NAMES;
-  commonTimezones = COMMON_TIMEZONES;
 
   toolSource: 'mcp' | 'builtin' = 'mcp';
 
@@ -274,11 +198,6 @@ export class ProbeDialogComponent implements OnInit {
     { value: 'builtin', label: 'Built-in' },
   ];
 
-  scheduleTypeOptions = [
-    { value: 'time', label: 'Time-based (recommended)' },
-    { value: 'cron', label: 'Custom cron' },
-  ];
-
   get clientSelectOptions() {
     return this.clientsList.map((c) => ({ value: c.id, label: c.name + ' (' + c.shortCode + ')' }));
   }
@@ -291,24 +210,8 @@ export class ProbeDialogComponent implements OnInit {
     return this.availableTools.map((t) => ({ value: t.name, label: t.name + ' — ' + t.description }));
   }
 
-  get hourSelectOptions() {
-    return this.hourOptions.map((h) => ({ value: h.value.toString(), label: h.label }));
-  }
-
-  get minuteSelectOptions() {
-    return this.minuteOptions.map((m) => ({ value: m.value.toString(), label: m.label }));
-  }
-
   get categorySelectOptions() {
     return [{ value: '', label: 'None' }, ...this.categoriesList.map((c) => ({ value: c.value, label: c.label }))];
-  }
-
-  get cronHumanReadable(): string {
-    return describeCron(this.cronExpression);
-  }
-
-  get computedUtcTime(): string {
-    return computeUtcPreview(this.scheduleHour, this.scheduleMinute, this.selectedDays, this.scheduleTimezone);
   }
 
   getToolParam(name: string): string {
@@ -359,10 +262,6 @@ export class ProbeDialogComponent implements OnInit {
         }
       }
     }
-
-    // Set cron preset if it matches
-    const match = CRON_PRESETS.find((pr) => pr.value === this.cronExpression);
-    this.cronPreset = match ? match.value : '';
 
     // Load built-in tools
     this.probeService.getBuiltinTools().subscribe((tools) => {
@@ -436,14 +335,13 @@ export class ProbeDialogComponent implements OnInit {
     }
   }
 
-  onScheduleTypeChange(): void {
-    // no-op, just triggers re-render
-  }
-
-  onPresetChange(): void {
-    if (this.cronPreset) {
-      this.cronExpression = this.cronPreset;
-    }
+  onScheduleChange(val: CronSchedulerValue): void {
+    this.scheduleType = val.scheduleType;
+    this.scheduleHour = val.scheduleHour;
+    this.scheduleMinute = val.scheduleMinute;
+    this.selectedDays = val.selectedDays;
+    this.scheduleTimezone = val.scheduleTimezone;
+    this.cronExpression = val.cronExpression;
   }
 
   canSave(): boolean {
@@ -586,85 +484,3 @@ export class ProbeDialogComponent implements OnInit {
   }
 }
 
-function describeCron(expr: string): string {
-  const parts = expr.trim().split(/\s+/);
-  if (parts.length !== 5) return expr;
-  const [min, hour, dom, mon, dow] = parts;
-
-  if (min === '0' && hour === '*' && dom === '*' && mon === '*' && dow === '*') return 'Every hour at :00';
-  if (min === '0' && hour?.startsWith('*/') && dom === '*' && mon === '*' && dow === '*') return `Every ${hour.slice(2)} hours`;
-  if (min !== '*' && hour !== '*' && dom === '*' && mon === '*' && dow === '*') return `Daily at ${hour}:${min.padStart(2, '0')}`;
-  if (min !== '*' && hour !== '*' && dom === '*' && mon === '*' && dow !== '*') {
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const dayName = days[Number(dow)] ?? dow;
-    return `Every ${dayName} at ${hour}:${min.padStart(2, '0')}`;
-  }
-  return expr;
-}
-
-function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[], timezone: string): string {
-  try {
-    const now = new Date();
-    const localStr = now.toLocaleDateString('en-US', { timeZone: timezone, year: 'numeric', month: '2-digit', day: '2-digit' });
-    const [month, day, year] = localStr.split('/').map(Number);
-    const target = new Date(Date.UTC(year, month - 1, day, hour, minute));
-
-    const utcParts = new Intl.DateTimeFormat('en-US', {
-      timeZone: 'UTC',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).formatToParts(target);
-    const localParts = new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).formatToParts(target);
-
-    const getVal = (parts: Intl.DateTimeFormatPart[], type: string) => {
-      const v = parts.find((p) => p.type === type)?.value ?? '0';
-      return type === 'hour' && v === '24' ? 0 : Number(v);
-    };
-
-    const toUtcMillis = (parts: Intl.DateTimeFormatPart[]) =>
-      Date.UTC(getVal(parts, 'year'), getVal(parts, 'month') - 1, getVal(parts, 'day'), getVal(parts, 'hour'), getVal(parts, 'minute'));
-
-    const offsetMinutes = Math.round((toUtcMillis(localParts) - toUtcMillis(utcParts)) / 60000);
-    let resultMinutes = (hour * 60 + minute) - offsetMinutes;
-    if (resultMinutes < 0) resultMinutes += 24 * 60;
-    if (resultMinutes >= 24 * 60) resultMinutes -= 24 * 60;
-
-    let utcMinute = minute - (offsetMinutes % 60);
-    let utcHour = hour - Math.trunc(offsetMinutes / 60);
-    if (utcMinute < 0) { utcMinute += 60; utcHour -= 1; }
-    else if (utcMinute >= 60) { utcMinute -= 60; utcHour += 1; }
-    let dayShift = 0;
-    if (utcHour < 0) { dayShift = -1; }
-    else if (utcHour >= 24) { dayShift = 1; }
-
-    const rH = Math.floor(resultMinutes / 60);
-    const rM = resultMinutes % 60;
-
-    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const anySelected = selectedDays.some(Boolean);
-    let displayDays = selectedDays.map((c, i) => c ? i : -1).filter((i) => i >= 0);
-    if (dayShift !== 0) {
-      displayDays = displayDays.map((d) => ((d + dayShift) % 7 + 7) % 7);
-      displayDays.sort((a, b) => a - b);
-    }
-    const daysText = !anySelected || selectedDays.every(Boolean)
-      ? 'Daily'
-      : displayDays.map((d) => dayNames[d]).join(', ');
-
-    return `${daysText} at ${rH.toString().padStart(2, '0')}:${rM.toString().padStart(2, '0')}`;
-  } catch {
-    return 'Unable to compute';
-  }
-}

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { Subject, Subscription, debounceTime, switchMap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import {
@@ -794,7 +795,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
     .strategyOptions { max-width: 400px; }
   `],
 })
-export class SettingsComponent implements OnInit {
+export class SettingsComponent implements OnInit, OnDestroy {
   private toast = inject(ToastService);
   private extSvc = inject(ExternalServiceService);
   private settingsSvc = inject(SettingsService);
@@ -857,6 +858,9 @@ export class SettingsComponent implements OnInit {
   selfAnalysisScheduleDays = signal<boolean[]>([false, false, false, false, false, false, false]);
   selfAnalysisScheduleTimezone = signal(this.getBrowserTimezone());
 
+  private scheduleChangeSubject = new Subject<void>();
+  private scheduleChangeSub?: Subscription;
+
   selectedTab = signal(0);
 
   trackStatus = (s: TicketStatusConfig) => s.value;
@@ -878,6 +882,30 @@ export class SettingsComponent implements OnInit {
     this.loadAnalysisStrategyVersion();
     this.loadSelfAnalysis();
     this.loadSystemConfigs();
+
+    // Debounced scheduler-field save: collapses rapid weekday/hour/minute changes
+    // into a single PATCH and cancels in-flight requests on newer changes.
+    this.scheduleChangeSub = this.scheduleChangeSubject.pipe(
+      debounceTime(300),
+      switchMap(() => this.settingsSvc.saveSelfAnalysis({
+        scheduledCron: this.selfAnalysisCron(),
+        scheduleType: this.selfAnalysisScheduleType(),
+        scheduleHour: this.selfAnalysisScheduleHour(),
+        scheduleMinute: this.selfAnalysisScheduleMinute(),
+        scheduleDaysOfWeek: this.selfAnalysisScheduleDays()
+          .map((checked, i) => (checked ? i : -1))
+          .filter((i) => i >= 0)
+          .join(',') || null,
+        scheduleTimezone: this.selfAnalysisScheduleTimezone(),
+      })),
+    ).subscribe({
+      next: (saved) => this.applySelfAnalysisResponse(saved),
+      error: () => this.toast.error('Failed to save schedule'),
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.scheduleChangeSub?.unsubscribe();
   }
 
   onTabChange(index: number): void {
@@ -1185,6 +1213,33 @@ export class SettingsComponent implements OnInit {
     });
   }
 
+  /** Apply a full server response to local signals (used by both save paths). */
+  private applySelfAnalysisResponse(saved: SelfAnalysisConfig): void {
+    this.selfAnalysisPostAnalysis.set(saved.postAnalysisTrigger);
+    this.selfAnalysisTicketClose.set(saved.ticketCloseTrigger);
+    this.selfAnalysisScheduled.set(saved.scheduledEnabled);
+    this.selfAnalysisCron.set(saved.scheduledCron);
+    this.selfAnalysisRepoUrl.set(saved.repoUrl);
+    this.selfAnalysisScheduleType.set(saved.scheduleType ?? 'cron');
+    this.selfAnalysisScheduleHour.set(saved.scheduleHour ?? 9);
+    this.selfAnalysisScheduleMinute.set(saved.scheduleMinute ?? 0);
+    this.selfAnalysisScheduleTimezone.set(saved.scheduleTimezone ?? this.getBrowserTimezone());
+    const days: boolean[] = [false, false, false, false, false, false, false];
+    if (saved.scheduleDaysOfWeek) {
+      saved.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
+        if (d >= 0 && d <= 6) days[d] = true;
+      });
+    }
+    this.selfAnalysisScheduleDays.set(days);
+  }
+
+  /**
+   * Save a partial self-analysis config update. Used by toggle switches
+   * (postAnalysisTrigger / ticketCloseTrigger / scheduledEnabled / repoUrl)
+   * which are discrete low-frequency clicks and save immediately with a toast.
+   * Scheduler field changes (hour, minute, days, timezone) go through the
+   * debounced path in onSelfAnalysisScheduleChange instead.
+   */
   updateSelfAnalysis(partial: Partial<SelfAnalysisConfig>): void {
     if (partial.postAnalysisTrigger !== undefined) this.selfAnalysisPostAnalysis.set(partial.postAnalysisTrigger);
     if (partial.ticketCloseTrigger !== undefined) this.selfAnalysisTicketClose.set(partial.ticketCloseTrigger);
@@ -1192,8 +1247,8 @@ export class SettingsComponent implements OnInit {
     if (partial.scheduledCron !== undefined) this.selfAnalysisCron.set(partial.scheduledCron);
     if (partial.repoUrl !== undefined) this.selfAnalysisRepoUrl.set(partial.repoUrl);
     if (partial.scheduleType !== undefined) this.selfAnalysisScheduleType.set(partial.scheduleType);
-    if (partial.scheduleHour != null) this.selfAnalysisScheduleHour.set(partial.scheduleHour);
-    if (partial.scheduleMinute != null) this.selfAnalysisScheduleMinute.set(partial.scheduleMinute);
+    if (partial.scheduleHour !== undefined) this.selfAnalysisScheduleHour.set(partial.scheduleHour ?? 0);
+    if (partial.scheduleMinute !== undefined) this.selfAnalysisScheduleMinute.set(partial.scheduleMinute ?? 0);
     if (partial.scheduleTimezone !== undefined) this.selfAnalysisScheduleTimezone.set(partial.scheduleTimezone);
     if (partial.scheduleDaysOfWeek !== undefined) {
       const days: boolean[] = [false, false, false, false, false, false, false];
@@ -1207,22 +1262,7 @@ export class SettingsComponent implements OnInit {
 
     this.settingsSvc.saveSelfAnalysis(partial).subscribe({
       next: (saved) => {
-        this.selfAnalysisPostAnalysis.set(saved.postAnalysisTrigger);
-        this.selfAnalysisTicketClose.set(saved.ticketCloseTrigger);
-        this.selfAnalysisScheduled.set(saved.scheduledEnabled);
-        this.selfAnalysisCron.set(saved.scheduledCron);
-        this.selfAnalysisRepoUrl.set(saved.repoUrl);
-        this.selfAnalysisScheduleType.set(saved.scheduleType ?? 'cron');
-        this.selfAnalysisScheduleHour.set(saved.scheduleHour ?? 9);
-        this.selfAnalysisScheduleMinute.set(saved.scheduleMinute ?? 0);
-        this.selfAnalysisScheduleTimezone.set(saved.scheduleTimezone ?? this.getBrowserTimezone());
-        const days: boolean[] = [false, false, false, false, false, false, false];
-        if (saved.scheduleDaysOfWeek) {
-          saved.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
-            if (d >= 0 && d <= 6) days[d] = true;
-          });
-        }
-        this.selfAnalysisScheduleDays.set(days);
+        this.applySelfAnalysisResponse(saved);
         this.toast.success('Self-analysis config saved');
       },
       error: () => {
@@ -1232,20 +1272,20 @@ export class SettingsComponent implements OnInit {
     });
   }
 
+  /**
+   * Called by the cron-scheduler component on every internal change (hour tick,
+   * weekday toggle, timezone change, etc.). Updates local signals immediately
+   * for optimistic UI, then pushes to the debounced save pipeline so rapid edits
+   * collapse into a single PATCH and in-flight saves are cancelled by newer ones.
+   */
   onSelfAnalysisScheduleChange(val: CronSchedulerValue): void {
-    const daysOfWeek = val.selectedDays
-      .map((checked, i) => (checked ? i : -1))
-      .filter((i) => i >= 0)
-      .join(',') || null;
-
-    this.updateSelfAnalysis({
-      scheduledCron: val.utcCron,
-      scheduleType: val.scheduleType,
-      scheduleHour: val.scheduleHour,
-      scheduleMinute: val.scheduleMinute,
-      scheduleDaysOfWeek: daysOfWeek,
-      scheduleTimezone: val.scheduleTimezone,
-    });
+    this.selfAnalysisScheduleType.set(val.scheduleType);
+    this.selfAnalysisScheduleHour.set(val.scheduleHour);
+    this.selfAnalysisScheduleMinute.set(val.scheduleMinute);
+    this.selfAnalysisScheduleDays.set(val.selectedDays);
+    this.selfAnalysisScheduleTimezone.set(val.scheduleTimezone);
+    this.selfAnalysisCron.set(val.utcCron);
+    this.scheduleChangeSubject.next();
   }
 
   // ─── System Config (SMTP, DevOps, GitHub, IMAP, Slack, Prompt Retention) ───

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -35,7 +35,9 @@ import {
   DropdownItemComponent,
   DialogComponent,
   IconComponent,
+  CronSchedulerComponent,
 } from '../../shared/components/index.js';
+import type { CronSchedulerValue } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
 const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis Strategy', 'Self Analysis', 'SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention'] as const;
@@ -57,6 +59,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
     DropdownItemComponent,
     DialogComponent,
     IconComponent,
+    CronSchedulerComponent,
     ExternalServiceDialogComponent,
     StatusConfigDialogComponent,
     CategoryConfigDialogComponent,
@@ -419,9 +422,15 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
 
                 @if (selfAnalysisScheduled()) {
                   <div class="form-grid" style="margin-top: 16px;">
-                    <app-form-field label="Cron Expression" hint="Standard cron (e.g., &quot;0 9 * * 1&quot; = Monday 9am UTC)">
-                      <input class="text-input" [value]="selfAnalysisCron()" (blur)="updateSelfAnalysis({ scheduledCron: $any($event.target).value })">
-                    </app-form-field>
+                    <app-cron-scheduler
+                      [initialScheduleType]="selfAnalysisScheduleType()"
+                      [initialHour]="selfAnalysisScheduleHour()"
+                      [initialMinute]="selfAnalysisScheduleMinute()"
+                      [initialDays]="selfAnalysisScheduleDays()"
+                      [initialTimezone]="selfAnalysisScheduleTimezone()"
+                      [initialCronExpression]="selfAnalysisCron()"
+                      (valueChange)="onSelfAnalysisScheduleChange($event)"
+                    />
 
                     <app-form-field label="Repository URL" hint="Git repo URL for code-aware analysis via mcp-repo">
                       <input class="text-input" [value]="selfAnalysisRepoUrl()" (blur)="updateSelfAnalysis({ repoUrl: $any($event.target).value })">
@@ -842,6 +851,11 @@ export class SettingsComponent implements OnInit {
   selfAnalysisScheduled = signal(false);
   selfAnalysisCron = signal('0 9 * * 1');
   selfAnalysisRepoUrl = signal('https://github.com/siir/bronco');
+  selfAnalysisScheduleType = signal<'time' | 'cron'>('cron');
+  selfAnalysisScheduleHour = signal(9);
+  selfAnalysisScheduleMinute = signal(0);
+  selfAnalysisScheduleDays = signal<boolean[]>([false, false, false, false, false, false, false]);
+  selfAnalysisScheduleTimezone = signal('America/Chicago');
 
   selectedTab = signal(0);
 
@@ -1143,6 +1157,17 @@ export class SettingsComponent implements OnInit {
         this.selfAnalysisScheduled.set(config.scheduledEnabled);
         this.selfAnalysisCron.set(config.scheduledCron);
         this.selfAnalysisRepoUrl.set(config.repoUrl);
+        this.selfAnalysisScheduleType.set(config.scheduleType ?? 'cron');
+        this.selfAnalysisScheduleHour.set(config.scheduleHour ?? 9);
+        this.selfAnalysisScheduleMinute.set(config.scheduleMinute ?? 0);
+        this.selfAnalysisScheduleTimezone.set(config.scheduleTimezone ?? 'America/Chicago');
+        const days: boolean[] = [false, false, false, false, false, false, false];
+        if (config.scheduleDaysOfWeek) {
+          config.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
+            if (d >= 0 && d <= 6) days[d] = true;
+          });
+        }
+        this.selfAnalysisScheduleDays.set(days);
         this.selfAnalysisLoading.set(false);
       },
       error: () => {
@@ -1158,6 +1183,19 @@ export class SettingsComponent implements OnInit {
     if (partial.scheduledEnabled !== undefined) this.selfAnalysisScheduled.set(partial.scheduledEnabled);
     if (partial.scheduledCron !== undefined) this.selfAnalysisCron.set(partial.scheduledCron);
     if (partial.repoUrl !== undefined) this.selfAnalysisRepoUrl.set(partial.repoUrl);
+    if (partial.scheduleType !== undefined) this.selfAnalysisScheduleType.set(partial.scheduleType);
+    if (partial.scheduleHour != null) this.selfAnalysisScheduleHour.set(partial.scheduleHour);
+    if (partial.scheduleMinute != null) this.selfAnalysisScheduleMinute.set(partial.scheduleMinute);
+    if (partial.scheduleTimezone !== undefined) this.selfAnalysisScheduleTimezone.set(partial.scheduleTimezone);
+    if (partial.scheduleDaysOfWeek !== undefined) {
+      const days: boolean[] = [false, false, false, false, false, false, false];
+      if (partial.scheduleDaysOfWeek) {
+        partial.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
+          if (d >= 0 && d <= 6) days[d] = true;
+        });
+      }
+      this.selfAnalysisScheduleDays.set(days);
+    }
 
     this.settingsSvc.saveSelfAnalysis(partial).subscribe({
       next: (saved) => {
@@ -1172,6 +1210,22 @@ export class SettingsComponent implements OnInit {
         this.toast.error('Failed to save self-analysis config');
         this.loadSelfAnalysis();
       },
+    });
+  }
+
+  onSelfAnalysisScheduleChange(val: CronSchedulerValue): void {
+    const daysOfWeek = val.selectedDays
+      .map((checked, i) => (checked ? i : -1))
+      .filter((i) => i >= 0)
+      .join(',') || null;
+
+    this.updateSelfAnalysis({
+      scheduledCron: val.utcCron,
+      scheduleType: val.scheduleType,
+      scheduleHour: val.scheduleHour,
+      scheduleMinute: val.scheduleMinute,
+      scheduleDaysOfWeek: daysOfWeek,
+      scheduleTimezone: val.scheduleTimezone,
     });
   }
 

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -855,7 +855,7 @@ export class SettingsComponent implements OnInit {
   selfAnalysisScheduleHour = signal(9);
   selfAnalysisScheduleMinute = signal(0);
   selfAnalysisScheduleDays = signal<boolean[]>([false, false, false, false, false, false, false]);
-  selfAnalysisScheduleTimezone = signal('America/Chicago');
+  selfAnalysisScheduleTimezone = signal(this.getBrowserTimezone());
 
   selectedTab = signal(0);
 
@@ -1148,6 +1148,14 @@ export class SettingsComponent implements OnInit {
 
   // ─── Self Analysis ───
 
+  private getBrowserTimezone(): string {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch {
+      return 'UTC';
+    }
+  }
+
   loadSelfAnalysis(): void {
     this.selfAnalysisLoading.set(true);
     this.settingsSvc.getSelfAnalysis().subscribe({
@@ -1160,7 +1168,7 @@ export class SettingsComponent implements OnInit {
         this.selfAnalysisScheduleType.set(config.scheduleType ?? 'cron');
         this.selfAnalysisScheduleHour.set(config.scheduleHour ?? 9);
         this.selfAnalysisScheduleMinute.set(config.scheduleMinute ?? 0);
-        this.selfAnalysisScheduleTimezone.set(config.scheduleTimezone ?? 'America/Chicago');
+        this.selfAnalysisScheduleTimezone.set(config.scheduleTimezone ?? this.getBrowserTimezone());
         const days: boolean[] = [false, false, false, false, false, false, false];
         if (config.scheduleDaysOfWeek) {
           config.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
@@ -1204,6 +1212,17 @@ export class SettingsComponent implements OnInit {
         this.selfAnalysisScheduled.set(saved.scheduledEnabled);
         this.selfAnalysisCron.set(saved.scheduledCron);
         this.selfAnalysisRepoUrl.set(saved.repoUrl);
+        this.selfAnalysisScheduleType.set(saved.scheduleType ?? 'cron');
+        this.selfAnalysisScheduleHour.set(saved.scheduleHour ?? 9);
+        this.selfAnalysisScheduleMinute.set(saved.scheduleMinute ?? 0);
+        this.selfAnalysisScheduleTimezone.set(saved.scheduleTimezone ?? this.getBrowserTimezone());
+        const days: boolean[] = [false, false, false, false, false, false, false];
+        if (saved.scheduleDaysOfWeek) {
+          saved.scheduleDaysOfWeek.split(',').map(Number).forEach((d) => {
+            if (d >= 0 && d <= 6) days[d] = true;
+          });
+        }
+        this.selfAnalysisScheduleDays.set(days);
         this.toast.success('Self-analysis config saved');
       },
       error: () => {

--- a/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
+++ b/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
@@ -78,7 +78,7 @@ export interface CronSchedulerValue {
         <app-select [value]="scheduleTimezone" [options]="timezoneOptions" (valueChange)="scheduleTimezone = $event; emit()"></app-select>
       </app-form-field>
 
-      <div class="utc-hint">Next run: {{ computedUtcTime }} UTC</div>
+      <div class="utc-hint">Runs at (UTC): {{ computedUtcTime }}</div>
     }
 
     @if (scheduleType === 'cron') {
@@ -281,7 +281,20 @@ function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[]
   }
 }
 
-/** Convert a local-time schedule into a UTC cron expression using Intl for DST-aware offset. */
+/**
+ * Convert a local-time schedule into a static UTC cron expression using the
+ * timezone's CURRENT offset (at the instant of conversion). The result is a
+ * fixed UTC cron — NOT DST-aware over time.
+ *
+ * Limitation: if the operator saves a schedule during a DST period and the
+ * timezone transitions (e.g., US EST ↔ EDT), the UTC cron will drift by
+ * 1 hour from the operator's local wall-clock intent until re-saved. For
+ * precise timing across DST boundaries, operators should re-save the schedule
+ * after DST transitions, or a future refactor should move timezone
+ * interpretation to the worker using a TZ-aware scheduler.
+ *
+ * For non-DST timezones (UTC, most of Asia, etc.), this limitation doesn't apply.
+ */
 function buildUtcCronFromLocal(hour: number, minute: number, selectedDays: boolean[], timezone: string): string {
   try {
     const now = new Date();

--- a/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
+++ b/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
@@ -75,7 +75,7 @@ export interface CronSchedulerValue {
       </div>
 
       <app-form-field label="Timezone">
-        <app-select [value]="scheduleTimezone" [options]="commonTimezones" (valueChange)="scheduleTimezone = $event; emit()"></app-select>
+        <app-select [value]="scheduleTimezone" [options]="timezoneOptions" (valueChange)="scheduleTimezone = $event; emit()"></app-select>
       </app-form-field>
 
       <div class="utc-hint">Next run: {{ computedUtcTime }} UTC</div>
@@ -113,7 +113,7 @@ export class CronSchedulerComponent implements OnInit {
   initialHour = input<number>(8);
   initialMinute = input<number>(0);
   initialDays = input<boolean[]>([false, false, false, false, false, false, false]);
-  initialTimezone = input<string>('America/Chicago');
+  initialTimezone = input<string | undefined>(undefined);
   initialCronExpression = input<string>('0 * * * *');
 
   valueChange = output<CronSchedulerValue>();
@@ -121,7 +121,7 @@ export class CronSchedulerComponent implements OnInit {
   scheduleType: 'time' | 'cron' = 'time';
   scheduleHour = 8;
   scheduleMinute = 0;
-  scheduleTimezone = 'America/Chicago';
+  scheduleTimezone = this.getBrowserTimezone();
   selectedDays: boolean[] = [false, false, false, false, false, false, false];
   cronExpression = '0 * * * *';
   cronPreset = '';
@@ -134,7 +134,23 @@ export class CronSchedulerComponent implements OnInit {
   hourSelectOptions = HOUR_OPTIONS.map((h) => ({ value: h.value.toString(), label: h.label }));
   minuteSelectOptions = MINUTE_OPTIONS.map((m) => ({ value: m.value.toString(), label: m.label }));
   dayNames = DAY_NAMES;
-  commonTimezones = COMMON_TIMEZONES;
+
+  protected get timezoneOptions(): Array<{ value: string; label: string }> {
+    const base = [...COMMON_TIMEZONES];
+    const current = this.scheduleTimezone;
+    if (current && !base.some((o) => o.value === current)) {
+      base.unshift({ value: current, label: current });
+    }
+    return base;
+  }
+
+  private getBrowserTimezone(): string {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch {
+      return 'UTC';
+    }
+  }
 
   get cronHumanReadable(): string {
     return describeCron(this.cronExpression);
@@ -149,7 +165,7 @@ export class CronSchedulerComponent implements OnInit {
     this.scheduleHour = this.initialHour();
     this.scheduleMinute = this.initialMinute();
     this.selectedDays = [...this.initialDays()];
-    this.scheduleTimezone = this.initialTimezone();
+    this.scheduleTimezone = this.initialTimezone() ?? this.getBrowserTimezone();
     this.cronExpression = this.initialCronExpression();
     const match = CRON_PRESETS.find((pr) => pr.value === this.cronExpression);
     this.cronPreset = match ? match.value : '';

--- a/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
+++ b/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
@@ -1,0 +1,309 @@
+import { Component, OnInit, input, output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FormFieldComponent } from './form-field.component.js';
+import { TextInputComponent } from './text-input.component.js';
+import { SelectComponent } from './select.component.js';
+
+const CRON_PRESETS = [
+  { label: 'Every hour', value: '0 * * * *' },
+  { label: 'Every 6 hours', value: '0 */6 * * *' },
+  { label: 'Daily at 2 AM', value: '0 2 * * *' },
+  { label: 'Daily at 8 AM', value: '0 8 * * *' },
+  { label: 'Every Monday at 9 AM', value: '0 9 * * 1' },
+  { label: 'Custom', value: '' },
+];
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) => {
+  const h12 = i === 0 ? 12 : i > 12 ? i - 12 : i;
+  const ampm = i < 12 ? 'AM' : 'PM';
+  return { value: i, label: `${h12}:00 ${ampm}` };
+});
+
+const MINUTE_OPTIONS = [0, 15, 30, 45].map((m) => ({ value: m, label: m.toString().padStart(2, '0') }));
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const COMMON_TIMEZONES = [
+  { value: 'America/New_York', label: 'America/New_York (Eastern)' },
+  { value: 'America/Chicago', label: 'America/Chicago (Central)' },
+  { value: 'America/Denver', label: 'America/Denver (Mountain)' },
+  { value: 'America/Los_Angeles', label: 'America/Los_Angeles (Pacific)' },
+  { value: 'UTC', label: 'UTC' },
+];
+
+export interface CronSchedulerValue {
+  scheduleType: 'time' | 'cron';
+  scheduleHour: number;
+  scheduleMinute: number;
+  selectedDays: boolean[];
+  scheduleTimezone: string;
+  cronExpression: string;
+  /** UTC cron derived from time fields (time mode) or equal to cronExpression (cron mode). */
+  utcCron: string;
+}
+
+@Component({
+  selector: 'app-cron-scheduler',
+  standalone: true,
+  imports: [FormsModule, FormFieldComponent, TextInputComponent, SelectComponent],
+  template: `
+    <app-form-field label="Schedule Type">
+      <app-select [value]="scheduleType" [options]="scheduleTypeOptions" (valueChange)="onScheduleTypeChange($event)"></app-select>
+    </app-form-field>
+
+    @if (scheduleType === 'time') {
+      <div class="time-row">
+        <app-form-field label="Hour">
+          <app-select [value]="scheduleHour.toString()" [options]="hourSelectOptions" (valueChange)="scheduleHour = +$event; emit()"></app-select>
+        </app-form-field>
+        <app-form-field label="Minute">
+          <app-select [value]="scheduleMinute.toString()" [options]="minuteSelectOptions" (valueChange)="scheduleMinute = +$event; emit()"></app-select>
+        </app-form-field>
+      </div>
+
+      <div class="days-section">
+        <label class="days-label">Days</label>
+        <div class="days-row">
+          @for (day of dayNames; track $index) {
+            <label class="checkbox-item">
+              <input type="checkbox" class="form-checkbox" [checked]="selectedDays[$index]" (change)="onDayToggle($index)">
+              {{ day }}
+            </label>
+          }
+        </div>
+        <span class="days-hint">Leave all unchecked for every day</span>
+      </div>
+
+      <app-form-field label="Timezone">
+        <app-select [value]="scheduleTimezone" [options]="commonTimezones" (valueChange)="scheduleTimezone = $event; emit()"></app-select>
+      </app-form-field>
+
+      <div class="utc-hint">Next run: {{ computedUtcTime }} UTC</div>
+    }
+
+    @if (scheduleType === 'cron') {
+      <app-form-field label="Schedule Preset">
+        <app-select [value]="cronPreset" [options]="cronPresets" (valueChange)="cronPreset = $event; onPresetChange()"></app-select>
+      </app-form-field>
+
+      <app-form-field label="Cron Expression" [hint]="cronHumanReadable">
+        <app-text-input [value]="cronExpression" (valueChange)="cronExpression = $event; emit()" placeholder="0 * * * *"></app-text-input>
+      </app-form-field>
+    }
+  `,
+  styles: [`
+    .time-row { display: flex; gap: 12px; }
+    .time-row app-form-field { flex: 1; }
+    .days-section { margin-bottom: 16px; }
+    .days-label { font-size: 12px; color: var(--text-tertiary); display: block; margin-bottom: 4px; }
+    .days-row { display: flex; gap: 4px; flex-wrap: wrap; }
+    .days-hint { font-size: 11px; color: var(--text-tertiary); display: block; margin-top: 2px; }
+    .utc-hint { font-size: 12px; color: var(--color-info); margin-bottom: 12px; padding: 4px 8px; background: var(--color-info-subtle); border-radius: 4px; }
+    .checkbox-item { display: flex; align-items: center; gap: 6px; font-size: 13px; cursor: pointer; }
+    .form-checkbox { width: 15px; height: 15px; cursor: pointer; accent-color: var(--accent); }
+
+    @media (max-width: 767.98px) {
+      .time-row { flex-direction: column; gap: 12px; }
+      .checkbox-item, .form-checkbox { min-height: 44px; }
+    }
+  `],
+})
+export class CronSchedulerComponent implements OnInit {
+  initialScheduleType = input<'time' | 'cron'>('time');
+  initialHour = input<number>(8);
+  initialMinute = input<number>(0);
+  initialDays = input<boolean[]>([false, false, false, false, false, false, false]);
+  initialTimezone = input<string>('America/Chicago');
+  initialCronExpression = input<string>('0 * * * *');
+
+  valueChange = output<CronSchedulerValue>();
+
+  scheduleType: 'time' | 'cron' = 'time';
+  scheduleHour = 8;
+  scheduleMinute = 0;
+  scheduleTimezone = 'America/Chicago';
+  selectedDays: boolean[] = [false, false, false, false, false, false, false];
+  cronExpression = '0 * * * *';
+  cronPreset = '';
+
+  scheduleTypeOptions = [
+    { value: 'time', label: 'Time-based (recommended)' },
+    { value: 'cron', label: 'Custom cron' },
+  ];
+  cronPresets = CRON_PRESETS;
+  hourSelectOptions = HOUR_OPTIONS.map((h) => ({ value: h.value.toString(), label: h.label }));
+  minuteSelectOptions = MINUTE_OPTIONS.map((m) => ({ value: m.value.toString(), label: m.label }));
+  dayNames = DAY_NAMES;
+  commonTimezones = COMMON_TIMEZONES;
+
+  get cronHumanReadable(): string {
+    return describeCron(this.cronExpression);
+  }
+
+  get computedUtcTime(): string {
+    return computeUtcPreview(this.scheduleHour, this.scheduleMinute, this.selectedDays, this.scheduleTimezone);
+  }
+
+  ngOnInit(): void {
+    this.scheduleType = this.initialScheduleType();
+    this.scheduleHour = this.initialHour();
+    this.scheduleMinute = this.initialMinute();
+    this.selectedDays = [...this.initialDays()];
+    this.scheduleTimezone = this.initialTimezone();
+    this.cronExpression = this.initialCronExpression();
+    const match = CRON_PRESETS.find((pr) => pr.value === this.cronExpression);
+    this.cronPreset = match ? match.value : '';
+  }
+
+  onScheduleTypeChange(val: string): void {
+    this.scheduleType = val === 'cron' ? 'cron' : 'time';
+    this.emit();
+  }
+
+  onPresetChange(): void {
+    if (this.cronPreset) {
+      this.cronExpression = this.cronPreset;
+    }
+    this.emit();
+  }
+
+  onDayToggle(index: number): void {
+    this.selectedDays = [...this.selectedDays];
+    this.selectedDays[index] = !this.selectedDays[index];
+    this.emit();
+  }
+
+  emit(): void {
+    const utcCron = this.scheduleType === 'time'
+      ? buildUtcCronFromLocal(this.scheduleHour, this.scheduleMinute, this.selectedDays, this.scheduleTimezone)
+      : this.cronExpression;
+
+    this.valueChange.emit({
+      scheduleType: this.scheduleType,
+      scheduleHour: this.scheduleHour,
+      scheduleMinute: this.scheduleMinute,
+      selectedDays: [...this.selectedDays],
+      scheduleTimezone: this.scheduleTimezone,
+      cronExpression: this.cronExpression,
+      utcCron,
+    });
+  }
+}
+
+function describeCron(expr: string): string {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return expr;
+  const [min, hour, dom, mon, dow] = parts;
+
+  if (min === '0' && hour === '*' && dom === '*' && mon === '*' && dow === '*') return 'Every hour at :00';
+  if (min === '0' && hour?.startsWith('*/') && dom === '*' && mon === '*' && dow === '*') return `Every ${hour.slice(2)} hours`;
+  if (min !== '*' && hour !== '*' && dom === '*' && mon === '*' && dow === '*') return `Daily at ${hour}:${min.padStart(2, '0')}`;
+  if (min !== '*' && hour !== '*' && dom === '*' && mon === '*' && dow !== '*') {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const dayName = days[Number(dow)] ?? dow;
+    return `Every ${dayName} at ${hour}:${min.padStart(2, '0')}`;
+  }
+  return expr;
+}
+
+function computeUtcPreview(hour: number, minute: number, selectedDays: boolean[], timezone: string): string {
+  try {
+    const now = new Date();
+    const localStr = now.toLocaleDateString('en-US', { timeZone: timezone, year: 'numeric', month: '2-digit', day: '2-digit' });
+    const [month, day, year] = localStr.split('/').map(Number);
+    const target = new Date(Date.UTC(year, month - 1, day, hour, minute));
+
+    const utcParts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'UTC',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(target);
+    const localParts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(target);
+
+    const getVal = (parts: Intl.DateTimeFormatPart[], type: string) => {
+      const v = parts.find((p) => p.type === type)?.value ?? '0';
+      return type === 'hour' && v === '24' ? 0 : Number(v);
+    };
+
+    const toUtcMillis = (parts: Intl.DateTimeFormatPart[]) =>
+      Date.UTC(getVal(parts, 'year'), getVal(parts, 'month') - 1, getVal(parts, 'day'), getVal(parts, 'hour'), getVal(parts, 'minute'));
+
+    const offsetMinutes = Math.round((toUtcMillis(localParts) - toUtcMillis(utcParts)) / 60000);
+    let resultMinutes = (hour * 60 + minute) - offsetMinutes;
+    if (resultMinutes < 0) resultMinutes += 24 * 60;
+    if (resultMinutes >= 24 * 60) resultMinutes -= 24 * 60;
+
+    let utcMinute = minute - (offsetMinutes % 60);
+    let utcHour = hour - Math.trunc(offsetMinutes / 60);
+    if (utcMinute < 0) { utcMinute += 60; utcHour -= 1; }
+    else if (utcMinute >= 60) { utcMinute -= 60; utcHour += 1; }
+    let dayShift = 0;
+    if (utcHour < 0) { dayShift = -1; }
+    else if (utcHour >= 24) { dayShift = 1; }
+
+    const rH = Math.floor(resultMinutes / 60);
+    const rM = resultMinutes % 60;
+
+    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const anySelected = selectedDays.some(Boolean);
+    let displayDays = selectedDays.map((c, i) => c ? i : -1).filter((i) => i >= 0);
+    if (dayShift !== 0) {
+      displayDays = displayDays.map((d) => ((d + dayShift) % 7 + 7) % 7);
+      displayDays.sort((a, b) => a - b);
+    }
+    const daysText = !anySelected || selectedDays.every(Boolean)
+      ? 'Daily'
+      : displayDays.map((d) => dayNames[d]).join(', ');
+
+    return `${daysText} at ${rH.toString().padStart(2, '0')}:${rM.toString().padStart(2, '0')}`;
+  } catch {
+    return 'Unable to compute';
+  }
+}
+
+/** Convert a local-time schedule into a UTC cron expression using Intl for DST-aware offset. */
+function buildUtcCronFromLocal(hour: number, minute: number, selectedDays: boolean[], timezone: string): string {
+  try {
+    const now = new Date();
+    const fmt = (tz: string) => new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(now);
+
+    const getVal = (parts: Intl.DateTimeFormatPart[], type: string): number => {
+      const v = parts.find((p) => p.type === type)?.value ?? '0';
+      return type === 'hour' && v === '24' ? 0 : Number(v);
+    };
+    const toMs = (parts: Intl.DateTimeFormatPart[]) =>
+      Date.UTC(getVal(parts, 'year'), getVal(parts, 'month') - 1, getVal(parts, 'day'), getVal(parts, 'hour'), getVal(parts, 'minute'));
+
+    const offsetMinutes = Math.round((toMs(fmt(timezone)) - toMs(fmt('UTC'))) / 60000);
+
+    let utcMinute = minute - (offsetMinutes % 60);
+    let utcHour = hour - Math.trunc(offsetMinutes / 60);
+
+    if (utcMinute < 0) { utcMinute += 60; utcHour -= 1; }
+    else if (utcMinute >= 60) { utcMinute -= 60; utcHour += 1; }
+
+    let dayShift = 0;
+    if (utcHour < 0) { utcHour += 24; dayShift = -1; }
+    else if (utcHour >= 24) { utcHour -= 24; dayShift = 1; }
+
+    const anySelected = selectedDays.some(Boolean);
+    if (!anySelected) {
+      return `${utcMinute} ${utcHour} * * *`;
+    }
+
+    const days = selectedDays.map((c, i) => c ? i : -1).filter((i) => i >= 0);
+    const shifted = dayShift !== 0 ? days.map((d) => ((d + dayShift) % 7 + 7) % 7) : days;
+    const unique = [...new Set(shifted)].sort((a, b) => a - b);
+    return `${utcMinute} ${utcHour} * * ${unique.join(',')}`;
+  } catch {
+    return `${minute} ${hour} * * *`;
+  }
+}

--- a/services/control-panel/src/app/shared/components/index.ts
+++ b/services/control-panel/src/app/shared/components/index.ts
@@ -25,3 +25,4 @@ export {
 } from './dropdown-menu.component.js';
 export { IconComponent, type IconSize } from './icon.component.js';
 export { ICON_REGISTRY, type IconName } from './icon-registry.js';
+export { CronSchedulerComponent, type CronSchedulerValue } from './cron-scheduler.component.js';

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -1207,6 +1207,11 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     scheduledEnabled: z.boolean().default(false),
     scheduledCron: z.string().default('0 9 * * 1'),
     repoUrl: z.string().default('https://github.com/siir/bronco'),
+    scheduleType: z.enum(['time', 'cron']).default('cron'),
+    scheduleHour: z.number().int().min(0).max(23).nullable().default(null),
+    scheduleMinute: z.number().int().min(0).max(59).nullable().default(null),
+    scheduleDaysOfWeek: z.string().nullable().default(null),
+    scheduleTimezone: z.string().default('America/Chicago'),
   });
 
   type SelfAnalysisConfig = z.output<typeof selfAnalysisConfigSchema>;
@@ -1217,6 +1222,11 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     scheduledEnabled: false,
     scheduledCron: '0 9 * * 1',
     repoUrl: 'https://github.com/siir/bronco',
+    scheduleType: 'cron',
+    scheduleHour: null,
+    scheduleMinute: null,
+    scheduleDaysOfWeek: null,
+    scheduleTimezone: 'America/Chicago',
   };
 
   // GET /api/settings/self-analysis

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -1211,7 +1211,7 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     scheduleHour: z.number().int().min(0).max(23).nullable().default(null),
     scheduleMinute: z.number().int().min(0).max(59).nullable().default(null),
     scheduleDaysOfWeek: z.string().nullable().default(null),
-    scheduleTimezone: z.string().default('America/Chicago'),
+    scheduleTimezone: z.string().default('UTC'),
   });
 
   type SelfAnalysisConfig = z.output<typeof selfAnalysisConfigSchema>;
@@ -1226,7 +1226,7 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     scheduleHour: null,
     scheduleMinute: null,
     scheduleDaysOfWeek: null,
-    scheduleTimezone: 'America/Chicago',
+    scheduleTimezone: 'UTC',
   };
 
   // GET /api/settings/self-analysis


### PR DESCRIPTION
Fixes #338. Extracts the scheduler UI from probe-dialog into a shared standalone component, then reuses it on Settings → Self Analysis.

## What's in

- **New component**: `services/control-panel/src/app/shared/components/cron-scheduler.component.ts` — standalone Angular component with frequency / time / weekday pickers + timezone select + advanced cron escape hatch. Emits `CronSchedulerValue` on every change (mirrors the contract probe-dialog already used).
- **Probe dialog refactor**: scheduler block (-224 lines) removed from `probe-dialog.component.ts`; now delegates to `<app-cron-scheduler>` and maps the emitted value back to the existing probe-update payload. No behavior change for probe creation / edit.
- **Settings Self Analysis tab**: raw `Cron Expression` text input + "Standard cron (e.g., 0 9 * * 1 = Monday 9am UTC)" hint replaced with the scheduler.
- **Setting shape extended**: `packages/shared-utils/src/self-analysis-config.ts` + `services/copilot-api/src/routes/settings.ts` Zod schema add optional `scheduleType` / `scheduleHour` / `scheduleMinute` / `scheduleDaysOfWeek` / `scheduleTimezone` fields with safe defaults. Existing string-only stored values still load cleanly.
- **Default timezone**: derived from `Intl.DateTimeFormat().resolvedOptions().timeZone` — not hardcoded to a region.
- **Fallback TZ dropdown**: if the resolved browser TZ isn't in `COMMON_TIMEZONES`, the component prepends it so the select shows the correct value on load.
- **Save happy-path**: all new scheduler fields re-sync from server response after save, so normalization on the backend can't silently diverge from UI state.

## Known tradeoffs

- **Worker uses pre-computed `scheduledCron`**: the UI converts the operator's local schedule + timezone into a UTC cron (`val.utcCron`) before saving to `scheduledCron`; the scheduler-worker reads that field as before. The new TZ + time fields are stored as metadata but not re-interpreted server-side. Functionally fine for UI-driven edits; if someone writes the setting directly via REST without passing a pre-computed UTC cron, the worker won't re-derive from the TZ fields. A future refactor can consolidate.
- **`cron-tz.ts` helper not reused**: `control-panel` doesn't depend on `@bronco/shared-utils` today, and the existing `buildUtcCron` helper takes `daysOfWeek` as a comma-string while the component works in `boolean[]`. Local `buildUtcCronFromLocal` was retained. Consolidation is a follow-up.

## Test plan

- [ ] Scheduled Probes: create + edit a probe using the scheduler (e.g., 'Every Monday 9am $LOCAL_TZ'); probe-worker fires at the expected local time
- [ ] Settings → Self Analysis: raw cron input replaced; saving + reloading round-trips cleanly; timezone pre-populated to browser's resolved TZ
- [ ] Pre-existing self-analysis configs (string-only value) load without errors
- [ ] Browser TZ outside `COMMON_TIMEZONES` shows up in the dropdown on first open