### PR TITLE
refactor(control-panel): reorganize Settings page — group cards by function

### DIFF
--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -41,7 +41,7 @@ import {
 import type { CronSchedulerValue } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
-const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis Strategy', 'Self Analysis', 'SMTP', 'Azure DevOps', 'GitHub', 'IMAP', 'Slack', 'Prompt Retention'] as const;
+const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis', 'Integrations'] as const;
 
 @Component({
   standalone: true,
@@ -73,7 +73,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
         <!-- General tab -->
         <app-tab label="General">
           <div class="tab-content">
-            <p class="hint" style="padding-top:8px;">General settings are managed under the individual tabs (SMTP, GitHub, IMAP, etc.).</p>
+            <p class="hint" style="padding-top:8px;">General settings are managed under the individual tabs (Integrations, Analysis, etc.).</p>
           </div>
         </app-tab>
 
@@ -301,8 +301,8 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
           </div>
         </app-tab>
 
-        <!-- Analysis Strategy tab -->
-        <app-tab label="Analysis Strategy">
+        <!-- Analysis tab — Analysis Strategy, Strategy Version, Self Analysis, Tool Request Rate Limit, Prompt Retention -->
+        <app-tab label="Analysis">
           <div class="tab-content">
             <app-card>
               <h2 class="section-title">Analysis Strategy</h2>
@@ -379,12 +379,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 </div>
               }
             </app-card>
-          </div>
-        </app-tab>
 
-        <!-- Self Analysis tab -->
-        <app-tab label="Self Analysis">
-          <div class="tab-content">
             <app-card>
               <h2 class="section-title">Self Analysis</h2>
               <p class="hint">
@@ -440,11 +435,34 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 }
               }
             </app-card>
+
+            <app-card>
+              <h2 class="section-title">Tool Request Rate Limit</h2>
+              <p class="hint">Caps how often the analyzer can call <code>request_tool</code> within a single analysis run. Prevents runaway requests when an agent loops on missing capabilities.</p>
+              <div class="form-grid">
+                <app-form-field label="Maximum request_tool calls per analysis run"><input class="text-input" type="number" [(ngModel)]="toolRequestRateLimit.limit" min="1" max="100" placeholder="5"></app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="saveToolRequestRateLimit()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
+              </div>
+            </app-card>
+
+            <app-card>
+              <h2 class="section-title">Prompt Retention Policy</h2>
+              <p class="hint">Configure how long full AI prompt/response archives are retained before being summarized and deleted.</p>
+              <div class="form-grid">
+                <app-form-field label="Full prompt retention (days)"><input class="text-input" type="number" [(ngModel)]="promptRetention.fullRetentionDays" min="1" placeholder="30"></app-form-field>
+                <app-form-field label="Summary retention (days after summarization)"><input class="text-input" type="number" [(ngModel)]="promptRetention.summaryRetentionDays" min="1" placeholder="90"></app-form-field>
+              </div>
+              <div class="card-actions">
+                <app-bronco-button variant="primary" (click)="savePromptRetention()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
+              </div>
+            </app-card>
           </div>
         </app-tab>
 
-        <!-- SMTP Tab -->
-        <app-tab label="SMTP">
+        <!-- Integrations tab — SMTP, Azure DevOps, GitHub, IMAP, Slack -->
+        <app-tab label="Integrations">
           <div class="tab-content">
             <app-card>
               <h2 class="section-title">SMTP Configuration</h2>
@@ -462,12 +480,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 <app-bronco-button variant="secondary" (click)="testSmtp()" [disabled]="sysConfigTesting()">{{ sysConfigTesting() ? 'Testing...' : 'Test Connection' }}</app-bronco-button>
               </div>
             </app-card>
-          </div>
-        </app-tab>
 
-        <!-- Azure DevOps Tab -->
-        <app-tab label="Azure DevOps">
-          <div class="tab-content">
             <app-card>
               <h2 class="section-title">Azure DevOps Configuration</h2>
               <p class="hint">Configure the Azure DevOps integration for work item sync. PAT is encrypted at rest.</p>
@@ -484,12 +497,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 <app-bronco-button variant="secondary" (click)="testDevOps()" [disabled]="sysConfigTesting()">{{ sysConfigTesting() ? 'Testing...' : 'Test Connection' }}</app-bronco-button>
               </div>
             </app-card>
-          </div>
-        </app-tab>
 
