### PR TITLE
feat: GitHub as a first-class Integration type

### DIFF
--- a/mcp-servers/repo/src/github-clone-url.ts
+++ b/mcp-servers/repo/src/github-clone-url.ts
@@ -1,0 +1,153 @@
+import type { PrismaClient } from '@bronco/db';
+import type { GithubCredentials } from '@bronco/shared-types';
+import { IntegrationType } from '@bronco/shared-types';
+import { createLogger, decrypt, looksEncrypted } from '@bronco/shared-utils';
+
+const logger = createLogger('mcp-repo-github-clone-url');
+
+/**
+ * Resolution order for a repo clone URL:
+ * 1. If the repo has `githubIntegrationId` set, use that integration's creds.
+ * 2. Else, fall back to the platform-scoped GITHUB integration (clientId IS NULL).
+ * 3. Else, leave the URL untouched (caller will use legacy SSH / unauth path).
+ *
+ * For `github_app` kind credentials, we currently log a TODO and fall through
+ * to the next level — JWT → installation token minting is tracked as a
+ * follow-up. Do not block clones on that for v1.
+ */
+export async function resolveCloneUrl(
+  db: PrismaClient,
+  encryptionKey: string,
+  repo: { id: string; repoUrl: string; githubIntegrationId: string | null; clientId: string },
+): Promise<string> {
+  // Only apply HTTPS-token rewriting to URLs that look like HTTPS GitHub (or GHES).
+  // SSH URLs ("git@github.com:owner/repo.git") are left alone and will clone
+  // via the legacy SSH-key path if one is mounted.
+  if (!repo.repoUrl.startsWith('https://') && !repo.repoUrl.startsWith('http://')) {
+    return repo.repoUrl;
+  }
+
+  // 1. Repo-level integration
+  if (repo.githubIntegrationId) {
+    const direct = await db.clientIntegration.findUnique({
+      where: { id: repo.githubIntegrationId },
+      select: { id: true, type: true, config: true, isActive: true, clientId: true },
+    });
+    if (direct && direct.isActive && direct.type === IntegrationType.GITHUB) {
+      const rewritten = applyCredentialsToUrl(repo.repoUrl, direct.config, encryptionKey, { repoId: repo.id, source: 'repo' });
+      if (rewritten) return rewritten;
+    } else if (direct) {
+      logger.warn(
+        { repoId: repo.id, integrationId: direct.id, type: direct.type, active: direct.isActive },
+        'Repo has githubIntegrationId but integration is inactive or wrong type — falling back to platform default',
+      );
+    }
+  }
+
+  // 2. Platform-scoped GITHUB integration
+  const platform = await db.clientIntegration.findFirst({
+    where: { type: IntegrationType.GITHUB, clientId: null, isActive: true },
+    select: { id: true, config: true },
+    orderBy: { createdAt: 'asc' },
+  });
+  if (platform) {
+    const rewritten = applyCredentialsToUrl(repo.repoUrl, platform.config, encryptionKey, { repoId: repo.id, source: 'platform' });
+    if (rewritten) return rewritten;
+  }
+
+  // 3. Legacy fallback — unchanged URL. Caller's environment must provide SSH
+  // keys or public access for this to succeed.
+  return repo.repoUrl;
+}
+
+/**
+ * Given an HTTPS repo URL and a GITHUB integration config, return a
+ * token-embedded URL suitable for `git clone`.
+ *
+ * Returns null if the credential shape is unsupported (e.g. github_app for
+ * v1) so the caller can fall through to the next resolution level.
+ */
+function applyCredentialsToUrl(
+  repoUrl: string,
+  rawConfig: unknown,
+  encryptionKey: string,
+  ctx: { repoId: string; source: 'repo' | 'platform' },
+): string | null {
+  const creds = parseCredentials(rawConfig);
+  if (!creds) {
+    logger.warn({ ...ctx }, 'GITHUB integration config malformed — skipping');
+    return null;
+  }
+
+  if (creds.kind === 'github_app') {
+    // TODO(#368-followup): mint a short-lived installation token from the
+    // GitHub App JWT, then rewrite the URL with it. For v1 we log and fall
+    // through so the next resolution level (platform default / SSH) can run.
+    logger.warn(
+      { ...ctx, appId: creds.appId, installationId: creds.installationId },
+      'GITHUB integration uses github_app kind but token-minting is not yet implemented — falling through',
+    );
+    return null;
+  }
+
+  let token: string;
+  try {
+    token = looksEncrypted(creds.encryptedToken)
+      ? decrypt(creds.encryptedToken, encryptionKey)
+      : creds.encryptedToken;
+  } catch (err) {
+    logger.error({ ...ctx, err: err instanceof Error ? err.message : String(err) }, 'Failed to decrypt GITHUB PAT');
+    return null;
+  }
+  if (!token) return null;
+
+  // Parse the URL so we can reliably swap auth + host. URL mutation is safer
+  // than string concatenation (handles subpaths under GHES, trailing .git, etc.).
+  try {
+    const parsed = new URL(repoUrl);
+    parsed.username = 'x-access-token';
+    parsed.password = token;
+    // Only override host if the integration specifies one. Leaving the URL's
+    // original host alone by default keeps github.com repos clone-compatible
+    // when a GHES-scoped integration is also present.
+    if (creds.host && creds.host !== parsed.host) {
+      logger.debug(
+        { ...ctx, urlHost: parsed.host, credHost: creds.host },
+        'GITHUB integration host does not match repo URL host — leaving URL host unchanged',
+      );
+    }
+    return parsed.toString();
+  } catch (err) {
+    logger.warn({ ...ctx, err: err instanceof Error ? err.message : String(err) }, 'Repo URL failed to parse — using raw URL');
+    return null;
+  }
+}
+
+function parseCredentials(raw: unknown): GithubCredentials | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const kind = obj.kind;
+  if (kind === 'pat' && typeof obj.encryptedToken === 'string' && obj.encryptedToken.length > 0) {
+    return {
+      kind: 'pat',
+      encryptedToken: obj.encryptedToken,
+      host: typeof obj.host === 'string' ? obj.host : undefined,
+    };
+  }
+  if (
+    kind === 'github_app' &&
+    typeof obj.appId === 'string' &&
+    typeof obj.installationId === 'string' &&
+    typeof obj.encryptedPrivateKey === 'string' &&
+    obj.encryptedPrivateKey.length > 0
+  ) {
+    return {
+      kind: 'github_app',
+      appId: obj.appId,
+      installationId: obj.installationId,
+      encryptedPrivateKey: obj.encryptedPrivateKey,
+      host: typeof obj.host === 'string' ? obj.host : undefined,
+    };
+  }
+  return null;
+}

