### PR TITLE
feat: structured MCP tool errors + retry-limiter + agent guidance (fixes #334)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,7 @@ pnpm dev:portal           # Start ticket portal (Angular, port 4201)
 | `services/copilot-api/src/routes/ai-config.ts` | AI model config CRUD + resolution preview endpoints (`/api/ai-config`). |
 | `services/copilot-api/src/routes/tickets.ts` | Ticket CRUD endpoints. |
 | `services/imap-worker/src/processor.ts` | Email collector: parse, noise-filter, push to ingestion queue. |
+| `services/ticket-analyzer/src/analysis/shared.ts` | Agentic tool-call execution + structured MCP error envelopes (`_mcp_tool_error`), per-run retry-limiter, and error-class categorization consumed by v2 runners. |
 | `services/ticket-analyzer/src/analyzer.ts` | Ticket analysis with repo cloning (bare+worktree) and MCP tools. |
 | `services/ticket-analyzer/src/index.ts` | Ticket analyzer service entry (BullMQ workers, probe scheduler, health). |
 | `services/ticket-analyzer/src/probe-worker.ts` | Scheduled probe execution (cron + one-off via API). |

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
@@ -3,7 +3,7 @@ import { CommonModule, DecimalPipe, JsonPipe } from '@angular/common';
 import { DialogComponent, BroncoButtonComponent, IconComponent } from '../../../shared/components/index.js';
 import { TicketService } from '../../../core/services/ticket.service.js';
 import type { TraceNode, TraceToolPill } from './analysis-trace.types.js';
-import { firstUserMessageText, isStructuredMcpToolError, parsedMcpToolError, responseText } from './analysis-trace.merge.js';
+import { firstUserMessageText, parsedMcpToolError, responseText } from './analysis-trace.merge.js';
 
 export interface ExpandPayload {
   kind: 'node' | 'pill';
@@ -120,13 +120,14 @@ export interface ExpandPayload {
         </div>
       } @else if (payload()?.kind === 'pill') {
         @let p = payload()!.pill!;
+        @let se = structuredError(p);
         <div class="expand-sections">
           <div class="expand-row">
             <code class="meta-chip model-chip">{{ p.toolName }}</code>
             @if (p.durationMs != null) { <span class="meta-chip duration-chip">{{ p.durationMs | number }}ms</span> }
             @if (p.truncated) { <span class="meta-chip truncated-chip">truncated</span> }
-            @if (p.isError && !structuredError(p)) { <span class="meta-chip err-chip">error</span> }
-            @if (structuredError(p); as se) {
+            @if (p.isError && !se) { <span class="meta-chip err-chip">error</span> }
+            @if (se) {
               <span class="meta-chip err-chip">{{ se.errorClass }}</span>
               <span class="meta-chip" [class.retryable-chip]="se.retryable" [class.err-chip]="!se.retryable">
                 {{ se.retryable ? 'retryable' : 'not retryable' }}
@@ -134,7 +135,7 @@ export interface ExpandPayload {
             }
           </div>
 
-          @if (structuredError(p); as se) {
+          @if (se) {
             <section class="expand-section">
               <header><span class="expand-label">Error Details</span></header>
               <div class="structured-error-body">
@@ -154,7 +155,7 @@ export interface ExpandPayload {
           }
 
           @if (p.result) {
-            @if (structuredError(p)) {
+            @if (se) {
               <details class="raw-json-details">
                 <summary class="raw-json-summary">Show raw JSON</summary>
                 <pre class="expand-pre">{{ p.result }}</pre>

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
@@ -3,7 +3,7 @@ import { CommonModule, DecimalPipe, JsonPipe } from '@angular/common';
 import { DialogComponent, BroncoButtonComponent, IconComponent } from '../../../shared/components/index.js';
 import { TicketService } from '../../../core/services/ticket.service.js';
 import type { TraceNode, TraceToolPill } from './analysis-trace.types.js';
-import { firstUserMessageText, responseText } from './analysis-trace.merge.js';
+import { firstUserMessageText, isStructuredMcpToolError, parsedMcpToolError, responseText } from './analysis-trace.merge.js';
 
 export interface ExpandPayload {
   kind: 'node' | 'pill';
@@ -125,8 +125,26 @@ export interface ExpandPayload {
             <code class="meta-chip model-chip">{{ p.toolName }}</code>
             @if (p.durationMs != null) { <span class="meta-chip duration-chip">{{ p.durationMs | number }}ms</span> }
             @if (p.truncated) { <span class="meta-chip truncated-chip">truncated</span> }
-            @if (p.isError) { <span class="meta-chip err-chip">error</span> }
+            @if (p.isError && !structuredError(p)) { <span class="meta-chip err-chip">error</span> }
+            @if (structuredError(p); as se) {
+              <span class="meta-chip err-chip">{{ se.errorClass }}</span>
+              <span class="meta-chip" [class.retryable-chip]="se.retryable" [class.err-chip]="!se.retryable">
+                {{ se.retryable ? 'retryable' : 'not retryable' }}
+              </span>
+            }
           </div>
+
+          @if (structuredError(p); as se) {
+            <section class="expand-section">
+              <header><span class="expand-label">Error Details</span></header>
+              <div class="structured-error-body">
+                <div class="se-row"><span class="se-key">errorClass</span><code class="meta-chip err-chip">{{ se.errorClass }}</code></div>
+                <div class="se-row"><span class="se-key">retryable</span><code class="meta-chip">{{ se.retryable }}</code></div>
+                <div class="se-row se-row-block"><span class="se-key">message</span><span class="se-value">{{ se.message }}</span></div>
+                <div class="se-row se-row-block"><span class="se-key">guidance</span><span class="se-value se-guidance">{{ se.guidance }}</span></div>
+              </div>
+            </section>
+          }
 
           @if (p.input) {
             <section class="expand-section">
@@ -136,15 +154,22 @@ export interface ExpandPayload {
           }
 
           @if (p.result) {
-            <section class="expand-section">
-              <header>
-                <span class="expand-label">Tool result</span>
-                <app-bronco-button variant="ghost" size="sm" (click)="copy(p.result!)">
-                  <app-icon name="copy" size="xs" /> Copy
-                </app-bronco-button>
-              </header>
-              <pre class="expand-pre">{{ p.result }}</pre>
-            </section>
+            @if (structuredError(p)) {
+              <details class="raw-json-details">
+                <summary class="raw-json-summary">Show raw JSON</summary>
+                <pre class="expand-pre">{{ p.result }}</pre>
+              </details>
+            } @else {
+              <section class="expand-section">
+                <header>
+                  <span class="expand-label">Tool result</span>
+                  <app-bronco-button variant="ghost" size="sm" (click)="copy(p.result!)">
+                    <app-icon name="copy" size="xs" /> Copy
+                  </app-bronco-button>
+                </header>
+                <pre class="expand-pre">{{ p.result }}</pre>
+              </section>
+            }
           }
 
           @if (p.artifactId) {
@@ -176,6 +201,15 @@ export interface ExpandPayload {
       border-radius: 4px; font-size: 13px; background: none; cursor: pointer; font: inherit; align-self: flex-start;
     }
     .artifact-download:hover { background: var(--color-info-subtle); }
+    .retryable-chip { background: var(--color-warning-subtle); color: var(--color-warning); }
+    .structured-error-body { padding: 8px 10px; display: flex; flex-direction: column; gap: 6px; }
+    .se-row { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+    .se-row-block { align-items: flex-start; flex-direction: column; gap: 2px; }
+    .se-key { font-weight: 700; color: var(--text-tertiary); font-size: 11px; min-width: 80px; }
+    .se-value { font-size: 12px; color: var(--text-primary); white-space: pre-wrap; word-break: break-word; }
+    .se-guidance { color: var(--text-secondary); font-style: italic; }
+    .raw-json-details { border: 1px solid var(--border-light); border-radius: 4px; overflow: hidden; }
+    .raw-json-summary { font-size: 11px; font-weight: 700; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.5px; padding: 4px 8px; background: var(--bg-muted); cursor: pointer; }
   `],
 })
 export class AnalysisTraceExpandDialogComponent {
@@ -228,6 +262,10 @@ export class AnalysisTraceExpandDialogComponent {
     } catch {
       void this.copy(String(ctx));
     }
+  }
+
+  structuredError(p: TraceToolPill) {
+    return parsedMcpToolError(p.result ?? '');
   }
 
   async copy(text: string): Promise<void> {

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-tool-pill.component.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-tool-pill.component.ts
@@ -1,14 +1,18 @@
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
 import { CommonModule, DecimalPipe } from '@angular/common';
 import { IconComponent } from '../../../shared/components/index.js';
 import type { TraceToolPill } from './analysis-trace.types.js';
+import { isStructuredMcpToolError, parsedMcpToolError } from './analysis-trace.merge.js';
 
 @Component({
   selector: 'app-analysis-trace-tool-pill',
   standalone: true,
   imports: [CommonModule, DecimalPipe, IconComponent],
   template: `
-    <button type="button" class="tool-pill" [class.tool-pill-error]="pill().isError" (click)="activate.emit(pill())">
+    <button type="button" class="tool-pill"
+      [class.tool-pill-error]="pill().isError"
+      [class.tool-pill-structured-error]="isStructured()"
+      (click)="activate.emit(pill())">
       <app-icon [name]="pill().isError ? 'close' : 'wrench'" size="xs" />
       <code class="tool-pill-name">{{ pill().toolName }}</code>
       @if (pill().durationMs != null) {
@@ -16,6 +20,9 @@ import type { TraceToolPill } from './analysis-trace.types.js';
       }
       @if (pill().truncated) {
         <span class="meta-chip truncated-chip">truncated</span>
+      }
+      @if (isStructured()) {
+        <span class="meta-chip err-class-chip">{{ errorClass() }}</span>
       }
       @if (pill().artifactId) {
         <app-icon name="download" size="xs" class="artifact-indicator" />
@@ -38,6 +45,7 @@ import type { TraceToolPill } from './analysis-trace.types.js';
     }
     .tool-pill:hover { background: var(--bg-hover); }
     .tool-pill-error { border-color: var(--color-error); color: var(--color-error); }
+    .tool-pill-structured-error { border-style: dashed; }
     .tool-pill-name { font-family: monospace; background: transparent; padding: 0; }
     .tool-pill-meta { font-size: 10px; color: var(--text-tertiary); }
     .meta-chip {
@@ -45,10 +53,14 @@ import type { TraceToolPill } from './analysis-trace.types.js';
       background: var(--color-warning-subtle); color: var(--color-warning);
     }
     .truncated-chip { background: var(--color-warning-subtle); color: var(--color-warning); }
+    .err-class-chip { background: var(--color-error-subtle); color: var(--color-error); }
     .artifact-indicator { color: var(--color-info); }
   `],
 })
 export class AnalysisTraceToolPillComponent {
   pill = input.required<TraceToolPill>();
   activate = output<TraceToolPill>();
+
+  isStructured = computed(() => isStructuredMcpToolError(this.pill().result ?? ''));
+  errorClass = computed(() => parsedMcpToolError(this.pill().result ?? '')?.errorClass ?? '');
 }

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
@@ -383,26 +383,31 @@ interface McpToolErrorEnvelope {
   guidance: string;
 }
 
-/** Returns true when the tool result content is a structured MCP error envelope. */
-export function isStructuredMcpToolError(content: string): boolean {
+/**
+ * Parses the content once and returns the structured MCP error envelope, or null
+ * if the content is not a structured envelope. Consumers that only need a boolean
+ * can coerce via `!!tryParseStructuredMcpToolError(content)`.
+ */
+export function tryParseStructuredMcpToolError(content: string): McpToolErrorEnvelope | null {
   const trimmed = content.trimStart();
   if (!trimmed.startsWith('{"_mcp_tool_error":') && !trimmed.startsWith('{\n  "_mcp_tool_error":')) {
-    return false;
+    return null;
   }
   try {
     const parsed = JSON.parse(content) as Record<string, unknown>;
-    return parsed['_mcp_tool_error'] === true;
+    if (parsed['_mcp_tool_error'] !== true) return null;
+    return parsed as unknown as McpToolErrorEnvelope;
   } catch {
-    return false;
+    return null;
   }
+}
+
+/** Returns true when the tool result content is a structured MCP error envelope. */
+export function isStructuredMcpToolError(content: string): boolean {
+  return tryParseStructuredMcpToolError(content) !== null;
 }
 
 /** Parses and returns the structured error envelope, or null if not structured. */
 export function parsedMcpToolError(content: string): McpToolErrorEnvelope | null {
-  if (!isStructuredMcpToolError(content)) return null;
-  try {
-    return JSON.parse(content) as McpToolErrorEnvelope;
-  } catch {
-    return null;
-  }
+  return tryParseStructuredMcpToolError(content);
 }

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
@@ -369,3 +369,40 @@ export function flattenTree(roots: TraceNode[]): TraceNode[] {
   walk(roots);
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Structured MCP tool error helpers (used by pill + expand dialog)
+// ---------------------------------------------------------------------------
+
+interface McpToolErrorEnvelope {
+  _mcp_tool_error: true;
+  toolName: string;
+  errorClass: string;
+  message: string;
+  retryable: boolean;
+  guidance: string;
+}
+
+/** Returns true when the tool result content is a structured MCP error envelope. */
+export function isStructuredMcpToolError(content: string): boolean {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith('{"_mcp_tool_error":') && !trimmed.startsWith('{\n  "_mcp_tool_error":')) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return parsed['_mcp_tool_error'] === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Parses and returns the structured error envelope, or null if not structured. */
+export function parsedMcpToolError(content: string): McpToolErrorEnvelope | null {
+  if (!isStructuredMcpToolError(content)) return null;
+  try {
+    return JSON.parse(content) as McpToolErrorEnvelope;
+  } catch {
+    return null;
+  }
+}

--- a/services/ticket-analyzer/src/analysis/flat-v2.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.ts
@@ -33,6 +33,7 @@ import {
   KD_SYSTEM_PROMPT_SNIPPET,
   PREFER_EXISTING_TOOLS_SNIPPET,
   REQUEST_NEW_TOOL_SNIPPET,
+  TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
   TRUNCATION_SYSTEM_PROMPT_SNIPPET,
 } from './v2-prompts.js';
 import { loadKnowledgeDoc } from '@bronco/shared-utils';
@@ -115,6 +116,7 @@ export async function runFlatV2(
   systemParts.push(TRUNCATION_SYSTEM_PROMPT_SNIPPET);
   systemParts.push(PREFER_EXISTING_TOOLS_SNIPPET);
   systemParts.push(REQUEST_NEW_TOOL_SNIPPET);
+  systemParts.push(TOOL_ERROR_SYSTEM_PROMPT_SNIPPET);
   systemParts.push(KD_SYSTEM_PROMPT_SNIPPET);
   const repoNudge = buildRepoNudgeSnippet(clientRepos);
   if (repoNudge) systemParts.push(repoNudge);
@@ -135,6 +137,7 @@ export async function runFlatV2(
   let finalAnalysis = '';
   let iterationsRun = 0;
   let previousAiCallId: string | undefined;
+  const failureTracker = new Map<string, number>();
   for (let i = 0; i < maxIterations; i++) {
     iterationsRun = i + 1;
     const aiCallId = randomUUID();
@@ -209,7 +212,7 @@ export async function runFlatV2(
 
     for (const toolUse of toolUseBlocks) {
       const start = Date.now();
-      const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId, ticketId);
+      const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId, ticketId, failureTracker);
       const elapsed = Date.now() - start;
 
       const fullResult = result.result;

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -48,6 +48,7 @@ import {
   KD_SYSTEM_PROMPT_SNIPPET,
   PREFER_EXISTING_TOOLS_SNIPPET,
   REQUEST_NEW_TOOL_SNIPPET,
+  TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
   TRUNCATION_SYSTEM_PROMPT_SNIPPET,
 } from './v2-prompts.js';
 
@@ -104,8 +105,8 @@ async function executeOrchestratedSubTaskV2(
     ? `\n\n## Prior Artifacts You May Need\nThese artifact IDs from prior runs may be relevant. Read them via \`platform__read_tool_result_artifact\` before re-querying:\n${task.priorArtifactIds.map(id => `- ${id}`).join('\n')}`
     : '';
   const subTaskSystemPrompt = combinedContext
-    ? `${subTaskInstructions}\n\n${combinedContext}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`
-    : `${subTaskInstructions}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`;
+    ? `${subTaskInstructions}\n\n${combinedContext}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${TOOL_ERROR_SYSTEM_PROMPT_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`
+    : `${subTaskInstructions}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${TOOL_ERROR_SYSTEM_PROMPT_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`;
 
   // Resolve tools using ranked matching (exact → base name → substring → fuzzy)
   const resolution = task.tools.length > 0
@@ -154,6 +155,8 @@ async function executeOrchestratedSubTaskV2(
    * Run a sub-task with the given tool set and return the result plus
    * whether any "irrelevant" signals were detected.
    */
+  const failureTracker = new Map<string, number>();
+
   async function runSubTaskPass(
     tools: AIToolDefinition[],
   ): Promise<{ result: SubTaskResult; seemsIrrelevant: boolean }> {
@@ -190,7 +193,7 @@ async function executeOrchestratedSubTaskV2(
 
         for (const toolUse of toolUseBlocks) {
           const start = Date.now();
-          const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId, ticketId);
+          const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId, ticketId, failureTracker);
           const elapsed = Date.now() - start;
 
           const fullResult = result.result;
@@ -467,6 +470,7 @@ export async function runOrchestratedV2(
     TRUNCATION_SYSTEM_PROMPT_SNIPPET,
     PREFER_EXISTING_TOOLS_SNIPPET,
     REQUEST_NEW_TOOL_SNIPPET,
+    TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
     KD_SYSTEM_PROMPT_SNIPPET,
     buildRepoNudgeSnippet(clientRepos),
   ].join('\n');

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -496,6 +496,95 @@ export async function buildAgenticTools(
   return { tools, mcpIntegrations, repoIdByPrefix, repos: repoInfos };
 }
 
+// ---------------------------------------------------------------------------
+// Structured MCP tool error envelopes
+// ---------------------------------------------------------------------------
+
+export type McpToolErrorClass =
+  | 'transport'
+  | 'auth'
+  | 'tool_not_registered'
+  | 'tool_logic'
+  | 'timeout'
+  | 'rate_limit'
+  | 'repeated_failure'
+  | 'unknown';
+
+export interface McpToolErrorEnvelope {
+  _mcp_tool_error: true;
+  toolName: string;
+  errorClass: McpToolErrorClass;
+  message: string;
+  retryable: boolean;
+  guidance: string;
+}
+
+export function buildMcpToolErrorResult(env: McpToolErrorEnvelope): string {
+  // Plain JSON string — tool_result content is a string from Anthropic's
+  // perspective. The agent sees the JSON and recognizes `_mcp_tool_error: true`.
+  return JSON.stringify(env, null, 2);
+}
+
+export function classifyMcpError(err: unknown): { errorClass: McpToolErrorClass; retryable: boolean } {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+
+  // Order matters — check specific patterns before generic ones.
+  if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('etimedout')) {
+    return { errorClass: 'timeout', retryable: true };
+  }
+  if (lower.includes('rate') && lower.includes('limit')) return { errorClass: 'rate_limit', retryable: true };
+  if (lower.includes('429')) return { errorClass: 'rate_limit', retryable: true };
+  if (lower.includes('401') || lower.includes('403') || lower.includes('unauthorized') || lower.includes('forbidden')) {
+    return { errorClass: 'auth', retryable: false };
+  }
+  if (lower.includes('method not found') || lower.includes('unknown tool') || lower.includes('tool not found')) {
+    return { errorClass: 'tool_not_registered', retryable: false };
+  }
+  if (lower.includes('econnrefused') || lower.includes('enotfound') || lower.includes('network') || lower.includes('fetch failed')) {
+    return { errorClass: 'transport', retryable: true };
+  }
+  // Many git/ssh/shell failures read as "transport" to the agent — missing binary, refused connection, etc.
+  if (lower.includes('cannot run ssh') || lower.includes('unable to fork') || lower.includes('no such file or directory')) {
+    return { errorClass: 'transport', retryable: false };
+  }
+  // JSON-RPC errors from the MCP SDK
+  if (lower.includes('jsonrpc') || lower.includes('json-rpc')) return { errorClass: 'tool_logic', retryable: false };
+  return { errorClass: 'unknown', retryable: false };
+}
+
+function guidanceFor(errorClass: McpToolErrorClass, toolName: string): string {
+  switch (errorClass) {
+    case 'transport':
+      return `The MCP server backing ${toolName} is unreachable or the underlying infrastructure is broken. Do not retry. Consider whether your investigation can proceed without this tool class, or call request_tool with kind=BROKEN_TOOL to flag the outage.`;
+    case 'auth':
+      return `${toolName} rejected the call with an auth error. This is an operator-level configuration issue. Do not retry. Move on with what you have and mention the auth gap in your analysis.`;
+    case 'tool_not_registered':
+      return `No MCP tool by that name is registered for this run. Check the Available Tools list for the exact name (including prefix).`;
+    case 'timeout':
+      return `${toolName} timed out. Retry at most once with the same inputs. If it times out twice, stop and try a narrower query.`;
+    case 'rate_limit':
+      return `Rate-limited. Wait before trying ${toolName} again. Consider batching or reducing call frequency.`;
+    case 'tool_logic':
+      return `${toolName} rejected the input or hit an internal error. Re-read the tool description, adjust inputs, and retry at most once. If it fails again, switch approaches.`;
+    case 'repeated_failure':
+      return `This exact ${toolName} + input combination has already failed in this run and is now blocked. Try a different tool, different inputs, or abandon this line of investigation.`;
+    default:
+      return `${toolName} failed with an unrecognized error. Do not retry blindly — change inputs or switch tools.`;
+  }
+}
+
+function sortedStringify(obj: unknown): string {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return JSON.stringify(obj);
+  }
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj as Record<string, unknown>).sort()) {
+    sorted[key] = (obj as Record<string, unknown>)[key];
+  }
+  return JSON.stringify(sorted);
+}
+
 /**
  * Execute a single tool call from the agentic loop.
  * Returns the tool result text and whether it was an error.
@@ -506,8 +595,24 @@ export async function executeAgenticToolCall(
   repoIdByPrefix: Map<string, string>,
   clientId?: string,
   ticketId?: string,
+  failureTracker?: Map<string, number>,
 ): Promise<{ toolUseId: string; result: string; isError: boolean }> {
   const { id: toolUseId, name, input } = toolCall;
+
+  const failureKey = `${name}::${sortedStringify(input)}`;
+
+  // Short-circuit if this (tool, input) pair has already failed twice
+  if (failureTracker && (failureTracker.get(failureKey) ?? 0) >= 2) {
+    const envelope: McpToolErrorEnvelope = {
+      _mcp_tool_error: true,
+      toolName: name,
+      errorClass: 'repeated_failure',
+      message: `This exact (${name}, input) combination has already failed twice in this run and is blocked.`,
+      retryable: false,
+      guidance: guidanceFor('repeated_failure', name),
+    };
+    return { toolUseId, result: buildMcpToolErrorResult(envelope), isError: true };
+  }
 
   try {
     // MCP tool — parse prefix
@@ -558,7 +663,19 @@ export async function executeAgenticToolCall(
     return { toolUseId, result, isError: false };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { toolUseId, result: `Tool error: ${msg}`, isError: true };
+    if (failureTracker) {
+      failureTracker.set(failureKey, (failureTracker.get(failureKey) ?? 0) + 1);
+    }
+    const { errorClass, retryable } = classifyMcpError(err);
+    const envelope: McpToolErrorEnvelope = {
+      _mcp_tool_error: true,
+      toolName: name,
+      errorClass,
+      message: msg,
+      retryable,
+      guidance: guidanceFor(errorClass, name),
+    };
+    return { toolUseId, result: buildMcpToolErrorResult(envelope), isError: true };
   }
 }
 

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -553,10 +553,12 @@ export function classifyMcpError(err: unknown): { errorClass: McpToolErrorClass;
   return { errorClass: 'unknown', retryable: false };
 }
 
-function guidanceFor(errorClass: McpToolErrorClass, toolName: string): string {
+function guidanceFor(errorClass: McpToolErrorClass, toolName: string, retryable: boolean): string {
   switch (errorClass) {
     case 'transport':
-      return `The MCP server backing ${toolName} is unreachable or the underlying infrastructure is broken. Do not retry. Consider whether your investigation can proceed without this tool class, or call request_tool with kind=BROKEN_TOOL to flag the outage.`;
+      return retryable
+        ? `${toolName} hit a transient transport error (network blip, connection refused, DNS hiccup). Retry at most once. If it fails again, suspect infrastructure and consider request_tool with kind=BROKEN_TOOL.`
+        : `The MCP server backing ${toolName} is unreachable or the underlying infrastructure is broken (e.g. missing binary, persistent connection failure). Do not retry. Consider whether your investigation can proceed without this tool class, or call request_tool with kind=BROKEN_TOOL to flag the outage.`;
     case 'auth':
       return `${toolName} rejected the call with an auth error. This is an operator-level configuration issue. Do not retry. Move on with what you have and mention the auth gap in your analysis.`;
     case 'tool_not_registered':
@@ -609,7 +611,7 @@ export async function executeAgenticToolCall(
       errorClass: 'repeated_failure',
       message: `This exact (${name}, input) combination has already failed twice in this run and is blocked.`,
       retryable: false,
-      guidance: guidanceFor('repeated_failure', name),
+      guidance: guidanceFor('repeated_failure', name, false),
     };
     return { toolUseId, result: buildMcpToolErrorResult(envelope), isError: true };
   }
@@ -673,7 +675,7 @@ export async function executeAgenticToolCall(
       errorClass,
       message: msg,
       retryable,
-      guidance: guidanceFor(errorClass, name),
+      guidance: guidanceFor(errorClass, name, retryable),
     };
     return { toolUseId, result: buildMcpToolErrorResult(envelope), isError: true };
   }

--- a/services/ticket-analyzer/src/analysis/v2-prompts.ts
+++ b/services/ticket-analyzer/src/analysis/v2-prompts.ts
@@ -88,6 +88,39 @@ export const REQUEST_NEW_TOOL_SNIPPET = [
 ].join('\n');
 
 /**
+ * System-prompt snippet teaching the agent how to recognize and react to
+ * structured MCP tool errors. Pairs with buildMcpToolErrorResult() in
+ * analysis/shared.ts — failed tool calls return a JSON envelope with
+ * `_mcp_tool_error: true`, plus `errorClass`, `retryable`, and `guidance`.
+ */
+export const TOOL_ERROR_SYSTEM_PROMPT_SNIPPET = [
+  '',
+  '## Handling Tool Failures',
+  '',
+  'Some tool calls fail. A failed tool_result is a JSON object starting with',
+  '`{"_mcp_tool_error": true, ...}`. When you see this, do NOT treat the message',
+  'as data — it is a failure signal.',
+  '',
+  'Inspect these fields and react:',
+  '- `errorClass` — kind of failure (transport / auth / tool_not_registered /',
+  '  tool_logic / timeout / rate_limit / repeated_failure / unknown)',
+  '- `retryable` — boolean. If `false`, do NOT call the same tool with the same',
+  '  inputs again in this run. It will be short-circuited.',
+  '- `guidance` — human-readable next step tailored to the error class.',
+  '',
+  'Rules:',
+  '- If `retryable: true` (e.g. timeout, rate_limit), retry at most ONCE, with',
+  '  the same inputs.',
+  '- If `retryable: false`, switch approach: try a different tool, change inputs,',
+  '  or abandon this line of investigation and note the gap in your analysis.',
+  '- If multiple tools in the same class fail (e.g. every repo tool returns',
+  '  `transport` errors), suspect infrastructure. Stop calling that class and',
+  '  flag the outage via `request_tool` with `kind: "BROKEN_TOOL"`.',
+  '- After 2 failures of the same `(tool, input)` pair, the runner blocks further',
+  '  attempts automatically — you will get `errorClass: "repeated_failure"`.',
+].join('\n');
+
+/**
  * System-prompt snippet appended to v2 agentic system prompts. Agent adoption
  * is opt-out — findings must flow through the `kd_*` tools so the knowledge
  * doc stays the authoritative source. At end-of-run a fallback pass fills any


### PR DESCRIPTION
## Summary

- MCP tool failures now return a structured `{"_mcp_tool_error": true, errorClass, retryable, guidance, ...}` JSON envelope (paired with `is_error: true`) instead of a bare `Tool error: <msg>` string.
- New `classifyMcpError()` maps exceptions to one of: `transport` / `auth` / `tool_not_registered` / `tool_logic` / `timeout` / `rate_limit` / `repeated_failure` / `unknown`.
- Per-run `failureTracker: Map<string, number>` short-circuits a third call for the same `(toolName, input)` pair after 2 failures.
- `TOOL_ERROR_SYSTEM_PROMPT_SNIPPET` teaches the v2 agent to read `errorClass`/`retryable`/`guidance` instead of retrying blindly. Wired into both flat-v2 and orchestrated-v2; v1 modules untouched.
- Analysis Trace: structured-error pills get a dashed border + errorClass badge; expand dialog renders a key-value block (errorClass / retryable / message / guidance) above a collapsible raw-JSON `<details>`.

Fixes #334.

## Test plan

- [ ] `pnpm build` + `pnpm typecheck` pass
- [ ] Induce a failing MCP tool (e.g. unreachable mcp-repo) — agent receives structured envelope, not bare error string
- [ ] Agent does NOT retry the same `(tool, input)` after 2 failures in the same run (gets `repeated_failure`)
- [ ] Analysis Trace renders structured error with errorClass badge + dashed pill, and the expand dialog shows the key-value block
- [ ] v1 flat and orchestrated modules show zero diff vs staging (`git diff origin/staging..HEAD -- services/ticket-analyzer/src/analysis/flat-v1.ts services/ticket-analyzer/src/analysis/orchestrated-v1.ts` is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