-        <!-- GitHub Tab -->
-        <app-tab label="GitHub">
-          <div class="tab-content">
             <app-card>
               <h2 class="section-title">GitHub Configuration</h2>
               <p class="hint">Configure the GitHub token used for repository access and release notes. Token is encrypted at rest.</p>
@@ -499,7 +507,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               </div>
               <p class="github-scope-blurb">
                 This integration is for the Bronco app itself — release notes, automatic GitHub issue creation from tool requests, and code fetching for analysis.
-                Client-specific repositories are managed under <strong>Clients → Code Repositories</strong>.
+                Client-specific repositories are managed under <strong>Clients &#8594; Code Repositories</strong>.
               </p>
               <p class="github-scope-blurb">
                 <strong>Migration note (#368):</strong> GitHub is now a first-class Integration type. Tool-request issue creation reads from a
@@ -513,22 +521,6 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               </div>
             </app-card>
 
-            <app-card>
-              <h2 class="section-title">Tool Request Rate Limit</h2>
-              <p class="hint">Caps how often the analyzer can call <code>request_tool</code> within a single analysis run. Prevents runaway requests when an agent loops on missing capabilities.</p>
-              <div class="form-grid">
-                <app-form-field label="Maximum request_tool calls per analysis run"><input class="text-input" type="number" [(ngModel)]="toolRequestRateLimit.limit" min="1" max="100" placeholder="5"></app-form-field>
-              </div>
-              <div class="card-actions">
-                <app-bronco-button variant="primary" (click)="saveToolRequestRateLimit()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
-              </div>
-            </app-card>
-          </div>
-        </app-tab>
-
-        <!-- IMAP Tab -->
-        <app-tab label="IMAP">
-          <div class="tab-content">
             <app-card>
               <h2 class="section-title">IMAP Configuration</h2>
               <p class="hint">Configure the IMAP server used for polling inbound emails. Password is encrypted at rest.</p>
@@ -544,12 +536,7 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
                 <app-bronco-button variant="secondary" (click)="testImap()" [disabled]="sysConfigTesting()">{{ sysConfigTesting() ? 'Testing...' : 'Test Connection' }}</app-bronco-button>
               </div>
             </app-card>
-          </div>
-        </app-tab>
 
-        <!-- Slack Tab -->
-        <app-tab label="Slack">
-          <div class="tab-content">
             <app-card>
               <h2 class="section-title">Slack Configuration</h2>
               <p class="hint">Configure Slack integration for operator notifications via Socket Mode. Tokens are encrypted at rest.</p>
@@ -564,23 +551,6 @@ const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External
               <div class="card-actions">
                 <app-bronco-button variant="primary" (click)="saveSlackConfig()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
                 <app-bronco-button variant="secondary" (click)="testSlackConfig()" [disabled]="sysConfigTesting()">{{ sysConfigTesting() ? 'Testing...' : 'Test Connection' }}</app-bronco-button>
-              </div>
-            </app-card>
-          </div>
-        </app-tab>
-
-        <!-- Prompt Retention Tab -->
-        <app-tab label="Prompt Retention">
-          <div class="tab-content">
-            <app-card>
-              <h2 class="section-title">Prompt Retention Policy</h2>
-              <p class="hint">Configure how long full AI prompt/response archives are retained before being summarized and deleted.</p>
-              <div class="form-grid">
-                <app-form-field label="Full prompt retention (days)"><input class="text-input" type="number" [(ngModel)]="promptRetention.fullRetentionDays" min="1" placeholder="30"></app-form-field>
-                <app-form-field label="Summary retention (days after summarization)"><input class="text-input" type="number" [(ngModel)]="promptRetention.summaryRetentionDays" min="1" placeholder="90"></app-form-field>
-              </div>
-              <div class="card-actions">
-                <app-bronco-button variant="primary" (click)="savePromptRetention()" [disabled]="sysConfigSaving()">Save</app-bronco-button>
               </div>
             </app-card>
           </div>

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -41,7 +41,52 @@ import {
 import type { CronSchedulerValue } from '../../shared/components/index.js';
 import { ToastService } from '../../core/services/toast.service.js';
 
-const TAB_LABELS = ['General', 'Ticket Statuses', 'Ticket Categories', 'External Services', 'Action Safety', 'Analysis', 'Integrations'] as const;
+const TAB_LABELS = [
+  'General',
+  'Ticket Statuses',
+  'Ticket Categories',
+  'External Services',
+  'Action Safety',
+  'Analysis',
+  'Integrations',
+] as const;
+
+const TAB_SLUGS = [
+  'general',
+  'ticket-statuses',
+  'ticket-categories',
+  'external-services',
+  'action-safety',
+  'analysis',
+  'integrations',
+] as const satisfies readonly string[];
+
+/** Old tab slugs from before the Settings reorganization (PR #389). Maps old slug → new canonical slug. */
+const LEGACY_TAB_SLUGS: Readonly<Record<string, (typeof TAB_SLUGS)[number]>> = {
+  'analysis-strategy': 'analysis',
+  'self-analysis': 'analysis',
+  'prompt-retention': 'analysis',
+  'tool-request-rate-limit': 'analysis',
+  smtp: 'integrations',
+  'azure-dev-ops': 'integrations',
+  github: 'integrations',
+  imap: 'integrations',
+  slack: 'integrations',
+} as const;
+
+function resolveTabSlug(tab: string | null | undefined): (typeof TAB_SLUGS)[number] | null {
+  if (!tab) return null;
+  const normalized = tab.trim().toLowerCase();
+  const canonical = LEGACY_TAB_SLUGS[normalized] ?? normalized;
+  return (TAB_SLUGS as readonly string[]).includes(canonical)
+    ? (canonical as (typeof TAB_SLUGS)[number])
+    : null;
+}
+
+function getTabIndexFromSlug(tab: string | null | undefined): number {
+  const resolved = resolveTabSlug(tab);
+  return resolved ? TAB_SLUGS.indexOf(resolved) : 0;
+}
 
 @Component({
   standalone: true,
@@ -846,9 +891,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const tabSlug = this.route.snapshot.queryParamMap.get('tab');
-    if (tabSlug) {
-      const idx = TAB_LABELS.findIndex(l => this.toSlug(l) === tabSlug);
-      if (idx >= 0) this.selectedTab.set(idx);
+    if (tabSlug && resolveTabSlug(tabSlug) !== null) {
+      this.selectedTab.set(getTabIndexFromSlug(tabSlug));
     }
     this.loadServices();
     this.loadStatuses();
@@ -886,17 +930,13 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   onTabChange(index: number): void {
     this.selectedTab.set(index);
-    const slug = this.toSlug(TAB_LABELS[index] ?? '');
+    const slug = TAB_SLUGS[index] ?? null;
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: { tab: slug || null },
+      queryParams: { tab: slug },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
-  }
-
-  private toSlug(label: string): string {
-    return label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
   }
 
   loadServices(): void {


### PR DESCRIPTION
## Summary

Reorganize the Settings page to group cards by **function**, not by historical PR. The motivating case: **Tool Request Rate Limit** was parked on the **GitHub tab** (where tool-request issue creation was the first consumer), but it's an agent-behavior setting — an operator looking for analyzer settings would never check GitHub.

Consolidated 13 tabs → **7 functional groupings**. Pure UI reorganization — backend endpoints, persisted keys, save semantics, and role gating all unchanged.

### Final tab structure

| Tab | Cards |
|---|---|
| **General** | Placeholder hint text updated to reference new tab names |
| **Ticket Statuses** | Status config data table |
| **Ticket Categories** | Category config data table |
| **External Services** | External services data table |
| **Action Safety** | AI Action Safety card |
| **Analysis** | Analysis Strategy, Strategy Version, Self Analysis, **Tool Request Rate Limit**, Prompt Retention |
| **Integrations** | SMTP, Azure DevOps, GitHub, IMAP, Slack |

Card count: 10 before, 10 after — all accounted for, none added or removed.

Fixes #389.

## Changes

Single file: `services/control-panel/src/app/features/settings/settings.component.ts`. `github-scope-blurb` scoped styles still resolve (component-scoped SCSS). Right-arrow character in the GitHub card's "Clients → Code Repositories" hint was converted to the `&#8594;` HTML entity (safe-in-template).

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: visit Settings in the control panel. Walk through each tab and confirm:
  - All 10 cards are present, just under new tabs
  - Saving each card still works (each `Save` button hits the same endpoint it did before)
  - Tool Request Rate Limit is now under **Analysis**
  - Admin-only cards (if any) still gate correctly
- [ ] No visual regressions — scoped SCSS still resolves, hints render, form fields work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
