### PR TITLE
feat: surface MCP isError results through structured error envelope (fixes #360)

### DIFF
--- a/packages/shared-utils/src/mcp-client.ts
+++ b/packages/shared-utils/src/mcp-client.ts
@@ -317,7 +317,16 @@ export async function callMcpToolViaSdk(
     const texts = contentArray
       .filter((c: { type: string }) => c.type === 'text')
       .map((c: { type: string; text: string }) => c.text);
-    return texts.join('\n') || JSON.stringify(result);
+    const joined = texts.join('\n') || JSON.stringify(result);
+    // MCP tools may return normally with `isError: true` (input validation,
+    // rate-limit rejections, tool-logic errors the server returns as a result
+    // rather than throwing). Surface these as thrown exceptions so the agentic
+    // caller's catch block can classify them into the structured envelope
+    // alongside transport/timeout/auth failures. See #360.
+    if (result.isError === true) {
+      throw new Error(`MCP tool returned isError: ${joined}`);
+    }
+    return joined;
   } finally {
     if (timer !== undefined) clearTimeout(timer);
     try { await transport.close(); } catch { /* ignore close errors */ }

--- a/packages/shared-utils/src/mcp-client.ts
+++ b/packages/shared-utils/src/mcp-client.ts
@@ -324,7 +324,15 @@ export async function callMcpToolViaSdk(
     // caller's catch block can classify them into the structured envelope
     // alongside transport/timeout/auth failures. See #360.
     if (result.isError === true) {
-      throw new Error(`MCP tool returned isError: ${joined}`);
+      // Cap the embedded content so high-volume tools (e.g. repo_exec returning
+      // full stdout/stderr) don't bloat logs, error envelopes, and agent prompts.
+      // Classification patterns we care about (rate_limit / auth / timeout / etc.)
+      // land within the first hundred characters in practice.
+      const MAX_ERROR_BODY = 2000;
+      const truncated = joined.length > MAX_ERROR_BODY
+        ? `${joined.slice(0, MAX_ERROR_BODY)} [truncated ${joined.length - MAX_ERROR_BODY} chars]`
+        : joined;
+      throw new Error(`MCP tool returned isError: ${truncated}`);
     }
     return joined;
   } finally {

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -530,11 +530,6 @@ export function classifyMcpError(err: unknown): { errorClass: McpToolErrorClass;
   const lower = msg.toLowerCase();
 
   // Order matters — check specific patterns before generic ones.
-  // MCP-level isError results (surfaced by callMcpToolViaSdk throwing) —
-  // the tool ran but rejected the input or returned a logical failure.
-  if (lower.includes('mcp tool returned iserror')) {
-    return { errorClass: 'tool_logic', retryable: false };
-  }
   if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('etimedout')) {
     return { errorClass: 'timeout', retryable: true };
   }
@@ -555,6 +550,14 @@ export function classifyMcpError(err: unknown): { errorClass: McpToolErrorClass;
   }
   // JSON-RPC errors from the MCP SDK
   if (lower.includes('jsonrpc') || lower.includes('json-rpc')) return { errorClass: 'tool_logic', retryable: false };
+  // MCP-level isError results (surfaced by callMcpToolViaSdk throwing when the
+  // tool returned isError: true). This is a generic catch-all — the specific
+  // pattern checks above (rate_limit / auth / timeout / etc.) win first so an
+  // MCP-level "rate limit reached" still classifies as rate_limit, not
+  // tool_logic.
+  if (lower.includes('mcp tool returned iserror')) {
+    return { errorClass: 'tool_logic', retryable: false };
+  }
   return { errorClass: 'unknown', retryable: false };
 }
 

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -530,6 +530,11 @@ export function classifyMcpError(err: unknown): { errorClass: McpToolErrorClass;
   const lower = msg.toLowerCase();
 
   // Order matters — check specific patterns before generic ones.
+  // MCP-level isError results (surfaced by callMcpToolViaSdk throwing) —
+  // the tool ran but rejected the input or returned a logical failure.
+  if (lower.includes('mcp tool returned iserror')) {
+    return { errorClass: 'tool_logic', retryable: false };
+  }
   if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('etimedout')) {
     return { errorClass: 'timeout', retryable: true };
   }


### PR DESCRIPTION
## Summary

- `callMcpToolViaSdk` in `packages/shared-utils/src/mcp-client.ts` now throws `MCP tool returned isError: <content>` when the MCP response carries `isError: true` — previously the flag was silently discarded and the content returned as a normal success string.
- `classifyMcpError` in `services/ticket-analyzer/src/analysis/shared.ts` recognizes the new marker and categorizes it as `tool_logic` (`retryable: false`), so the agent receives the same structured `_mcp_tool_error` envelope treatment as thrown transport/auth/timeout errors.
- Implements **Option A** from the issue — minimal-churn path. `executeAgenticToolCall`'s existing `catch` block flows the thrown error into `buildMcpToolErrorResult`. v1 runners also continue working because they already catch any throws from `callMcpToolViaSdk`.

Fixes #360.

## Test plan

- [ ] `pnpm build` + `pnpm typecheck` pass
- [ ] Call an MCP tool that returns `{ isError: true, content: [...] }` — agent receives a structured envelope with `errorClass: "tool_logic"`, not a plain-text content string
- [ ] Analysis Trace renders the failure with the dashed red pill + errorClass badge (same UX as thrown errors)
- [ ] v1 runners still see thrown errors from `callMcpToolViaSdk` unchanged (no new regressions in historical-fidelity modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
