### PR TITLE
fix(portal-auth): scope refresh-token revocation by clientUserId

### DIFF
--- a/packages/db/prisma/migrations/20260423000000_add_refresh_token_client_user_id/migration.sql
+++ b/packages/db/prisma/migrations/20260423000000_add_refresh_token_client_user_id/migration.sql
@@ -1,0 +1,7 @@
+-- AddColumn: PersonRefreshToken.clientUserId
+-- Nullable FK to client_users so existing OPERATOR tokens stay NULL and
+-- existing CLIENT_USER tokens (pre-fix) also stay NULL and expire naturally.
+ALTER TABLE "person_refresh_tokens" ADD COLUMN "client_user_id" UUID REFERENCES "client_users"("id") ON DELETE SET NULL;
+
+-- Index for efficient revocation lookups by clientUserId
+CREATE INDEX "person_refresh_tokens_client_user_id_idx" ON "person_refresh_tokens"("client_user_id");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -31,17 +31,20 @@ model Person {
 }
 
 model PersonRefreshToken {
-  id         String     @id @default(uuid()) @db.Uuid
-  jti        String     @unique @db.Uuid
-  personId   String     @map("person_id") @db.Uuid
-  accessType AccessType @map("access_type")
-  expiresAt  DateTime   @map("expires_at")
-  revokedAt  DateTime?  @map("revoked_at")
-  createdAt  DateTime   @default(now()) @map("created_at")
+  id           String     @id @default(uuid()) @db.Uuid
+  jti          String     @unique @db.Uuid
+  personId     String     @map("person_id") @db.Uuid
+  accessType   AccessType @map("access_type")
+  clientUserId String?    @map("client_user_id") @db.Uuid
+  expiresAt    DateTime   @map("expires_at")
+  revokedAt    DateTime?  @map("revoked_at")
+  createdAt    DateTime   @default(now()) @map("created_at")
 
-  person Person @relation(fields: [personId], references: [id], onDelete: Cascade)
+  person     Person      @relation(fields: [personId], references: [id], onDelete: Cascade)
+  clientUser ClientUser? @relation(fields: [clientUserId], references: [id], onDelete: SetNull)
 
   @@index([personId])
+  @@index([clientUserId])
   @@map("person_refresh_tokens")
 }
 
