### PR TITLE
chore: post-audit follow-ups — filename encoding, title attrs, env docs, NEW lifecycle notes (fixes #355)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ JWT_SECRET=
 # MCP Database Server (runs in Azure App Service on same vnet as client Azure SQL MIs)
 # copilot-api calls this for DB tool operations; Claude Code connects to /mcp endpoint
 MCP_DATABASE_URL=https://your-mcp-app.azurewebsites.net
+MCP_REPO_URL=http://mcp-repo:3111
+MCP_PLATFORM_URL=http://mcp-platform:3110
 MCP_AUTH_TOKEN=
 
 # Cloudflare Tunnel token for cloudflared container. Create a tunnel at

--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,9 @@ JWT_SECRET=
 # MCP Database Server (runs in Azure App Service on same vnet as client Azure SQL MIs)
 # copilot-api calls this for DB tool operations; Claude Code connects to /mcp endpoint
 MCP_DATABASE_URL=https://your-mcp-app.azurewebsites.net
-MCP_REPO_URL=http://mcp-repo:3111
-MCP_PLATFORM_URL=http://mcp-platform:3110
+# For local host-run services use localhost; in Docker Compose the compose file overrides with service-network hostnames
+MCP_REPO_URL=http://localhost:3111
+MCP_PLATFORM_URL=http://localhost:3110
 MCP_AUTH_TOKEN=
 
 # Cloudflare Tunnel token for cloudflared container. Create a tunnel at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ AI-augmented database and software architecture operations platform. Single-oper
 - **Monorepo**: pnpm workspaces. Shared packages in `packages/`, services in `services/`, MCP servers in `mcp-servers/`.
 - **Control plane DB**: PostgreSQL (Prisma ORM). Schema at `packages/db/prisma/schema.prisma`.
 - **Client databases**: Azure SQL Managed Instances (primary, SQL cred auth), on-prem SQL Server (future clients). Connected via MCP database server (Node.js/Express) running on Hugo in Docker Compose. The MCP server reads system configs directly from the control plane Postgres `System` table and decrypts passwords using `ENCRYPTION_KEY`.
-- **MCP Platform Server**: Exposes all Bronco platform operations (tickets, clients, people, probes, AI usage, etc.) as MCP tools. Uses Prisma directly (no HTTP hop to copilot-api). Exception: `run_tool_request_dedupe` proxies to copilot-api via HTTP because the dedupe logic depends on AIRouter and `mcp-discovery` which don't live in the mcp-platform dep graph. Runs on Hugo in Docker Compose (port 3110).
+- **MCP Platform Server**: Exposes all Bronco platform operations (tickets, clients, people, probes, AI usage, etc.) as MCP tools. Uses Prisma directly (no HTTP hop to copilot-api). Exception: `run_tool_request_dedupe` proxies to copilot-api via HTTP because the dedupe logic depends on AIRouter and `mcp-discovery` which don't live in the mcp-platform dep graph. Runs on Hugo in Docker Compose (port 3110). MCP platform/repo/database URLs are configured per-service via `MCP_PLATFORM_URL`, `MCP_REPO_URL`, `MCP_DATABASE_URL` (defaults assume the Docker Compose network: `http://mcp-platform:3110`, `http://mcp-repo:3111`, `http://mcp-database:3100`).
 - **AI routing**: Local Ollama for triage/categorize/summarize/extract; Claude API for deep analysis, code review, architecture review, bug analysis, schema review, feature analysis.
 - **Hugo** (control plane VM): Ubuntu 24.04 LTS on ESXi NUC. Runs copilot-api (Fastify), imap-worker, ticket-analyzer, devops-worker, issue-resolver, status-monitor, slack-worker, scheduler-worker, mcp-database, mcp-platform, mcp-repo, Postgres, Redis, Caddy, and cloudflared (Cloudflare Tunnel for public ingress at `itrack.siirial.com`) via Docker Compose.
 - **Mac mini (siiriaplex)**: Runs Ollama for local LLM inference.
@@ -98,6 +98,8 @@ AZDO_POLL_INTERVAL_SECONDS=120
 | `CLOSED` | closed | Ticket is closed. |
 
 `NEW`, `OPEN`, `IN_PROGRESS`, and `WAITING` are all in `OPEN_STATUSES` and are treated as "active" tickets throughout the codebase (filters, notifications, MCP queries).
+
+**Replies arriving during NEW (pre-analysis):** a reply threads onto the ticket but does NOT trigger a re-analysis job — the in-flight initial analysis will read the thread when it reaches the ingestion step. Re-analysis is reserved for `WAITING` and `OPEN` tickets.
 
 ## Ticket Categories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ AZDO_POLL_INTERVAL_SECONDS=120
 
 `NEW`, `OPEN`, `IN_PROGRESS`, and `WAITING` are all in `OPEN_STATUSES` and are treated as "active" tickets throughout the codebase (filters, notifications, MCP queries).
 
-**Replies arriving during NEW (pre-analysis):** a reply threads onto the ticket but does NOT trigger a re-analysis job — the in-flight initial analysis will read the thread when it reaches the ingestion step. Re-analysis is reserved for `WAITING` and `OPEN` tickets.
+**Replies arriving during NEW (pre-analysis):** a reply threads onto the ticket but does NOT trigger a re-analysis job — the in-flight initial analysis will read the thread when it reaches the ingestion step. Once the initial analysis has completed, replies on active/open tickets with an existing findings email may enqueue re-analysis, including `OPEN`, `WAITING`, and `IN_PROGRESS`.
 
 ## Ticket Categories
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -342,6 +342,9 @@ services:
       API_KEY: ${API_KEY}
       MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:-}
       COPILOT_API_URL: http://copilot-api:3000
