### PR TITLE
feat(analyzer): orchestrated-v2 sub-tasks as focused agents + strategist tool access

### DIFF
--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -91,17 +91,18 @@ function fallbackFromToolResults(toolCalls: SubTaskRunResult['toolCalls']): stri
 }
 
 /**
- * Read a KD section and format it as a context block for injection into a
- * sub-task's user prompt. Returns empty string when the section is empty.
+ * Read a KD section from an already-loaded ticket document and format it as a
+ * context block for injection into a sub-task's user prompt.
+ * Returns empty string when the section is empty.
+ * The caller is responsible for loading the ticket once via `loadKnowledgeDoc`
+ * to avoid N separate DB queries when multiple sections are requested.
  */
-async function formatKdSectionAsContext(
-  db: Parameters<typeof readSection>[0] extends never ? never : Parameters<typeof loadKnowledgeDoc>[0],
-  ticketId: string,
+function formatKdSectionFromDoc(
+  knowledgeDoc: string,
+  sectionMeta: unknown,
   sectionKey: string,
-): Promise<string> {
-  const ticket = await loadKnowledgeDoc(db, ticketId);
-  if (!ticket?.knowledgeDoc) return '';
-  const { content } = readSection(ticket.knowledgeDoc, ticket.knowledgeDocSectionMeta, sectionKey as KnowledgeDocSectionKey);
+): string {
+  const { content } = readSection(knowledgeDoc, sectionMeta, sectionKey as KnowledgeDocSectionKey);
   if (!content.trim()) return '';
   return `### Knowledge Doc — ${sectionKey}\n${content.trim()}`;
 }
@@ -157,12 +158,17 @@ async function runSubTaskLoop(
   // Compose the user prompt for this sub-task
   const contextParts: string[] = [];
   if (contextKdSections.length > 0) {
-    const sectionBlocks = await Promise.all(
-      contextKdSections.map(key => formatKdSectionAsContext(deps.db, ticketId, key)),
-    );
-    const nonEmpty = sectionBlocks.filter(Boolean);
-    if (nonEmpty.length > 0) {
-      contextParts.push('## Context from Knowledge Document\n\n' + nonEmpty.join('\n\n'));
+    // Load the knowledge doc once and read all requested sections from it —
+    // avoids N separate DB round-trips when multiple section keys are requested.
+    const kdTicket = await loadKnowledgeDoc(deps.db, ticketId);
+    if (kdTicket?.knowledgeDoc) {
+      const sectionBlocks = contextKdSections.map(key =>
+        formatKdSectionFromDoc(kdTicket.knowledgeDoc!, kdTicket.knowledgeDocSectionMeta, key),
+      );
+      const nonEmpty = sectionBlocks.filter(Boolean);
+      if (nonEmpty.length > 0) {
+        contextParts.push('## Context from Knowledge Document\n\n' + nonEmpty.join('\n\n'));
+      }
     }
   }
   const budgetLine = `## Budget\nMax ${SUB_TASK_ITERATION_CAP} iterations, max ${SUB_TASK_TOKEN_BUDGET.toLocaleString()} tokens total, max ${SUB_TASK_CALL_BUDGET} tool calls. Call \`finalize_subtask\` once you are done — do not wait until budget is exhausted.`;
@@ -189,7 +195,9 @@ async function runSubTaskLoop(
       }
     : { logId: subTaskLogId };
 
+  let lastIterationRun = 0;
   for (let iteration = 0; iteration < SUB_TASK_ITERATION_CAP; iteration++) {
+    lastIterationRun = iteration + 1;
     const tokensSoFar = totalInputTokens + totalOutputTokens;
     if (tokensSoFar >= SUB_TASK_TOKEN_BUDGET) {
       appLog.info(
@@ -269,52 +277,6 @@ async function runSubTaskLoop(
     // Append assistant turn to conversation
     messages.push({ role: 'assistant', content: response.contentBlocks });
 
-    // Check for finalize_subtask call — break before executing other tools
-    const finalizeCall = response.contentBlocks.find(
-      (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'finalize_subtask',
-    );
-    if (finalizeCall) {
-      const input = finalizeCall.input as { summary?: string; updatedKdSections?: string[] };
-      const summary = typeof input.summary === 'string' ? input.summary : '(sub-task called finalize_subtask without a summary)';
-      const updatedKdSections = Array.isArray(input.updatedKdSections)
-        ? (input.updatedKdSections as unknown[]).filter((x): x is string => typeof x === 'string')
-        : [];
-
-      // Emit a synthetic tool_result so the conversation stays well-formed (not strictly
-      // required for our flow since we break here, but keeps the message history valid
-      // if it were ever inspected).
-      messages.push({
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: finalizeCall.id,
-            content: 'Sub-task finalized. Control returned to orchestrator.',
-          } satisfies AIToolResultBlock,
-        ],
-      });
-
-      appLog.info(
-        `Sub-task ${subTaskId} finalized at iteration ${iteration + 1}: ${summary.slice(0, 200)}`,
-        { ticketId, subTaskId, iteration: iteration + 1, updatedKdSections, summaryPreview: summary.slice(0, 500) },
-        ticketId,
-        'ticket',
-      );
-
-      return {
-        subTaskId,
-        intent,
-        summary,
-        updatedKdSections,
-        iterationsUsed: iteration + 1,
-        tokensUsed: totalInputTokens + totalOutputTokens,
-        stopReason: SubTaskStopReason.FINALIZED,
-        inputTokens: totalInputTokens,
-        outputTokens: totalOutputTokens,
-        toolCalls: toolCallLog,
-      };
-    }
-
     if (response.stopReason !== 'tool_use') {
       // Model ended turn without calling any tool (not even finalize_subtask)
       const textSummary = response.contentBlocks
@@ -344,7 +306,13 @@ async function runSubTaskLoop(
       };
     }
 
-    // Execute all tool calls (excluding finalize_subtask which was already handled above)
+    // Separate finalize_subtask from regular tool calls.
+    // Execute all regular tools FIRST so that kd_* writes and data-gathering calls
+    // are not silently dropped when finalize_subtask appears in the same assistant
+    // turn. The finalize result is handled after the regular tool loop completes.
+    const finalizeCall = response.contentBlocks.find(
+      (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'finalize_subtask',
+    );
     const toolUseBlocks = response.contentBlocks.filter(
       (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name !== 'finalize_subtask',
     );
@@ -417,17 +385,63 @@ async function runSubTaskLoop(
 
     totalToolCalls += toolResults.length;
 
-    // Append tool results as next user turn
-    messages.push({ role: 'user', content: toolResults });
+    // Append regular tool results as next user turn (may be empty if only finalize_subtask was called)
+    if (toolResults.length > 0) {
+      messages.push({ role: 'user', content: toolResults });
+    }
+
+    // Now handle finalize_subtask — all sibling tool calls have been executed above
+    // so their KD writes are flushed before we return control to the orchestrator.
+    if (finalizeCall) {
+      const input = finalizeCall.input as { summary?: string; updatedKdSections?: string[] };
+      const summary = typeof input.summary === 'string' ? input.summary : '(sub-task called finalize_subtask without a summary)';
+      const updatedKdSections = Array.isArray(input.updatedKdSections)
+        ? (input.updatedKdSections as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [];
+
+      // Emit a synthetic tool_result so the conversation stays well-formed.
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: finalizeCall.id,
+            content: 'Sub-task finalized. Control returned to orchestrator.',
+          } satisfies AIToolResultBlock,
+        ],
+      });
+
+      appLog.info(
+        `Sub-task ${subTaskId} finalized at iteration ${iteration + 1}: ${summary.slice(0, 200)}`,
+        { ticketId, subTaskId, iteration: iteration + 1, updatedKdSections, summaryPreview: summary.slice(0, 500) },
+        ticketId,
+        'ticket',
+      );
+
+      return {
+        subTaskId,
+        intent,
+        summary,
+        updatedKdSections,
+        iterationsUsed: iteration + 1,
+        tokensUsed: totalInputTokens + totalOutputTokens,
+        stopReason: SubTaskStopReason.FINALIZED,
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        toolCalls: toolCallLog,
+      };
+    }
   }
 
-  // Budget exhausted — compose best-effort summary from last tool calls
+  // Budget exhausted — compose best-effort summary from last tool calls.
+  // `lastIterationRun` is the actual number of iterations that started (including
+  // the one that hit a budget ceiling at the top of the loop).
   const partialSummary = toolCallLog.length > 0
     ? fallbackFromToolResults(toolCallLog)
     : '(sub-task exhausted budget without producing a summary)';
 
   appLog.info(
-    `Sub-task ${subTaskId} exhausted budget (iterationsUsed=${SUB_TASK_ITERATION_CAP}, toolCalls=${totalToolCalls})`,
+    `Sub-task ${subTaskId} exhausted budget (iterationsUsed=${lastIterationRun}, toolCalls=${totalToolCalls})`,
     { ticketId, subTaskId, tokensUsed: totalInputTokens + totalOutputTokens, totalToolCalls },
     ticketId,
     'ticket',
@@ -438,7 +452,7 @@ async function runSubTaskLoop(
     intent,
     summary: partialSummary,
     updatedKdSections: [],
-    iterationsUsed: SUB_TASK_ITERATION_CAP,
+    iterationsUsed: lastIterationRun,
     tokensUsed: totalInputTokens + totalOutputTokens,
     stopReason: SubTaskStopReason.BUDGET_EXHAUSTED,
     inputTokens: totalInputTokens,
@@ -971,6 +985,7 @@ export async function runOrchestratedV2(
     // --- Inner tool loop: call generateWithTools until strategist dispatches or completes ---
     let innerDone = false;
     let dispatchSubtasksInput: { subtasks: Array<{ id: string; intent: string; tools?: string[]; contextKdSectionKeys?: string[]; model?: string }> } | null = null;
+    let dispatchCallId: string | null = null; // track the tool_use_id of the current dispatch_subtasks call
     let completeAnalysisInput: { finalAnalysis: string } | null = null;
 
     for (let innerIter = 0; innerIter < 20; innerIter++) {
@@ -1034,10 +1049,24 @@ export async function runOrchestratedV2(
       }
 
       if (dispatchCall) {
+        dispatchCallId = dispatchCall.id; // capture current iteration's tool_use_id
         const rawInput = dispatchCall.input as { subtasks?: unknown };
         const rawSubtasks = Array.isArray(rawInput.subtasks) ? rawInput.subtasks : [];
+        // Clamp to 5 sub-tasks per dispatch regardless of what the model emits.
+        // This mirrors the maxItems:5 constraint in the schema and is a hard
+        // safety valve against runaway parallelism.
+        const MAX_SUBTASKS_PER_DISPATCH = 5;
+        const clampedSubtasks = (rawSubtasks as Array<Record<string, unknown>>).slice(0, MAX_SUBTASKS_PER_DISPATCH);
+        if (rawSubtasks.length > MAX_SUBTASKS_PER_DISPATCH) {
+          appLog.warn(
+            `Orchestrated iteration ${i + 1}: strategist dispatched ${rawSubtasks.length} sub-tasks (max ${MAX_SUBTASKS_PER_DISPATCH}); excess silently dropped`,
+            { ticketId, iteration: i + 1, requested: rawSubtasks.length, clamped: MAX_SUBTASKS_PER_DISPATCH },
+            ticketId,
+            'ticket',
+          );
+        }
         dispatchSubtasksInput = {
-          subtasks: (rawSubtasks as Array<Record<string, unknown>>).map(st => ({
+          subtasks: clampedSubtasks.map(st => ({
             id: typeof st['id'] === 'string' ? st['id'] : randomUUID(),
             intent: typeof st['intent'] === 'string' ? st['intent'] : '',
             tools: Array.isArray(st['tools']) ? (st['tools'] as string[]) : [],
@@ -1092,24 +1121,50 @@ export async function runOrchestratedV2(
         );
         const elapsed = Date.now() - start;
 
+        // Apply the same truncation + artifact path used for sub-task tool results
+        // so large kd_read_section / artifact reads don't balloon strategist history.
+        const fullResult = result.result;
+        const fullSizeChars = fullResult.length;
+        const threshold = toolResultMaxTokens ?? 4000;
+        const artifactId = deps.artifactStoragePath && !result.isError ? randomUUID() : undefined;
+        const truncated = !result.isError && !!artifactId && shouldTruncate(fullResult, threshold);
+        const contentForModel = truncated && artifactId
+          ? buildTruncatedPreview(fullResult, artifactId)
+          : fullResult;
+
         orchToolCallLog.push({
           tool: toolUse.name,
           system: (toolUse.input as Record<string, unknown>)?.system_name as string | undefined,
           input: toolUse.input,
-          output: result.result.slice(0, 500),
+          output: fullResult.slice(0, 500),
           durationMs: elapsed,
         });
 
         toolResults.push({
           type: 'tool_result',
           tool_use_id: toolUse.id,
-          content: result.result,
+          content: contentForModel,
           ...(result.isError ? { is_error: true } : {}),
         });
 
+        if (deps.artifactStoragePath && !result.isError) {
+          void saveMcpToolArtifact(deps.db, ticketId, toolUse.name, fullResult, deps.artifactStoragePath, artifactId).catch(err => {
+            logger.warn({ err, ticketId, toolName: toolUse.name }, 'Failed to persist strategist MCP tool artifact');
+          });
+        }
+
         appLog.info(
           `Strategist tool call: ${toolUse.name} (${elapsed}ms)`,
-          { ticketId, tool: toolUse.name, durationMs: elapsed, iteration: i + 1, innerIter: innerIter + 1 },
+          {
+            ticketId,
+            tool: toolUse.name,
+            durationMs: elapsed,
+            iteration: i + 1,
+            innerIter: innerIter + 1,
+            truncated,
+            fullSizeChars,
+            ...(artifactId ? { artifactId } : {}),
+          },
           ticketId,
           'ticket',
         );
@@ -1270,12 +1325,10 @@ export async function runOrchestratedV2(
         }
       }
 
-      // Append sub-task results to strategist messages as tool_result for the dispatch_subtasks call
-      const dispatchCallBlock = strategistMessages
-        .flatMap(m => (m.role === 'assistant' && Array.isArray(m.content) ? (m.content as AIToolUseBlock[]) : []))
-        .find((b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'dispatch_subtasks');
-
-      if (dispatchCallBlock) {
+      // Append sub-task results to strategist messages as tool_result for the dispatch_subtasks call.
+      // Use the captured `dispatchCallId` from this iteration (not a history scan) to ensure
+      // the tool_result is threaded onto the correct dispatch_subtasks tool_use block.
+      if (dispatchCallId) {
         const resultPayload = allSubTaskResults.map(r => ({
           sub_task_id: r.subTaskId,
           intent: r.intent,
@@ -1291,7 +1344,7 @@ export async function runOrchestratedV2(
           content: [
             {
               type: 'tool_result',
-              tool_use_id: dispatchCallBlock.id,
+              tool_use_id: dispatchCallId,
               content: JSON.stringify(resultPayload, null, 2),
             } satisfies AIToolResultBlock,
           ],

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -3,6 +3,7 @@ import {
   createLogger,
   initEmptyKnowledgeDoc,
   loadKnowledgeDoc,
+  readSection,
   updateSection,
   withTicketLock,
 } from '@bronco/shared-utils';
@@ -12,6 +13,7 @@ import type {
   AIToolDefinition,
   AIToolResultBlock,
   AIToolUseBlock,
+  AIMessage,
 } from '@bronco/shared-types';
 import {
   buildArtifactCatalog,
@@ -22,7 +24,6 @@ import {
   getToolResultMaxTokens,
   IRRELEVANT_SIGNALS,
   ORCHESTRATED_SYSTEM_PROMPT,
-  parseStrategistResponse,
   parseSufficiencyEvaluation,
   ReanalysisMode,
   resolveMaxParallelTasks,
@@ -37,7 +38,6 @@ import {
   type McpIntegrationInfo,
   type ReanalysisContext,
   type StrategyStep,
-  type SubTaskResult,
 } from './shared.js';
 import {
   composeFinalAnalysis,
@@ -51,21 +51,409 @@ import {
   TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
   TRUNCATION_SYSTEM_PROMPT_SNIPPET,
 } from './v2-prompts.js';
+import {
+  FINALIZE_SUBTASK_TOOL,
+  DISPATCH_SUBTASKS_TOOL,
+  COMPLETE_ANALYSIS_TOOL,
+  SubTaskStopReason,
+  type SubTaskRunResult,
+} from './v2-subtask-tools.js';
 
 const logger = createLogger('ticket-analyzer');
 
+// ---------------------------------------------------------------------------
+// Sub-task budget constants
+// ---------------------------------------------------------------------------
+
+/** Maximum model iterations per sub-task (each iteration = one generateWithTools call). */
+const SUB_TASK_ITERATION_CAP = 8;
+/** Maximum total tokens (input + output) a single sub-task may consume. */
+const SUB_TASK_TOKEN_BUDGET = 50_000;
+/** Maximum tool calls a single sub-task may make (not counting finalize_subtask). */
+const SUB_TASK_CALL_BUDGET = 20;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Fallback content when a sub-task's initial response has no text blocks.
- * Uses the first tool call's output preview so the Run Log still has
- * something actionable. Empty tool-calls array → placeholder string.
+ * Fallback content when a sub-task exhausts its budget without calling finalize_subtask.
+ * Uses the first tool call's output preview so the Run Log still has something actionable.
+ * Empty tool-calls array → placeholder string.
  */
-function fallbackFromToolResults(toolCalls: SubTaskResult['toolCalls']): string {
+function fallbackFromToolResults(toolCalls: SubTaskRunResult['toolCalls']): string {
   if (toolCalls.length === 0) return 'Sub-task produced no text output and no tool calls.';
   const first = toolCalls[0];
   const preview = (first.output ?? '').slice(0, 500);
   return `No summary text; first tool (${first.tool}) output preview:\n${preview}`;
 }
 
+/**
+ * Read a KD section and format it as a context block for injection into a
+ * sub-task's user prompt. Returns empty string when the section is empty.
+ */
+async function formatKdSectionAsContext(
+  db: Parameters<typeof readSection>[0] extends never ? never : Parameters<typeof loadKnowledgeDoc>[0],
+  ticketId: string,
+  sectionKey: string,
+): Promise<string> {
+  const ticket = await loadKnowledgeDoc(db, ticketId);
+  if (!ticket?.knowledgeDoc) return '';
+  const { content } = readSection(ticket.knowledgeDoc, ticket.knowledgeDocSectionMeta, sectionKey as KnowledgeDocSectionKey);
+  if (!content.trim()) return '';
+  return `### Knowledge Doc — ${sectionKey}\n${content.trim()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-task stateful loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a single sub-task as a stateful message loop.
+ *
+ * The loop appends assistant responses and tool results to a growing `messages`
+ * array on each iteration (flat-v2 pattern). The loop terminates when the model
+ * calls `finalize_subtask`, when `stop_reason !== 'tool_use'`, or when any
+ * budget is exhausted.
+ *
+ * The `finalize_subtask` tool is mixed into the tool list alongside whatever
+ * `buildAgenticTools` returned — it is NOT part of `buildAgenticTools` because
+ * it is orchestrated-v2–only and must not be visible to flat-v2 / v1 agents.
+ */
+async function runSubTaskLoop(
+  deps: AnalysisDeps,
+  ticketId: string,
+  clientId: string,
+  category: string,
+  skipClientMemory: boolean,
+  subTaskId: string,
+  intent: string,
+  contextKdSections: string[],
+  tools: AIToolDefinition[],
+  mcpIntegrations: Map<string, McpIntegrationInfo>,
+  repoIdByPrefix: Map<string, string>,
+  subTaskSystemPrompt: string,
+  model: string,
+  orchestration?: { id: string; iteration: number; parentLogId?: string },
+  toolResultMaxTokens?: number,
+  defaultMaxTokens?: number,
+): Promise<SubTaskRunResult> {
+  const { ai, appLog } = deps;
+
+  const toolCallLog: SubTaskRunResult['toolCalls'] = [];
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let totalToolCalls = 0;
+  const failureTracker = new Map<string, number>();
+
+  // Build the tool list: requested tools + finalize_subtask (always appended)
+  const toolsWithFinalize: AIToolDefinition[] = [
+    ...tools,
+    FINALIZE_SUBTASK_TOOL,
+  ];
+
+  // Compose the user prompt for this sub-task
+  const contextParts: string[] = [];
+  if (contextKdSections.length > 0) {
+    const sectionBlocks = await Promise.all(
+      contextKdSections.map(key => formatKdSectionAsContext(deps.db, ticketId, key)),
+    );
+    const nonEmpty = sectionBlocks.filter(Boolean);
+    if (nonEmpty.length > 0) {
+      contextParts.push('## Context from Knowledge Document\n\n' + nonEmpty.join('\n\n'));
+    }
+  }
+  const budgetLine = `## Budget\nMax ${SUB_TASK_ITERATION_CAP} iterations, max ${SUB_TASK_TOKEN_BUDGET.toLocaleString()} tokens total, max ${SUB_TASK_CALL_BUDGET} tool calls. Call \`finalize_subtask\` once you are done — do not wait until budget is exhausted.`;
+  const userPrompt = [
+    '## Intent',
+    intent,
+    ...contextParts,
+    budgetLine,
+  ].join('\n\n');
+
+  // Initialise the message array: [system is separate, first user turn here]
+  const messages: AIMessage[] = [
+    { role: 'user', content: userPrompt },
+  ];
+
+  const subTaskLogId = randomUUID();
+  const orchCtx = orchestration
+    ? {
+        orchestrationId: orchestration.id,
+        orchestrationIteration: orchestration.iteration,
+        isSubTask: true,
+        logId: subTaskLogId,
+        ...(orchestration.parentLogId ? { parentLogId: orchestration.parentLogId, parentLogType: 'ai' as const } : {}),
+      }
+    : { logId: subTaskLogId };
+
+  for (let iteration = 0; iteration < SUB_TASK_ITERATION_CAP; iteration++) {
+    const tokensSoFar = totalInputTokens + totalOutputTokens;
+    if (tokensSoFar >= SUB_TASK_TOKEN_BUDGET) {
+      appLog.info(
+        `Sub-task ${subTaskId} exhausted token budget (${tokensSoFar} >= ${SUB_TASK_TOKEN_BUDGET}) at iteration ${iteration + 1}`,
+        { ticketId, subTaskId, tokensSoFar, iteration: iteration + 1 },
+        ticketId,
+        'ticket',
+      );
+      break;
+    }
+    if (totalToolCalls >= SUB_TASK_CALL_BUDGET) {
+      appLog.info(
+        `Sub-task ${subTaskId} exhausted call budget (${totalToolCalls} >= ${SUB_TASK_CALL_BUDGET}) at iteration ${iteration + 1}`,
+        { ticketId, subTaskId, totalToolCalls, iteration: iteration + 1 },
+        ticketId,
+        'ticket',
+      );
+      break;
+    }
+
+    appLog.info(
+      `Sub-task ${subTaskId} iteration ${iteration + 1}/${SUB_TASK_ITERATION_CAP}`,
+      { ticketId, subTaskId, iteration: iteration + 1, tokensSoFar },
+      ticketId,
+      'ticket',
+    );
+
+    let response;
+    try {
+      response = await ai.generateWithTools({
+        taskType: TaskType.DEEP_ANALYSIS,
+        context: {
+          ticketId,
+          clientId,
+          entityId: ticketId,
+          entityType: 'ticket',
+          ticketCategory: category,
+          skipClientMemory,
+          strategy: 'orchestrated' as const,
+          strategyVersion: 'v2' as const,
+          ...orchCtx,
+        },
+        messages,
+        tools: toolsWithFinalize,
+        systemPrompt: subTaskSystemPrompt,
+        providerOverride: 'CLAUDE',
+        modelOverride: model,
+        maxTokens: defaultMaxTokens ?? 4096,
+      });
+    } catch (error) {
+      if (error instanceof Error && /tool/i.test(error.message) && /support/i.test(error.message)) {
+        appLog.warn(
+          `Sub-task ${subTaskId}: provider does not support tool use — returning early`,
+          { ticketId, subTaskId, error: error.message },
+          ticketId,
+          'ticket',
+        );
+        return {
+          subTaskId,
+          intent,
+          summary: `Sub-task could not run: provider does not support tool use (${error.message})`,
+          updatedKdSections: [],
+          iterationsUsed: iteration + 1,
+          tokensUsed: totalInputTokens + totalOutputTokens,
+          stopReason: SubTaskStopReason.TOOL_NOT_SUPPORTED,
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          toolCalls: toolCallLog,
+        };
+      }
+      throw error;
+    }
+
+    totalInputTokens += response.usage?.inputTokens ?? 0;
+    totalOutputTokens += response.usage?.outputTokens ?? 0;
+
+    // Append assistant turn to conversation
+    messages.push({ role: 'assistant', content: response.contentBlocks });
+
+    // Check for finalize_subtask call — break before executing other tools
+    const finalizeCall = response.contentBlocks.find(
+      (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'finalize_subtask',
+    );
+    if (finalizeCall) {
+      const input = finalizeCall.input as { summary?: string; updatedKdSections?: string[] };
+      const summary = typeof input.summary === 'string' ? input.summary : '(sub-task called finalize_subtask without a summary)';
+      const updatedKdSections = Array.isArray(input.updatedKdSections)
+        ? (input.updatedKdSections as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [];
+
+      // Emit a synthetic tool_result so the conversation stays well-formed (not strictly
+      // required for our flow since we break here, but keeps the message history valid
+      // if it were ever inspected).
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: finalizeCall.id,
+            content: 'Sub-task finalized. Control returned to orchestrator.',
+          } satisfies AIToolResultBlock,
+        ],
+      });
+
+      appLog.info(
+        `Sub-task ${subTaskId} finalized at iteration ${iteration + 1}: ${summary.slice(0, 200)}`,
+        { ticketId, subTaskId, iteration: iteration + 1, updatedKdSections, summaryPreview: summary.slice(0, 500) },
+        ticketId,
+        'ticket',
+      );
+
+      return {
+        subTaskId,
+        intent,
+        summary,
+        updatedKdSections,
+        iterationsUsed: iteration + 1,
+        tokensUsed: totalInputTokens + totalOutputTokens,
+        stopReason: SubTaskStopReason.FINALIZED,
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        toolCalls: toolCallLog,
+      };
+    }
+
+    if (response.stopReason !== 'tool_use') {
+      // Model ended turn without calling any tool (not even finalize_subtask)
+      const textSummary = response.contentBlocks
+        .filter((b): b is AITextBlock => b.type === 'text')
+        .map(b => b.text)
+        .join('\n')
+        .trim();
+
+      appLog.info(
+        `Sub-task ${subTaskId} ended without finalize_subtask at iteration ${iteration + 1} (stop_reason=${response.stopReason})`,
+        { ticketId, subTaskId, iteration: iteration + 1, stopReason: response.stopReason },
+        ticketId,
+        'ticket',
+      );
+
+      return {
+        subTaskId,
+        intent,
+        summary: textSummary || '(sub-task ended without finalize_subtask call)',
+        updatedKdSections: [],
+        iterationsUsed: iteration + 1,
+        tokensUsed: totalInputTokens + totalOutputTokens,
+        stopReason: SubTaskStopReason.NO_TOOL_USE_ENDED,
+        inputTokens: totalInputTokens,
+        outputTokens: totalOutputTokens,
+        toolCalls: toolCallLog,
+      };
+    }
+
+    // Execute all tool calls (excluding finalize_subtask which was already handled above)
+    const toolUseBlocks = response.contentBlocks.filter(
+      (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name !== 'finalize_subtask',
+    );
+
+    const toolResults: AIToolResultBlock[] = [];
+
+    for (const toolUse of toolUseBlocks) {
+      const start = Date.now();
+      const result = await executeAgenticToolCall(
+        toolUse,
+        mcpIntegrations,
+        repoIdByPrefix,
+        clientId,
+        ticketId,
+        failureTracker,
+      );
+      const elapsed = Date.now() - start;
+
+      const fullResult = result.result;
+      const fullSizeChars = fullResult.length;
+      const threshold = toolResultMaxTokens ?? 4000;
+      const artifactId = deps.artifactStoragePath && !result.isError ? randomUUID() : undefined;
+      const truncated = !result.isError && !!artifactId && shouldTruncate(fullResult, threshold);
+      const contentForModel = truncated && artifactId
+        ? buildTruncatedPreview(fullResult, artifactId)
+        : fullResult;
+
+      toolCallLog.push({
+        tool: toolUse.name,
+        system: (toolUse.input as Record<string, unknown>)?.system_name as string | undefined,
+        input: toolUse.input,
+        output: fullResult.slice(0, 500),
+        durationMs: elapsed,
+      });
+
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: contentForModel,
+        ...(result.isError ? { is_error: true } : {}),
+      });
+
+      if (deps.artifactStoragePath && !result.isError) {
+        void saveMcpToolArtifact(deps.db, ticketId, toolUse.name, fullResult, deps.artifactStoragePath, artifactId).catch(err => {
+          logger.warn({ err, ticketId, toolName: toolUse.name }, 'Failed to persist MCP tool artifact');
+        });
+      }
+
+      appLog.info(
+        `Sub-task ${subTaskId} tool call: ${toolUse.name} (${elapsed}ms)`,
+        {
+          ticketId,
+          subTaskId,
+          tool: toolUse.name,
+          durationMs: elapsed,
+          iteration: iteration + 1,
+          params: toolUse.input ? JSON.stringify(toolUse.input).slice(0, 1000) : null,
+          resultPreview: fullResult?.slice(0, 2000) ?? null,
+          isError: result.isError ?? false,
+          truncated,
+          fullSizeChars,
+          parentLogId: subTaskLogId,
+          parentLogType: 'ai',
+          ...(artifactId ? { artifactId } : {}),
+        },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    totalToolCalls += toolResults.length;
+
+    // Append tool results as next user turn
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  // Budget exhausted — compose best-effort summary from last tool calls
+  const partialSummary = toolCallLog.length > 0
+    ? fallbackFromToolResults(toolCallLog)
+    : '(sub-task exhausted budget without producing a summary)';
+
+  appLog.info(
+    `Sub-task ${subTaskId} exhausted budget (iterationsUsed=${SUB_TASK_ITERATION_CAP}, toolCalls=${totalToolCalls})`,
+    { ticketId, subTaskId, tokensUsed: totalInputTokens + totalOutputTokens, totalToolCalls },
+    ticketId,
+    'ticket',
+  );
+
+  return {
+    subTaskId,
+    intent,
+    summary: partialSummary,
+    updatedKdSections: [],
+    iterationsUsed: SUB_TASK_ITERATION_CAP,
+    tokensUsed: totalInputTokens + totalOutputTokens,
+    stopReason: SubTaskStopReason.BUDGET_EXHAUSTED,
+    inputTokens: totalInputTokens,
+    outputTokens: totalOutputTokens,
+    toolCalls: toolCallLog,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-task dispatcher (replaces executeOrchestratedSubTaskV2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch a single sub-task using the stateful loop.
+ * Handles tool resolution, system-prompt construction, and fuzzy-tool-retry
+ * logic (retained from the prior implementation for robustness).
+ */
 async function executeOrchestratedSubTaskV2(
   deps: AnalysisDeps,
   ticketId: string,
@@ -73,37 +461,40 @@ async function executeOrchestratedSubTaskV2(
   category: string,
   clientContext: string,
   environmentContext: string,
-  task: { prompt: string; tools: string[]; model: string; priorArtifactIds?: string[] },
+  task: {
+    id: string;
+    prompt: string;
+    tools: string[];
+    model: string;
+    contextKdSectionKeys?: string[];
+    priorArtifactIds?: string[];
+  },
   agenticTools: AIToolDefinition[],
   mcpIntegrations: Map<string, McpIntegrationInfo>,
   repoIdByPrefix: Map<string, string>,
   orchestration?: { id: string; iteration: number; parentLogId?: string },
   modelMap?: Record<string, string>,
   toolResultMaxTokens?: number,
-): Promise<SubTaskResult> {
-  const { ai, appLog } = deps;
+): Promise<SubTaskRunResult> {
   const map = modelMap ?? {};
   const model = map[task.model] ?? map.sonnet ?? 'claude-sonnet-4-6';
   const defaultMaxTokens = await deps.loadDefaultMaxTokens?.() ?? undefined;
 
-  const toolCalls: SubTaskResult['toolCalls'] = [];
-  let inputTokens = 0;
-  let outputTokens = 0;
-
-  // If client/environment context was already injected into the strategist prompt, skip AIRouter
-  // re-injection for sub-tasks to avoid duplicating it in every sub-task system prompt.
   const skipClientMemory = !!clientContext;
   const combinedContext = [clientContext, environmentContext].filter(Boolean).join('\n\n');
   const subTaskInstructions = [
-    'Execute the requested investigation step. Call the relevant tools, analyze the results,',
-    'and record each finding by calling platform__kd_add_subsection(parentSectionKey="evidence",',
-    'title, content) — do NOT dump the findings back into the response text for the orchestrator',
-    'to concatenate; the knowledge doc is the source of truth. Your response text should only be',
-    'a concise one-paragraph summary so the orchestrator can log progress.',
+    'You are a focused investigator. Execute your sub-task intent thoroughly using the available tools.',
+    'Record each finding by calling kd_* tools (platform__kd_add_subsection, platform__kd_update_section).',
+    'Do NOT dump raw tool output into your response — the knowledge doc is the source of truth.',
+    'When you have completed your investigation, call `finalize_subtask` with a concise summary (100-300 words)',
+    'and the list of KD section keys you updated. Call `finalize_subtask` as the LAST action — do not call',
+    'it before you have gathered all the data you need.',
   ].join(' ');
+
   const priorArtifactsHint = task.priorArtifactIds && task.priorArtifactIds.length > 0
     ? `\n\n## Prior Artifacts You May Need\nThese artifact IDs from prior runs may be relevant. Read them via \`platform__read_tool_result_artifact\` before re-querying:\n${task.priorArtifactIds.map(id => `- ${id}`).join('\n')}`
     : '';
+
   const subTaskSystemPrompt = combinedContext
     ? `${subTaskInstructions}\n\n${combinedContext}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${TOOL_ERROR_SYSTEM_PROMPT_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`
     : `${subTaskInstructions}\n${TRUNCATION_SYSTEM_PROMPT_SNIPPET}\n${PREFER_EXISTING_TOOLS_SNIPPET}\n${REQUEST_NEW_TOOL_SNIPPET}\n${TOOL_ERROR_SYSTEM_PROMPT_SNIPPET}\n${KD_SYSTEM_PROMPT_SNIPPET}${priorArtifactsHint}`;
@@ -114,7 +505,6 @@ async function executeOrchestratedSubTaskV2(
     : { resolved: [] as AIToolDefinition[], fuzzy: new Map<string, Array<{ tool: AIToolDefinition; score: number }>>(), unmatched: [] as string[] };
 
   // Build initial tool set: resolved + top fuzzy candidate per entry + ALWAYS include kd_* tools
-  // so every sub-task can write findings via the templated doc, regardless of what the strategist listed.
   const kdTools = agenticTools.filter(t => t.name.startsWith('platform__kd_'));
   const initialTools = [...resolution.resolved];
   const initialToolNames = new Set(initialTools.map(t => t.name));
@@ -135,8 +525,15 @@ async function executeOrchestratedSubTaskV2(
     }
   }
 
+  // Also include read_tool_result_artifact so sub-tasks can page into artifacts
+  const artifactTool = agenticTools.find(t => t.name === 'platform__read_tool_result_artifact');
+  if (artifactTool && !initialToolNames.has(artifactTool.name)) {
+    initialTools.push(artifactTool);
+    initialToolNames.add(artifactTool.name);
+  }
+
   // If tools were requested but none matched at all (kd_* tools excluded), return early with guidance
-  const nonKdInitial = initialTools.filter(t => !t.name.startsWith('platform__kd_'));
+  const nonKdInitial = initialTools.filter(t => !t.name.startsWith('platform__kd_') && t.name !== 'platform__read_tool_result_artifact');
   if (task.tools.length > 0 && nonKdInitial.length === 0) {
     const MAX_TOOLS_IN_ERROR = 10;
     const toolNames = agenticTools.map(t => t.name);
@@ -144,172 +541,46 @@ async function executeOrchestratedSubTaskV2(
       ? `${toolNames.slice(0, MAX_TOOLS_IN_ERROR).join(', ')} … (${toolNames.length - MAX_TOOLS_IN_ERROR} more)`
       : toolNames.join(', ');
     return {
-      content: `Tool resolution failed: requested [${task.tools.join(', ')}] but no matching tools found. Available tools: [${availableList}]. Use exact tool names from this list.`,
+      subTaskId: task.id,
+      intent: task.prompt,
+      summary: `Tool resolution failed: requested [${task.tools.join(', ')}] but no matching tools found. Available tools: [${availableList}]. Use exact tool names from this list.`,
+      updatedKdSections: [],
+      iterationsUsed: 0,
+      tokensUsed: 0,
+      stopReason: SubTaskStopReason.ERROR,
       inputTokens: 0,
       outputTokens: 0,
       toolCalls: [],
     };
   }
 
-  /**
-   * Run a sub-task with the given tool set and return the result plus
-   * whether any "irrelevant" signals were detected.
-   */
-  const failureTracker = new Map<string, number>();
-
-  async function runSubTaskPass(
-    tools: AIToolDefinition[],
-  ): Promise<{ result: SubTaskResult; seemsIrrelevant: boolean }> {
-    const passToolCalls: SubTaskResult['toolCalls'] = [];
-    let passInput = 0;
-    let passOutput = 0;
-    let hasToolError = false;
-
-    if (tools.length > 0) {
-      const subTaskLogId = randomUUID();
-      const orchCtx = orchestration
-        ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true, logId: subTaskLogId, ...(orchestration.parentLogId ? { parentLogId: orchestration.parentLogId, parentLogType: 'ai' as const } : {}) }
-        : { logId: subTaskLogId };
-      const response = await ai.generateWithTools({
-        taskType: TaskType.DEEP_ANALYSIS,
-        context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, strategy: 'orchestrated' as const, strategyVersion: 'v2' as const, ...orchCtx },
-        messages: [{ role: 'user', content: task.prompt }],
-        tools,
-        systemPrompt: subTaskSystemPrompt,
-        providerOverride: 'CLAUDE',
-        modelOverride: model,
-        maxTokens: defaultMaxTokens ?? 4096,
-      });
-
-      passInput += response.usage?.inputTokens ?? 0;
-      passOutput += response.usage?.outputTokens ?? 0;
-
-      const toolUseBlocks = response.contentBlocks.filter(
-        (b): b is AIToolUseBlock => b.type === 'tool_use',
-      );
-
-      if (toolUseBlocks.length > 0) {
-        const toolResults: Array<{ type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean }> = [];
-
-        for (const toolUse of toolUseBlocks) {
-          const start = Date.now();
-          const result = await executeAgenticToolCall(toolUse, mcpIntegrations, repoIdByPrefix, clientId, ticketId, failureTracker);
-          const elapsed = Date.now() - start;
-
-          const fullResult = result.result;
-          const fullSizeChars = fullResult.length;
-          const artifactId = deps.artifactStoragePath && !result.isError ? randomUUID() : undefined;
-          const threshold = toolResultMaxTokens ?? 4000;
-          const truncated = !result.isError && !!artifactId && shouldTruncate(fullResult, threshold);
-          const contentForModel = truncated && artifactId
-            ? buildTruncatedPreview(fullResult, artifactId)
-            : fullResult;
-
-          passToolCalls.push({
-            tool: toolUse.name,
-            system: (toolUse.input as Record<string, unknown>)?.system_name as string | undefined,
-            input: toolUse.input,
-            output: fullResult.slice(0, 500),
-            durationMs: elapsed,
-          });
-          toolResults.push({
-            type: 'tool_result',
-            tool_use_id: toolUse.id,
-            content: contentForModel,
-            ...(result.isError ? { is_error: true } : {}),
-          });
-          if (deps.artifactStoragePath && !result.isError) {
-            void saveMcpToolArtifact(deps.db, ticketId, toolUse.name, fullResult, deps.artifactStoragePath, artifactId).catch(error => {
-              logger.warn({
-                err: error,
-                ticketId,
-                toolName: toolUse.name,
-              }, 'Failed to persist MCP tool artifact');
-            });
-          }
-          if (result.isError) hasToolError = true;
-          appLog.info(
-            `Sub-task tool call: ${toolUse.name} (${elapsed}ms)`,
-            {
-              ticketId,
-              tool: toolUse.name,
-              durationMs: elapsed,
-              params: toolUse.input ? JSON.stringify(toolUse.input).slice(0, 1000) : null,
-              resultPreview: fullResult?.slice(0, 2000) ?? null,
-              isError: result.isError ?? false,
-              truncated,
-              fullSizeChars,
-              parentLogId: subTaskLogId,
-              parentLogType: 'ai',
-              ...(artifactId ? { artifactId } : {}),
-            },
-            ticketId,
-            'ticket',
-          );
-        }
-
-        const textBlocks = response.contentBlocks.filter((b): b is AITextBlock => b.type === 'text');
-        const initialText = textBlocks.map(b => b.text).join('\n').trim();
-        const content = initialText || fallbackFromToolResults(passToolCalls);
-
-        const lowered = content.slice(0, 500).toLowerCase();
-        const hasIrrelevantSignal = IRRELEVANT_SIGNALS.some(s => lowered.includes(s));
-
-        return {
-          result: { content, inputTokens: passInput, outputTokens: passOutput, toolCalls: passToolCalls },
-          seemsIrrelevant: hasToolError || hasIrrelevantSignal,
-        };
-      }
-
-      // No tool calls — just text response
-      const textContent = response.contentBlocks
-        .filter((b): b is AITextBlock => b.type === 'text')
-        .map(b => b.text)
-        .join('\n');
-
-      const lowered = textContent.slice(0, 500).toLowerCase();
-      const hasIrrelevantSignal = IRRELEVANT_SIGNALS.some(s => lowered.includes(s));
-
-      return {
-        result: { content: textContent, inputTokens: passInput, outputTokens: passOutput, toolCalls: passToolCalls },
-        seemsIrrelevant: hasIrrelevantSignal,
-      };
-    }
-
-    // No tools — pure analysis
-    const pureLogId = randomUUID();
-    const orchCtx = orchestration
-      ? { orchestrationId: orchestration.id, orchestrationIteration: orchestration.iteration, isSubTask: true, logId: pureLogId, ...(orchestration.parentLogId ? { parentLogId: orchestration.parentLogId, parentLogType: 'ai' as const } : {}) }
-      : { logId: pureLogId };
-    const response = await ai.generate({
-      taskType: TaskType.DEEP_ANALYSIS,
-      context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory, strategy: 'orchestrated' as const, strategyVersion: 'v2' as const, ...orchCtx },
-      prompt: task.prompt,
-      providerOverride: 'CLAUDE',
-      modelOverride: model,
-      maxTokens: 4096,
-    });
-
-    passInput += response.usage?.inputTokens ?? 0;
-    passOutput += response.usage?.outputTokens ?? 0;
-
-    return {
-      result: { content: response.content, inputTokens: passInput, outputTokens: passOutput, toolCalls: [] },
-      seemsIrrelevant: false,
-    };
-  }
-
-  // --- First pass ---
-  const firstPass = await runSubTaskPass(initialTools);
-  inputTokens += firstPass.result.inputTokens;
-  outputTokens += firstPass.result.outputTokens;
-  toolCalls.push(...firstPass.result.toolCalls);
+  // Run the stateful loop
+  const firstResult = await runSubTaskLoop(
+    deps,
+    ticketId,
+    clientId,
+    category,
+    skipClientMemory,
+    task.id,
+    task.prompt,
+    task.contextKdSectionKeys ?? [],
+    // When task.tools is empty, give the sub-task all available tools
+    task.tools.length === 0 ? agenticTools : initialTools,
+    mcpIntegrations,
+    repoIdByPrefix,
+    subTaskSystemPrompt,
+    model,
+    orchestration,
+    toolResultMaxTokens,
+    defaultMaxTokens,
+  );
 
   // --- Retry with alternate fuzzy candidates if first pass seems irrelevant ---
-  if (firstPass.seemsIrrelevant && fuzzyUsed.size > 0) {
-    let lastRetryResult: SubTaskResult | undefined;
-    let lastRetryScore = 0;
+  const lowered = firstResult.summary.slice(0, 500).toLowerCase();
+  const seemsIrrelevant = firstResult.stopReason === SubTaskStopReason.ERROR
+    || IRRELEVANT_SIGNALS.some(s => lowered.includes(s));
 
+  if (seemsIrrelevant && fuzzyUsed.size > 0) {
     for (const [reqName, used] of fuzzyUsed) {
       const candidates = resolution.fuzzy.get(reqName);
       if (!candidates || candidates.length <= used.candidateIndex + 1) continue;
@@ -319,38 +590,116 @@ async function executeOrchestratedSubTaskV2(
         .filter(t => t.name !== used.tool.name)
         .concat(nextCandidate.tool);
 
-      const retryPass = await runSubTaskPass(retryTools);
-      inputTokens += retryPass.result.inputTokens;
-      outputTokens += retryPass.result.outputTokens;
-      toolCalls.push(...retryPass.result.toolCalls);
-      lastRetryResult = retryPass.result;
-      lastRetryScore = nextCandidate.score;
+      const retryResult = await runSubTaskLoop(
+        deps,
+        ticketId,
+        clientId,
+        category,
+        skipClientMemory,
+        task.id,
+        task.prompt,
+        task.contextKdSectionKeys ?? [],
+        retryTools,
+        mcpIntegrations,
+        repoIdByPrefix,
+        subTaskSystemPrompt,
+        model,
+        orchestration,
+        toolResultMaxTokens,
+        defaultMaxTokens,
+      );
 
-      if (!retryPass.seemsIrrelevant) {
-        return { content: retryPass.result.content, inputTokens, outputTokens, toolCalls };
+      const retryLowered = retryResult.summary.slice(0, 500).toLowerCase();
+      if (!IRRELEVANT_SIGNALS.some(s => retryLowered.includes(s))) {
+        return retryResult;
       }
-    }
 
-    if (lastRetryResult !== undefined) {
+      // Last retry — annotate with warning
       return {
-        content: `Warning: Tool match was uncertain (fuzzy match score: ${lastRetryScore.toFixed(2)}) — results may not be fully relevant.\n\n${lastRetryResult.content}`,
-        inputTokens,
-        outputTokens,
-        toolCalls,
+        ...retryResult,
+        summary: `Warning: Tool match was uncertain (fuzzy match score: ${nextCandidate.score.toFixed(2)}) — results may not be fully relevant.\n\n${retryResult.summary}`,
       };
     }
-
-    const topScore = [...fuzzyUsed.values()].reduce((max, v) => Math.max(max, v.score), 0);
-    return {
-      content: `Warning: Tool match was uncertain (fuzzy match score: ${topScore.toFixed(2)}) — results may not be fully relevant.\n\n${firstPass.result.content}`,
-      inputTokens,
-      outputTokens,
-      toolCalls,
-    };
   }
 
-  return { content: firstPass.result.content, inputTokens, outputTokens, toolCalls };
+  return firstResult;
 }
+
+// ---------------------------------------------------------------------------
+// Strategist tool definitions (kd_* read-only + dispatch + complete)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the tool list for the orchestrator strategist.
+ * Includes:
+ *   - platform__kd_read_toc — so the strategist can see what's been documented
+ *   - platform__kd_read_section — so it can read specific sections
+ *   - platform__read_tool_result_artifact — so it can page into sub-task artifacts
+ *   - dispatch_subtasks — the primary work-dispatch mechanism
+ *   - complete_analysis — the termination signal
+ *
+ * Write tools (kd_update_section, kd_add_subsection) are intentionally excluded
+ * from the strategist — only sub-tasks should write to the knowledge doc.
+ */
+function buildStrategistTools(agenticTools: AIToolDefinition[]): AIToolDefinition[] {
+  const kdReadToc = agenticTools.find(t => t.name === 'platform__kd_read_toc');
+  const kdReadSection = agenticTools.find(t => t.name === 'platform__kd_read_section');
+  const readArtifact = agenticTools.find(t => t.name === 'platform__read_tool_result_artifact');
+
+  const tools: AIToolDefinition[] = [
+    DISPATCH_SUBTASKS_TOOL,
+    COMPLETE_ANALYSIS_TOOL,
+  ];
+  if (kdReadToc) tools.push(kdReadToc);
+  if (kdReadSection) tools.push(kdReadSection);
+  if (readArtifact) tools.push(readArtifact);
+  return tools;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrated v2 strategist system prompt (updated for tool-use loop)
+// ---------------------------------------------------------------------------
+
+const ORCHESTRATED_V2_STRATEGIST_PROMPT = [
+  ORCHESTRATED_SYSTEM_PROMPT,
+  '',
+  '## Orchestration Tools (v2)',
+  '',
+  'You now have access to the following tools:',
+  '',
+  '**`dispatch_subtasks`** — Dispatch a batch of parallel sub-task agents to investigate specific questions.',
+  'Each sub-task has its own tool loop and writes findings to the knowledge doc via kd_* tools.',
+  'After sub-tasks complete, their summaries are returned to you as a tool_result.',
+  '',
+  '**`complete_analysis`** — Call when the investigation is complete. Include a concise executive summary.',
+  'The knowledge doc (Root Cause, Recommended Fix, Risks) will be merged with your summary automatically.',
+  '',
+  '**`platform__kd_read_toc`** / **`platform__kd_read_section`** — Read the knowledge doc directly.',
+  'Use these between sub-task batches to see what has been documented before planning the next batch.',
+  '',
+  '**`platform__read_tool_result_artifact`** — Page into a truncated tool-result artifact by ID.',
+  '',
+  '## Workflow',
+  '1. On the first iteration, call `dispatch_subtasks` with an initial batch of sub-tasks.',
+  '2. After sub-tasks return, optionally call `platform__kd_read_toc` and `platform__kd_read_section`',
+  '   to review what was documented, then either dispatch another batch or call `complete_analysis`.',
+  '3. Call `complete_analysis` when you have enough evidence for a root cause and recommendation.',
+  '',
+  '## Knowledge Document Discipline',
+  'You are the PLANNER — sub-tasks are the WRITERS. Do not write to the knowledge doc yourself.',
+  'Instruct sub-tasks to call platform__kd_add_subsection / platform__kd_update_section to record findings.',
+  'Provide `contextKdSectionKeys` in dispatch_subtasks so sub-tasks receive relevant prior context.',
+  '',
+  TRUNCATION_SYSTEM_PROMPT_SNIPPET,
+  PREFER_EXISTING_TOOLS_SNIPPET,
+  REQUEST_NEW_TOOL_SNIPPET,
+  TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
+  KD_SYSTEM_PROMPT_SNIPPET,
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Main orchestrated v2 entry point
+// ---------------------------------------------------------------------------
 
 /**
  * Orchestrated v2 agentic analysis. The strategist plans iterative sub-tasks;
@@ -385,13 +734,6 @@ export async function runOrchestratedV2(
   const orchModelMap = await resolveOrchestratedModelMap(db);
 
   // --- One-time knowledge-doc init -----------------------------------------
-  // Guarantees that both `knowledgeDoc` (template skeleton) and
-  // `knowledgeDocSectionMeta` (empty object, non-null) are populated from
-  // iteration 0 forward, so `composeFinalAnalysis` / snapshot / fallback-fill
-  // at loop end can rely on a consistent schema. This is the ONE permitted
-  // raw write inside v2 orchestrated — every subsequent doc mutation flows
-  // through the templated `kd_*` path (sub-task tool calls or shared-utils
-  // `updateSection` from the orchestrator itself for the Run Log).
   const kdInitial = await loadKnowledgeDoc(db, ticketId);
   const needsInit = !kdInitial?.knowledgeDoc
     || !kdInitial.knowledgeDocSectionMeta
@@ -414,9 +756,8 @@ export async function runOrchestratedV2(
     artifactCatalog = await buildArtifactCatalog(db, ticketId, { maxEntries: 20 });
   }
 
-  let orchNextPrompt = '';
-  let orchIterationsRun = 0;
   let agentExecutiveSummary = '';
+  let orchIterationsRun = 0;
   let orchTotalInputTokens = 0;
   let orchTotalOutputTokens = 0;
   const orchToolCallLog: Array<{ tool: string; system?: string; input: Record<string, unknown>; output: string; durationMs: number }> = [];
@@ -441,9 +782,6 @@ export async function runOrchestratedV2(
   const toolListSection = `\n## Available Tools\n${availableToolNames.join(', ')}`;
   contextParts.push(toolListSection);
 
-  // For re-analysis surfaces, include a compact preview of the existing doc
-  // (the fresh doc just got initialized, but prior content may exist on the
-  // ticket from an earlier run).
   let priorRunsContext = '';
   if (existingKnowledgeDoc) {
     priorRunsContext = existingKnowledgeDoc.length > 2000
@@ -451,180 +789,432 @@ export async function runOrchestratedV2(
       : existingKnowledgeDoc;
   }
 
+  // Build the strategist's tool list (read-only kd_* + dispatch + complete)
+  const finalStrategistTools = buildStrategistTools(agenticTools);
+
+  // Compose the updated strategist system prompt (includes tool-use discipline)
   const strategistSystemPrompt = [
-    ORCHESTRATED_SYSTEM_PROMPT,
-    '',
-    '## Knowledge Document Discipline (v2)',
-    'The knowledge doc is the source of truth for this investigation. Sub-tasks you dispatch MUST call',
-    'platform__kd_add_subsection(parentSectionKey="evidence", title, content) to record each finding.',
-    'In iteration 1, your FIRST task prompt should instruct the sub-task to call',
-    'platform__kd_update_section(sectionKey="problemStatement", content=...) with a concise restatement',
-    'of the issue before any tool-call investigation begins. Before planning each iteration after the',
-    'first, assume the doc has been updated by prior sub-tasks — if you need to see what has been',
-    'recorded, instruct a sub-task to call platform__kd_read_toc / platform__kd_read_section and return',
-    'the summary.',
-    '',
-    'When setting "done": true, your finalAnalysis should be a concise executive summary. The detail',
-    'belongs in the doc — Problem Statement / Root Cause / Recommended Fix / Risks sections will be',
-    'merged into the final rendered analysis automatically.',
-    TRUNCATION_SYSTEM_PROMPT_SNIPPET,
-    PREFER_EXISTING_TOOLS_SNIPPET,
-    REQUEST_NEW_TOOL_SNIPPET,
-    TOOL_ERROR_SYSTEM_PROMPT_SNIPPET,
-    KD_SYSTEM_PROMPT_SNIPPET,
+    ORCHESTRATED_V2_STRATEGIST_PROMPT,
     buildRepoNudgeSnippet(clientRepos),
   ].join('\n');
+
+  // Compose the initial user prompt for the strategist
+  let initialStrategistPrompt: string;
+  {
+    const priorNote = priorRunsContext
+      ? `\n\n## Prior Analysis Runs (for context)\n${priorRunsContext}\n\n---\n\n`
+      : '';
+
+    if (isReanalysis && reanalysisCtx) {
+      const modeIntro = reanalysisMode === ReanalysisMode.REFINE
+        ? [
+            'The operator has replied asking for clarification or refinement. Use the prior',
+            'knowledge document and artifacts as ground truth. Do NOT fire fresh MCP tool',
+            'calls unless the operator\'s request explicitly requires new data — prefer',
+            'reading prior artifacts via `platform__read_tool_result_artifact`.',
+          ].join(' ')
+        : [
+            'The operator has replied. Plan the next iteration that addresses their reply.',
+            'A catalog of prior tool-result artifacts is provided below — re-query only when',
+            'necessary; prefer reading prior artifacts via `platform__read_tool_result_artifact`',
+            'or hint at them via `contextKdSectionKeys` in a sub-task.',
+          ].join(' ');
+
+      const sections = [
+        modeIntro,
+        '',
+        '## Operator Reply',
+        reanalysisCtx.triggerReplyText || '(no reply text available — see conversation history)',
+        '',
+        '## Prior Knowledge Document',
+        priorRunsContext || existingKnowledgeDoc || '(no prior knowledge document)',
+      ];
+      if (artifactCatalog) {
+        sections.push('', '## Prior Artifacts', artifactCatalog);
+      }
+      sections.push('', '## Conversation History', reanalysisCtx.conversationHistory);
+      sections.push('', '## Ticket Context', contextParts.join('\n'));
+
+      initialStrategistPrompt = sections.join('\n');
+    } else {
+      const includePriorNote = reanalysisMode !== ReanalysisMode.FRESH_START;
+      const effectivePriorNote = includePriorNote ? priorNote : '';
+      initialStrategistPrompt = `Investigate this ticket. Here is the full context:\n\n${contextParts.join('\n')}${effectivePriorNote}`;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Strategist message loop
+  // ---------------------------------------------------------------------------
+  // The strategist now uses generateWithTools so it can:
+  //   - call dispatch_subtasks to request parallel sub-task batches
+  //   - call complete_analysis to signal the end of investigation
+  //   - call kd_read_toc / kd_read_section to inspect the knowledge doc
+  //   - call read_tool_result_artifact to inspect prior artifacts
+  //
+  // The outer `for` loop represents strategist iterations (planning passes).
+  // Within each iteration, the strategist may issue multiple tool calls (kd_read_*,
+  // read_artifact) before dispatching sub-tasks or completing. The inner tool loop
+  // handles those until the strategist emits dispatch_subtasks or complete_analysis.
+
+  const strategistMessages: AIMessage[] = [
+    { role: 'user', content: initialStrategistPrompt },
+  ];
 
   for (let i = 0; i < orchMaxIterations; i++) {
     orchIterationsRun = i + 1;
     const orchestrationId = randomUUID();
     appLog.info(`Orchestrated analysis iteration ${i + 1}/${orchMaxIterations}`, { ticketId, iteration: i + 1, orchestrationId }, ticketId, 'ticket');
 
-    let strategistPrompt: string;
-    if (i === 0) {
-      const priorNote = priorRunsContext
-        ? `\n\n## Prior Analysis Runs (for context)\n${priorRunsContext}\n\n---\n\n`
-        : '';
-
-      if (isReanalysis && reanalysisCtx) {
-        const modeIntro = reanalysisMode === ReanalysisMode.REFINE
-          ? [
-              'The operator has replied asking for clarification or refinement. Use the prior',
-              'knowledge document and artifacts as ground truth. Do NOT fire fresh MCP tool',
-              'calls unless the operator\'s request explicitly requires new data — prefer',
-              'reading prior artifacts via `platform__read_tool_result_artifact`.',
-            ].join(' ')
-          : [
-              'The operator has replied. Plan the next iteration that addresses their reply.',
-              'A catalog of prior tool-result artifacts is provided below — re-query only when',
-              'necessary; prefer reading prior artifacts via `platform__read_tool_result_artifact`',
-              'or hint at them via `priorArtifactIds` in a sub-task.',
-            ].join(' ');
-
-        const sections = [
-          modeIntro,
-          '',
-          '## Operator Reply',
-          reanalysisCtx.triggerReplyText || '(no reply text available — see conversation history)',
-          '',
-          '## Prior Knowledge Document',
-          priorRunsContext || existingKnowledgeDoc || '(no prior knowledge document)',
-        ];
-        if (artifactCatalog) {
-          sections.push('', '## Prior Artifacts', artifactCatalog);
-        }
-        sections.push('', '## Conversation History', reanalysisCtx.conversationHistory);
-        sections.push('', '## Ticket Context', contextParts.join('\n'));
-
-        strategistPrompt = sections.join('\n');
-      } else {
-        const includePriorNote = reanalysisMode !== ReanalysisMode.FRESH_START;
-        const effectivePriorNote = includePriorNote ? priorNote : '';
-        strategistPrompt = `Investigate this ticket. Here is the full context:\n\n${contextParts.join('\n')}${effectivePriorNote}`;
-      }
-    } else {
-      strategistPrompt = `Continue the investigation. Sub-tasks from prior iterations have recorded their findings via platform__kd_add_subsection into the knowledge doc. Dispatch the next round of sub-tasks.\n\n## Next Investigation Step\n${orchNextPrompt}`;
-    }
-
     const strategistLogId = randomUUID();
-    const strategistResponse = await ai.generate({
-      taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
-      context: { ticketId, clientId, entityId: ticketId, entityType: 'ticket', ticketCategory: category, skipClientMemory: !!clientContext, orchestrationId, orchestrationIteration: i + 1, logId: strategistLogId, strategy: 'orchestrated' as const, strategyVersion: 'v2' as const },
-      prompt: strategistPrompt,
-      systemPrompt: strategistSystemPrompt,
-      providerOverride: 'CLAUDE',
-      modelOverride: 'claude-opus-4-6',
-      maxTokens: defaultMaxTokens ?? 4096,
-    });
 
-    orchTotalInputTokens += strategistResponse.usage?.inputTokens ?? 0;
-    orchTotalOutputTokens += strategistResponse.usage?.outputTokens ?? 0;
+    // --- Inner tool loop: call generateWithTools until strategist dispatches or completes ---
+    let innerDone = false;
+    let dispatchSubtasksInput: { subtasks: Array<{ id: string; intent: string; tools?: string[]; contextKdSectionKeys?: string[]; model?: string }> } | null = null;
+    let completeAnalysisInput: { finalAnalysis: string } | null = null;
 
-    const plan = parseStrategistResponse(strategistResponse.content);
+    for (let innerIter = 0; innerIter < 20; innerIter++) {
+      // Each inner iteration is one generateWithTools call for the strategist
+      const strategistResponse = await ai.generateWithTools({
+        taskType: (step.taskTypeOverride ?? TaskType.DEEP_ANALYSIS) as TaskType,
+        context: {
+          ticketId,
+          clientId,
+          entityId: ticketId,
+          entityType: 'ticket',
+          ticketCategory: category,
+          skipClientMemory: !!clientContext,
+          orchestrationId,
+          orchestrationIteration: i + 1,
+          logId: innerIter === 0 ? strategistLogId : randomUUID(),
+          strategy: 'orchestrated' as const,
+          strategyVersion: 'v2' as const,
+        },
+        messages: strategistMessages,
+        tools: finalStrategistTools,
+        systemPrompt: strategistSystemPrompt,
+        providerOverride: 'CLAUDE',
+        modelOverride: 'claude-opus-4-6',
+        maxTokens: defaultMaxTokens ?? 4096,
+      });
 
-    if (plan.parseError) {
-      appLog.error(
-        `Strategist JSON parse failed: ${plan.parseError}. Raw content used as final analysis.`,
-        { ticketId, iteration: i + 1, error: plan.parseError },
-        ticketId, 'ticket',
+      orchTotalInputTokens += strategistResponse.usage?.inputTokens ?? 0;
+      orchTotalOutputTokens += strategistResponse.usage?.outputTokens ?? 0;
+
+      // Append assistant turn
+      strategistMessages.push({ role: 'assistant', content: strategistResponse.contentBlocks });
+
+      // Check for dispatch_subtasks or complete_analysis (decision tools)
+      const dispatchCall = strategistResponse.contentBlocks.find(
+        (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'dispatch_subtasks',
       );
+      const completeCall = strategistResponse.contentBlocks.find(
+        (b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'complete_analysis',
+      );
+
+      if (completeCall) {
+        const input = completeCall.input as { finalAnalysis?: string };
+        completeAnalysisInput = {
+          finalAnalysis: typeof input.finalAnalysis === 'string' ? input.finalAnalysis : '',
+        };
+
+        // Synthesize tool_result so the conversation stays valid
+        strategistMessages.push({
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: completeCall.id,
+              content: 'Analysis marked complete. Investigation concluded.',
+            } satisfies AIToolResultBlock,
+          ],
+        });
+        innerDone = true;
+        break;
+      }
+
+      if (dispatchCall) {
+        const rawInput = dispatchCall.input as { subtasks?: unknown };
+        const rawSubtasks = Array.isArray(rawInput.subtasks) ? rawInput.subtasks : [];
+        dispatchSubtasksInput = {
+          subtasks: (rawSubtasks as Array<Record<string, unknown>>).map(st => ({
+            id: typeof st['id'] === 'string' ? st['id'] : randomUUID(),
+            intent: typeof st['intent'] === 'string' ? st['intent'] : '',
+            tools: Array.isArray(st['tools']) ? (st['tools'] as string[]) : [],
+            contextKdSectionKeys: Array.isArray(st['contextKdSectionKeys']) ? (st['contextKdSectionKeys'] as string[]) : [],
+            model: typeof st['model'] === 'string' ? st['model'] : 'sonnet',
+          })),
+        };
+        innerDone = true;
+        break;
+      }
+
+      // No decision tool — handle any non-decision tool calls (kd_read_*, read_artifact)
+      if (strategistResponse.stopReason !== 'tool_use') {
+        // Strategist ended without calling any tool — treat as done
+        appLog.info(
+          `Strategist ended without decision tool at iteration ${i + 1} (inner ${innerIter + 1})`,
+          { ticketId, iteration: i + 1, innerIter: innerIter + 1, stopReason: strategistResponse.stopReason },
+          ticketId,
+          'ticket',
+        );
+        // Extract any text as the final analysis
+        const finalText = strategistResponse.contentBlocks
+          .filter((b): b is AITextBlock => b.type === 'text')
+          .map(b => b.text)
+          .join('\n')
+          .trim();
+        if (finalText) {
+          completeAnalysisInput = { finalAnalysis: finalText };
+        }
+        innerDone = true;
+        break;
+      }
+
+      // Execute non-decision tool calls (kd_read_toc, kd_read_section, read_tool_result_artifact)
+      const nonDecisionToolUses = strategistResponse.contentBlocks.filter(
+        (b): b is AIToolUseBlock =>
+          b.type === 'tool_use' &&
+          b.name !== 'dispatch_subtasks' &&
+          b.name !== 'complete_analysis',
+      );
+
+      const toolResults: AIToolResultBlock[] = [];
+      for (const toolUse of nonDecisionToolUses) {
+        const start = Date.now();
+        const result = await executeAgenticToolCall(
+          toolUse,
+          mcpIntegrations,
+          repoIdByPrefix,
+          clientId,
+          ticketId,
+          undefined, // no failure tracker for strategist read tools
+        );
+        const elapsed = Date.now() - start;
+
+        orchToolCallLog.push({
+          tool: toolUse.name,
+          system: (toolUse.input as Record<string, unknown>)?.system_name as string | undefined,
+          input: toolUse.input,
+          output: result.result.slice(0, 500),
+          durationMs: elapsed,
+        });
+
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: result.result,
+          ...(result.isError ? { is_error: true } : {}),
+        });
+
+        appLog.info(
+          `Strategist tool call: ${toolUse.name} (${elapsed}ms)`,
+          { ticketId, tool: toolUse.name, durationMs: elapsed, iteration: i + 1, innerIter: innerIter + 1 },
+          ticketId,
+          'ticket',
+        );
+      }
+
+      if (toolResults.length > 0) {
+        strategistMessages.push({ role: 'user', content: toolResults });
+      }
     }
 
-    appLog.info(
-      `Orchestrated iteration ${i + 1}: ${plan.tasks.length} tasks, done=${plan.done}`,
-      { ticketId, iteration: i + 1, taskCount: plan.tasks.length, done: plan.done, findingsPreview: plan.findings.slice(0, 500) },
-      ticketId, 'ticket',
-    );
-
-    // Record a Run Log entry through the templated writer — this updates both
-    // `knowledgeDoc` and `knowledgeDocSectionMeta` atomically via
-    // `withTicketLock` (see packages/shared-utils/src/knowledge-doc.ts).
-    // This is NOT a raw knowledgeDoc write.
-    try {
-      const runLogEntry = `### Iteration ${i + 1}\n${plan.findings || '(no findings summary from strategist)'}\n`;
-      await updateSection(
-        db,
-        ticketId,
-        KnowledgeDocSectionKey.RUN_LOG,
-        runLogEntry,
-        KnowledgeDocUpdateMode.APPEND,
-      );
-    } catch (err) {
-      logger.warn({ err, ticketId, iteration: i + 1 }, 'Failed to append Run Log entry — continuing');
-    }
-
-    if (plan.done) {
-      agentExecutiveSummary = plan.finalAnalysis ?? plan.findings;
+    // --- Handle complete_analysis ---
+    if (completeAnalysisInput) {
+      agentExecutiveSummary = completeAnalysisInput.finalAnalysis;
       await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
       break;
     }
 
-    orchNextPrompt = plan.nextPrompt ?? '';
+    // --- Handle dispatch_subtasks ---
+    if (dispatchSubtasksInput && dispatchSubtasksInput.subtasks.length > 0) {
+      const plan = dispatchSubtasksInput;
 
-    // Execute tasks in parallel batches. Sub-tasks write findings via kd_*
-    // tools — no local knowledgeDoc accumulation here. Sub-task response text
-    // is kept for AppLog / telemetry only; the doc is authoritative.
-    const taskBatches = chunkArray(plan.tasks, maxParallelTasks);
-    for (const batch of taskBatches) {
-      const results = await Promise.allSettled(
-        batch.map(task => executeOrchestratedSubTaskV2(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId }, orchModelMap, toolResultMaxTokens)),
+      appLog.info(
+        `Orchestrated iteration ${i + 1}: dispatching ${plan.subtasks.length} sub-task(s)`,
+        { ticketId, iteration: i + 1, subtaskCount: plan.subtasks.length, subtaskIds: plan.subtasks.map(s => s.id) },
+        ticketId,
+        'ticket',
       );
 
-      for (let j = 0; j < results.length; j++) {
-        const result = results[j];
-        const task = batch[j];
-        if (result.status === 'fulfilled') {
-          orchTotalInputTokens += result.value.inputTokens;
-          orchTotalOutputTokens += result.value.outputTokens;
-          orchToolCallLog.push(...result.value.toolCalls);
-          appLog.info(
-            `Sub-task complete: ${task.prompt.slice(0, 120)}`,
-            { ticketId, iteration: i + 1, toolCallCount: result.value.toolCalls.length, contentPreview: result.value.content.slice(0, 500) },
-            ticketId, 'ticket',
-          );
-        } else {
-          // Retry once on failure
-          try {
-            const retryResult = await executeOrchestratedSubTaskV2(deps, ticketId, clientId, category, clientContext, environmentContext, task, agenticTools, mcpIntegrations, repoIdByPrefix, { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId }, orchModelMap, toolResultMaxTokens);
-            orchTotalInputTokens += retryResult.inputTokens;
-            orchTotalOutputTokens += retryResult.outputTokens;
-            orchToolCallLog.push(...retryResult.toolCalls);
+      // Record iteration start in Run Log
+      try {
+        const intentsSummary = plan.subtasks.map(s => `- ${s.id}: ${s.intent.slice(0, 100)}`).join('\n');
+        const runLogEntry = `### Iteration ${i + 1} — Dispatched ${plan.subtasks.length} sub-task(s)\n${intentsSummary}\n`;
+        await updateSection(db, ticketId, KnowledgeDocSectionKey.RUN_LOG, runLogEntry, KnowledgeDocUpdateMode.APPEND);
+      } catch (err) {
+        logger.warn({ err, ticketId, iteration: i + 1 }, 'Failed to append Run Log entry — continuing');
+      }
+
+      // Execute sub-tasks in parallel batches
+      const subtaskBatches = chunkArray(plan.subtasks, maxParallelTasks);
+      const allSubTaskResults: SubTaskRunResult[] = [];
+
+      for (const batch of subtaskBatches) {
+        const batchResults = await Promise.allSettled(
+          batch.map(subtask =>
+            executeOrchestratedSubTaskV2(
+              deps,
+              ticketId,
+              clientId,
+              category,
+              clientContext,
+              environmentContext,
+              {
+                id: subtask.id,
+                prompt: subtask.intent,
+                tools: subtask.tools ?? [],
+                model: subtask.model ?? 'sonnet',
+                contextKdSectionKeys: subtask.contextKdSectionKeys ?? [],
+              },
+              agenticTools,
+              mcpIntegrations,
+              repoIdByPrefix,
+              { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId },
+              orchModelMap,
+              toolResultMaxTokens,
+            ),
+          ),
+        );
+
+        for (let j = 0; j < batchResults.length; j++) {
+          const result = batchResults[j];
+          const subtask = batch[j];
+          if (result.status === 'fulfilled') {
+            orchTotalInputTokens += result.value.inputTokens;
+            orchTotalOutputTokens += result.value.outputTokens;
+            orchToolCallLog.push(...result.value.toolCalls);
+            allSubTaskResults.push(result.value);
             appLog.info(
-              `Sub-task complete (retry): ${task.prompt.slice(0, 120)}`,
-              { ticketId, iteration: i + 1, toolCallCount: retryResult.toolCalls.length, contentPreview: retryResult.content.slice(0, 500) },
-              ticketId, 'ticket',
+              `Sub-task ${subtask.id} complete (${result.value.stopReason}): ${result.value.summary.slice(0, 200)}`,
+              {
+                ticketId,
+                subtaskId: subtask.id,
+                iteration: i + 1,
+                stopReason: result.value.stopReason,
+                toolCallCount: result.value.toolCalls.length,
+                updatedKdSections: result.value.updatedKdSections,
+                tokensUsed: result.value.tokensUsed,
+              },
+              ticketId,
+              'ticket',
             );
-          } catch (retryErr) {
-            appLog.warn(`Orchestrated task failed after retry: ${task.prompt}`, { ticketId, task: task.prompt, err: retryErr }, ticketId, 'ticket');
+          } else {
+            // Retry once on failure
+            try {
+              const retryResult = await executeOrchestratedSubTaskV2(
+                deps,
+                ticketId,
+                clientId,
+                category,
+                clientContext,
+                environmentContext,
+                {
+                  id: subtask.id,
+                  prompt: subtask.intent,
+                  tools: subtask.tools ?? [],
+                  model: subtask.model ?? 'sonnet',
+                  contextKdSectionKeys: subtask.contextKdSectionKeys ?? [],
+                },
+                agenticTools,
+                mcpIntegrations,
+                repoIdByPrefix,
+                { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId },
+                orchModelMap,
+                toolResultMaxTokens,
+              );
+              orchTotalInputTokens += retryResult.inputTokens;
+              orchTotalOutputTokens += retryResult.outputTokens;
+              orchToolCallLog.push(...retryResult.toolCalls);
+              allSubTaskResults.push(retryResult);
+              appLog.info(
+                `Sub-task ${subtask.id} complete (retry, ${retryResult.stopReason}): ${retryResult.summary.slice(0, 200)}`,
+                { ticketId, subtaskId: subtask.id, iteration: i + 1, stopReason: retryResult.stopReason },
+                ticketId,
+                'ticket',
+              );
+            } catch (retryErr) {
+              appLog.warn(
+                `Sub-task ${subtask.id} failed after retry`,
+                { ticketId, subtaskId: subtask.id, err: retryErr },
+                ticketId,
+                'ticket',
+              );
+              // Add a stub result so the strategist gets a tool_result for this sub-task
+              allSubTaskResults.push({
+                subTaskId: subtask.id,
+                intent: subtask.intent,
+                summary: `Sub-task failed after retry: ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+                updatedKdSections: [],
+                iterationsUsed: 0,
+                tokensUsed: 0,
+                stopReason: SubTaskStopReason.ERROR,
+                inputTokens: 0,
+                outputTokens: 0,
+                toolCalls: [],
+              });
+            }
           }
         }
       }
-    }
 
-    await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+      // Append sub-task results to strategist messages as tool_result for the dispatch_subtasks call
+      const dispatchCallBlock = strategistMessages
+        .flatMap(m => (m.role === 'assistant' && Array.isArray(m.content) ? (m.content as AIToolUseBlock[]) : []))
+        .find((b): b is AIToolUseBlock => b.type === 'tool_use' && b.name === 'dispatch_subtasks');
+
+      if (dispatchCallBlock) {
+        const resultPayload = allSubTaskResults.map(r => ({
+          sub_task_id: r.subTaskId,
+          intent: r.intent,
+          summary: r.summary,
+          updatedKdSections: r.updatedKdSections,
+          stopReason: r.stopReason,
+          iterationsUsed: r.iterationsUsed,
+          tokensUsed: r.tokensUsed,
+        }));
+
+        strategistMessages.push({
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: dispatchCallBlock.id,
+              content: JSON.stringify(resultPayload, null, 2),
+            } satisfies AIToolResultBlock,
+          ],
+        });
+      } else {
+        // Fallback: append as a plain user message (shouldn't happen in practice)
+        const resultSummary = allSubTaskResults.map(r =>
+          `**Sub-task ${r.subTaskId}** (${r.stopReason}): ${r.summary}\nUpdated KD sections: ${r.updatedKdSections.join(', ') || 'none'}`,
+        ).join('\n\n');
+        strategistMessages.push({
+          role: 'user',
+          content: `## Sub-task Results\n\n${resultSummary}\n\nUse \`platform__kd_read_toc\` or \`platform__kd_read_section\` to review what was written, then either \`dispatch_subtasks\` for more investigation or \`complete_analysis\` if sufficient.`,
+        });
+      }
+
+      await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+    } else if (innerDone) {
+      // Strategist ended the inner loop but without a decision — treat as done
+      await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+      break;
+    } else {
+      // No dispatch and no complete — shouldn't happen but break to avoid infinite loop
+      appLog.warn(
+        `Orchestrated iteration ${i + 1}: strategist made no decision — breaking`,
+        { ticketId, iteration: i + 1 },
+        ticketId,
+        'ticket',
+      );
+      await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+      break;
+    }
   }
 
-  // --- End of loop: fallback-fill + compose ------------------------------
+  // --- End of loop: fallback-fill + compose ---
   await fallbackFillRequiredSections(db, ticketId, 'orchestrated-v2 loop end');
   const kdAfter = await loadKnowledgeDoc(db, ticketId);
   const composedAnalysis = composeFinalAnalysis(
@@ -645,3 +1235,7 @@ export async function runOrchestratedV2(
     sufficiencyEval: orchSufficiency,
   };
 }
+
+// Re-export public helpers consumed by the pipeline
+export { composeFinalAnalysis } from './v2-knowledge-doc.js';
+export { fallbackFillRequiredSections } from './v2-knowledge-doc.js';

--- a/services/ticket-analyzer/src/analysis/v2-subtask-tools.ts
+++ b/services/ticket-analyzer/src/analysis/v2-subtask-tools.ts
@@ -1,0 +1,193 @@
+/**
+ * v2-only tool definitions for the orchestrated-v2 sub-task / strategist loop.
+ *
+ * These tools are NOT added to `buildAgenticTools` (shared.ts) because they are
+ * specific to the orchestrated-v2 architecture and must not be visible to flat-v2,
+ * flat-v1, or orchestrated-v1 agents.
+ *
+ * Three tools are defined here:
+ *
+ * 1. `finalize_subtask` — emitted by a sub-task to return structured results to
+ *    the strategist. The sub-task loop detects this call and breaks out of its
+ *    iteration loop, returning control with a structured summary.
+ *
+ * 2. `dispatch_subtasks` — emitted by the strategist to request a batch of
+ *    parallel sub-tasks. Each entry carries an intent string, optional KD section
+ *    keys to pre-pack as context, and an optional tool allowlist.
+ *
+ * 3. `complete_analysis` — emitted by the strategist when it has enough information
+ *    to conclude the investigation. Carries the final executive summary.
+ */
+
+import type { AIToolDefinition } from '@bronco/shared-types';
+
+/**
+ * Tool added to every sub-task's tool list (alongside `buildAgenticTools` output).
+ * When the model calls this, the sub-task runner breaks its loop and returns a
+ * structured result to the strategist.
+ */
+export const FINALIZE_SUBTASK_TOOL: AIToolDefinition = {
+  name: 'finalize_subtask',
+  description: [
+    'Call when you have completed your sub-task. Returns control to the orchestrator strategist.',
+    'Include a short summary (100-300 words) of what you found and a list of KD section keys',
+    'you updated so the strategist can read them on its next planning pass.',
+    'Do NOT call this until you have finished all tool calls you intend to make — use your',
+    'remaining iterations to gather data, then call finalize_subtask once as the last action.',
+  ].join(' '),
+  input_schema: {
+    type: 'object',
+    properties: {
+      summary: {
+        type: 'string',
+        description: [
+          'Concise findings, 100-300 words.',
+          'Do NOT restate raw tool output — distill what the strategist needs to know.',
+          'Include: what you found, what hypothesis it supports or refutes, and any open questions.',
+        ].join(' '),
+      },
+      updatedKdSections: {
+        type: 'array',
+        items: { type: 'string' },
+        description: [
+          'KD section keys you wrote content to during this sub-task',
+          '(e.g. ["evidence.deadlock-graph", "hypotheses.lock-wait"]).',
+          'Include both top-level keys (rootCause) and dotted subsection keys (evidence.foo).',
+        ].join(' '),
+      },
+    },
+    required: ['summary', 'updatedKdSections'],
+  },
+};
+
+/**
+ * Tool added to the strategist's tool list. The strategist emits this with a
+ * batch of sub-task descriptors to request parallel investigation.
+ */
+export const DISPATCH_SUBTASKS_TOOL: AIToolDefinition = {
+  name: 'dispatch_subtasks',
+  description: [
+    'Dispatch a batch of parallel sub-tasks for investigation. Each sub-task runs as a',
+    'focused mini-agent with its own tool loop. After all sub-tasks complete, their',
+    'summaries are returned to you as a tool_result so you can plan the next iteration.',
+    'Use this instead of attempting to investigate everything yourself — sub-tasks have',
+    'direct tool access and can write findings to the knowledge doc via kd_* tools.',
+  ].join(' '),
+  input_schema: {
+    type: 'object',
+    properties: {
+      subtasks: {
+        type: 'array',
+        description: 'Array of sub-task descriptors. Run in parallel; max 5 per dispatch.',
+        items: {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              description: 'Short identifier for this sub-task (e.g. "st-1", "deadlock-investigation"). Used in the result to correlate summaries.',
+            },
+            intent: {
+              type: 'string',
+              description: [
+                'Clear, specific goal for this sub-task (1-3 sentences).',
+                'Be precise: include system names, time ranges, query patterns, or error codes',
+                'so the sub-task can issue targeted tool calls immediately.',
+              ].join(' '),
+            },
+            tools: {
+              type: 'array',
+              items: { type: 'string' },
+              description: [
+                'Exact tool names this sub-task should use (copy from the Available Tools list).',
+                'Always include platform__kd_add_subsection if the sub-task should record findings.',
+                'Leave empty to give the sub-task access to all available tools.',
+              ].join(' '),
+            },
+            contextKdSectionKeys: {
+              type: 'array',
+              items: { type: 'string' },
+              description: [
+                'KD section keys to pre-load as context for this sub-task',
+                '(e.g. ["problemStatement", "evidence.prior-investigation"]).',
+                'The runner reads these sections and includes them in the sub-task\'s user prompt.',
+                'The sub-task can also call kd_read_section itself if it needs more.',
+              ].join(' '),
+            },
+            model: {
+              type: 'string',
+              enum: ['haiku', 'sonnet', 'opus'],
+              description: 'Model tier for this sub-task. Use haiku for simple data gathering, sonnet for moderate analysis, opus for complex reasoning.',
+            },
+          },
+          required: ['id', 'intent'],
+        },
+      },
+    },
+    required: ['subtasks'],
+  },
+};
+
+/**
+ * Tool added to the strategist's tool list. The strategist emits this when the
+ * investigation is complete and it is ready to provide a final executive summary.
+ */
+export const COMPLETE_ANALYSIS_TOOL: AIToolDefinition = {
+  name: 'complete_analysis',
+  description: [
+    'Call when the investigation is complete and you have a final conclusion.',
+    'The executive summary you provide here will be combined with the knowledge document',
+    '(Problem Statement, Root Cause, Recommended Fix, Risks) to produce the final analysis.',
+    'Include a ---SUFFICIENCY--- block at the end of the finalAnalysis if you have enough',
+    'information to propose a resolution plan (or if you need user input).',
+  ].join(' '),
+  input_schema: {
+    type: 'object',
+    properties: {
+      finalAnalysis: {
+        type: 'string',
+        description: [
+          'Concise executive summary of findings (markdown). Keep it focused — the detail',
+          'belongs in the knowledge doc sections (Root Cause, Recommended Fix, Risks, etc.).',
+          'Optionally include a ---SUFFICIENCY--- block at the end.',
+        ].join(' '),
+      },
+    },
+    required: ['finalAnalysis'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-task run result — returned from the stateful loop per sub-task
+// ---------------------------------------------------------------------------
+
+export const SubTaskStopReason = {
+  FINALIZED: 'FINALIZED',
+  NO_TOOL_USE_ENDED: 'NO_TOOL_USE_ENDED',
+  BUDGET_EXHAUSTED: 'BUDGET_EXHAUSTED',
+  TOOL_NOT_SUPPORTED: 'TOOL_NOT_SUPPORTED',
+  ERROR: 'ERROR',
+} as const;
+export type SubTaskStopReason = (typeof SubTaskStopReason)[keyof typeof SubTaskStopReason];
+
+export interface SubTaskRunResult {
+  /** Short ID provided by the strategist in dispatch_subtasks (e.g. "st-1"). */
+  subTaskId: string;
+  /** The intent string from the dispatch_subtasks call. */
+  intent: string;
+  /** Distilled summary from finalize_subtask.summary, or a fallback message. */
+  summary: string;
+  /** KD section keys written during this sub-task (from finalize_subtask.updatedKdSections). */
+  updatedKdSections: string[];
+  /** Number of model iterations consumed. */
+  iterationsUsed: number;
+  /** Total tokens used (input + output) by this sub-task. */
+  tokensUsed: number;
+  /** Why the sub-task loop exited. */
+  stopReason: SubTaskStopReason;
+  /** Total input tokens for budget/accounting. */
+  inputTokens: number;
+  /** Total output tokens for budget/accounting. */
+  outputTokens: number;
+  /** Raw tool call log entries for telemetry. */
+  toolCalls: Array<{ tool: string; system?: string; input: Record<string, unknown>; output: string; durationMs: number }>;
+}

--- a/services/ticket-analyzer/src/analysis/v2-subtask-tools.ts
+++ b/services/ticket-analyzer/src/analysis/v2-subtask-tools.ts
@@ -79,6 +79,7 @@ export const DISPATCH_SUBTASKS_TOOL: AIToolDefinition = {
       subtasks: {
         type: 'array',
         description: 'Array of sub-task descriptors. Run in parallel; max 5 per dispatch.',
+        maxItems: 5,
         items: {
           type: 'object',
           properties: {


### PR DESCRIPTION
## Summary

Restructures the orchestrated-v2 analysis runner so agents can actually reason about tool results. Root cause of the stuck-loop behavior we symptom-fixed in #371.

**Two gaps the earlier runner had:**
- Sub-tasks called `generateWithTools` once, executed tools, but never fed results back to the model — a one-shot call pretending to be a loop
- Strategist used `ai.generate()` (no tools) and only received a prompt string between iterations — couldn't read the knowledge doc it was asking about

**What this PR does:**

### Sub-tasks become focused mini-agents

Each sub-task now runs a stateful `generateWithTools` loop (pattern matches `flat-v2.ts:152-266`) with scoped context, explicit termination, and a per-sub-task budget:
- **Intent** — one-paragraph mission from the strategist
- **Context pack** — strategist-picked KD section keys injected into the sub-task's user prompt (sub-task can still call `kd_read_section` if it needs more)
- **Budget** — 8 iterations, 50k tokens, 20 tool calls per sub-task (configurable via constants `SUB_TASK_ITERATION_CAP` / `SUB_TASK_TOKEN_BUDGET` / `SUB_TASK_CALL_BUDGET`). Token usage read from `response.usage.inputTokens + outputTokens` — no invented fallback counter
- **Completion** — sub-task emits `finalize_subtask` with `{ summary, updatedKdSections[] }`. Budget exhaustion returns `stopReason: 'BUDGET_EXHAUSTED'` with partial summary

### Strategist gets tool access

Strategist now uses `ai.generateWithTools()` with `platform__kd_read_toc`, `platform__kd_read_section`, `platform__read_tool_result_artifact`, plus two new control tools:
- `dispatch_subtasks` — strategist emits with `[{ intent, contextKdSectionKeys, toolAllowlist? }, ...]`
- `complete_analysis` — strategist emits with a final executive summary when ready to stop

Sub-task results come back as a structured `tool_result` block for the `dispatch_subtasks` call (well-formed conversation threading), so the strategist sees `[{ sub_task_id, intent, summary, updatedKdSections, stopReason }, ...]` and can `kd_read_section` the listed sections before planning the next batch.

### Parallel isolation preserved

Sub-tasks within one dispatch batch run in parallel with no sibling cross-pollination. If cross-context is needed, the strategist dispatches a follow-up sub-task explicitly. Matches the original architecture.

### Stall guard ported from #371

The stall-guard was merged in #371 against the old loop structure. Reconciled into the new architecture:
- All 3 rules preserved (2-consecutive-no-progress, 3-consecutive-same-hash, zero KD writes after iteration 3)
- One semantically correct adaptation: response hash now computes from `JSON.stringify(plan.subtasks)` instead of text response (strategist emits tool calls now, not text — same detector, new signal)
- `KD_WRITE_TOOL_NAMES`, `countKdWrites`, `StallState`, `updateStallState`, `writeStallMarker`, `NO_STALL_SYSTEM_PROMPT_SNIPPET` all in place
- Per-sub-task budgets bound runaway sub-tasks; stall-guard catches stuck *strategist* (repeated identical dispatch plans)

### Files touched

`orchestrated-v2.ts` +1302/-354, new `v2-subtask-tools.ts` (193 lines, 3 tool defs). `flat-v2.ts`, `flat-v1.ts`, `orchestrated-v1.ts`, `shared.ts` — untouched (parallel-file rule).

Fixes #377.

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: replay ticket `cbcc4dde-65f2-4edb-a2fe-95a986d936e2` (Altman Plants deadlock probe) via Retry Analysis — expected: strategist converges in ≤5 iterations, sub-tasks call multiple tools each and `finalize_subtask` with real summaries, `rootCause` KD section is populated with real findings (not the fallback/stall marker)
- [ ] Inspect `ai_usage_logs` for the replayed ticket — strategist calls should show multiple tool-use turns (kd_read_* + dispatch_subtasks); sub-task calls should show internal iteration counts > 1 where they actually investigated
- [ ] Pick a ticket that previously produced an empty `rootCause` under the old runner and confirm the replayed run now has content
- [ ] Confirm `platform__read_tool_result_artifact` is called at least once across a representative replay (agents drilling into large tool results)
- [ ] Stall-guard sanity: construct a ticket whose analysis would loop (tight KD without forward-movable findings) — confirm the stall marker still writes `⚠️ Orchestrator stalled at iteration N: …` into `rootCause`
- [ ] Check Analysis Trace tab for a post-fix ticket — tree should render strategist → dispatch_subtasks → sub-task internal iterations cleanly (existing three-pass merge should handle it, eyeball for regressions)

## Follow-ups uncovered (not in this PR)

- `ORCHESTRATED_SYSTEM_PROMPT` (in `shared.ts`) still describes the old JSON plan format and gets concatenated onto the new strategist system prompt. Low-risk because the new tool descriptions dominate, but worth retiring/overriding cleanly in a cleanup PR
- `resolveTaskTools` fuzzy-retry logic in `orchestrated-v2.ts` is less needed now that the strategist specifies exact tool names via `dispatch_subtasks` — could be simplified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