@@ -85,8 +88,9 @@ model ClientUser {
   createdAt   DateTime       @default(now()) @map("created_at")
   updatedAt   DateTime       @updatedAt @map("updated_at")
 
-  person Person @relation(fields: [personId], references: [id], onDelete: Cascade)
-  client Client @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  person         Person               @relation(fields: [personId], references: [id], onDelete: Cascade)
+  client         Client               @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  refreshTokens  PersonRefreshToken[]
 
   @@unique([personId, clientId])
   @@index([personId])

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -544,14 +544,18 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       await fastify.db.$transaction(async (tx) => {
-        await tx.clientUser.delete({ where: { id: cu.id } });
-
-        // Scope revocation to the specific ClientUser being removed so that a
-        // multi-tenant Person is not logged out of other clients.
+        // Revoke tokens BEFORE deleting the ClientUser. The FK on
+        // person_refresh_tokens.client_user_id is ON DELETE SET NULL, so
+        // deleting cu first would null out clientUserId and the updateMany
+        // below would match nothing, leaving active tokens un-revoked.
         await tx.personRefreshToken.updateMany({
           where: { clientUserId: cu.id, revokedAt: null },
           data: { revokedAt: new Date() },
         });
+
+        // Scope revocation to the specific ClientUser being removed so that a
+        // multi-tenant Person is not logged out of other clients.
+        await tx.clientUser.delete({ where: { id: cu.id } });
 
         // If Person has no remaining ClientUser AND no Operator, null the passwordHash
         // so they cannot log in even if re-added later with stale credentials.

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -546,9 +546,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       await fastify.db.$transaction(async (tx) => {
         await tx.clientUser.delete({ where: { id: cu.id } });
 
-        // Revoke active portal tokens for this client scope
+        // Scope revocation to the specific ClientUser being removed so that a
+        // multi-tenant Person is not logged out of other clients.
         await tx.personRefreshToken.updateMany({
-          where: { personId: id, accessType: 'CLIENT_USER', revokedAt: null },
+          where: { clientUserId: cu.id, revokedAt: null },
           data: { revokedAt: new Date() },
         });
 

--- a/services/copilot-api/src/routes/portal-auth.ts
+++ b/services/copilot-api/src/routes/portal-auth.ts
@@ -32,7 +32,7 @@ export async function portalAuthRoutes(fastify: FastifyInstance): Promise<void> 
     const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS);
 
     await fastify.db.personRefreshToken.create({
-      data: { jti, personId, accessType: AccessType.CLIENT_USER, expiresAt },
+      data: { jti, personId, accessType: AccessType.CLIENT_USER, clientUserId, expiresAt },
     });
 
     return signPortalRefreshToken(fastify.portalJwtSecret, personId, clientUserId, jti);

--- a/services/copilot-api/src/routes/portal-users.ts
+++ b/services/copilot-api/src/routes/portal-users.ts
@@ -214,13 +214,17 @@ export async function portalUserRoutes(fastify: FastifyInstance): Promise<void> 
       if (!cu) return reply.code(404).send({ error: 'User not found' });
 
       await fastify.db.$transaction(async (tx) => {
-        await tx.clientUser.delete({ where: { id: cu.id } });
-        // Scope revocation to the specific ClientUser being removed so that a
-        // multi-tenant Person is not logged out of other clients.
+        // Revoke tokens BEFORE deleting the ClientUser. The FK on
+        // person_refresh_tokens.client_user_id is ON DELETE SET NULL, so
+        // deleting cu first would null out clientUserId and the updateMany
+        // below would match nothing, leaving active tokens un-revoked.
         await tx.personRefreshToken.updateMany({
           where: { clientUserId: cu.id, revokedAt: null },
           data: { revokedAt: new Date() },
         });
+        // Scope revocation to the specific ClientUser being removed so that a
+        // multi-tenant Person is not logged out of other clients.
+        await tx.clientUser.delete({ where: { id: cu.id } });
 
         // If the Person has no remaining ClientUser anywhere AND no Operator
         // record, they now have no way to authenticate — but their stored

--- a/services/copilot-api/src/routes/portal-users.ts
+++ b/services/copilot-api/src/routes/portal-users.ts
@@ -215,8 +215,10 @@ export async function portalUserRoutes(fastify: FastifyInstance): Promise<void> 
 
       await fastify.db.$transaction(async (tx) => {
         await tx.clientUser.delete({ where: { id: cu.id } });
+        // Scope revocation to the specific ClientUser being removed so that a
+        // multi-tenant Person is not logged out of other clients.
         await tx.personRefreshToken.updateMany({
-          where: { personId: id, accessType: 'CLIENT_USER', revokedAt: null },
+          where: { clientUserId: cu.id, revokedAt: null },
           data: { revokedAt: new Date() },
         });
 


### PR DESCRIPTION
## Summary

Add `PersonRefreshToken.clientUserId` column and scope portal client-scoped revocations by it instead of by `{ personId, accessType: 'CLIENT_USER' }`. Today's behavior logs a multi-tenant Person out of every client when one client revokes access — zero prod impact (no multi-tenant Persons exist) but the bug class is real and Copilot flagged it during the #219 auth-unification review.

Fixes #293.

## Changes

- **Schema:** `PersonRefreshToken.clientUserId String?` + FK to `ClientUser` + index. Back-relation on `ClientUser.refreshTokens`. Nullable because OPERATOR tokens stay null, and existing CLIENT_USER tokens (issued pre-fix) stay null and expire naturally.
- **Migration:** `20260423000000_add_refresh_token_client_user_id` — additive `ALTER TABLE ADD COLUMN` + index. Safe on production-scale table at single-operator scale.
- **Issuance:** `issueRefreshToken()` in `services/copilot-api/src/routes/portal-auth.ts:35` populates `clientUserId` on new token rows.
- **Client-scoped revocation sites** (2):
  - `services/copilot-api/src/routes/portal-users.ts:218` — DELETE `/api/portal/users/:id`
  - `services/copilot-api/src/routes/people.ts:550` — DELETE `/api/people/:id`
  
  Both now filter by `{ clientUserId: cu.id, revokedAt: null }`.

## Intentionally left untouched

Four revocation sites correctly stay as-is:
- `auth.ts:156` — Operator refresh rotation (keyed by unique `jti`, already token-precise)
- `auth.ts:196` — Operator logout (`personId + accessType: OPERATOR` — global session wipe is the correct semantic for Operator logout)
- `mcp-servers/platform/src/tools/operators.ts:260` — Delete operator (same global semantic)
- `portal-auth.ts:172` — Portal refresh rotation (keyed by unique `jti`)

## Deploy note

Includes a new Prisma migration. `copilot-api` runs `prisma migrate deploy` on container start. Additive, safe.

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: `ssh hugo-app "docker exec bronco-postgres-1 psql -U bronco -d bronco -c '\d person_refresh_tokens'"` shows `client_user_id` column
- [ ] Login a portal user — confirm the new token row's `client_user_id` is populated
- [ ] Revoke a portal user via DELETE `/api/portal/users/:id` — confirm only THAT `client_user_id`'s tokens flip `revokedAt`, not all of the person's CLIENT_USER tokens
- [ ] Operator logout still revokes all operator sessions (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