--- a/mcp-servers/repo/src/github-clone-url.ts
+++ b/mcp-servers/repo/src/github-clone-url.ts
@@ -20,10 +20,11 @@ export async function resolveCloneUrl(
   encryptionKey: string,
   repo: { id: string; repoUrl: string; githubIntegrationId: string | null; clientId: string },
 ): Promise<string> {
-  // Only apply HTTPS-token rewriting to URLs that look like HTTPS GitHub (or GHES).
-  // SSH URLs ("git@github.com:owner/repo.git") are left alone and will clone
-  // via the legacy SSH-key path if one is mounted.
-  if (!repo.repoUrl.startsWith('https://') && !repo.repoUrl.startsWith('http://')) {
+  // Only apply token rewriting to HTTPS URLs. Plain HTTP URLs must be left
+  // untouched so credentials are never embedded into a clone URL that would be
+  // sent over an unencrypted connection. SSH URLs ("git@github.com:owner/repo.git")
+  // are also left alone and will clone via the legacy SSH-key path if one is mounted.
+  if (!repo.repoUrl.startsWith('https://')) {
     return repo.repoUrl;
   }
 
@@ -33,9 +34,22 @@ export async function resolveCloneUrl(
       where: { id: repo.githubIntegrationId },
       select: { id: true, type: true, config: true, isActive: true, clientId: true },
     });
-    if (direct && direct.isActive && direct.type === IntegrationType.GITHUB) {
+    // Guard against cross-tenant credential use: only use an integration if it is
+    // platform-scoped (clientId IS NULL) or belongs to the same client as the repo.
+    const matchesClient = direct ? direct.clientId === null || direct.clientId === repo.clientId : false;
+    if (direct && direct.isActive && direct.type === IntegrationType.GITHUB && matchesClient) {
       const rewritten = applyCredentialsToUrl(repo.repoUrl, direct.config, encryptionKey, { repoId: repo.id, source: 'repo' });
       if (rewritten) return rewritten;
+    } else if (direct && !matchesClient) {
+      logger.warn(
+        {
+          repoId: repo.id,
+          repoClientId: repo.clientId,
+          integrationId: direct.id,
+          integrationClientId: direct.clientId,
+        },
+        'Repo has githubIntegrationId for a different client — falling back to platform default',
+      );
     } else if (direct) {
       logger.warn(
         { repoId: repo.id, integrationId: direct.id, type: direct.type, active: direct.isActive },
@@ -44,11 +58,11 @@ export async function resolveCloneUrl(
     }
   }
 
-  // 2. Platform-scoped GITHUB integration
+  // 2. Platform-scoped GITHUB integration — prefer the "default" label so
+  //    selection is deterministic when multiple platform-scoped rows exist.
   const platform = await db.clientIntegration.findFirst({
-    where: { type: IntegrationType.GITHUB, clientId: null, isActive: true },
+    where: { type: IntegrationType.GITHUB, clientId: null, isActive: true, label: 'default' },
     select: { id: true, config: true },
-    orderBy: { createdAt: 'asc' },
   });
   if (platform) {
     const rewritten = applyCredentialsToUrl(repo.repoUrl, platform.config, encryptionKey, { repoId: repo.id, source: 'platform' });

--- a/mcp-servers/repo/src/repo-manager.ts
+++ b/mcp-servers/repo/src/repo-manager.ts
@@ -64,10 +64,12 @@ export class RepoManager {
     });
 
     if (await this.pathExists(barePath)) {
-      // Update the origin URL in case credentials rotated (or an integration
-      // was added/removed since the last fetch). We log at debug because this
-      // fires on every refresh.
-      if (cloneUrl !== repo.repoUrl) {
+      // Compare against the current remote URL rather than `repo.repoUrl` so we
+      // also reset stale tokenized remotes back to the plain URL when an integration
+      // is removed (not just when a new token is injected).
+      const { stdout: originUrlStdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: barePath });
+      const originUrl = originUrlStdout.trim();
+      if (originUrl !== cloneUrl) {
         await execFileAsync('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: barePath });
       }
       logger.info({ repoId, barePath }, 'Fetching updates for bare clone');
@@ -76,6 +78,15 @@ export class RepoManager {
       logger.info({ repoId, barePath, usedGithubIntegration: cloneUrl !== repo.repoUrl }, 'Cloning bare repository');
       await mkdir(this.config.REPO_WORKSPACE_PATH, { recursive: true });
       await execFileAsync('git', ['clone', '--bare', cloneUrl, barePath]);
+    }
+
+    // Scrub the token-embedded URL from .git/config so the PAT is not stored on
+    // disk at rest. We reset the remote to the plain URL immediately after the
+    // clone/fetch completes; future operations will re-inject via the in-memory
+    // cloneUrl resolved above.  This does NOT break subsequent git operations on
+    // the bare repo because all fetched objects are already in the object store.
+    if (cloneUrl !== repo.repoUrl) {
+      await execFileAsync('git', ['remote', 'set-url', 'origin', repo.repoUrl], { cwd: barePath });
     }
 
     return barePath;

--- a/mcp-servers/repo/src/repo-manager.ts
+++ b/mcp-servers/repo/src/repo-manager.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import type { PrismaClient } from '@bronco/db';
 import { createLogger } from '@bronco/shared-utils';
 import type { Config } from './config.js';
+import { resolveCloneUrl } from './github-clone-url.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('repo-manager');
@@ -51,13 +52,30 @@ export class RepoManager {
 
     const barePath = join(this.config.REPO_WORKSPACE_PATH, `${repoId}.git`);
 
+    // Resolve the clone URL through the GITHUB integration chain (repo-level →
+    // platform-scoped → legacy/unchanged). Rebuild on every call so rotated
+    // tokens and newly-configured integrations take effect without restarting
+    // this service.
+    const cloneUrl = await resolveCloneUrl(this.db, this.config.ENCRYPTION_KEY, {
+      id: repo.id,
+      repoUrl: repo.repoUrl,
+      githubIntegrationId: repo.githubIntegrationId,
+      clientId: repo.clientId,
+    });
+
     if (await this.pathExists(barePath)) {
+      // Update the origin URL in case credentials rotated (or an integration
+      // was added/removed since the last fetch). We log at debug because this
+      // fires on every refresh.
+      if (cloneUrl !== repo.repoUrl) {
+        await execFileAsync('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: barePath });
+      }
       logger.info({ repoId, barePath }, 'Fetching updates for bare clone');
       await execFileAsync('git', ['fetch', '--all'], { cwd: barePath });
     } else {
-      logger.info({ repoId, barePath }, 'Cloning bare repository');
+      logger.info({ repoId, barePath, usedGithubIntegration: cloneUrl !== repo.repoUrl }, 'Cloning bare repository');
       await mkdir(this.config.REPO_WORKSPACE_PATH, { recursive: true });
-      await execFileAsync('git', ['clone', '--bare', repo.repoUrl, barePath]);
+      await execFileAsync('git', ['clone', '--bare', cloneUrl, barePath]);
     }
 
     return barePath;

--- a/packages/db/prisma/migrations/20260422030000_add_github_integration_type/migration.sql
+++ b/packages/db/prisma/migrations/20260422030000_add_github_integration_type/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+-- NOTE: Postgres requires new enum values to be committed before they can be used.
+-- The second migration (20260422030100) alters the ClientIntegration table shape
+-- and is split out so this ALTER TYPE commits in its own transaction first.
+ALTER TYPE "integration_type" ADD VALUE 'GITHUB';

--- a/packages/db/prisma/migrations/20260422030100_github_integration_schema/migration.sql
+++ b/packages/db/prisma/migrations/20260422030100_github_integration_schema/migration.sql
@@ -1,0 +1,27 @@
+-- Make ClientIntegration.client_id nullable to allow platform-scoped integrations
+-- (e.g. a single platform-wide GITHUB integration used by tool-request issue
+-- creation and issue-resolver pushes).
+ALTER TABLE "client_integrations"
+  ALTER COLUMN "client_id" DROP NOT NULL;
+
+-- Partial unique index: enforce one platform integration per (type, label).
+-- The existing composite UNIQUE(client_id, type, label) only covers rows where
+-- client_id IS NOT NULL (Postgres treats NULLs as distinct in a UNIQUE
+-- constraint), so platform-scoped rows need their own partial index.
+CREATE UNIQUE INDEX "client_integrations_platform_type_label_key"
+  ON "client_integrations" ("type", "label")
+  WHERE "client_id" IS NULL;
+
+-- Add github_integration_id FK on CodeRepo.
+ALTER TABLE "code_repos"
+  ADD COLUMN "github_integration_id" UUID;
+
+ALTER TABLE "code_repos"
+  ADD CONSTRAINT "code_repos_github_integration_id_fkey"
+  FOREIGN KEY ("github_integration_id")
+  REFERENCES "client_integrations"("id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;
+
+CREATE INDEX "code_repos_github_integration_id_idx"
+  ON "code_repos" ("github_integration_id");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -537,12 +537,20 @@ model CodeRepo {
 
   environmentId String? @map("environment_id") @db.Uuid
 
-  client      Client             @relation(fields: [clientId], references: [id])
-  environment ClientEnvironment? @relation(fields: [environmentId], references: [id])
-  issueJobs   IssueJob[]
+  /// Optional FK to a GITHUB-type ClientIntegration. When set, mcp-repo uses
+  /// that integration's credentials to clone over HTTPS. When null, mcp-repo
+  /// falls back to the platform-scoped GITHUB integration, and finally to the
+  /// legacy SSH key path.
+  githubIntegrationId String? @map("github_integration_id") @db.Uuid
+
+  client            Client             @relation(fields: [clientId], references: [id])
+  environment       ClientEnvironment? @relation(fields: [environmentId], references: [id])
+  githubIntegration ClientIntegration? @relation(fields: [githubIntegrationId], references: [id], onDelete: SetNull)
+  issueJobs         IssueJob[]
 
   @@unique([clientId, repoUrl])
   @@index([environmentId])
+  @@index([githubIntegrationId])
   @@map("code_repos")
 }
 
@@ -630,7 +638,11 @@ model ExternalService {
 
 model ClientIntegration {
   id        String          @id @default(uuid()) @db.Uuid
-  clientId  String          @map("client_id") @db.Uuid
+  /// Nullable: null = platform-scoped (e.g. the single platform-wide GITHUB
+  /// integration used by tool-request issue creation and issue-resolver
+  /// pushes). A partial unique index (see migration) enforces one platform
+  /// integration per (type, label).
+  clientId  String?         @map("client_id") @db.Uuid
   type      IntegrationType
   label     String          @default("default") // e.g. "prod", "dev", "staging"
   config    Json
@@ -642,9 +654,10 @@ model ClientIntegration {
 
   environmentId String? @map("environment_id") @db.Uuid
 
-  client      Client             @relation(fields: [clientId], references: [id])
+  client      Client?            @relation(fields: [clientId], references: [id])
   environment ClientEnvironment? @relation(fields: [environmentId], references: [id])
   scheduledProbes ScheduledProbe[]
+  codeRepos       CodeRepo[]
 
   @@unique([clientId, type, label])
   @@index([environmentId])
@@ -1093,6 +1106,7 @@ enum IntegrationType {
   AZURE_DEVOPS
   MCP_DATABASE
   SLACK
+  GITHUB
 
   @@map("integration_type")
 }

--- a/packages/shared-types/src/code-repo.ts
+++ b/packages/shared-types/src/code-repo.ts
@@ -48,6 +48,13 @@ export interface CodeRepo {
   description: string | null;
   fileExtensions: string[];
   environmentId: string | null;
+  /**
+   * Optional FK to a GITHUB-type ClientIntegration. When set, mcp-repo uses that
+   * integration's credentials to clone over HTTPS. When null, mcp-repo falls
+   * back to the platform-scoped GITHUB integration, and finally to the legacy
+   * SSH key path.
+   */
+  githubIntegrationId: string | null;
   isActive: boolean;
   createdAt: Date;
   updatedAt: Date;

--- a/packages/shared-types/src/integration.ts
+++ b/packages/shared-types/src/integration.ts
@@ -46,8 +46,11 @@ export interface SlackIntegrationConfig {
  *
  * NOTE: `github_app` support is stubbed for v1 — the Zod schema accepts it and
  * the data round-trips, but token-minting (JWT → installation token exchange)
- * is a follow-up. mcp-repo / tool-request-github will log a TODO and fall
- * through to PAT / legacy paths when they encounter `kind: 'github_app'`.
+ * is a follow-up (#369). mcp-repo falls through to the next resolution level
+ * (platform default / SSH) when it encounters `kind: 'github_app'`.
+ * tool-request-github throws a clear error rather than silently falling back,
+ * because an operator who configured a github_app integration almost certainly
+ * intended it to be used.
  */
 export interface GithubPatCredentials {
   kind: 'pat';

--- a/packages/shared-types/src/integration.ts
+++ b/packages/shared-types/src/integration.ts
@@ -3,6 +3,7 @@ export const IntegrationType = {
   AZURE_DEVOPS: 'AZURE_DEVOPS',
   MCP_DATABASE: 'MCP_DATABASE',
   SLACK: 'SLACK',
+  GITHUB: 'GITHUB',
 } as const;
 export type IntegrationType = (typeof IntegrationType)[keyof typeof IntegrationType];
 
@@ -34,15 +35,56 @@ export interface SlackIntegrationConfig {
   enabled: boolean;
 }
 
+/**
+ * GitHub credentials — discriminated union supporting both PAT and GitHub App
+ * installation tokens. Host defaults to `github.com` when omitted, which unlocks
+ * GitHub Enterprise Server targets.
+ *
+ * Tokens and private keys are stored encrypted (AES-256-GCM via shared-utils).
+ * The `encryptedToken` / `encryptedPrivateKey` fields hold ciphertext at rest;
+ * callers must decrypt before use.
+ *
+ * NOTE: `github_app` support is stubbed for v1 — the Zod schema accepts it and
+ * the data round-trips, but token-minting (JWT → installation token exchange)
+ * is a follow-up. mcp-repo / tool-request-github will log a TODO and fall
+ * through to PAT / legacy paths when they encounter `kind: 'github_app'`.
+ */
+export interface GithubPatCredentials {
+  kind: 'pat';
+  /** Encrypted PAT — ciphertext. Decrypt with shared-utils.decrypt before use. */
+  encryptedToken: string;
+  /** Defaults to `github.com`. Set for GitHub Enterprise Server. */
+  host?: string;
+}
+
+export interface GithubAppCredentials {
+  kind: 'github_app';
+  appId: string;
+  installationId: string;
+  /** Encrypted private key (PEM) — ciphertext. */
+  encryptedPrivateKey: string;
+  host?: string;
+}
+
+export type GithubCredentials = GithubPatCredentials | GithubAppCredentials;
+
+export type GithubIntegrationConfig = GithubCredentials;
+
 export type IntegrationConfig =
   | ImapIntegrationConfig
   | AzureDevOpsIntegrationConfig
   | McpDatabaseIntegrationConfig
-  | SlackIntegrationConfig;
+  | SlackIntegrationConfig
+  | GithubIntegrationConfig;
 
+/**
+ * ClientIntegration — integration config. clientId is nullable for
+ * platform-scoped integrations (e.g. the single platform-wide GITHUB
+ * integration used by tool-request issue creation and issue-resolver pushes).
+ */
 export interface ClientIntegration {
   id: string;
-  clientId: string;
+  clientId: string | null;
   type: IntegrationType;
   label: string;
   config: IntegrationConfig;

--- a/packages/shared-utils/src/tool-request-github.ts
+++ b/packages/shared-utils/src/tool-request-github.ts
@@ -36,10 +36,10 @@ async function resolvePlatformGithubCreds(
   db: PrismaClient,
   encryptionKey: string,
 ): Promise<ResolvedGithubCreds | null> {
-  // 1. Prefer platform-scoped GITHUB integration
+  // 1. Prefer the default platform-scoped GITHUB integration — use label: 'default'
+  //    so selection is deterministic when multiple platform-scoped rows exist.
   const integration = await db.clientIntegration.findFirst({
-    where: { type: 'GITHUB', clientId: null, isActive: true },
-    orderBy: { createdAt: 'asc' },
+    where: { type: 'GITHUB', clientId: null, isActive: true, label: 'default' },
   });
   if (integration) {
     const cfg = integration.config as Record<string, unknown> | null;
@@ -218,7 +218,7 @@ export async function createToolRequestGithubIssue(
   const creds = await resolvePlatformGithubCreds(db, encryptionKey);
   if (!creds) {
     throw new Error(
-      'GitHub credentials not configured — add a platform-scoped GITHUB integration (Settings → Integrations) or set the legacy system-config-github AppSetting',
+      'GitHub credentials not configured — add a GITHUB integration under Clients → Integrations (platform-scoped integrations are created via API) or set the legacy system-config-github AppSetting',
     );
   }
 
@@ -234,7 +234,7 @@ export async function createToolRequestGithubIssue(
   }
   if (!owner || !name) {
     throw new Error(
-      'GitHub default repo not configured — set the `tool-requests-github-default-repo` AppSetting or pass repoOwner/repoName',
+      'GitHub default repo not configured — set the `tool-requests-github-default-repo` AppSetting, configure the legacy `system-config-github.repo` field, or pass repoOwner/repoName',
     );
   }
 

--- a/packages/shared-utils/src/tool-request-github.ts
+++ b/packages/shared-utils/src/tool-request-github.ts
@@ -5,6 +5,100 @@ import { decrypt, looksEncrypted } from './crypto.js';
 const logger = createLogger('tool-request-github');
 
 const SETTINGS_KEY_GITHUB = 'system-config-github';
+const SETTINGS_KEY_GITHUB_DEFAULT_REPO = 'tool-requests-github-default-repo';
+
+interface ResolvedGithubCreds {
+  /** Decrypted PAT, ready to send as `Authorization: Bearer <token>`. */
+  token: string;
+  /** Optional host override (GitHub Enterprise). Defaults to github.com. */
+  host?: string;
+  /** For logging/debugging: where the credential came from. */
+  source: 'integration-platform' | 'app-setting';
+}
+
+/**
+ * Resolve the platform-level GitHub credentials used for tool-request issue
+ * creation. Prefers a platform-scoped GITHUB integration (clientId IS NULL);
+ * falls back to the legacy `system-config-github` AppSetting so deploys that
+ * haven't been migrated keep working.
+ *
+ * Returns null if no source is configured. Callers should throw with a
+ * helpful message in that case.
+ *
+ * Dual-read is intentional (issue #368): for one release we read from both
+ * sources so the operator can migrate at their own pace. The AppSetting can be
+ * removed in a later release.
+ *
+ * NOTE: `github_app` kind is not yet supported here; the caller will see a
+ * thrown error. PAT remains the v1 flow.
+ */
+async function resolvePlatformGithubCreds(
+  db: PrismaClient,
+  encryptionKey: string,
+): Promise<ResolvedGithubCreds | null> {
+  // 1. Prefer platform-scoped GITHUB integration
+  const integration = await db.clientIntegration.findFirst({
+    where: { type: 'GITHUB', clientId: null, isActive: true },
+    orderBy: { createdAt: 'asc' },
+  });
+  if (integration) {
+    const cfg = integration.config as Record<string, unknown> | null;
+    if (cfg && cfg.kind === 'pat' && typeof cfg.encryptedToken === 'string' && cfg.encryptedToken.length > 0) {
+      const token = looksEncrypted(cfg.encryptedToken)
+        ? decrypt(cfg.encryptedToken, encryptionKey)
+        : cfg.encryptedToken;
+      return {
+        token,
+        host: typeof cfg.host === 'string' ? cfg.host : undefined,
+        source: 'integration-platform',
+      };
+    }
+    if (cfg && cfg.kind === 'github_app') {
+      // Surface a clear error rather than silently falling back — if the
+      // operator configured a github_app integration, they intended for it to
+      // be used.
+      throw new Error(
+        'Platform GITHUB integration uses kind="github_app" but tool-request issue creation does not yet support GitHub App token-minting. Configure a PAT integration or use the legacy system-config-github AppSetting for now.',
+      );
+    }
+    logger.warn(
+      { integrationId: integration.id },
+      'Platform GITHUB integration found but config is malformed — falling back to system-config-github AppSetting',
+    );
+  }
+
+  // 2. Legacy AppSetting fallback
+  const githubRow = await db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB } });
+  if (!githubRow) return null;
+  const cfg = githubRow.value as { token?: string } | null;
+  if (!cfg || typeof cfg.token !== 'string' || cfg.token.length === 0) return null;
+  const token = looksEncrypted(cfg.token) ? decrypt(cfg.token, encryptionKey) : cfg.token;
+  return { token, source: 'app-setting' };
+}
+
+/**
+ * Resolve the default "owner/name" target repo for tool-request issues. Prefers
+ * the `tool-requests-github-default-repo` AppSetting, then falls back to the
+ * legacy `system-config-github.repo` field (for backward compat with deploys
+ * that only set the latter).
+ */
+async function resolveDefaultRepoString(db: PrismaClient): Promise<string | null> {
+  const override = await db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB_DEFAULT_REPO } });
+  if (override) {
+    const v = override.value;
+    if (typeof v === 'string' && v.trim().length > 0) return v.trim();
+    if (v && typeof v === 'object' && 'repo' in v && typeof (v as { repo?: unknown }).repo === 'string') {
+      const r = (v as { repo: string }).repo.trim();
+      if (r) return r;
+    }
+  }
+  const legacy = await db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB } });
+  if (legacy) {
+    const v = legacy.value as { repo?: string } | null;
+    if (v && typeof v.repo === 'string' && v.repo.trim().length > 0) return v.repo.trim();
+  }
+  return null;
+}
 
 export interface CreateGithubIssueInput {
   toolRequestId: string;
@@ -121,20 +215,17 @@ export async function createToolRequestGithubIssue(
     }
   }
 
-  const githubRow = await db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB } });
-  if (!githubRow) {
-    throw new Error('GitHub token not configured (system-config-github AppSetting missing)');
+  const creds = await resolvePlatformGithubCreds(db, encryptionKey);
+  if (!creds) {
+    throw new Error(
+      'GitHub credentials not configured — add a platform-scoped GITHUB integration (Settings → Integrations) or set the legacy system-config-github AppSetting',
+    );
   }
-  const cfg = githubRow.value as { token?: string; repo?: string } | null;
-  if (!cfg || typeof cfg.token !== 'string' || cfg.token.length === 0) {
-    throw new Error('GitHub token missing from system-config-github');
-  }
-  const token = looksEncrypted(cfg.token) ? decrypt(cfg.token, encryptionKey) : cfg.token;
 
   let owner = input.repoOwner?.trim();
   let name = input.repoName?.trim();
   if (!owner || !name) {
-    const repoStr = typeof cfg.repo === 'string' ? cfg.repo.trim() : '';
+    const repoStr = await resolveDefaultRepoString(db);
     if (repoStr) {
       const parsed = parseRepoString(repoStr);
       owner = owner || parsed.owner;
@@ -143,20 +234,26 @@ export async function createToolRequestGithubIssue(
   }
   if (!owner || !name) {
     throw new Error(
-      'GitHub default repo not configured — set the Repository field on the GitHub tab in Settings',
+      'GitHub default repo not configured — set the `tool-requests-github-default-repo` AppSetting or pass repoOwner/repoName',
     );
   }
 
   const body = buildToolRequestIssueBody(row);
   const title = `[tool-request] ${row.displayTitle}`;
 
-  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues`;
+  // Build the API base URL so GHES hosts are supported. GHES uses
+  // `https://<host>/api/v3` whereas github.com uses `https://api.github.com`.
+  const apiBase =
+    !creds.host || creds.host === 'github.com'
+      ? 'https://api.github.com'
+      : `https://${creds.host}/api/v3`;
+  const url = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues`;
   const labels = input.labels && input.labels.length > 0 ? input.labels : ['tool-request'];
 
   const res = await fetch(url, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${creds.token}`,
       Accept: 'application/vnd.github+json',
       'X-GitHub-Api-Version': '2022-11-28',
       'Content-Type': 'application/json',
@@ -183,7 +280,7 @@ export async function createToolRequestGithubIssue(
   });
 
   logger.info(
-    { toolRequestId: row.id, repo: `${owner}/${name}`, issueNumber: issue.number },
+    { toolRequestId: row.id, repo: `${owner}/${name}`, issueNumber: issue.number, credSource: creds.source },
     'Created GitHub issue for tool request',
   );
 

--- a/services/control-panel/src/app/core/services/integration.service.ts
+++ b/services/control-panel/src/app/core/services/integration.service.ts
@@ -41,9 +41,8 @@ export class IntegrationService {
   }
 
   /**
-   * Typed helper for the repo form's GitHub Integration dropdown. Returns all
-   * GITHUB integrations visible to a given client: the client's own
-   * integrations plus any platform-scoped ones.
+   * Typed helper for the repo form's GitHub Integration dropdown. Returns
+   * GITHUB integrations scoped to the given client.
    */
   getGithubIntegrationsForClient(clientId: string): Observable<ClientIntegration[]> {
     return this.api.get<ClientIntegration[]>('/integrations', { clientId, type: 'GITHUB' });

--- a/services/control-panel/src/app/core/services/integration.service.ts
+++ b/services/control-panel/src/app/core/services/integration.service.ts
@@ -19,7 +19,8 @@ export interface McpDiscoveryMetadata {
 
 export interface ClientIntegration {
   id: string;
-  clientId: string;
+  /** null = platform-scoped (e.g. platform-wide GITHUB integration). */
+  clientId: string | null;
   type: string;
   label: string;
   config: Record<string, unknown>;
@@ -37,6 +38,19 @@ export class IntegrationService {
 
   getIntegrations(clientId?: string): Observable<ClientIntegration[]> {
     return this.api.get<ClientIntegration[]>('/integrations', clientId ? { clientId } : {});
+  }
+
+  /**
+   * Typed helper for the repo form's GitHub Integration dropdown. Returns all
+   * GITHUB integrations visible to a given client: the client's own
+   * integrations plus any platform-scoped ones.
+   */
+  getGithubIntegrationsForClient(clientId: string): Observable<ClientIntegration[]> {
+    return this.api.get<ClientIntegration[]>('/integrations', { clientId, type: 'GITHUB' });
+  }
+
+  getPlatformGithubIntegrations(): Observable<ClientIntegration[]> {
+    return this.api.get<ClientIntegration[]>('/integrations', { scope: 'platform', type: 'GITHUB' });
   }
 
   getIntegration(id: string): Observable<ClientIntegration> {

--- a/services/control-panel/src/app/core/services/repo.service.ts
+++ b/services/control-panel/src/app/core/services/repo.service.ts
@@ -10,6 +10,8 @@ export interface CodeRepo {
   defaultBranch: string;
   branchPrefix: string;
   description?: string;
+  /** FK to a GITHUB-type ClientIntegration. null = use platform default / legacy SSH. */
+  githubIntegrationId?: string | null;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/integrations-tab.component.ts
@@ -13,7 +13,7 @@ import {
 import { McpServerInfoComponent } from '../../../../shared/components/mcp-server-info.component.js';
 import { IntegrationDialogComponent } from '../../../integrations/integration-dialog.component.js';
 
-const SENSITIVE_KEYS = ['encryptedPassword', 'encryptedPat', 'encryptedBotToken', 'encryptedAppToken', 'password', 'pat', 'token', 'secret', 'apiKey'];
+const SENSITIVE_KEYS = ['encryptedPassword', 'encryptedPat', 'encryptedBotToken', 'encryptedAppToken', 'encryptedToken', 'encryptedPrivateKey', 'password', 'pat', 'token', 'secret', 'apiKey', 'privateKey'];
 
 @Component({
   selector: 'app-client-integrations-tab',
@@ -237,6 +237,7 @@ export class ClientIntegrationsTabComponent implements OnInit {
       case 'AZURE_DEVOPS': return '\u2699'; // ⚙
       case 'MCP_DATABASE': return '\u{1F5C4}'; // 🗄
       case 'SLACK': return '\u{1F4AC}';     // 💬
+      case 'GITHUB': return '\u{1F5C2}';    // 🗂 (until a real GitHub octocat icon is available)
       default: return '\u{1F50C}';          // 🔌
     }
   }

--- a/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
+++ b/services/control-panel/src/app/features/integrations/integration-dialog.component.ts
@@ -153,6 +153,49 @@ import { DialogComponent, FormFieldComponent, TextInputComponent, TextareaCompon
           (checkedChange)="slack.enabled = $event" />
       }
 
+      @if (type === 'GITHUB') {
+        <app-form-field label="Credential Kind" hint="Personal Access Token or GitHub App installation (app support is stubbed — token minting comes in a follow-up)">
+          <app-select
+            [value]="github.kind"
+            [options]="githubKindOptions"
+            [disabled]="editing"
+            (valueChange)="setGithubKind($event)" />
+        </app-form-field>
+
+        @if (github.kind === 'pat') {
+          <app-form-field label="Personal Access Token" [hint]="editing ? 'Leave blank to keep existing token' : 'fine-grained or classic PAT'">
+            <app-text-input
+              [value]="github.encryptedToken"
+              type="password"
+              [placeholder]="editing ? '(unchanged)' : 'ghp_... or github_pat_...'"
+              (valueChange)="github.encryptedToken = $event" />
+          </app-form-field>
+        }
+
+        @if (github.kind === 'github_app') {
+          <app-form-field label="App ID">
+            <app-text-input [value]="github.appId" placeholder="123456" (valueChange)="github.appId = $event" />
+          </app-form-field>
+          <app-form-field label="Installation ID">
+            <app-text-input [value]="github.installationId" placeholder="87654321" (valueChange)="github.installationId = $event" />
+          </app-form-field>
+          <app-form-field label="Private Key (PEM)" [hint]="editing ? 'Leave blank to keep existing key' : 'paste the full -----BEGIN RSA PRIVATE KEY----- block'">
+            <app-textarea
+              [value]="github.encryptedPrivateKey"
+              [rows]="6"
+              [placeholder]="editing ? '(unchanged)' : '-----BEGIN RSA PRIVATE KEY-----'"
+              (valueChange)="github.encryptedPrivateKey = $event" />
+          </app-form-field>
+        }
+
+        <app-form-field label="Host" hint="Defaults to github.com. Set for GitHub Enterprise Server (e.g. github.enterprise.example.com).">
+          <app-text-input
+            [value]="github.host"
+            placeholder="github.com"
+            (valueChange)="github.host = $event" />
+        </app-form-field>
+      }
+
       <app-form-field label="Notes">
         <app-textarea [value]="notes" [rows]="2" (valueChange)="notes = $event" />
       </app-form-field>
@@ -213,6 +256,14 @@ export class IntegrationDialogComponent implements OnInit {
   azdo = { orgUrl: '', project: '', encryptedPat: '', assignedUser: '', pollIntervalSeconds: 120 };
   mcp: { url: string; healthPath: string | null; mcpPath: string; apiKey: string; authHeader: string } = { url: '', healthPath: '', mcpPath: '', apiKey: '', authHeader: 'bearer' };
   slack = { encryptedBotToken: '', encryptedAppToken: '', defaultChannelId: '', enabled: true };
+  github: { kind: 'pat' | 'github_app'; encryptedToken: string; appId: string; installationId: string; encryptedPrivateKey: string; host: string } = {
+    kind: 'pat',
+    encryptedToken: '',
+    appId: '',
+    installationId: '',
+    encryptedPrivateKey: '',
+    host: '',
+  };
   showAdvanced = false;
   discoveredTools: Array<{ name: string; description: string }> = [];
   disabledTools = new Set<string>();
@@ -224,6 +275,7 @@ export class IntegrationDialogComponent implements OnInit {
     { value: 'AZURE_DEVOPS', label: 'Azure DevOps' },
     { value: 'MCP_DATABASE', label: 'MCP Database' },
     { value: 'SLACK', label: 'Slack' },
+    { value: 'GITHUB', label: 'GitHub' },
   ];
 
   authHeaderOptions = [
@@ -231,11 +283,17 @@ export class IntegrationDialogComponent implements OnInit {
     { value: 'x-api-key', label: 'x-api-key' },
   ];
 
+  githubKindOptions = [
+    { value: 'pat', label: 'Personal Access Token (PAT)' },
+    { value: 'github_app', label: 'GitHub App installation (stub — token minting not yet implemented)' },
+  ];
+
   private readonly secretFields: Record<string, string[]> = {
     IMAP: ['encryptedPassword'],
     AZURE_DEVOPS: ['encryptedPat'],
     MCP_DATABASE: ['apiKey'],
     SLACK: ['encryptedBotToken', 'encryptedAppToken'],
+    GITHUB: ['encryptedToken', 'encryptedPrivateKey'],
   };
 
   ngOnInit(): void {
@@ -277,8 +335,22 @@ export class IntegrationDialogComponent implements OnInit {
         case 'SLACK':
           Object.assign(this.slack, config);
           break;
+        case 'GITHUB': {
+          const kind = config['kind'];
+          if (kind === 'pat' || kind === 'github_app') this.github.kind = kind;
+          if (typeof config['appId'] === 'string') this.github.appId = config['appId'];
+          if (typeof config['installationId'] === 'string') this.github.installationId = config['installationId'];
+          if (typeof config['host'] === 'string') this.github.host = config['host'];
+          // encryptedToken / encryptedPrivateKey are cleared by the secretFields
+          // blanking above — the UI shows "(unchanged)" placeholder on edit.
+          break;
+        }
       }
     }
+  }
+
+  setGithubKind(value: string): void {
+    if (value === 'pat' || value === 'github_app') this.github.kind = value;
   }
 
   onTypeChange(): void {
@@ -286,6 +358,7 @@ export class IntegrationDialogComponent implements OnInit {
     this.azdo = { orgUrl: '', project: '', encryptedPat: '', assignedUser: '', pollIntervalSeconds: 120 };
     this.mcp = { url: '', healthPath: '', mcpPath: '', apiKey: '', authHeader: 'bearer' };
     this.slack = { encryptedBotToken: '', encryptedAppToken: '', defaultChannelId: '', enabled: true };
+    this.github = { kind: 'pat', encryptedToken: '', appId: '', installationId: '', encryptedPrivateKey: '', host: '' };
     this.showAdvanced = false;
     this.discoveredTools = [];
     this.disabledTools = new Set();
@@ -329,6 +402,26 @@ export class IntegrationDialogComponent implements OnInit {
       case 'SLACK':
         config = { ...this.slack };
         break;
+      case 'GITHUB': {
+        // Assemble the discriminated-union payload. The API schema validates
+        // `kind` at /api/integrations.
+        if (this.github.kind === 'pat') {
+          config = {
+            kind: 'pat',
+            encryptedToken: this.github.encryptedToken,
+          };
+        } else {
+          config = {
+            kind: 'github_app',
+            appId: this.github.appId,
+            installationId: this.github.installationId,
+            encryptedPrivateKey: this.github.encryptedPrivateKey,
+          };
+        }
+        const host = this.github.host.trim();
+        if (host && host !== 'github.com') config['host'] = host;
+        break;
+      }
     }
 
     if (this.type === 'MCP_DATABASE') {

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, DestroyRef, inject, OnInit, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RepoService, type CodeRepo } from '../../core/services/repo.service.js';
 import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service.js';
@@ -112,20 +113,15 @@ export class RepoDialogComponent implements OnInit {
     }
 
     // Load GITHUB integrations visible to this client (client-scoped + platform-scoped).
-    // Using forkJoin keeps both requests independent; if one fails the dropdown
-    // still renders with whatever loaded successfully.
+    // Each request is guarded with catchError so a failure on one source still allows
+    // the dropdown to render with whatever loaded successfully from the other source.
     forkJoin({
-      client: this.integrationService.getGithubIntegrationsForClient(this.clientId()),
-      platform: this.integrationService.getPlatformGithubIntegrations(),
+      client: this.integrationService.getGithubIntegrationsForClient(this.clientId()).pipe(catchError(() => of([] as ClientIntegration[]))),
+      platform: this.integrationService.getPlatformGithubIntegrations().pipe(catchError(() => of([] as ClientIntegration[]))),
     })
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: ({ client, platform }) => {
-          this.githubIntegrationOptions.set(this.buildOptions(client, platform));
-        },
-        error: () => {
-          // Non-fatal — user can still save with Platform default selected.
-        },
+      .subscribe(({ client, platform }) => {
+        this.githubIntegrationOptions.set(this.buildOptions(client, platform));
       });
   }
 
@@ -133,7 +129,7 @@ export class RepoDialogComponent implements OnInit {
     const options: Array<{ value: string; label: string }> = [{ value: '', label: '(Platform default)' }];
     for (const i of clientScoped) {
       if (!i.isActive) continue;
-      options.push({ value: i.id, label: `${i.label}${i.label === 'default' ? '' : ''} — client` });
+      options.push({ value: i.id, label: `${i.label} — client` });
     }
     for (const i of platformScoped) {
       if (!i.isActive) continue;

--- a/services/control-panel/src/app/features/repos/repo-dialog.component.ts
+++ b/services/control-panel/src/app/features/repos/repo-dialog.component.ts
@@ -1,13 +1,16 @@
-import { Component, inject, OnInit, input, output } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { forkJoin } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RepoService, type CodeRepo } from '../../core/services/repo.service.js';
+import { IntegrationService, type ClientIntegration } from '../../core/services/integration.service.js';
 import { ToastService } from '../../core/services/toast.service.js';
-import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent } from '../../shared/components/index.js';
+import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent, SelectComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-repo-dialog-content',
   standalone: true,
-  imports: [FormsModule, FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent],
+  imports: [FormsModule, FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButtonComponent, SelectComponent],
   template: `
     <div class="form-grid">
       <app-form-field label="Name">
@@ -27,6 +30,12 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButton
           [rows]="2"
           placeholder="SQL Server stored procedures, table schemas, and ETL jobs for..."
           (valueChange)="form.description = $event" />
+      </app-form-field>
+      <app-form-field label="GitHub Integration" hint="Credentials used to clone. Leave on Platform default unless this repo needs its own token.">
+        <app-select
+          [value]="form.githubIntegrationId ?? ''"
+          [options]="githubIntegrationOptions()"
+          (valueChange)="form.githubIntegrationId = $event === '' ? null : $event" />
       </app-form-field>
       <div class="row">
         <app-form-field label="Default Branch">
@@ -60,7 +69,9 @@ import { FormFieldComponent, TextInputComponent, TextareaComponent, BroncoButton
 })
 export class RepoDialogComponent implements OnInit {
   private repoService = inject(RepoService);
+  private integrationService = inject(IntegrationService);
   private toast = inject(ToastService);
+  private destroyRef = inject(DestroyRef);
 
   clientId = input.required<string>();
   repo = input<CodeRepo>();
@@ -77,7 +88,13 @@ export class RepoDialogComponent implements OnInit {
     description: '',
     defaultBranch: 'master',
     branchPrefix: 'claude',
+    githubIntegrationId: null as string | null,
   };
+
+  // Signal so the Select options refresh after async integration load.
+  githubIntegrationOptions = signal<Array<{ value: string; label: string }>>([
+    { value: '', label: '(Platform default)' },
+  ]);
 
   ngOnInit(): void {
     const r = this.repo();
@@ -90,8 +107,39 @@ export class RepoDialogComponent implements OnInit {
         description: r.description ?? '',
         defaultBranch: r.defaultBranch ?? 'master',
         branchPrefix: r.branchPrefix ?? 'claude',
+        githubIntegrationId: r.githubIntegrationId ?? null,
       };
     }
+
+    // Load GITHUB integrations visible to this client (client-scoped + platform-scoped).
+    // Using forkJoin keeps both requests independent; if one fails the dropdown
+    // still renders with whatever loaded successfully.
+    forkJoin({
+      client: this.integrationService.getGithubIntegrationsForClient(this.clientId()),
+      platform: this.integrationService.getPlatformGithubIntegrations(),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ client, platform }) => {
+          this.githubIntegrationOptions.set(this.buildOptions(client, platform));
+        },
+        error: () => {
+          // Non-fatal — user can still save with Platform default selected.
+        },
+      });
+  }
+
+  private buildOptions(clientScoped: ClientIntegration[], platformScoped: ClientIntegration[]): Array<{ value: string; label: string }> {
+    const options: Array<{ value: string; label: string }> = [{ value: '', label: '(Platform default)' }];
+    for (const i of clientScoped) {
+      if (!i.isActive) continue;
+      options.push({ value: i.id, label: `${i.label}${i.label === 'default' ? '' : ''} — client` });
+    }
+    for (const i of platformScoped) {
+      if (!i.isActive) continue;
+      options.push({ value: i.id, label: `${i.label} — platform` });
+    }
+    return options;
   }
 
   save(): void {
@@ -101,6 +149,7 @@ export class RepoDialogComponent implements OnInit {
       description: this.form.description || undefined,
       defaultBranch: this.form.defaultBranch,
       branchPrefix: this.form.branchPrefix,
+      githubIntegrationId: this.form.githubIntegrationId,
     };
 
     const r = this.repo();

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -501,6 +501,12 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 This integration is for the Bronco app itself — release notes, automatic GitHub issue creation from tool requests, and code fetching for analysis.
                 Client-specific repositories are managed under <strong>Clients → Code Repositories</strong>.
               </p>
+              <p class="github-scope-blurb">
+                <strong>Migration note (#368):</strong> GitHub is now a first-class Integration type. Tool-request issue creation reads from a
+                platform-scoped <code>GITHUB</code> integration when one exists, and falls back to this AppSetting otherwise (dual-read for one release).
+                To migrate, create a <code>GITHUB</code> integration under any client's Integrations tab with PAT credentials — choose "platform" scope when
+                the UI surfaces that option. The existing token here will continue to work until migration is complete.
+              </p>
               <div class="card-actions">
                 <app-bronco-button variant="primary" (click)="saveGithub()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
                 <app-bronco-button variant="secondary" (click)="testGithub()" [disabled]="sysConfigTesting()">{{ sysConfigTesting() ? 'Testing...' : 'Test Connection' }}</app-bronco-button>

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -504,8 +504,8 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               <p class="github-scope-blurb">
                 <strong>Migration note (#368):</strong> GitHub is now a first-class Integration type. Tool-request issue creation reads from a
                 platform-scoped <code>GITHUB</code> integration when one exists, and falls back to this AppSetting otherwise (dual-read for one release).
-                To migrate, create a <code>GITHUB</code> integration under any client's Integrations tab with PAT credentials — choose "platform" scope when
-                the UI surfaces that option. The existing token here will continue to work until migration is complete.
+                To migrate in v1, create a platform-scoped <code>GITHUB</code> integration with PAT credentials via <code>POST /api/integrations</code>.
+                The existing token here will continue to work until migration is complete.
               </p>
               <div class="card-actions">
                 <app-bronco-button variant="primary" (click)="saveGithub()" [disabled]="sysConfigSaving()">Save</app-bronco-button>

--- a/services/copilot-api/src/routes/integrations.ts
+++ b/services/copilot-api/src/routes/integrations.ts
@@ -54,11 +54,33 @@ const slackConfigSchema = z.object({
   enabled: z.boolean(),
 }).passthrough();
 
+const githubHostSchema = z.string().min(1).optional();
+
+const githubPatConfigSchema = z.object({
+  kind: z.literal('pat'),
+  encryptedToken: z.string().min(1),
+  host: githubHostSchema,
+}).passthrough();
+
+const githubAppConfigSchema = z.object({
+  kind: z.literal('github_app'),
+  appId: z.string().min(1),
+  installationId: z.string().min(1),
+  encryptedPrivateKey: z.string().min(1),
+  host: githubHostSchema,
+}).passthrough();
+
+const githubConfigSchema = z.discriminatedUnion('kind', [
+  githubPatConfigSchema,
+  githubAppConfigSchema,
+]);
+
 const configSchemaByType: Record<string, z.ZodType> = {
   [IntegrationType.IMAP]: imapConfigSchema,
   [IntegrationType.AZURE_DEVOPS]: azureDevOpsConfigSchema,
   [IntegrationType.MCP_DATABASE]: mcpDatabaseConfigSchema,
   [IntegrationType.SLACK]: slackConfigSchema,
+  [IntegrationType.GITHUB]: githubConfigSchema,
 };
 
 function validateIntegrationConfig(type: string, config: unknown): string | null {
@@ -81,6 +103,11 @@ const SECRET_FIELDS: Record<string, string[]> = {
   [IntegrationType.AZURE_DEVOPS]: ['encryptedPat'],
   [IntegrationType.MCP_DATABASE]: ['apiKey'],
   [IntegrationType.SLACK]: ['encryptedBotToken', 'encryptedAppToken'],
+  // GitHub stores credentials under a discriminated union — both kinds have
+  // secret fields (encryptedToken for PAT, encryptedPrivateKey for app).
+  // encryptConfigSecrets() just checks each field name; fields absent from the
+  // incoming config are skipped harmlessly.
+  [IntegrationType.GITHUB]: ['encryptedToken', 'encryptedPrivateKey'],
 };
 
 function encryptConfigSecrets(
@@ -109,20 +136,29 @@ interface IntegrationRouteOpts {
 
 export async function integrationRoutes(fastify: FastifyInstance, opts: IntegrationRouteOpts): Promise<void> {
   const { encryptionKey, mcpDiscoveryQueue, onSlackIntegrationChange } = opts;
-  fastify.get<{ Querystring: { clientId?: string; type?: string } }>(
+  fastify.get<{ Querystring: { clientId?: string; type?: string; scope?: string } }>(
     '/api/integrations',
     async (request) => {
-      const { clientId, type } = request.query;
+      const { clientId, type, scope } = request.query;
       if (type && !VALID_INTEGRATION_TYPES.includes(type as IntegrationType)) {
         return fastify.httpErrors.badRequest(
           `Invalid type. Must be one of: ${VALID_INTEGRATION_TYPES.join(', ')}`,
         );
       }
+      // `scope=platform` narrows to platform-scoped (clientId IS NULL) rows.
+      // `scope=client` narrows to client-scoped rows (clientId IS NOT NULL).
+      // A `clientId` query param takes precedence when both are set.
+      const where: Record<string, unknown> = {};
+      if (clientId) {
+        where.clientId = clientId;
+      } else if (scope === 'platform') {
+        where.clientId = null;
+      } else if (scope === 'client') {
+        where.clientId = { not: null };
+      }
+      if (type) where.type = type;
       return fastify.db.clientIntegration.findMany({
-        where: {
-          ...(clientId && { clientId }),
-          ...(type && { type: type as never }),
-        },
+        where,
         include: {
           client: { select: { name: true, shortCode: true } },
         },
@@ -144,7 +180,7 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
 
   fastify.post<{
     Body: {
-      clientId: string;
+      clientId?: string | null;
       type: string;
       label?: string;
       config: Record<string, unknown>;
@@ -162,8 +198,19 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
     if (configError) {
       return fastify.httpErrors.badRequest(`Invalid config for ${request.body.type}: ${configError}`);
     }
-    const { clientId, environmentId } = request.body;
+    const { clientId, environmentId, type } = request.body;
+    // Platform-scoped integrations are only supported for GITHUB today.
+    // Other types always require a client.
+    const isPlatformScoped = clientId === null || clientId === undefined;
+    if (isPlatformScoped && type !== IntegrationType.GITHUB) {
+      return fastify.httpErrors.badRequest(
+        `clientId is required for ${type} integrations. Only GITHUB integrations may be platform-scoped.`,
+      );
+    }
     if (environmentId !== undefined && environmentId !== null) {
+      if (!clientId) {
+        return fastify.httpErrors.badRequest('environmentId cannot be set on a platform-scoped integration');
+      }
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: environmentId },
         select: { clientId: true },
@@ -174,7 +221,11 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
     const encryptedConfig = encryptConfigSecrets(request.body.type, request.body.config, encryptionKey);
     try {
       const integration = await fastify.db.clientIntegration.create({
-        data: { ...request.body, config: encryptedConfig } as never,
+        data: {
+          ...request.body,
+          clientId: clientId ?? null,
+          config: encryptedConfig,
+        } as never,
       });
       // Trigger async MCP discovery for MCP_DATABASE integrations
       if (request.body.type === IntegrationType.MCP_DATABASE) {
@@ -208,7 +259,7 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
   }>('/api/integrations/:id', async (request) => {
     let existingType: string | undefined;
     const needsExisting = request.body.config !== undefined || request.body.environmentId !== undefined;
-    let existingClientId: string | undefined;
+    let existingClientId: string | null | undefined;
     if (needsExisting) {
       const existing = await fastify.db.clientIntegration.findUnique({
         where: { id: request.params.id },
@@ -233,7 +284,10 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
         request.body.config = encryptConfigSecrets(existing.type, mergedConfig, encryptionKey);
       }
     }
-    if (request.body.environmentId !== undefined && request.body.environmentId !== null && existingClientId) {
+    if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
+      if (!existingClientId) {
+        return fastify.httpErrors.badRequest('environmentId cannot be set on a platform-scoped integration');
+      }
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: request.body.environmentId },
         select: { clientId: true },

--- a/services/copilot-api/src/routes/repos.ts
+++ b/services/copilot-api/src/routes/repos.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { PROTECTED_BRANCH_NAMES } from '@bronco/shared-types';
+import { IntegrationType, PROTECTED_BRANCH_NAMES } from '@bronco/shared-types';
 
 class BranchPrefixError extends Error {
   statusCode = 400;
@@ -26,6 +26,33 @@ function validateBranchPrefix(prefix: string | undefined): void {
 
 function isPrismaError(err: unknown, code: string): boolean {
   return err instanceof Error && 'code' in err && (err as { code: string }).code === code;
+}
+
+/**
+ * Validate that a provided githubIntegrationId refers to a GITHUB-type
+ * ClientIntegration and that its scope is compatible with the repo's client
+ * (either the same client, or platform-scoped / clientId IS NULL).
+ *
+ * Returns an error message (caller should respond with 400) or null on success.
+ */
+async function validateGithubIntegration(
+  fastify: FastifyInstance,
+  githubIntegrationId: string,
+  repoClientId: string,
+): Promise<string | null> {
+  const integ = await fastify.db.clientIntegration.findUnique({
+    where: { id: githubIntegrationId },
+    select: { type: true, clientId: true },
+  });
+  if (!integ) return 'Referenced githubIntegrationId not found';
+  if (integ.type !== IntegrationType.GITHUB) {
+    return `githubIntegrationId must reference a GITHUB integration (got ${integ.type})`;
+  }
+  // Allow client-scoped match, or platform-scoped (null clientId).
+  if (integ.clientId !== null && integ.clientId !== repoClientId) {
+    return 'githubIntegrationId belongs to a different client';
+  }
+  return null;
 }
 
 export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
@@ -67,11 +94,12 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
       defaultBranch?: string;
       branchPrefix?: string;
       environmentId?: string | null;
+      githubIntegrationId?: string | null;
     };
   }>('/api/repos', async (request, reply) => {
     validateBranchPrefix(request.body.branchPrefix);
 
-    const { clientId, environmentId } = request.body;
+    const { clientId, environmentId, githubIntegrationId } = request.body;
     if (environmentId !== undefined && environmentId !== null) {
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: environmentId },
@@ -79,6 +107,11 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
       });
       if (!env) return fastify.httpErrors.badRequest('Referenced environment not found');
       if (env.clientId !== clientId) return fastify.httpErrors.forbidden('environmentId belongs to a different client');
+    }
+
+    if (githubIntegrationId) {
+      const err = await validateGithubIntegration(fastify, githubIntegrationId, clientId);
+      if (err) return fastify.httpErrors.badRequest(err);
     }
 
     try {
@@ -107,23 +140,38 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
       defaultBranch?: string;
       branchPrefix?: string;
       environmentId?: string | null;
+      githubIntegrationId?: string | null;
       isActive?: boolean;
     };
   }>('/api/repos/:id', async (request) => {
     validateBranchPrefix(request.body.branchPrefix);
 
-    if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
+    const needsExistingRepo =
+      (request.body.environmentId !== undefined && request.body.environmentId !== null) ||
+      (request.body.githubIntegrationId !== undefined && request.body.githubIntegrationId !== null);
+
+    let existingRepoClientId: string | undefined;
+    if (needsExistingRepo) {
       const repo = await fastify.db.codeRepo.findUnique({
         where: { id: request.params.id },
         select: { clientId: true },
       });
       if (!repo) return fastify.httpErrors.notFound('Code repo not found');
+      existingRepoClientId = repo.clientId;
+    }
+
+    if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: request.body.environmentId },
         select: { clientId: true },
       });
       if (!env) return fastify.httpErrors.badRequest('Referenced environment not found');
-      if (env.clientId !== repo.clientId) return fastify.httpErrors.forbidden('environmentId belongs to a different client');
+      if (env.clientId !== existingRepoClientId) return fastify.httpErrors.forbidden('environmentId belongs to a different client');
+    }
+
+    if (request.body.githubIntegrationId !== undefined && request.body.githubIntegrationId !== null && existingRepoClientId) {
+      const err = await validateGithubIntegration(fastify, request.body.githubIntegrationId, existingRepoClientId);
+      if (err) return fastify.httpErrors.badRequest(err);
     }
 
     try {

--- a/services/copilot-api/src/routes/system-status.ts
+++ b/services/copilot-api/src/routes/system-status.ts
@@ -708,7 +708,16 @@ export async function systemStatusRoutes(
       getDockerContainers(),
       fastify.db.externalService.findMany({ where: { isMonitored: true }, orderBy: { createdAt: 'asc' } }),
       fastify.db.clientIntegration.findMany({
-        where: { type: IntegrationType.MCP_DATABASE, isActive: true, client: { isActive: true } },
+        // MCP_DATABASE integrations are always client-scoped. Filter clientId
+        // not-null so the Prisma type reflects that (client: {...} filter alone
+        // doesn't narrow the type since clientId is nullable at the schema
+        // level post-#368).
+        where: {
+          type: IntegrationType.MCP_DATABASE,
+          isActive: true,
+          clientId: { not: null },
+          client: { isActive: true },
+        },
         select: { id: true, label: true, config: true, metadata: true, client: { select: { name: true, shortCode: true } } },
         orderBy: { client: { name: 'asc' } },
       }),
@@ -721,8 +730,13 @@ export async function systemStatusRoutes(
 
     // Start MCP checks concurrently with the main health checks (not sequentially after).
     // Each check is wrapped in try/catch so one bad config doesn't crash all checks.
+    // Narrow to rows with a present client relation — the `client: { isActive: true }`
+    // filter above ensures this at the DB level, but Prisma's generated types
+    // still mark the relation as optional (clientId is nullable at the schema
+    // level post-#368).
+    const scopedMcp = mcpIntegrations.filter((i): i is typeof i & { client: NonNullable<typeof i.client> } => i.client !== null);
     const mcpPromise = Promise.all(
-      mcpIntegrations.map(async (i): Promise<McpServerStatus> => {
+      scopedMcp.map(async (i): Promise<McpServerStatus> => {
         const cfg = typeof i.config === 'object' && i.config !== null && !Array.isArray(i.config) ? i.config as Record<string, unknown> : {};
         const meta = typeof i.metadata === 'object' && i.metadata !== null && !Array.isArray(i.metadata) ? i.metadata as Record<string, unknown> : null;
         try {

--- a/services/copilot-api/src/services/client-slack-manager.ts
+++ b/services/copilot-api/src/services/client-slack-manager.ts
@@ -55,8 +55,10 @@ export class ClientSlackManager {
    * Safe to call multiple times — disconnects stale connections and reconnects changed ones.
    */
   async refreshConnections(): Promise<void> {
+    // SLACK integrations are always client-scoped (platform scope only exists
+    // for GITHUB today). Filter clientId not-null defensively.
     const integrations = await this.db.clientIntegration.findMany({
-      where: { type: IntegrationType.SLACK, isActive: true },
+      where: { type: IntegrationType.SLACK, isActive: true, clientId: { not: null } },
       select: { id: true, clientId: true, config: true },
     });
 
@@ -73,6 +75,7 @@ export class ClientSlackManager {
 
     // Connect new integrations; reconnect if config has changed; disconnect if disabled
     for (const integ of integrations) {
+      if (!integ.clientId) continue; // defensive — clientId: not null filter should guarantee this
       const cfg = integ.config as Record<string, unknown>;
       const enabled = cfg['enabled'] !== false;
       const currentSnapshot = JSON.stringify(cfg);

--- a/services/devops-worker/src/index.ts
+++ b/services/devops-worker/src/index.ts
@@ -160,6 +160,13 @@ async function main(): Promise<void> {
       logger.warn({ integrationId }, 'Integration not found or inactive — cannot create processor');
       return undefined;
     }
+    // AZURE_DEVOPS integrations are always client-scoped (platform-scoped only
+    // exists for GITHUB today). Skip if the row is somehow platform-scoped to
+    // satisfy the nullable-clientId type without crashing.
+    if (!integ.client) {
+      logger.warn({ integrationId }, 'AZURE_DEVOPS integration is missing a client — skipping');
+      return undefined;
+    }
 
     const rawCfg = integ.config as {
       orgUrl?: string;
@@ -313,11 +320,12 @@ async function main(): Promise<void> {
   async function initPerClientProcessors(): Promise<void> {
     try {
       const integrations = await db.clientIntegration.findMany({
-        where: { type: 'AZURE_DEVOPS', isActive: true },
+        where: { type: 'AZURE_DEVOPS', isActive: true, clientId: { not: null } },
         include: { client: { select: { name: true, shortCode: true } } },
       });
 
       for (const integ of integrations) {
+        if (!integ.client) continue; // defensive — clientId: not null filter should guarantee this
         const rawCfg = integ.config as {
           orgUrl?: string;
           project?: string;
@@ -392,11 +400,12 @@ async function main(): Promise<void> {
   const pollPerClient = async () => {
     try {
       const integrations = await db.clientIntegration.findMany({
-        where: { type: 'AZURE_DEVOPS', isActive: true },
+        where: { type: 'AZURE_DEVOPS', isActive: true, clientId: { not: null } },
         include: { client: { select: { name: true, shortCode: true } } },
       });
 
       for (const integ of integrations) {
+        if (!integ.client) continue; // defensive — clientId: not null filter should guarantee this
         const rawCfg = integ.config as {
           orgUrl?: string;
           project?: string;

--- a/services/imap-worker/src/index.ts
+++ b/services/imap-worker/src/index.ts
@@ -99,11 +99,12 @@ async function main(): Promise<void> {
     // 2. Poll per-client IMAP integrations from the database
     try {
       const imapIntegrations = await db.clientIntegration.findMany({
-        where: { type: 'IMAP', isActive: true },
+        where: { type: 'IMAP', isActive: true, clientId: { not: null } },
         include: { client: { select: { name: true, shortCode: true } } },
       });
 
       for (const integ of imapIntegrations) {
+        if (!integ.client) continue; // defensive — clientId: not null filter should guarantee this
         const rawCfg = integ.config as { host?: string; port?: number; user?: string; encryptedPassword?: string };
         let password = rawCfg.encryptedPassword;
         if (password) {

--- a/services/slack-worker/src/client-slack-manager.ts
+++ b/services/slack-worker/src/client-slack-manager.ts
@@ -55,8 +55,10 @@ export class ClientSlackManager {
    * Safe to call multiple times — disconnects stale connections and reconnects changed ones.
    */
   async refreshConnections(): Promise<void> {
+    // SLACK integrations are always client-scoped (platform scope only exists
+    // for GITHUB today). Filter out platform-scoped rows defensively.
     const integrations = await this.db.clientIntegration.findMany({
-      where: { type: IntegrationType.SLACK, isActive: true },
+      where: { type: IntegrationType.SLACK, isActive: true, clientId: { not: null } },
       select: { id: true, clientId: true, config: true },
     });
 
@@ -73,6 +75,10 @@ export class ClientSlackManager {
 
     // Connect new integrations; reconnect if config has changed; disconnect if disabled
     for (const integ of integrations) {
+      // defensive — clientId: not null filter should guarantee this, but the
+      // Prisma type still allows null. Skip so downstream code can assume a
+      // non-null clientId.
+      if (!integ.clientId) continue;
       const cfg = integ.config as Record<string, unknown>;
       const enabled = cfg['enabled'] !== false;
       const currentSnapshot = JSON.stringify(cfg);


### PR DESCRIPTION
## Summary

- Add `GITHUB` as a first-class Integration type with two scopes: **client-scoped** (per-client PAT for repo access) and **platform-scoped** (single platform-wide credential, replaces the invisible `system-config-github` AppSetting).
- Credentials stored as a discriminated union in the existing `Integration.config` JSON, encrypted via the shared `encrypt` / `decrypt` utilities. `pat` kind works end-to-end; `github_app` kind accepted by schema with a TODO fallthrough (full App token-minting tracked in #369).
- `CodeRepo.githubIntegrationId` FK lets each repo pick an integration via a dropdown on the Repos form; mcp-repo resolves client → platform → legacy-SSH in order and clones via `https://x-access-token:<token>@<host>/<owner>/<repo>.git`. Token is refreshed on every `clone()` via `git remote set-url` so rotated creds take effect without restarts.
- `tool-request-github.ts` dual-reads: platform `GITHUB` integration first, `system-config-github` AppSetting fallback. Legacy path stays working until #369 retires it.
- Control panel: GITHUB added to the client Integrations dialog + GitHub Integration dropdown on the Repo dialog. Platform-scoped integrations are created via `POST /api/integrations` with `clientId: null` for v1 (admin UI tracked in #369).

Prisma migrations split for Postgres enum-in-same-txn safety (same pattern as the `ticket_status NEW` hotfix):
- `20260422030000_add_github_integration_type` — `ALTER TYPE` only, commits in its own tx
- `20260422030100_github_integration_schema` — nullable `clientId` + partial unique index + FK on `CodeRepo`

Fixes #368. Follow-up P3 work tracked in #369.

## Test plan

- [ ] CI passes on the PR (typecheck + build green on all 20 workspaces)
- [ ] After merge + deploy to Hugo: create a client-scoped PAT integration via the Integrations tab, assign it to an existing `CodeRepo` via the Repos tab edit dialog, trigger analysis on a ticket — confirm `prepare_repo` clones via HTTPS with no SSH key required and no "Host key verification failed" errors
- [ ] Create a platform-scoped integration via `curl -X POST /api/integrations -d '{"clientId": null, "type": "GITHUB", "config": {...}}'`, trigger a tool-request flow, confirm the GitHub issue is opened in `siir/bronco` via the new integration path (not the AppSetting)
- [ ] Toggle the client-scoped integration's `isActive` to false — confirm mcp-repo falls through to the platform-scoped one
- [ ] Delete the platform-scoped integration — confirm `tool-request-github.ts` falls back to the legacy `system-config-github` AppSetting (dual-read still working)
- [ ] Rotate the PAT on the integration — confirm the next clone uses the new token without an mcp-repo restart
- [ ] `GET /api/integrations` does NOT return plaintext tokens in the response body — verify with DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
