### PR TITLE
fix: NEW-status sweep — catch call sites missed during #345 (pre-release cleanup)

### DIFF
--- a/packages/db/prisma/seed-prompts.ts
+++ b/packages/db/prisma/seed-prompts.ts
@@ -59,7 +59,7 @@ const keywords: KeywordSeed[] = [
   {
     token: 'status',
     label: 'Status',
-    description: 'The current ticket status (OPEN, IN_PROGRESS, WAITING, RESOLVED, CLOSED).',
+    description: 'The current ticket status (NEW, OPEN, IN_PROGRESS, WAITING, RESOLVED, CLOSED).',
     sampleValue: 'OPEN',
     category: 'TICKET',
   },

--- a/services/control-panel/src/app/core/services/ticket.service.ts
+++ b/services/control-panel/src/app/core/services/ticket.service.ts
@@ -224,7 +224,7 @@ export class TicketService {
 
   private static readonly ACTIVE_STATUSES = ACTIVE_STATUS_FILTER.split(',');
 
-  /** Active ticket count (OPEN + IN_PROGRESS + WAITING), updated on every getStats() call. */
+  /** Active ticket count (NEW + OPEN + IN_PROGRESS + WAITING), updated on every getStats() call. */
   readonly activeCount = signal(0);
 
   getTickets(filters?: { clientId?: string; status?: string; category?: string; priority?: string; source?: string; analysisStatus?: string; createdFrom?: string; createdTo?: string; limit?: number; offset?: number }): Observable<Ticket[]> {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1136,6 +1136,9 @@ async function deepAnalysis(
       '',
       '## Available actions (use these exact "action" values)',
       '',
+      // Note: `NEW` is deliberately excluded from set_status options — NEW is a pre-analysis state
+      // assigned automatically at ingestion and auto-transitioned to OPEN at end-of-run. The AI
+      // should never regress a ticket to NEW.
       '- { "action": "set_status", "value": "OPEN|IN_PROGRESS|WAITING|RESOLVED|CLOSED", "reason": "..." }',
       '- { "action": "set_priority", "value": "LOW|MEDIUM|HIGH|CRITICAL", "reason": "..." }',
       '- { "action": "set_category", "value": "DATABASE_PERF|BUG_FIX|FEATURE_REQUEST|SCHEMA_CHANGE|CODE_REVIEW|ARCHITECTURE|GENERAL", "reason": "..." }',
@@ -2813,6 +2816,9 @@ async function executeRoutePipeline(
             `Current status: ${currentTicket.status}`, '',
             'Analysis findings:', analysis, '',
             '## Available actions (use these exact "action" values)', '',
+            // Note: `NEW` is deliberately excluded from set_status options — NEW is a pre-analysis state
+            // assigned automatically at ingestion and auto-transitioned to OPEN at end-of-run. The AI
+            // should never regress a ticket to NEW.
             '- { "action": "set_status", "value": "OPEN|IN_PROGRESS|WAITING|RESOLVED|CLOSED", "reason": "..." }',
             '- { "action": "set_priority", "value": "LOW|MEDIUM|HIGH|CRITICAL", "reason": "..." }',
             '- { "action": "set_category", "value": "DATABASE_PERF|BUG_FIX|FEATURE_REQUEST|SCHEMA_CHANGE|CODE_REVIEW|ARCHITECTURE|GENERAL", "reason": "..." }',

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -9,6 +9,7 @@ import {
   TaskType,
   TicketCategory,
   TicketSource,
+  isOpenStatus,
 } from '@bronco/shared-types';
 import type {
   IngestionJob,
@@ -1009,9 +1010,9 @@ async function maybeEnqueueReanalysis(
   });
   if (!ticket) return;
 
-  // Only re-analyze tickets in WAITING or OPEN status
-  if (ticket.status !== 'WAITING' && ticket.status !== 'OPEN') {
-    log.info({ ticketId, status: ticket.status }, 'Reply on non-active ticket — re-analysis skipped');
+  // Only re-analyze tickets in an open/active status (NEW, OPEN, IN_PROGRESS, WAITING)
+  if (!isOpenStatus(ticket.status)) {
+    log.info({ ticketId, status: ticket.status }, 'Reply on closed ticket — re-analysis skipped');
     return;
   }
 

--- a/services/ticket-analyzer/src/recommendation-executor.ts
+++ b/services/ticket-analyzer/src/recommendation-executor.ts
@@ -14,7 +14,7 @@ const logger = createLogger('recommendation-executor');
 
 const SETTINGS_KEY_ACTION_SAFETY = 'system-config-action-safety';
 
-const VALID_STATUSES = new Set(['OPEN', 'IN_PROGRESS', 'WAITING', 'RESOLVED', 'CLOSED']);
+const VALID_STATUSES = new Set(['NEW', 'OPEN', 'IN_PROGRESS', 'WAITING', 'RESOLVED', 'CLOSED']);
 const VALID_PRIORITIES = new Set(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
 const VALID_CATEGORIES = new Set([
   'DATABASE_PERF', 'BUG_FIX', 'FEATURE_REQUEST', 'SCHEMA_CHANGE',


### PR DESCRIPTION
Pre-release cleanup found during gap-analysis on staging before cutting master. Fixes one real data-loss bug plus four cosmetic NEW-status sweep misses.

## What's in

- **CRITICAL** — `services/ticket-analyzer/src/ingestion-engine.ts`: `maybeEnqueueReanalysis` now uses `isOpenStatus()` from shared-types for the guard. Previously checked only `!== 'WAITING' && !== 'OPEN'`, so reply emails arriving during the pre-analysis race window on NEW-status tickets were silently dropped. Log message updated from the misleading "non-active ticket" wording to accurate "closed ticket".
- `services/ticket-analyzer/src/recommendation-executor.ts`: `VALID_STATUSES` now includes NEW.
- `services/control-panel/src/app/core/services/ticket.service.ts`: `activeCount` JSDoc reflects that NEW is part of `ACTIVE_STATUS_FILTER`.
- `packages/db/prisma/seed-prompts.ts`: `ticket_status` prompt description lists all 6 statuses.
- `services/ticket-analyzer/src/analyzer.ts`: two `set_status` prompt locations got clarifying comments explaining why NEW is deliberately excluded from AI-selectable options (auto-managed at ingestion + end-of-run).

## Why not sooner

Gap-analysis on staging pre-promotion caught these. #345's original sweep covered the 4 `db.ticket.create` sites and the filter-chips UI; these were the downstream consequences in re-analysis, AI prompts, seeds, and stale comments.

## Test plan

- [ ] A reply email on a NEW-status ticket is correctly enqueued for re-analysis (verify `log.info('Reply on closed ticket — …')` does NOT fire)
- [ ] `pnpm lint` + `pnpm typecheck` + `pnpm build` all pass
- [ ] Settings → Ticket Statuses still renders all 6 statuses correctly (unchanged, but smoke)

## Scope

5 files, +13/-6. No schema changes, no migrations, no dep changes.