### PR TITLE
fix(analyzer): retry analysis creates unique job IDs to avoid BullMQ dedupe

### DIFF
--- a/packages/shared-types/src/ticket.ts
+++ b/packages/shared-types/src/ticket.ts
@@ -176,6 +176,14 @@ export interface TicketCreatedJob {
   clientId: string;
   source: TicketSource;
   category: TicketCategory | null;
+  /**
+   * When true, this ticket-created event was triggered by an operator clicking
+   * "Retry Analysis" rather than by an initial ingestion. The route dispatcher
+   * uses this flag to enqueue the downstream ticket-analysis job with a
+   * `reanalysis-<ticketId>-<ts>` jobId instead of `analysis-<ticketId>`, so
+   * BullMQ does not silently dedupe against the completed initial run. See #375.
+   */
+  reanalysis?: boolean;
 }
 
 /** BullMQ job payload for the 'ticket-analysis' queue. */

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -3,6 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule, DatePipe, DecimalPipe, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse, type TicketArtifact } from '../../core/services/ticket.service.js';
 import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service.js';
@@ -1445,13 +1446,37 @@ export class TicketDetailComponent implements OnInit {
   reanalyze(): void {
     this.reanalyzing.set(true);
     this.ticketService.reanalyze(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: () => {
+      next: (resp) => {
         this.reanalyzing.set(false);
+        // #375: only claim "analysis running" when the backend actually created
+        // a new job. A `queued: false` response (shouldn't normally fire now
+        // that jobIds are timestamped, but we check defensively) means the
+        // enqueue was a no-op and the UI must not pretend otherwise.
+        if (resp && resp.queued === false) {
+          this.toast.error(
+            'Analysis was not re-queued. A previous job is still being tracked — check the Analysis Trace tab or try again in a moment.',
+          );
+          return;
+        }
         this.toast.success('Analysis re-queued');
         this.load();
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.reanalyzing.set(false);
+        // #375: 409 Conflict = BullMQ dedupe hit at enqueue time. Show a clear
+        // message instead of a generic "Failed to re-queue analysis" so the
+        // operator knows the click was received but did not fire a new job.
+        if (err?.status === 409) {
+          const bodyMessage = typeof err.error === 'object' && err.error !== null
+            ? (err.error as { error?: string; message?: string }).error
+              ?? (err.error as { error?: string; message?: string }).message
+            : undefined;
+          this.toast.error(
+            bodyMessage
+              ?? 'Analysis job with this ID already exists — was not re-enqueued. Check the Analysis Trace tab for current state.',
+          );
+          return;
+        }
         this.toast.error('Failed to re-queue analysis');
       },
     });

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -571,7 +571,28 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     },
   );
 
