### PR TITLE
fix(analyzer): skip UPDATE_ANALYSIS on system-authored comments

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3422,12 +3422,27 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
           });
           triggerReplyText = triggerEvent?.content ?? '';
         }
-        // If no trigger event found, use the most recent inbound email, comment, or chat message
+        // If no trigger event found, use the most recent inbound email, comment, or chat message.
+        // Skip system-authored events (actor prefix 'system:') — these are auto-posted findings
+        // comments or recommendation notes that should never be treated as a user reply (#384).
         if (!triggerReplyText) {
           const latestReply = conversationHistory
-            .filter((e) => e.eventType === 'EMAIL_INBOUND' || e.eventType === 'COMMENT' || e.eventType === 'CHAT_MESSAGE')
+            .filter((e) => (e.eventType === 'EMAIL_INBOUND' || e.eventType === 'COMMENT' || e.eventType === 'CHAT_MESSAGE') && !e.actor?.startsWith('system:'))
             .pop();
-          triggerReplyText = latestReply?.content ?? '';
+          if (!latestReply) {
+            appLog.info(
+              'Re-analysis skipped — no non-system trigger event found (most recent reply is system-authored)',
+              { ticketId },
+              ticketId,
+              'ticket',
+            );
+            await deps.db.ticket.update({
+              where: { id: ticketId },
+              data: { analysisStatus: AnalysisStatus.COMPLETED, analysisError: null, lastAnalyzedAt: new Date() },
+            });
+            return;
+          }
+          triggerReplyText = latestReply.content ?? '';
         }
         const reanalysisContext: ReanalysisContext = {
           conversationHistory: formatConversationHistory(conversationHistory),

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3423,11 +3423,12 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
           triggerReplyText = triggerEvent?.content ?? '';
         }
         // If no trigger event found, use the most recent inbound email, comment, or chat message.
