### PR TITLE
fix(users): avoid redundant Operator writes when slackUserId unchanged

### DIFF
--- a/services/control-panel/src/app/features/users/user-dialog.component.ts
+++ b/services/control-panel/src/app/features/users/user-dialog.component.ts
@@ -114,7 +114,7 @@ export class UserDialogComponent {
         email: this.email,
         role: this.role,
         isActive: this.isActive,
-        ...(this.slackUserId !== undefined && { slackUserId: this.slackUserId }),
+        ...(this.slackUserId !== (u.slackUserId ?? '') && { slackUserId: this.slackUserId }),
       }).subscribe({
         next: () => {
           this.haptic.success();


### PR DESCRIPTION
## Summary

Fix a one-character-off guard that was causing every user update to write `slackUserId` regardless of whether the field changed. The update path used `this.slackUserId !== undefined` but the property is initialized to `''` (never undefined), so the guard was always true — the PATCH payload always included `slackUserId`, triggering spurious Operator writes and any `slackUserId`-change side effects (Slack worker resubscribe, etc).

Fixes #289.

## Changes

One line in `services/control-panel/src/app/features/users/user-dialog.component.ts`:

```diff
-...(this.slackUserId !== undefined && { slackUserId: this.slackUserId }),
+...(this.slackUserId !== (u.slackUserId ?? '') && { slackUserId: this.slackUserId }),
```

Now only includes `slackUserId` when it actually differs from the stored value.

The **create** path was already correct (`this.slackUserId && { ... }` — falsy guard). Only the update handler had the bug.

No backend changes. No other endpoints found with the same pattern — the `people` / `contacts` routes operate on `Person` which doesn't have `slackUserId`.

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: edit a user via the control panel, change a field that isn't `slackUserId` (name, email, etc.), save, and confirm:
  - The PATCH request body does NOT include `slackUserId`
  - No Operator update hook fires (no redundant slack worker resubscribe, no new audit row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
