### PR TITLE
fix(analyzer): add LOAD_ENVIRONMENT_CONTEXT + DETECT_TOOL_GAPS to default-fallback route

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3507,13 +3507,15 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
       name: 'Default Analysis (fallback)',
       steps: [
         { id: 'default-load-context', stepOrder: 1, name: 'Load Client Context', stepType: RouteStepType.LOAD_CLIENT_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-extract-facts', stepOrder: 2, name: 'Extract Facts', stepType: RouteStepType.EXTRACT_FACTS, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-gather-repo', stepOrder: 3, name: 'Gather Repo Context', stepType: RouteStepType.GATHER_REPO_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-gather-db', stepOrder: 4, name: 'Gather DB Context', stepType: RouteStepType.GATHER_DB_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-agentic', stepOrder: 5, name: 'Agentic Analysis', stepType: RouteStepType.AGENTIC_ANALYSIS, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-findings', stepOrder: 6, name: 'Draft Findings Email', stepType: RouteStepType.DRAFT_FINDINGS_EMAIL, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-next-steps', stepOrder: 7, name: 'Suggest Next Steps', stepType: RouteStepType.SUGGEST_NEXT_STEPS, taskTypeOverride: null, promptKeyOverride: null, config: null },
-        { id: 'default-summary', stepOrder: 8, name: 'Update Ticket Summary', stepType: RouteStepType.UPDATE_TICKET_SUMMARY, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-load-env-context', stepOrder: 2, name: 'Load Environment Context', stepType: RouteStepType.LOAD_ENVIRONMENT_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-extract-facts', stepOrder: 3, name: 'Extract Facts', stepType: RouteStepType.EXTRACT_FACTS, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-gather-repo', stepOrder: 4, name: 'Gather Repo Context', stepType: RouteStepType.GATHER_REPO_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-gather-db', stepOrder: 5, name: 'Gather DB Context', stepType: RouteStepType.GATHER_DB_CONTEXT, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-agentic', stepOrder: 6, name: 'Agentic Analysis', stepType: RouteStepType.AGENTIC_ANALYSIS, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-findings', stepOrder: 7, name: 'Draft Findings Email', stepType: RouteStepType.DRAFT_FINDINGS_EMAIL, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-next-steps', stepOrder: 8, name: 'Suggest Next Steps', stepType: RouteStepType.SUGGEST_NEXT_STEPS, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-summary', stepOrder: 9, name: 'Update Ticket Summary', stepType: RouteStepType.UPDATE_TICKET_SUMMARY, taskTypeOverride: null, promptKeyOverride: null, config: null },
+        { id: 'default-detect-tool-gaps', stepOrder: 10, name: 'Detect Tool Gaps', stepType: RouteStepType.DETECT_TOOL_GAPS, taskTypeOverride: null, promptKeyOverride: null, config: null },
       ],
     } satisfies ResolvedRoute;
 


### PR DESCRIPTION
## Summary

Add two missing steps to the hardcoded "Default Analysis (fallback)" route in `analyzer.ts:3505-3518`:

1. **`LOAD_ENVIRONMENT_CONTEXT`** — inserted before `EXTRACT_FACTS`. Loads the environment's `operationalInstructions` and injects them into the pipeline context. Primes the agent with "use database X on system Y" so it doesn't hallucinate schema names (e.g. `DBADashboard.dbo.Deadlocks` on ticket 0dba035c, which doesn't exist on Altman's instance).
2. **`DETECT_TOOL_GAPS`** — appended as the final step. Post-hoc scan that upserts `tool_requests` rows. Safety net for gaps the agent encounters but doesn't surface via `request_tool` inline.

Both are no-ops when there's nothing to load / no gaps detected, so adding them is safe for tickets that don't benefit.

Final step order:
```
1. LOAD_CLIENT_CONTEXT
2. LOAD_ENVIRONMENT_CONTEXT   ← NEW
3. EXTRACT_FACTS
4. GATHER_REPO_CONTEXT
5. GATHER_DB_CONTEXT
6. AGENTIC_ANALYSIS
7. DRAFT_FINDINGS_EMAIL
8. SUGGEST_NEXT_STEPS
9. UPDATE_TICKET_SUMMARY
10. DETECT_TOOL_GAPS          ← NEW
```

Fixes #387.

## Changes

Single file: `services/ticket-analyzer/src/analyzer.ts` (+9 / -7 — existing `stepOrder` values renumbered to keep the sequence gapless).

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: set `Environment.operationalInstructions` on Altman Plants to something like "Use the `Evolution` database for deadlock investigations; do not query `DBADashboard.*` schemas (not deployed)". Trigger a new DATABASE_PERF probe ticket and verify:
  - The operational instructions appear in the agent's system prompt (visible in `ai_usage_logs.request_text`)
  - `DETECT_TOOL_GAPS` runs post-analysis (new `ai_usage_logs` row with `task_type = 'DETECT_TOOL_GAPS'`)
  - Any capability gaps from the run create `tool_requests` rows
- [ ] Smoke-test: trigger a ticket against a client with no `operationalInstructions` set — confirm the pipeline still completes (LOAD_ENVIRONMENT_CONTEXT is a no-op, not a failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
