### PR TITLE
fix(ui): repo URL pill readable in Apple/Vercel themes

### DIFF
--- a/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/ai-credentials-tab.component.ts
@@ -151,7 +151,7 @@ const PROVIDER_OPTIONS = [
     .key-mask {
       font-family: ui-monospace, 'SF Mono', Menlo, monospace;
       font-size: 12px;
-      color: var(--text-secondary);
+      color: var(--text-code);
       background: var(--bg-code);
       padding: 1px 6px;
       border-radius: var(--radius-sm);

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/repos-tab.component.ts
@@ -98,7 +98,7 @@ import { RepoDialogComponent } from '../../../repos/repo-dialog.component.js';
     .repo-url {
       font-family: ui-monospace, 'SF Mono', Menlo, monospace;
       font-size: 12px;
-      color: var(--text-secondary);
+      color: var(--text-code);
       background: var(--bg-code);
       padding: 1px 6px;
       border-radius: var(--radius-sm);

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/systems-tab.component.ts
@@ -117,7 +117,7 @@ import { SystemDialogComponent } from '../../../systems/system-dialog.component.
     .host {
       font-family: ui-monospace, 'SF Mono', Menlo, monospace;
       font-size: 13px;
-      color: var(--text-secondary);
+      color: var(--text-code);
       background: var(--bg-code);
       padding: 1px 6px;
       border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary

- Fix dark-on-dark rendering of three "code surface" pills on Client Detail tabs in light themes (Apple, Vercel): git URLs on the Repos tab, DB host strings on the Systems tab, masked API keys on the AI Credentials tab. Previously used `--bg-code` (always-dark) paired with `--text-secondary` (dark in light themes) → completely unreadable.
- Swap `color: var(--text-secondary)` → `color: var(--text-code)`, matching the convention already used correctly by 7 other surfaces (memory tab, environments tab, integrations tab, prompt detail, ticket knowledge/timeline, probe runs).
- Zero new theme tokens — `--text-code` already defined in all 6 theme files (default Apple + Linear, NVIDIA, Sentry, Supabase, Vercel). Grep confirms no other `bg-code` + `text-secondary` combinations remain in the codebase.

Drive-by fix, no tracking issue (screen reader verified small-scope visual bug reported during operator review).

## Test plan

- [ ] CI passes on the PR
- [ ] Visually verify in the control panel with each theme:
  - [ ] Apple (default) — URL / host / key pills show light text on dark pill background
  - [ ] Vercel — same
  - [ ] Linear, NVIDIA, Sentry, Supabase — no regression (still readable; they were already fine)
- [ ] Spot-check affected tabs on a real client: Repos, Systems, AI Credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)