-        // Skip system-authored events (actor prefix 'system:') — these are auto-posted findings
-        // comments or recommendation notes that should never be treated as a user reply (#384).
+        // Skip system-authored events (bare 'system' default or 'system:*' prefix) — these are
+        // auto-posted findings comments or recommendation notes that should never be treated as
+        // a user reply (#384).
         if (!triggerReplyText) {
           const latestReply = conversationHistory
-            .filter((e) => (e.eventType === 'EMAIL_INBOUND' || e.eventType === 'COMMENT' || e.eventType === 'CHAT_MESSAGE') && !e.actor?.startsWith('system:'))
+            .filter((e) => (e.eventType === 'EMAIL_INBOUND' || e.eventType === 'COMMENT' || e.eventType === 'CHAT_MESSAGE') && e.actor !== 'system' && !e.actor?.startsWith('system:'))
             .pop();
           if (!latestReply) {
             appLog.info(
@@ -3438,7 +3439,12 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
             );
             await deps.db.ticket.update({
               where: { id: ticketId },
-              data: { analysisStatus: AnalysisStatus.COMPLETED, analysisError: null, lastAnalyzedAt: new Date() },
+              data: {
+                analysisStatus: AnalysisStatus.COMPLETED,
+                analysisError: null,
+                lastAnalyzedAt: new Date(),
+                reanalysisCount: { decrement: 1 },
+              },
             });
             return;
           }

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1099,8 +1099,9 @@ async function maybeEnqueueReanalysis(
 
   // 5b. Author gate — skip if the most recent reply-type event (EMAIL_INBOUND or COMMENT)
   // is system-authored. This prevents a spurious UPDATE_ANALYSIS when the analyzer's own
-  // auto-posted findings comment (actor: 'system:recommendation-executor') is the last
-  // event on the ticket and the re-analysis would only "echo back" that comment (#384).
+  // auto-posted findings comment (actor: 'system:recommendation-executor' or the bare
+  // Prisma default 'system') is the last event on the ticket and the re-analysis would
+  // only "echo back" that comment (#384).
   //
   // EMAIL_INBOUND events created by RESOLVE_THREAD use actor `email:<address>` — never
   // system-prefixed — so this check only skips when no real inbound exists and the most
@@ -1111,7 +1112,7 @@ async function maybeEnqueueReanalysis(
       orderBy: { createdAt: 'desc' },
       select: { id: true, actor: true },
     });
-    if (latestReplyEvent?.actor?.startsWith('system:')) {
+    if (latestReplyEvent?.actor === 'system' || latestReplyEvent?.actor?.startsWith('system:')) {
       log.info(
         { ticketId, actor: latestReplyEvent.actor, eventId: latestReplyEvent.id },
         'Most recent reply event is system-authored — skipping UPDATE_ANALYSIS enqueue (#384)',

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1097,6 +1097,29 @@ async function maybeEnqueueReanalysis(
     select: { id: true },
   });
 
+  // 5b. Author gate — skip if the most recent reply-type event (EMAIL_INBOUND or COMMENT)
+  // is system-authored. This prevents a spurious UPDATE_ANALYSIS when the analyzer's own
+  // auto-posted findings comment (actor: 'system:recommendation-executor') is the last
+  // event on the ticket and the re-analysis would only "echo back" that comment (#384).
+  //
+  // EMAIL_INBOUND events created by RESOLVE_THREAD use actor `email:<address>` — never
+  // system-prefixed — so this check only skips when no real inbound exists and the most
+  // recent COMMENT is from the system itself.
+  if (!triggerEvent) {
+    const latestReplyEvent = await db.ticketEvent.findFirst({
+      where: { ticketId, eventType: { in: ['EMAIL_INBOUND', 'COMMENT'] } },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, actor: true },
+    });
+    if (latestReplyEvent?.actor?.startsWith('system:')) {
+      log.info(
+        { ticketId, actor: latestReplyEvent.actor, eventId: latestReplyEvent.id },
+        'Most recent reply event is system-authored — skipping UPDATE_ANALYSIS enqueue (#384)',
+      );
+      return;
+    }
+  }
+
   // All conditions met — enqueue re-analysis with a unique, timestamped ID
   // so BullMQ cannot silently collapse this into a previously completed job.
   const reanalysisJobId = `reanalysis-${ticketId}-${Date.now()}`;


### PR DESCRIPTION
## Summary

Gate `UPDATE_ANALYSIS` (delta re-analysis) on comment-author type so the analyzer's own auto-posted findings comment doesn't trigger a spurious re-run against itself.

Observed on ticket `0dba035c-8cef-40cd-8a70-228e400ce958` (Altman Plants, 2026-04-23 17:52:46→17:53:01): auto-posted findings comment fired `UPDATE_ANALYSIS` within 3 seconds. The delta run self-diagnosed (*"system echoing back its own comment"*) but only after burning a full Opus call (~$0.03) and flipping status `OPEN → WAITING`. Across all probe-triggered tickets this adds up.

Uses existing `TicketEvent.actor` field (Prisma schema: `String @default("system")`) with the established convention `system:<subsystem>` (e.g. `system:recommendation-executor`, `system:analyzer`). Email replies use `email:<address>`, operator/client actions use their own prefixes — real replies still trigger re-analysis as designed.

Fixes #384.

## Changes — defense in depth

1. **Primary gate in `services/ticket-analyzer/src/ingestion-engine.ts`** — at the enqueue site, when no `EMAIL_INBOUND` is present and the fallback looks at the most recent `COMMENT`, check if the actor starts with `system:` and skip the enqueue entirely (log at INFO).

2. **Secondary defense in `services/ticket-analyzer/src/analyzer.ts`** (`createAnalysisProcessor`) — if a re-analysis job is already enqueued and the fallback trigger-text selection would pick a system-authored event, filter those out. If nothing remains, mark `analysisStatus: COMPLETED` and return without calling Claude. Catches any path that bypassed the primary gate.

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: trigger a new probe-sourced ticket on Altman Plants. Watch events:
  - Findings auto-post at time T
  - Expected: no subsequent `AI_ANALYSIS` event within 30s after T
  - Status should settle at `OPEN` (or whatever sufficiency eval returned from the main analysis), NOT `WAITING`
- [ ] Real-reply regression test: have someone post a genuine operator/client comment on a ticket (via UI or email) and confirm `UPDATE_ANALYSIS` still fires correctly
- [ ] `ai_usage_logs` across the next 24h post-deploy should show fewer same-day duplicate `UPDATE_ANALYSIS` entries per ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)
