### PR TITLE
fix(analyzer): orchestrated-v2 stall guard for no-progress iterations

### DIFF
--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -681,11 +681,15 @@ export async function runOrchestratedV2(
 
     orchNextPrompt = plan.nextPrompt ?? '';
 
-    // Stall-detection accumulators for this iteration. `subTaskCount` is the
-    // number of tasks we actually dispatched (after the chunking loop runs);
-    // `iterationKdWrites` counts kd_update_section + kd_add_subsection calls
-    // across this iteration's sub-task tool-call logs.
-    let iterationSubTaskCount = 0;
+    // Stall-detection accumulators for this iteration.
+    // `iterationDispatchAttempts` is the number of tasks the strategist
+    // planned (i.e. actually dispatched to the execution loop), regardless
+    // of whether they succeeded or failed. Counting attempts — not successful
+    // completions — means a batch where all tasks fail still registers as
+    // "tasks were dispatched" and does not falsely trip the zero-dispatch
+    // stall rule. `iterationKdWrites` counts kd_update_section +
+    // kd_add_subsection calls across this iteration's sub-task tool-call logs.
+    const iterationDispatchAttempts = plan.tasks.length;
     let iterationKdWrites = 0;
 
     // Execute tasks in parallel batches. Sub-tasks write findings via kd_*
@@ -704,7 +708,6 @@ export async function runOrchestratedV2(
           orchTotalInputTokens += result.value.inputTokens;
           orchTotalOutputTokens += result.value.outputTokens;
           orchToolCallLog.push(...result.value.toolCalls);
-          iterationSubTaskCount += 1;
           iterationKdWrites += countKdWrites(result.value.toolCalls);
           appLog.info(
             `Sub-task complete: ${task.prompt.slice(0, 120)}`,
@@ -718,7 +721,6 @@ export async function runOrchestratedV2(
             orchTotalInputTokens += retryResult.inputTokens;
             orchTotalOutputTokens += retryResult.outputTokens;
             orchToolCallLog.push(...retryResult.toolCalls);
-            iterationSubTaskCount += 1;
             iterationKdWrites += countKdWrites(retryResult.toolCalls);
             appLog.info(
               `Sub-task complete (retry): ${task.prompt.slice(0, 120)}`,
@@ -741,7 +743,7 @@ export async function runOrchestratedV2(
     // don't burn further budget on a non-progressing agent; the fallback +
     // compose path below will render a real stall marker.
     const stallCheck = updateStallState(stallState, {
-      subTaskCount: iterationSubTaskCount,
+      subTaskCount: iterationDispatchAttempts,
       kdWrites: iterationKdWrites,
       responseHash: hashOrchestratorResponse(strategistResponse.content),
     });

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   createLogger,
   initEmptyKnowledgeDoc,
@@ -43,9 +43,11 @@ import {
   composeFinalAnalysis,
   fallbackFillRequiredSections,
   writeKnowledgeDocSnapshot,
+  writeStallMarker,
 } from './v2-knowledge-doc.js';
 import {
   KD_SYSTEM_PROMPT_SNIPPET,
+  NO_STALL_SYSTEM_PROMPT_SNIPPET,
   PREFER_EXISTING_TOOLS_SNIPPET,
   REQUEST_NEW_TOOL_SNIPPET,
   TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
@@ -353,6 +355,92 @@ async function executeOrchestratedSubTaskV2(
 }
 
 /**
+ * Tool names that count as a knowledge-doc write. Reads (kd_read_toc /
+ * kd_read_section) do NOT count — the stall detector (#366) treats pure
+ * reads as no-progress. Update in lockstep with MCP platform's kd_* tool
+ * registration in `mcp-servers/platform/src/tools/knowledge-doc.ts`.
+ */
+const KD_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'platform__kd_update_section',
+  'platform__kd_add_subsection',
+]);
+
+function countKdWrites(toolCalls: ReadonlyArray<{ tool: string }>): number {
+  let n = 0;
+  for (const tc of toolCalls) {
+    if (KD_WRITE_TOOL_NAMES.has(tc.tool)) n++;
+  }
+  return n;
+}
+
+/**
+ * Cheap fingerprint of an orchestrator response. Used to detect N consecutive
+ * iterations that return nearly-identical plans (the #366 symptom). We strip
+ * whitespace + lowercase before hashing so that trivial cosmetic deltas don't
+ * mask a stuck agent; we take only the first 4k chars so huge pasted contexts
+ * don't dominate the fingerprint.
+ */
+function hashOrchestratorResponse(content: string): string {
+  const normalized = content.slice(0, 4000).replace(/\s+/g, ' ').trim().toLowerCase();
+  return createHash('sha1').update(normalized).digest('hex');
+}
+
+/**
+ * Stall-detection state for a single orchestrated-v2 run. The three rules map
+ * 1:1 to #366:
+ *   1. `consecutiveNoProgress >= 2` — two iterations in a row with zero
+ *      sub-task dispatches AND zero KD writes.
+ *   2. `consecutiveSameHash >= 3` — three iterations in a row with identical
+ *      (normalized) strategist response hashes.
+ *   3. `totalKdWrites === 0 && completedIterations >= 3` — the agent has had
+ *      three full turns without touching the doc.
+ *
+ * Returns a human-readable reason string when any rule fires, otherwise null.
+ * State is mutated in-place so the caller can keep running counters across the
+ * loop; call this at the end of every iteration after the sub-task batch (and
+ * its KD writes) has been accounted for.
+ */
+interface StallState {
+  consecutiveNoProgress: number;
+  consecutiveSameHash: number;
+  lastResponseHash: string | null;
+  totalKdWrites: number;
+  completedIterations: number;
+}
+
+function updateStallState(
+  state: StallState,
+  iteration: { subTaskCount: number; kdWrites: number; responseHash: string },
+): string | null {
+  state.completedIterations += 1;
+  state.totalKdWrites += iteration.kdWrites;
+
+  if (iteration.subTaskCount === 0 && iteration.kdWrites === 0) {
+    state.consecutiveNoProgress += 1;
+  } else {
+    state.consecutiveNoProgress = 0;
+  }
+
+  if (state.lastResponseHash !== null && state.lastResponseHash === iteration.responseHash) {
+    state.consecutiveSameHash += 1;
+  } else {
+    state.consecutiveSameHash = 1;
+  }
+  state.lastResponseHash = iteration.responseHash;
+
+  if (state.consecutiveNoProgress >= 2) {
+    return `${state.consecutiveNoProgress} consecutive iterations with zero sub-task dispatch and zero knowledge-doc writes`;
+  }
+  if (state.consecutiveSameHash >= 3) {
+    return `${state.consecutiveSameHash} consecutive iterations with identical strategist response fingerprints`;
+  }
+  if (state.totalKdWrites === 0 && state.completedIterations >= 3) {
+    return `zero knowledge-doc writes across ${state.completedIterations} iterations`;
+  }
+  return null;
+}
+
+/**
  * Orchestrated v2 agentic analysis. The strategist plans iterative sub-tasks;
  * sub-tasks write findings exclusively via the kd_* MCP tools under the
  * advisory lock. The orchestrator never writes raw text into
@@ -472,8 +560,20 @@ export async function runOrchestratedV2(
     REQUEST_NEW_TOOL_SNIPPET,
     TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
     KD_SYSTEM_PROMPT_SNIPPET,
+    NO_STALL_SYSTEM_PROMPT_SNIPPET,
     buildRepoNudgeSnippet(clientRepos),
   ].join('\n');
+
+  // Stall-detection state — see updateStallState for the three rules (#366).
+  const stallState: StallState = {
+    consecutiveNoProgress: 0,
+    consecutiveSameHash: 0,
+    lastResponseHash: null,
+    totalKdWrites: 0,
+    completedIterations: 0,
+  };
+  let stallReason: string | null = null;
+  let stallIteration = 0;
 
   for (let i = 0; i < orchMaxIterations; i++) {
     orchIterationsRun = i + 1;
@@ -581,6 +681,13 @@ export async function runOrchestratedV2(
 
     orchNextPrompt = plan.nextPrompt ?? '';
 
+    // Stall-detection accumulators for this iteration. `subTaskCount` is the
+    // number of tasks we actually dispatched (after the chunking loop runs);
+    // `iterationKdWrites` counts kd_update_section + kd_add_subsection calls
+    // across this iteration's sub-task tool-call logs.
+    let iterationSubTaskCount = 0;
+    let iterationKdWrites = 0;
+
     // Execute tasks in parallel batches. Sub-tasks write findings via kd_*
     // tools — no local knowledgeDoc accumulation here. Sub-task response text
     // is kept for AppLog / telemetry only; the doc is authoritative.
@@ -597,6 +704,8 @@ export async function runOrchestratedV2(
           orchTotalInputTokens += result.value.inputTokens;
           orchTotalOutputTokens += result.value.outputTokens;
           orchToolCallLog.push(...result.value.toolCalls);
+          iterationSubTaskCount += 1;
+          iterationKdWrites += countKdWrites(result.value.toolCalls);
           appLog.info(
             `Sub-task complete: ${task.prompt.slice(0, 120)}`,
             { ticketId, iteration: i + 1, toolCallCount: result.value.toolCalls.length, contentPreview: result.value.content.slice(0, 500) },
@@ -609,6 +718,8 @@ export async function runOrchestratedV2(
             orchTotalInputTokens += retryResult.inputTokens;
             orchTotalOutputTokens += retryResult.outputTokens;
             orchToolCallLog.push(...retryResult.toolCalls);
+            iterationSubTaskCount += 1;
+            iterationKdWrites += countKdWrites(retryResult.toolCalls);
             appLog.info(
               `Sub-task complete (retry): ${task.prompt.slice(0, 120)}`,
               { ticketId, iteration: i + 1, toolCallCount: retryResult.toolCalls.length, contentPreview: retryResult.content.slice(0, 500) },
@@ -622,15 +733,58 @@ export async function runOrchestratedV2(
     }
 
     await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+
+    // --- Stall detection (#366) ------------------------------------------
+    // After the iteration's sub-task batch has completed and its KD writes
+    // have been counted, feed the per-iteration signals into the stall state
+    // machine. If any of the three rules fires, break out of the loop so we
+    // don't burn further budget on a non-progressing agent; the fallback +
+    // compose path below will render a real stall marker.
+    const stallCheck = updateStallState(stallState, {
+      subTaskCount: iterationSubTaskCount,
+      kdWrites: iterationKdWrites,
+      responseHash: hashOrchestratorResponse(strategistResponse.content),
+    });
+    if (stallCheck !== null) {
+      stallReason = stallCheck;
+      stallIteration = i + 1;
+      appLog.warn(
+        `Orchestrator stall detected at iteration ${i + 1}: ${stallCheck}. Terminating loop early.`,
+        {
+          ticketId,
+          iteration: i + 1,
+          stallReason: stallCheck,
+          consecutiveNoProgress: stallState.consecutiveNoProgress,
+          consecutiveSameHash: stallState.consecutiveSameHash,
+          totalKdWrites: stallState.totalKdWrites,
+        },
+        ticketId, 'ticket',
+      );
+      break;
+    }
   }
 
-  // --- End of loop: fallback-fill + compose ------------------------------
-  await fallbackFillRequiredSections(db, ticketId, 'orchestrated-v2 loop end');
+  // --- End of loop: stall marker (if any) + fallback-fill + compose ------
+  // When the stall detector fired we write a real rootCause marker BEFORE the
+  // generic fallback-fill runs. `fallbackFillRequiredSections` only touches
+  // empty required sections, so populating rootCause first means the operator
+  // sees the actual stall reason in the composed analysis instead of the
+  // generic `[agent did not populate this section — …]` placeholder.
+  if (stallReason) {
+    await writeStallMarker(db, ticketId, stallIteration, stallReason);
+  }
+  const fallbackReason = stallReason
+    ? `orchestrated-v2 stalled at iteration ${stallIteration}`
+    : 'orchestrated-v2 loop end';
+  await fallbackFillRequiredSections(db, ticketId, fallbackReason);
   const kdAfter = await loadKnowledgeDoc(db, ticketId);
+  const fallbackExecutiveSummary = stallReason
+    ? `Orchestrated analysis terminated early by stall detector at iteration ${stallIteration}: ${stallReason}. No substantive findings were produced — see the Root Cause section for details.`
+    : 'Orchestrated analysis reached maximum iterations without a final conclusion. Review the knowledge document for partial findings.';
   const composedAnalysis = composeFinalAnalysis(
     kdAfter?.knowledgeDoc ?? null,
     kdAfter?.knowledgeDocSectionMeta ?? null,
-    agentExecutiveSummary || 'Orchestrated analysis reached maximum iterations without a final conclusion. Review the knowledge document for partial findings.',
+    agentExecutiveSummary || fallbackExecutiveSummary,
   );
   await writeKnowledgeDocSnapshot(db, ticketId, orchIterationsRun);
 

--- a/services/ticket-analyzer/src/analysis/v2-knowledge-doc.ts
+++ b/services/ticket-analyzer/src/analysis/v2-knowledge-doc.ts
@@ -98,6 +98,10 @@ export async function writeKnowledgeDocSnapshot(
  * fallback will skip it, so the Analysis Trace and composed email surface the
  * *real reason* the analysis is blank instead of the generic placeholder.
  *
+ * If rootCause already has content (the agent wrote partial findings before
+ * stalling), the marker is appended rather than replacing the existing text,
+ * so real investigative findings are preserved for the operator.
+ *
  * Swallows errors so a stall-marker write failure can't block the downstream
  * fallback-fill pass.
  */
@@ -108,7 +112,7 @@ export async function writeStallMarker(
   reason: string,
 ): Promise<void> {
   const body = [
-    `WARNING: Orchestrator stalled at iteration ${iteration}: ${reason}.`,
+    `⚠️ Orchestrator stalled at iteration ${iteration}: ${reason}.`,
     '',
     'See Run Log and iteration snapshots for context. This analysis was terminated',
     'early by the stall detector to avoid burning further budget on a non-progressing',
@@ -116,12 +120,20 @@ export async function writeStallMarker(
     'a root cause — escalate, re-run with more context, or flag as a prompt issue.',
   ].join('\n');
   try {
+    const ticket = await loadKnowledgeDoc(db, ticketId);
+    const existing = ticket
+      ? readSection(ticket.knowledgeDoc, ticket.knowledgeDocSectionMeta, KnowledgeDocSectionKey.ROOT_CAUSE).content.trim()
+      : '';
+    // If the agent already wrote partial findings, append so real content is
+    // preserved. If the section is empty, use REPLACE so the marker is the
+    // first and only text (avoids a blank line before the marker).
+    const mode = existing.length > 0 ? KnowledgeDocUpdateMode.APPEND : KnowledgeDocUpdateMode.REPLACE;
     await updateSection(
       db,
       ticketId,
       KnowledgeDocSectionKey.ROOT_CAUSE,
       body,
-      KnowledgeDocUpdateMode.REPLACE,
+      mode,
     );
   } catch (err) {
     logger.warn({ err, ticketId, iteration, reason }, 'Failed to write stall marker to rootCause — continuing');

--- a/services/ticket-analyzer/src/analysis/v2-knowledge-doc.ts
+++ b/services/ticket-analyzer/src/analysis/v2-knowledge-doc.ts
@@ -90,6 +90,45 @@ export async function writeKnowledgeDocSnapshot(
 }
 
 /**
+ * Write an operator-readable stall marker to the rootCause section when the
+ * orchestrator loop terminates early because it detected no forward progress.
+ *
+ * Called BEFORE `fallbackFillRequiredSections` at end-of-run — once rootCause
+ * has real content, the generic `[agent did not populate this section — …]`
+ * fallback will skip it, so the Analysis Trace and composed email surface the
+ * *real reason* the analysis is blank instead of the generic placeholder.
+ *
+ * Swallows errors so a stall-marker write failure can't block the downstream
+ * fallback-fill pass.
+ */
+export async function writeStallMarker(
+  db: PrismaClient,
+  ticketId: string,
+  iteration: number,
+  reason: string,
+): Promise<void> {
+  const body = [
+    `WARNING: Orchestrator stalled at iteration ${iteration}: ${reason}.`,
+    '',
+    'See Run Log and iteration snapshots for context. This analysis was terminated',
+    'early by the stall detector to avoid burning further budget on a non-progressing',
+    'loop. The agent produced no investigative findings that could be composed into',
+    'a root cause — escalate, re-run with more context, or flag as a prompt issue.',
+  ].join('\n');
+  try {
+    await updateSection(
+      db,
+      ticketId,
+      KnowledgeDocSectionKey.ROOT_CAUSE,
+      body,
+      KnowledgeDocUpdateMode.REPLACE,
+    );
+  } catch (err) {
+    logger.warn({ err, ticketId, iteration, reason }, 'Failed to write stall marker to rootCause — continuing');
+  }
+}
+
+/**
  * End-of-run guard: for every required section the agent didn't populate
  * (problemStatement / rootCause / recommendedFix), write a fallback marker so
  * downstream `composeFinalAnalysis` always has something to render. Returns

--- a/services/ticket-analyzer/src/analysis/v2-prompts.ts
+++ b/services/ticket-analyzer/src/analysis/v2-prompts.ts
@@ -166,6 +166,6 @@ export const NO_STALL_SYSTEM_PROMPT_SNIPPET = [
   'return a plan that is only "I need to review the knowledge document" — if you need to',
   'check what has been recorded, dispatch a sub-task that calls `platform__kd_read_toc`',
   'and/or `platform__kd_read_section` and uses the result to decide the next investigation',
-  'step. An empty `tasks` array on a non-terminal turn will trip the stall detector and',
-  'the orchestrator will terminate early.',
+  'step. Repeated empty `tasks` arrays across consecutive turns will trip the stall',
+  'detector and the orchestrator will terminate early.',
 ].join('\n');

--- a/services/ticket-analyzer/src/analysis/v2-prompts.ts
+++ b/services/ticket-analyzer/src/analysis/v2-prompts.ts
@@ -149,3 +149,23 @@ export const KD_SYSTEM_PROMPT_SNIPPET = [
   '',
   'Your final analysis text (in the response) should be a concise executive summary — the detail lives in the knowledge doc. The AI_ANALYSIS composer will pull Root Cause + Recommended Fix + Risks from the doc to render the analysis view.',
 ].join('\n');
+
+/**
+ * Anti-stall snippet appended to the orchestrated-v2 strategist system prompt.
+ * The observed failure mode (issue #366) is the orchestrator repeatedly asking
+ * to re-read the KD without dispatching a sub-task or writing any section, so
+ * we require every non-terminal turn to produce concrete forward progress.
+ * This is advisory only — the runtime stall detector in orchestrated-v2.ts is
+ * the hard guard.
+ */
+export const NO_STALL_SYSTEM_PROMPT_SNIPPET = [
+  '',
+  '## Forward Progress Required',
+  'Every non-terminal iteration MUST produce concrete forward progress: either dispatch',
+  'at least one sub-task in `tasks`, or set `done: true` with a `finalAnalysis`. Do not',
+  'return a plan that is only "I need to review the knowledge document" — if you need to',
+  'check what has been recorded, dispatch a sub-task that calls `platform__kd_read_toc`',
+  'and/or `platform__kd_read_section` and uses the result to decide the next investigation',
+  'step. An empty `tasks` array on a non-terminal turn will trip the stall detector and',
+  'the orchestrator will terminate early.',
+].join('\n');


### PR DESCRIPTION
## Summary

- Add stall detection to the orchestrated-v2 analysis runner so it terminates early when the agent isn't making progress, instead of burning all 10 iterations.
- Triggers: 2 consecutive iterations with zero sub-task dispatches + zero KD writes, 3 consecutive iterations with identical response hashes, or zero KD writes total after iteration 3.
- On stall, writes a real operator-readable marker (`⚠️ Orchestrator stalled at iteration N…`) to `rootCause` BEFORE the generic `fallbackFillRequiredSections` so the Analysis Trace surfaces *why* the analysis is blank. Executive-summary fallback also becomes stall-aware.
- Additive prompt nudge discourages bare "I need to review the KD" responses — hard guard remains the runtime detector.
- Only touches the three v2-specific files; `orchestrated-v1.ts`, `flat-v1.ts`, `flat-v2.ts`, and `shared.ts` are untouched per the analysis-strategies parallel-file rule.

Fixes #366.

## Test plan

- [ ] CI passes on the PR
- [ ] After merge: replay ticket `cbcc4dde-65f2-4edb-a2fe-95a986d936e2` (Altman Plants deadlock probe) via the control panel re-analysis action and confirm the orchestrator terminates at ~iteration 3 with a real stall marker in `rootCause`, not the generic `[agent did not populate…]` fallback
- [ ] Trigger a normal ticket where the agent actually writes KD content — confirm the run completes without a false-positive stall abort
- [ ] Verify `ai_usage_logs` for the replayed ticket shows fewer orchestrator iterations (target: ≤3 instead of 10) and lower cost
- [ ] Spot-check the Analysis Trace tab for the stalled ticket — stall marker should be visible and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