+      MCP_PLATFORM_URL: http://mcp-platform:3110
+      MCP_REPO_URL: http://mcp-repo:3111
+      MCP_DATABASE_URL: ${MCP_DATABASE_URL:-http://mcp-database:3100}
       PORT: "3110"
       LOG_LEVEL: info
       ARTIFACT_STORAGE_PATH: ${ARTIFACT_STORAGE_PATH:-/mnt/qnap/artifacts}

--- a/services/control-panel/src/app/features/email-logs/email-log.component.ts
+++ b/services/control-panel/src/app/features/email-logs/email-log.component.ts
@@ -76,9 +76,9 @@ import { ToastService } from '../../core/services/toast.service.js';
           <app-data-column key="from" header="From" [sortable]="false">
             <ng-template #cell let-log>
               <div class="from-cell">
-                <span class="from-name">{{ log.fromName || log.from }}</span>
+                <span class="from-name" [title]="log.fromName || log.from">{{ log.fromName || log.from }}</span>
                 @if (log.fromName && log.fromName !== log.from) {
-                  <span class="from-address">{{ log.from }}</span>
+                  <span class="from-address" [title]="log.from">{{ log.from }}</span>
                 }
               </div>
             </ng-template>
@@ -86,7 +86,7 @@ import { ToastService } from '../../core/services/toast.service.js';
 
           <app-data-column key="subject" header="Subject" [sortable]="false" width="300px">
             <ng-template #cell let-log>
-              <span class="subject-text">{{ log.subject }}</span>
+              <span class="subject-text" [title]="log.subject">{{ log.subject }}</span>
             </ng-template>
           </app-data-column>
 

--- a/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
+++ b/services/control-panel/src/app/features/failed-jobs/failed-job-list.component.ts
@@ -105,7 +105,7 @@ const ALL_QUEUES = [
 
         <app-data-column key="name" header="Name" [sortable]="false" mobilePriority="primary">
           <ng-template #cell let-row>
-            <span class="job-name">{{ row.name }}</span>
+            <span class="job-name" [title]="row.name">{{ row.name }}</span>
           </ng-template>
         </app-data-column>
 

--- a/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
+++ b/services/control-panel/src/app/features/tool-requests/tool-request-list.component.ts
@@ -129,8 +129,8 @@ const KIND_OPTIONS = [
         <app-data-column key="displayTitle" header="Title" [sortable]="false">
           <ng-template #cell let-row>
             <div class="title-cell">
-              <span class="title">{{ row.displayTitle }}</span>
-              <span class="requested-name">{{ row.requestedName }}</span>
+              <span class="title" [title]="row.displayTitle">{{ row.displayTitle }}</span>
+              <span class="requested-name" [title]="row.requestedName">{{ row.requestedName }}</span>
               @if (row.suggestedDuplicateOfId) {
                 <span class="suggestion-pill suggestion-duplicate" title="AI dedupe flagged this as a duplicate">⚠ Suggested duplicate</span>
               }

--- a/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
+++ b/services/control-panel/src/app/shared/components/cron-scheduler.component.ts
@@ -1,3 +1,7 @@
+// NOTE: this component currently computes a static UTC cron expression from the
+// operator's current timezone offset. After a DST transition the stored cron
+// will drift by one hour until the operator re-saves. TZ-aware execution is a
+// future enhancement — see #355 audit and the broader scheduler rework.
 import { Component, OnInit, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FormFieldComponent } from './form-field.component.js';

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -31,8 +31,16 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
 
     const filePath = join(storagePath, artifact.storagePath);
+    const filename = artifact.filename;
+    const asciiFallback = filename.replace(/[^\x20-\x7e]/g, '_');
+    const encodedUtf8 = encodeURIComponent(filename)
+      .replace(/['()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+      .replace(/\*/g, '%2A');
     reply.header('Content-Type', artifact.mimeType);
-    reply.header('Content-Disposition', `attachment; filename="${artifact.filename}"`);
+    reply.header(
+      'Content-Disposition',
+      `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedUtf8}`,
+    );
     return reply.send(createReadStream(filePath));
   });
 

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import type { Config } from '../config.js';
 
@@ -32,7 +32,12 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
 
     const filePath = join(storagePath, artifact.storagePath);
     const filename = artifact.filename;
-    const asciiFallback = filename.replace(/[^\x20-\x7e]/g, '_');
+    // Sanitize the ASCII fallback: strip path separators (basename), control chars,
+    // quotes, and backslashes to prevent Content-Disposition header injection.
+    // Non-ASCII survives via filename*=UTF-8'' (RFC 5987).
+    const asciiFallback = basename(filename)
+      .replace(/[\x00-\x1f\x7f"\\]/g, '_')
+      .replace(/[^\x20-\x7e]/g, '_');
     const encodedUtf8 = encodeURIComponent(filename)
       .replace(/['()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
       .replace(/\*/g, '%2A');

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3549,7 +3549,7 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
               { ticketId, triggerType: 'POST_ANALYSIS' },
               {
                 jobId: `post-pipeline-${ticketId}-${Date.now()}`,
-                attempts: 4,              // 1 initial + 3 retries
+                attempts: 4,              // 1 initial attempt + 3 retries = 4 attempts total
                 backoff: { type: 'exponential', delay: 5000 },
               },
             );

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1010,13 +1010,18 @@ async function maybeEnqueueReanalysis(
   });
   if (!ticket) return;
 
-  // Only re-analyze tickets in an open/active status (NEW, OPEN, IN_PROGRESS, WAITING)
+  // Only re-analyze tickets in an open/active status (NEW, OPEN, IN_PROGRESS, WAITING).
+  // NOTE: NEW passes this check but is effectively excluded by step 2 below — a NEW
+  // ticket has no completed analysis (no findings email), so re-analysis is skipped there.
   if (!isOpenStatus(ticket.status)) {
     log.info({ ticketId, status: ticket.status }, 'Reply on closed ticket — re-analysis skipped');
     return;
   }
 
   // 2. Check the ticket has had a completed analysis (findings email was sent to requester).
+  // NEW tickets are intentionally excluded here: the initial analyzer pipeline hasn't finished yet,
+  // so there's nothing to "re-" analyze. The reply is already threaded onto the ticket and will
+  // be picked up when the initial job reads the thread.
   const findingsEmail = await db.ticketEvent.findFirst({
     where: {
       ticketId,


### PR DESCRIPTION
## Summary

Bundle of six small post-audit polish items from PRs #346, #348, #349, #351, #352, #353:

1. **RFC 5987 filename encoding** — `artifacts.ts` emits dual `filename=` / `filename*=UTF-8''…` so non-ASCII artifact filenames survive the browser round-trip.
2. **Retry-comment clarity** — `analyzer.ts` post-pipeline retry config comment now reads `1 initial attempt + 3 retries = 4 attempts total` (no behavior change).
3. **Hover tooltips** — 6 `[title]=…` attributes added to truncated cells on Failed Jobs, Email Logs, Tool Requests.
4. **NEW-status docs** — Explanatory comment in `ingestion-engine.ts` at the `findingsEmail` guard (where NEW is actually excluded in current code) + CLAUDE.md note in Ticket Statuses section.
5. **MCP URL env vars** — Declared `MCP_PLATFORM_URL`, `MCP_REPO_URL`, `MCP_DATABASE_URL` explicitly in the `mcp-platform` service block in `docker-compose.yml`, `.env.example`, and inline in CLAUDE.md's Architecture Quick Reference.
6. **DST caveat comment** — 4-line note added to `cron-scheduler.component.ts`; behavior deferred.

Fixes #355.

## Test plan

- [ ] `pnpm build` + `pnpm typecheck` pass
- [ ] Download an artifact with a non-ASCII filename (e.g. `résumé_日本.pdf`) — filename arrives correctly in the browser
- [ ] Hover on Failed Jobs / Email Logs / Tool Requests truncated cells — native tooltip shows full text
- [ ] `docker compose config` shows `MCP_PLATFORM_URL`, `MCP_REPO_URL`, `MCP_DATABASE_URL` resolved for `mcp-platform`
- [ ] Sending a reply to a NEW-status ticket threads the reply but does NOT enqueue a re-analysis job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
