### PR TITLE
fix(mcp-repo): provision SSH known_hosts + health probe

### DIFF
--- a/mcp-servers/repo/Dockerfile
+++ b/mcp-servers/repo/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /var/lib/mcp-repo/repos \
 # Without this the container has no known_hosts at all and every SSH-URL
 # clone aborts before reaching auth. See issue #367.
 RUN mkdir -p /home/node/.ssh \
-    && ssh-keyscan -t rsa,ed25519 github.com gitlab.com bitbucket.org \
+    && ssh-keyscan -T 5 -t rsa,ed25519 github.com gitlab.com bitbucket.org \
          >> /home/node/.ssh/known_hosts 2>/dev/null \
     && chown -R node:node /home/node/.ssh \
     && chmod 700 /home/node/.ssh \

--- a/mcp-servers/repo/Dockerfile
+++ b/mcp-servers/repo/Dockerfile
@@ -26,6 +26,22 @@ COPY --from=build /app /app
 RUN pnpm prune --prod
 RUN mkdir -p /var/lib/mcp-repo/repos \
     && chown -R node:node /var/lib/mcp-repo
+
+# Pre-populate SSH known_hosts for the common git forges so the first
+# `git clone git@…` attempt does not fail with "Host key verification failed".
+# Without this the container has no known_hosts at all and every SSH-URL
+# clone aborts before reaching auth. See issue #367.
+RUN mkdir -p /home/node/.ssh \
+    && ssh-keyscan -t rsa,ed25519 github.com gitlab.com bitbucket.org \
+         >> /home/node/.ssh/known_hosts 2>/dev/null \
+    && chown -R node:node /home/node/.ssh \
+    && chmod 700 /home/node/.ssh \
+    && chmod 644 /home/node/.ssh/known_hosts
+
+COPY --chown=node:node mcp-servers/repo/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 3111
 USER node
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "mcp-servers/repo/dist/index.js"]

--- a/mcp-servers/repo/docker-entrypoint.sh
+++ b/mcp-servers/repo/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if command -v ssh >/dev/null 2>&1; then
     -o ConnectTimeout=5 \
     git@github.com 2>&1 || true)
 
-  if echo "$probe_output" | grep -q "successfully authenticated"; then
+  if echo "$probe_output" | grep -qi "successfully authenticated"; then
     echo "[mcp-repo] SSH to github.com authenticated — SSH-URL clones should work" >&2
   else
     echo "[mcp-repo] WARNING: SSH to github.com not authenticating — SSH-URL repos will fail to clone. HTTPS-URL repos are unaffected." >&2

--- a/mcp-servers/repo/docker-entrypoint.sh
+++ b/mcp-servers/repo/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# mcp-repo entrypoint: non-fatal SSH preflight.
+#
+# We probe `ssh -T git@github.com` to surface broken SSH auth in the logs
+# early. This is intentionally informational — HTTPS-URL repos clone fine
+# without any SSH setup, so we never block startup on this check.
+#
+# See issue #367: first-time SSH clones were failing with
+# "Host key verification failed" because known_hosts was empty. The
+# Dockerfile now seeds known_hosts at build time; this probe helps
+# operators notice if the identity key is missing or rejected.
+
+set -e
+
+if command -v ssh >/dev/null 2>&1; then
+  # BatchMode=yes prevents any password/passphrase prompts.
+  # StrictHostKeyChecking=yes keeps us honest — we want to verify the
+  # baked-in known_hosts is actually trusted.
+  # `ssh -T git@github.com` exits non-zero even on success (github prints
+  # a greeting then disconnects), so we grep for the success string.
+  probe_output=$(ssh -T \
+    -o StrictHostKeyChecking=yes \
+    -o BatchMode=yes \
+    -o ConnectTimeout=5 \
+    git@github.com 2>&1 || true)
+
+  if echo "$probe_output" | grep -q "successfully authenticated"; then
+    echo "[mcp-repo] SSH to github.com authenticated — SSH-URL clones should work" >&2
+  else
+    echo "[mcp-repo] WARNING: SSH to github.com not authenticating — SSH-URL repos will fail to clone. HTTPS-URL repos are unaffected." >&2
+    echo "[mcp-repo] ssh probe output: $probe_output" >&2
+  fi
+fi
+
+exec "$@"

--- a/mcp-servers/repo/src/index.ts
+++ b/mcp-servers/repo/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import express from 'express';
 import { getDb, disconnectDb } from '@bronco/db';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -7,6 +8,68 @@ import { createMcpServer } from './server.js';
 import { RepoManager } from './repo-manager.js';
 
 const logger = createLogger('mcp-repo');