-  // POST /api/tickets/:id/reanalyze — re-enqueue ticket for route dispatch
+  // POST /api/tickets/:id/reanalyze — re-enqueue ticket for route dispatch.
+  //
+  // #375: BullMQ dedupes job IDs across all states (completed, active, waiting,
+  // etc.). The previous implementation used a deterministic jobId
+  // (`ticket-created-reanalyze-<ticketId>`) and the downstream route dispatcher
+  // in turn enqueued with `analysis-<ticketId>` — also deterministic. A Retry
+  // Analysis click on a ticket whose prior analysis had completed was therefore
+  // a silent no-op at the analysisQueue layer: queue.add() returned the old
+  // completed Job without creating a new one, the API still wrote the
+  // SYSTEM_NOTE audit event, and the UI showed "analysis running" while
+  // nothing ran.
+  //
+  // Fix:
+  //   - Use a timestamped `ticket-created-reanalyze-<ticketId>-<ts>` jobId so
+  //     every click creates a distinct outer ticket-created job.
+  //   - Pass `reanalysis: true` through to the route dispatcher so it routes
+  //     the downstream analysis enqueue to `reanalysis-<ticketId>-<ts>` as
+  //     well (see route-dispatcher.ts).
+  //   - Verify BullMQ actually created a NEW job by inspecting Job.timestamp;
+  //     if we somehow get back a dedupe hit, return 409 so the frontend can
+  //     show a real error rather than optimistic success.
+  //   - Only write the SYSTEM_NOTE audit row AFTER the enqueue confirms.
   fastify.post<{ Params: { id: string } }>('/api/tickets/:id/reanalyze', async (request, reply) => {
     const ticket = await fastify.db.ticket.findUnique({
       where: { id: request.params.id },
@@ -580,34 +601,39 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     if (!ticket) return fastify.httpErrors.notFound('Ticket not found');
     if (!opts?.ticketCreatedQueue) return fastify.httpErrors.serviceUnavailable('Ticket queue not available');
 
-    const jobId = `ticket-created-reanalyze-${ticket.id}`;
-    const existingJob = await opts.ticketCreatedQueue.getJob(jobId);
-    let queued = true;
+    const enqueuedAt = Date.now();
+    const jobId = `ticket-created-reanalyze-${ticket.id}-${enqueuedAt}`;
 
-    if (existingJob) {
-      const state = await existingJob.getState();
-      if (state === 'completed' || state === 'failed') {
-        await existingJob.remove();
-      } else {
-        queued = false;
-      }
-    }
+    await fastify.db.ticket.update({
+      where: { id: ticket.id },
+      data: { analysisStatus: AnalysisStatus.PENDING, analysisError: null },
+    });
 
-    if (queued) {
-      await fastify.db.ticket.update({
-        where: { id: ticket.id },
-        data: { analysisStatus: AnalysisStatus.PENDING, analysisError: null },
-      });
+    const enqueuedJob = await opts.ticketCreatedQueue.add('ticket-created', {
+      ticketId: ticket.id,
+      clientId: ticket.clientId,
+      source: (ticket.source ?? TicketSource.MANUAL) as TicketCreatedJob['source'],
+      category: ticket.category ?? null,
+      reanalysis: true,
+    }, {
+      jobId,
+      attempts: 4,
+      backoff: { type: 'exponential', delay: 30_000 },
+      removeOnComplete: { age: 3600, count: 1000 },
+      removeOnFail: { age: 24 * 3600, count: 1000 },
+    });
 
-      await opts.ticketCreatedQueue.add('ticket-created', {
+    // Belt-and-braces dedupe check. With a timestamped jobId this should never
+    // trigger, but catching it here means we never lie to the UI.
+    const DEDUPE_THRESHOLD_MS = 5_000;
+    if (enqueuedJob.timestamp && enqueuedAt - enqueuedJob.timestamp > DEDUPE_THRESHOLD_MS) {
+      return reply.code(409).send({
+        queued: false,
         ticketId: ticket.id,
-        clientId: ticket.clientId,
-        source: (ticket.source ?? TicketSource.MANUAL) as TicketCreatedJob['source'],
-        category: ticket.category ?? null,
-      }, {
         jobId,
-        attempts: 4,
-        backoff: { type: 'exponential', delay: 30_000 },
+        error:
+          'Analysis job with this ID already exists — was not re-enqueued. ' +
+          'Check the Analysis Trace tab for current state.',
       });
     }
 
@@ -615,9 +641,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       data: {
         ticketId: ticket.id,
         eventType: TicketEventType.SYSTEM_NOTE,
-        content: queued
-          ? 'Analysis pipeline re-triggered by operator.'
-          : 'Re-analysis skipped — a job is already queued or running.',
+        content: 'Analysis pipeline re-triggered by operator.',
         actor: 'operator',
       },
     });
@@ -625,7 +649,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     const updated = await fastify.db.ticket.findUnique({ where: { id: ticket.id } });
 
     reply.code(202);
-    return { queued, ticketId: ticket.id, jobId, ticket: updated };
+    return { queued: true, ticketId: ticket.id, jobId, ticket: updated };
   });
 
   // ─── Chat Tab (#312) ────────────────────────────────────────────────────────
@@ -685,6 +709,10 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       jobId,
       attempts: 4,
       backoff: { type: 'exponential', delay: 30_000 },
+      // #375: age completed jobs out of Redis so the dedupe state doesn't
+      // accumulate indefinitely.
+      removeOnComplete: { age: 3600, count: 1000 },
+      removeOnFail: { age: 24 * 3600, count: 1000 },
     });
     await fastify.db.ticket.update({
       where: { id: ticketId },

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1063,16 +1063,31 @@ async function maybeEnqueueReanalysis(
     return;
   }
 
-  // 4. Dedupe: use deterministic jobId to prevent duplicate reanalysis jobs
-  const reanalysisJobId = `reanalysis-${ticketId}`;
-  const existingJob = await analysisQueue.getJob(reanalysisJobId);
-  if (existingJob) {
-    const state = await existingJob.getState();
-    if (state === 'waiting' || state === 'delayed' || state === 'active') {
-      log.info({ ticketId, jobId: reanalysisJobId, state }, 'Re-analysis job already pending for this ticket — skipping');
+  // 4. Dedupe: scan for any in-flight re-analysis jobs for this ticket.
+  //
+  // #375: previously this path used a deterministic `reanalysis-<ticketId>` ID
+  // and removed the old Job if it was in a terminal state. That worked in
+  // practice because `removeOnComplete` wasn't set and completed jobs stayed
+  // in Redis, but it made the call order fragile: if BullMQ had already been
+  // asked to add the same ID elsewhere, the add() would silently dedupe.
+  // Switching to a timestamped ID removes that failure mode outright; we
+  // still skip enqueue if an active/waiting/delayed re-analysis exists so
+  // rapid-fire replies don't queue up redundant work.
+  const activeStates = new Set(['waiting', 'delayed', 'active', 'prioritized', 'waiting-children']);
+  const inflight = await analysisQueue.getJobs(['waiting', 'delayed', 'active', 'prioritized', 'waiting-children']);
+  const inflightMatch = inflight.find((j) => {
+    if (!j.id) return false;
+    return j.id.startsWith(`reanalysis-${ticketId}-`) || j.id === `reanalysis-${ticketId}`;
+  });
+  if (inflightMatch) {
+    const state = await inflightMatch.getState();
+    if (activeStates.has(state)) {
+      log.info(
+        { ticketId, jobId: inflightMatch.id, state },
+        'Re-analysis job already pending for this ticket — skipping',
+      );
       return;
     }
-    try { await existingJob.remove(); } catch { /* job may have been cleaned up already */ }
   }
 
   // 5. Find the trigger event (most recent EMAIL_INBOUND for this ticket)
@@ -1082,7 +1097,9 @@ async function maybeEnqueueReanalysis(
     select: { id: true },
   });
 
-  // All conditions met — enqueue re-analysis
+  // All conditions met — enqueue re-analysis with a unique, timestamped ID
+  // so BullMQ cannot silently collapse this into a previously completed job.
+  const reanalysisJobId = `reanalysis-${ticketId}-${Date.now()}`;
   await analysisQueue.add('analyze-ticket', {
     ticketId,
     clientId: ticket.clientId ?? undefined,
@@ -1092,9 +1109,11 @@ async function maybeEnqueueReanalysis(
     jobId: reanalysisJobId,
     attempts: 4,
     backoff: { type: 'exponential', delay: 30_000 },
+    removeOnComplete: { age: 3600, count: 1000 },
+    removeOnFail: { age: 24 * 3600, count: 1000 },
   });
 
-  log.info({ ticketId, triggerEventId: triggerEvent?.id }, 'Enqueued re-analysis for reply on analyzed ticket');
+  log.info({ ticketId, jobId: reanalysisJobId, triggerEventId: triggerEvent?.id }, 'Enqueued re-analysis for reply on analyzed ticket');
 }
 
 // ---------------------------------------------------------------------------

--- a/services/ticket-analyzer/src/route-dispatcher.ts
+++ b/services/ticket-analyzer/src/route-dispatcher.ts
@@ -12,9 +12,9 @@ export function createRouteDispatcher(deps: {
   analysisQueue: Queue<AnalysisJob>;
 }) {
   return async function processTicketCreated(job: Job<TicketCreatedJob>): Promise<void> {
-    const { ticketId, clientId, source, category } = job.data;
+    const { ticketId, clientId, source, category, reanalysis } = job.data;
 
-    logger.info({ ticketId, source, category }, 'Checking for matching route');
+    logger.info({ ticketId, source, category, reanalysis: reanalysis === true }, 'Checking for matching route');
 
     // Check if any active ANALYSIS route matches this ticket's source/category/client.
     // This is a lightweight check — full route resolution (including AI selection)
@@ -64,14 +64,42 @@ export function createRouteDispatcher(deps: {
       data: { analysisStatus: AnalysisStatus.IN_PROGRESS },
     });
 
-    // Deduplicate: use ticketId as job ID to prevent duplicate analysis
-    await deps.analysisQueue.add('analyze-ticket', {
+    // Job ID strategy (#375):
+    //   - Initial ticket-created dispatch uses the deterministic `analysis-<ticketId>`
+    //     ID so a burst of duplicate ticket-created events collapses to one job.
+    //   - Retries (operator-clicked Retry Analysis) use `reanalysis-<ticketId>-<ts>`
+    //     so every click produces a unique job and is not silently deduped against
+    //     the completed initial run. The timestamp also makes retries easy to count
+    //     in Redis telemetry.
+    //
+    // `removeOnComplete` ages completed jobs out of Redis after 1 hour so the
+    // initial-run ID can be reused if the pipeline genuinely needs to rerun later
+    // (defence-in-depth against the same dedupe-on-completed failure class).
+    const analysisJobId = reanalysis === true
+      ? `reanalysis-${ticketId}-${Date.now()}`
+      : `analysis-${ticketId}`;
+
+    const enqueuedJob = await deps.analysisQueue.add('analyze-ticket', {
       ticketId,
       clientId,
+      reanalysis: reanalysis === true ? true : undefined,
     }, {
-      jobId: `analysis-${ticketId}`,
+      jobId: analysisJobId,
       attempts: 4,
       backoff: { type: 'exponential', delay: 30_000 },
+      removeOnComplete: { age: 3600, count: 1000 },
+      removeOnFail: { age: 24 * 3600, count: 1000 },
     });
+
+    // Defence-in-depth: if BullMQ returned a pre-existing job (dedupe hit on a
+    // deterministic ID), the returned Job.timestamp will be much older than now.
+    // Surface it as a warning so the operator-triggered path can't silently no-op.
+    const DEDUPE_THRESHOLD_MS = 5_000;
+    if (enqueuedJob.timestamp && Date.now() - enqueuedJob.timestamp > DEDUPE_THRESHOLD_MS) {
+      logger.warn(
+        { ticketId, jobId: analysisJobId, jobTimestamp: enqueuedJob.timestamp, reanalysis: reanalysis === true },
+        'Analysis enqueue was a dedupe hit — existing job returned instead of creating a new one',
+      );
+    }
   };
 }


### PR DESCRIPTION
## Summary

- Fix silent no-op on Retry Analysis: BullMQ was deduping retry enqueues against the original `analysis-<ticketId>` job ID when a prior analysis had completed, returning the pre-existing `Job` handle without creating new work.
- Retry path now uses `reanalysis-<ticketId>-<timestamp>` (unique per click, semantically distinct from initial runs). Initial dispatch still uses `analysis-<ticketId>`.
- `removeOnComplete: { age: 3600, count: 1000 }` + `removeOnFail: { age: 24h }` added to all four ticket-analysis enqueue sites so completed jobs age out of Redis and dedupe state doesn't accumulate.
- Dispatch verifies `Job.timestamp` after `queue.add(...)`; if the returned job is older than ~5s, API returns 409 `{ queued: false, error, message }` so the frontend shows a distinct "not re-enqueued" toast instead of optimistic "analysis running".
- `SYSTEM_NOTE` audit event is now written **after** enqueue verification (previously always written, which is how the bug masked itself).
- Bonus: same dedupe hazard fixed in `ingestion-engine.ts` email-reply auto-reanalysis path (was using `reanalysis-${ticketId}` deterministically). Now scans inflight jobs by prefix and uses `reanalysis-${ticketId}-${Date.now()}`.

Fixes #375. Observed on ticket `cbcc4dde-65f2-4edb-a2fe-95a986d936e2` during post-deploy diagnostics on 2026-04-22.

## Other queues audited (flagged, not fixed in this PR)

7 other queues use deterministic job IDs. All are **intentional dedupe** (no retry-collides-with-completed failure mode):
- `ingest-email-<emailHash>` — message-hash dedupe
- `wi-<id>-rev<rev>` / `ingest-azdo-<integrationId>-<workItemId>` — Azure DevOps revision dedupe
- `resume-<issueJobId>` — operator double-click dedupe on Slack "resume" action
- `ticket-created-<ticketId>` (ingestion + probe-worker) — dedupes at ingestion source upstream

Missing `removeOnComplete` hygiene across those is a follow-up, separate issue.

## Test plan

- [ ] CI passes (runs on push to staging)
- [ ] After merge + deploy: on a ticket with completed analysis, click Retry Analysis — confirm a new BullMQ job appears: `ssh hugo-app "docker exec bronco-redis-1 redis-cli --scan --pattern 'bull:ticket-analysis:reanalysis-*'"`
- [ ] Confirm new `ai_usage_logs` and `ingestion_runs` rows are created for the retry
- [ ] Confirm the UI shows "analysis running" only when a new job was actually queued — if you click Retry twice quickly, the second click should show the "not re-enqueued" toast (returned 409)
- [ ] Verify SYSTEM_NOTE order: `Analysis pipeline re-triggered by operator` should appear only for successful re-enqueues, not for 409 dedupe hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
