### PR TITLE
fix(migration): split ticket_status NEW enum value from backfill (hotfix)

### DIFF
--- a/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
+++ b/packages/db/prisma/migrations/20260422000000_add_ticket_status_new/migration.sql
@@ -1,12 +1,5 @@
 -- AlterEnum
+-- NOTE: Postgres requires new enum values to be committed before they can be used.
+-- The backfill UPDATE that relies on 'NEW' lives in 20260422000500_backfill_new_ticket_status
+-- so that it runs in a separate transaction after this one commits.
 ALTER TYPE "ticket_status" ADD VALUE 'NEW';
-
--- Backfill: OPEN tickets with no AI_ANALYSIS event recorded (i.e., pre-analysis) → NEW
-UPDATE tickets
-SET status = 'NEW'
-WHERE status = 'OPEN'
-  AND NOT EXISTS (
-    SELECT 1 FROM ticket_events
-    WHERE ticket_events.ticket_id = tickets.id
-      AND event_type = 'AI_ANALYSIS'
-  );

--- a/packages/db/prisma/migrations/20260422000500_backfill_new_ticket_status/migration.sql
+++ b/packages/db/prisma/migrations/20260422000500_backfill_new_ticket_status/migration.sql
@@ -1,0 +1,12 @@
+-- Backfill: OPEN tickets with no AI_ANALYSIS event recorded (i.e., pre-analysis) → NEW
+-- Runs in its own transaction AFTER the ALTER TYPE in 20260422000000 has committed;
+-- splitting is required because Postgres rejects new enum values used in the same
+-- transaction that added them (error 55P04 — "unsafe use of new value").
+UPDATE tickets
+SET status = 'NEW'
+WHERE status = 'OPEN'
+  AND NOT EXISTS (
+    SELECT 1 FROM ticket_events
+    WHERE ticket_events.ticket_id = tickets.id
+      AND event_type = 'AI_ANALYSIS'
+  );


### PR DESCRIPTION
## Summary

**Hotfix directly to master.** The v0.3.0 deploy (merge commit `1fe2246`) failed on Hugo: copilot-api crash-looped on `prisma migrate deploy` with Postgres error `55P04`:

```
unsafe use of new value "NEW" of enum type ticket_status
HINT: New enum values must be committed before they can be used.
```

Root cause: `20260422000000_add_ticket_status_new/migration.sql` combined `ALTER TYPE ADD VALUE 'NEW'` with the `UPDATE tickets SET status = 'NEW'` backfill in a single Prisma migration transaction. Postgres rejects this — new enum values must be committed before they can be referenced.

## Fix

Split into two migrations:

- **20260422000000_add_ticket_status_new** — now contains only the `ALTER TYPE ADD VALUE 'NEW'`. Commits cleanly.
- **20260422000500_backfill_new_ticket_status** — runs the backfill `UPDATE` in a separate migration transaction after the enum value is durable.

Migration comment blocks explain the Postgres constraint so a future contributor doesn't reintroduce the pattern.

## Hugo state

The failed `_prisma_migrations` row for `20260422000000_add_ticket_status_new` has been deleted manually on Hugo's Postgres so Prisma re-runs the (now split) migration pair cleanly on the next container start. No data was written (the failed transaction rolled back — enum value absent, tickets untouched).

## Deploy expectations

Merge this PR → `tag-release.yml` cuts v0.3.1 → `deploy-hugo.yml` rebuilds copilot-api → container starts → `prisma migrate deploy` applies:

1. `20260422000000_add_ticket_status_new` — ALTER TYPE, commits
2. `20260422000500_backfill_new_ticket_status` — UPDATE, commits
3. `20260422010000_add_tool_request_kind` — previously blocked by the failed state; applies cleanly now

## Test plan

- [x] `pnpm typecheck` + `pnpm build` + `pnpm lint` pass locally (no code changes, just SQL)
- [ ] CI green on this PR
- [ ] After merge: Hugo `docker logs bronco-copilot-api-1` shows all three migrations applying in order
- [ ] `ssh hugo-app "docker exec bronco-postgres-1 psql -U bronco -d bronco -t -c \"SELECT unnest(enum_range(NULL::ticket_status))::text;\""` includes `NEW`
- [ ] `/api/health` on copilot-api returns 200

## Why direct to master

The broken migration blocks every subsequent migration until resolved, keeping Hugo in a pre-v0.3.0 state. Waiting for the staging → master cycle would leave production broken longer than needed.