+
+// --- SSH reachability probe (cached) ---
+// Checks whether `ssh -T git@github.com` authenticates, so the control
+// panel's status page can flag mcp-repo instances that have missing or
+// broken SSH keys before the operator tries to analyze a ticket whose
+// repos are SSH-only. Cached for 60s to avoid spawning ssh on every
+// health poll. See issue #367.
+const SSH_PROBE_TTL_MS = 60_000;
+let sshProbeCache: { value: boolean; at: number } | null = null;
+let sshProbeInflight: Promise<boolean> | null = null;
+
+function probeSshGithub(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      'ssh',
+      [
+        '-T',
+        '-o', 'StrictHostKeyChecking=yes',
+        '-o', 'BatchMode=yes',
+        '-o', 'ConnectTimeout=5',
+        'git@github.com',
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    let out = '';
+    child.stdout.on('data', (chunk) => { out += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { out += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve(false);
+    }, 8_000);
+
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+    // ssh -T against github exits non-zero even on success, so rely on output.
+    child.on('close', () => {
+      clearTimeout(timer);
+      resolve(/successfully authenticated/i.test(out));
+    });
+  });
+}
+
+async function getSshGithubReachable(): Promise<boolean> {
+  const now = Date.now();
+  if (sshProbeCache && now - sshProbeCache.at < SSH_PROBE_TTL_MS) {
+    return sshProbeCache.value;
+  }
+  if (sshProbeInflight) return sshProbeInflight;
+  sshProbeInflight = probeSshGithub()
+    .then((value) => {
+      sshProbeCache = { value, at: Date.now() };
+      return value;
+    })
+    .finally(() => {
+      sshProbeInflight = null;
+    });
+  return sshProbeInflight;
+}
 
 async function main(): Promise<void> {
   const config = getConfig();
@@ -20,8 +83,13 @@ async function main(): Promise<void> {
   app.use(express.json());
 
   // --- Health check (no auth) ---
-  app.get('/health', (_req, res) => {
-    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  app.get('/health', async (_req, res) => {
+    const sshGithubReachable = await getSshGithubReachable().catch(() => false);
+    res.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      sshGithubReachable,
+    });
   });
 
   // --- Auth middleware for all other routes ---

--- a/mcp-servers/repo/src/index.ts
+++ b/mcp-servers/repo/src/index.ts
@@ -54,21 +54,29 @@ function probeSshGithub(): Promise<boolean> {
   });
 }
 
-async function getSshGithubReachable(): Promise<boolean> {
+// Returns the cached SSH reachability value immediately (never waits for a live
+// probe on the hot path). If the cache is cold or stale, kicks off a background
+// refresh and returns `null` (unknown) until the first result arrives.  This
+// keeps /health non-blocking so it always responds well within the docker-compose
+// healthcheck timeout even when the 60-second cache has just expired.
+function getSshGithubReachable(): boolean | null {
   const now = Date.now();
   if (sshProbeCache && now - sshProbeCache.at < SSH_PROBE_TTL_MS) {
     return sshProbeCache.value;
   }
-  if (sshProbeInflight) return sshProbeInflight;
-  sshProbeInflight = probeSshGithub()
-    .then((value) => {
-      sshProbeCache = { value, at: Date.now() };
-      return value;
-    })
-    .finally(() => {
-      sshProbeInflight = null;
-    });
-  return sshProbeInflight;
+  // Cache is cold or stale — kick off a refresh in the background if one is
+  // not already running, then return null (unknown) for this request.
+  if (!sshProbeInflight) {
+    sshProbeInflight = probeSshGithub()
+      .then((value) => {
+        sshProbeCache = { value, at: Date.now() };
+        return value;
+      })
+      .finally(() => {
+        sshProbeInflight = null;
+      });
+  }
+  return null;
 }
 
 async function main(): Promise<void> {
@@ -83,8 +91,12 @@ async function main(): Promise<void> {
   app.use(express.json());
 
   // --- Health check (no auth) ---
-  app.get('/health', async (_req, res) => {
-    const sshGithubReachable = await getSshGithubReachable().catch(() => false);
+  // getSshGithubReachable() is synchronous and non-blocking: it returns the
+  // cached value (true/false) or null when no result is available yet (probe
+  // still running or cache cold).  Never awaits a live SSH probe here so the
+  // healthcheck always responds quickly regardless of TTL expiry.
+  app.get('/health', (_req, res) => {
+    const sshGithubReachable = getSshGithubReachable();
     res.json({
       status: 'ok',
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Provision SSH `known_hosts` in the `mcp-repo` container for `github.com` / `gitlab.com` / `bitbucket.org` at build time so first-time SSH clones don't fail with "Host key verification failed".
- Add a non-fatal startup preflight in `docker-entrypoint.sh` that logs a WARNING if `ssh -T git@github.com` isn't authenticating — surfaces misconfig (missing key mount, expired deploy key) without hard-failing the container.
- Extend `/health` with `sshGithubReachable: boolean` backed by a 60s-cached probe (TTL + in-flight dedupe, 8s ssh spawn timeout). Existing `{ status, timestamp }` shape preserved.
- Observed on ticket `cbcc4dde-65f2-4edb-a2fe-95a986d936e2`: all 5 Altman Plants repos failed `prepare_repo`, blocking code context for the entire analysis. Pipeline still reported success with an empty `GATHER_REPO_CONTEXT` result.

Fixes #367.

Note: this is the short-term patch. #368 is the structural replacement (HTTPS clone via per-client GitHub integrations) and #369 tracks retiring this SSH path once #368 has run in production.

## Test plan

- [ ] CI passes on the PR
- [ ] After merge + deploy: `ssh hugo-app "docker exec bronco-mcp-repo-1 ssh -T git@github.com 2>&1"` prints "Hi …! You've successfully authenticated …" (or similar) — confirms `known_hosts` is populated and the SSH key mount is correct
- [ ] Re-run analysis on an Altman Plants ticket — `GATHER_REPO_CONTEXT` should complete with non-empty code search results
- [ ] `ssh hugo-app "curl -s http://localhost:3111/health"` returns `sshGithubReachable: true`
- [ ] If SSH key isn't mounted: confirm container logs show the preflight WARNING but the container stays up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
