### PR TITLE
fix(deploy): restart cloudflared after caddy to eliminate tunnel drop

### DIFF
--- a/.github/workflows/deploy-hugo.yml
+++ b/.github/workflows/deploy-hugo.yml
@@ -338,9 +338,15 @@ jobs:
             # Migrations run automatically in the copilot-api entrypoint before the app starts.
             if [ "$COMPOSE_CHANGED" = "true" ] || [ "$ALL_SERVICES" = "true" ]; then
               docker compose up -d --no-build
+              # Full deploy — always cycle cloudflared to refresh tunnel routing
+              docker compose restart cloudflared
             else
               SVC_LIST=$(echo "$SERVICES" | jq -r '.[]' | tr '\n' ' ')
               docker compose up -d --no-build $SVC_LIST
+              # If caddy was restarted, cloudflared needs to re-resolve DNS
+              if echo "$SVC_LIST" | grep -qw caddy || echo "$SVC_LIST" | grep -qw control-panel; then
+                docker compose restart cloudflared
+              fi
             fi
 
             # Wait for copilot-api to pass its health check (includes migration completion)

--- a/.github/workflows/deploy-hugo.yml
+++ b/.github/workflows/deploy-hugo.yml
@@ -336,15 +336,39 @@ jobs:
 
             # Restart services
             # Migrations run automatically in the copilot-api entrypoint before the app starts.
+            wait_for_caddy() {
+              echo "Waiting for caddy to become reachable on localhost:80..."
+              for attempt in $(seq 1 30); do
+                if curl -sf http://localhost:80 >/dev/null 2>&1; then
+                  echo "caddy is reachable."
+                  return 0
+                fi
+                sleep 2
+              done
+              echo "caddy did not become reachable on localhost:80 in time." >&2
+              docker compose ps >&2
+              return 1
+            }
+
             if [ "$COMPOSE_CHANGED" = "true" ] || [ "$ALL_SERVICES" = "true" ]; then
               docker compose up -d --no-build
               # Full deploy — always cycle cloudflared to refresh tunnel routing
+              wait_for_caddy
               docker compose restart cloudflared
             else
-              SVC_LIST=$(echo "$SERVICES" | jq -r '.[]' | tr '\n' ' ')
+              # Translate image names to compose service names (control-panel image → caddy service)
+              SVC_LIST=$(
+                echo "$SERVICES" | jq -r '.[]' | while read -r svc; do
+                  case "$svc" in
+                    control-panel) echo "caddy" ;;
+                    *) echo "$svc" ;;
+                  esac
+                done | tr '\n' ' '
+              )
               docker compose up -d --no-build $SVC_LIST
               # If caddy was restarted, cloudflared needs to re-resolve DNS
-              if echo "$SVC_LIST" | grep -qw caddy || echo "$SVC_LIST" | grep -qw control-panel; then
+              if echo "$SVC_LIST" | grep -qw caddy; then
+                wait_for_caddy
                 docker compose restart cloudflared
               fi
             fi


### PR DESCRIPTION
## Summary

- Restart `cloudflared` after `caddy` so the tunnel re-resolves DNS against the fresh container instead of holding the stale DNS entry (currently produces 30-90s of 502s to public users on every deploy that touches caddy/control-panel).
- Both branches of the deploy script handled: full deploy always cycles cloudflared; partial deploy cycles it only when caddy or control-panel is in the services list.
- Blip shrinks from 30-90s indeterminate to ~3-5s deterministic (right after caddy is healthy).

Fixes #365.

## Test plan

- [ ] CI passes on the PR
- [ ] After merge + deploy: refresh `itrack.siirial.com` repeatedly during and immediately after the deploy — should hit at most one 3-5s window of unavailability, not 30-90s
- [ ] Confirm cloudflared container restarts in the deploy-hugo workflow log
- [ ] Verify `docker logs bronco-cloudflared-1` shows fresh tunnel registration after the restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
