### PR TITLE
fix(tickets): scope all /api/tickets/:id/* routes to caller tenant (#407 Critical 1)

### DIFF
--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -275,8 +275,10 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
   );
 
   fastify.get<{ Params: { id: string } }>('/api/tickets/:id', async (request) => {
-    const ticket = await fastify.db.ticket.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticket = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
       include: {
         client: true,
         system: true,
@@ -448,6 +450,15 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
 
     if (!VALID_EVENT_TYPES.has(eventType)) return fastify.httpErrors.badRequest(`Invalid eventType: ${eventType}`);
 
+    // Scope guard: verify the ticket exists and belongs to the caller's tenant.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticketGuard = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
+      select: { id: true },
+    });
+    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+
     const event = await fastify.db.ticketEvent.create({
       data: {
         ticketId: request.params.id,
@@ -470,15 +481,18 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       if (category && !VALID_CATEGORIES.has(category)) return fastify.httpErrors.badRequest(`Invalid category: ${category}`);
       if (sufficiencyStatus !== undefined && sufficiencyStatus !== null && !VALID_SUFFICIENCY_STATUSES.has(sufficiencyStatus)) return fastify.httpErrors.badRequest(`Invalid sufficiencyStatus: ${sufficiencyStatus}`);
 
-      const needsExisting = request.body.status !== undefined || environmentId !== undefined || assignedOperatorId !== undefined;
-      const existing = needsExisting
-        ? await fastify.db.ticket.findUnique({ where: { id: request.params.id }, select: { status: true, clientId: true, assignedOperatorId: true } })
-        : null;
-      if (request.body.status && !existing) return fastify.httpErrors.notFound('Ticket not found');
-      if (environmentId !== undefined && !existing) return fastify.httpErrors.notFound('Ticket not found');
-      if (assignedOperatorId !== undefined && !existing) return fastify.httpErrors.notFound('Ticket not found');
+      // Scope-gated lookup: always verify the ticket exists AND belongs to the caller's tenant.
+      // Using findFirst + scopeToWhere (not findUnique) so the scope where-clause is applied
+      // atomically. Returns 404 for missing-or-out-of-scope tickets to prevent ID enumeration.
+      const scope = await resolveClientScope(request);
+      const scopeWhere = scopeToWhere(scope);
+      const existing = await fastify.db.ticket.findFirst({
+        where: { id: request.params.id, ...scopeWhere },
+        select: { status: true, clientId: true, assignedOperatorId: true },
+      });
+      if (!existing) return fastify.httpErrors.notFound('Ticket not found');
 
-      if (environmentId !== undefined && environmentId !== null && existing) {
+      if (environmentId !== undefined && environmentId !== null) {
         const env = await fastify.db.clientEnvironment.findUnique({
           where: { id: environmentId },
           select: { clientId: true },
@@ -594,8 +608,10 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
   //     show a real error rather than optimistic success.
   //   - Only write the SYSTEM_NOTE audit row AFTER the enqueue confirms.
   fastify.post<{ Params: { id: string } }>('/api/tickets/:id/reanalyze', async (request, reply) => {
-    const ticket = await fastify.db.ticket.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticket = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
       select: { id: true, clientId: true, source: true, category: true },
     });
     if (!ticket) return fastify.httpErrors.notFound('Ticket not found');
@@ -925,6 +941,15 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       return fastify.httpErrors.badRequest(`Invalid level. Must be one of: ${Object.values(LogLevel).join(', ')}`);
     }
 
+    // Scope guard: verify the ticket exists and belongs to the caller's tenant.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticketGuard = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
+      select: { id: true },
+    });
+    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+
     const where: Record<string, unknown> = {
       entityId: request.params.id,
       entityType: 'ticket',
@@ -958,6 +983,15 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     if (!Number.isFinite(take) || take < 0 || !Number.isFinite(skip) || skip < 0) {
       return fastify.httpErrors.badRequest('limit and offset must be non-negative integers');
     }
+
+    // Scope guard: verify the ticket exists and belongs to the caller's tenant.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticketGuard = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
+      select: { id: true },
+    });
+    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
 
     const [logs, total] = await Promise.all([
       fastify.db.aiUsageLog.findMany({
@@ -1006,6 +1040,15 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     if (type && !VALID_UNIFIED_TYPES.has(type)) {
       return fastify.httpErrors.badRequest(`Invalid type. Must be one of: ${[...VALID_UNIFIED_TYPES].join(', ')}`);
     }
+
+    // Scope guard: verify the ticket exists and belongs to the caller's tenant.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticketGuard = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
+      select: { id: true },
+    });
+    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
 
     const ticketId = request.params.id;
     const wantArchive = includeArchive === 'true';
@@ -1166,6 +1209,15 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
   fastify.get<{
     Params: { id: string };
   }>('/api/tickets/:id/cost-summary', async (request) => {
+    // Scope guard: verify the ticket exists and belongs to the caller's tenant.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticketGuard = await fastify.db.ticket.findFirst({
+      where: { id: request.params.id, ...scopeWhere },
+      select: { id: true },
+    });
+    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+
     const ticketId = request.params.id;
 
     const [rows, toolCallCount, totalDurationResult] = await Promise.all([
@@ -1239,8 +1291,10 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     async (request) => {
       if (!opts?.ai) return fastify.httpErrors.serviceUnavailable('AI router not available');
 
-      const ticket = await fastify.db.ticket.findUnique({
-        where: { id: request.params.id },
+      const scope = await resolveClientScope(request);
+      const scopeWhere = scopeToWhere(scope);
+      const ticket = await fastify.db.ticket.findFirst({
+        where: { id: request.params.id, ...scopeWhere },
         include: {
           client: { select: { id: true, name: true } },
           system: { select: { name: true } },

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -27,6 +27,29 @@ const VALID_SUFFICIENCY_STATUSES: Set<string> = new Set(Object.values(Sufficienc
 const VALID_LOG_LEVELS: Set<string> = new Set(Object.values(LogLevel));
 
 export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteOpts): Promise<void> {
+  /**
+   * Assert that a ticket exists and belongs to the caller's tenant.
+   * Returns the ticket's id when found, or a 404 error object for routes that
+   * only need existence + scope verification (not the full ticket row).
+   * Returns null when out-of-scope or missing (caller must return the error).
+   *
+   * Use this for routes that do NOT need additional ticket fields — they can
+   * call this first, then proceed knowing the ticket is in-scope.
+   * Routes that already load the ticket with broader selects (PATCH, reanalyze,
+   * ai-help) embed the scope check in their own findFirst/include query.
+   */
+  async function assertTicketInScope(
+    request: Parameters<typeof resolveClientScope>[0],
+    ticketId: string,
+  ): Promise<{ id: string } | null> {
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    return fastify.db.ticket.findFirst({
+      where: { id: ticketId, ...scopeWhere },
+      select: { id: true },
+    });
+  }
+
   fastify.get<{ Querystring: { clientId?: string; status?: string; category?: string; priority?: string; source?: string; analysisStatus?: string; createdFrom?: string; createdTo?: string; environmentId?: string; assignedOperatorId?: string; limit?: string; offset?: string } }>(
     '/api/tickets',
     async (request) => {
@@ -451,13 +474,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     if (!VALID_EVENT_TYPES.has(eventType)) return fastify.httpErrors.badRequest(`Invalid eventType: ${eventType}`);
 
     // Scope guard: verify the ticket exists and belongs to the caller's tenant.
-    const scope = await resolveClientScope(request);
-    const scopeWhere = scopeToWhere(scope);
-    const ticketGuard = await fastify.db.ticket.findFirst({
-      where: { id: request.params.id, ...scopeWhere },
-      select: { id: true },
-    });
-    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+    if (!await assertTicketInScope(request, request.params.id)) {
+      return fastify.httpErrors.notFound('Ticket not found');
+    }
 
     const event = await fastify.db.ticketEvent.create({
       data: {
@@ -942,13 +961,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     }
 
     // Scope guard: verify the ticket exists and belongs to the caller's tenant.
-    const scope = await resolveClientScope(request);
-    const scopeWhere = scopeToWhere(scope);
-    const ticketGuard = await fastify.db.ticket.findFirst({
-      where: { id: request.params.id, ...scopeWhere },
-      select: { id: true },
-    });
-    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+    if (!await assertTicketInScope(request, request.params.id)) {
+      return fastify.httpErrors.notFound('Ticket not found');
+    }
 
     const where: Record<string, unknown> = {
       entityId: request.params.id,
@@ -985,13 +1000,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     }
 
     // Scope guard: verify the ticket exists and belongs to the caller's tenant.
-    const scope = await resolveClientScope(request);
-    const scopeWhere = scopeToWhere(scope);
-    const ticketGuard = await fastify.db.ticket.findFirst({
-      where: { id: request.params.id, ...scopeWhere },
-      select: { id: true },
-    });
-    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+    if (!await assertTicketInScope(request, request.params.id)) {
+      return fastify.httpErrors.notFound('Ticket not found');
+    }
 
     const [logs, total] = await Promise.all([
       fastify.db.aiUsageLog.findMany({
@@ -1042,13 +1053,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     }
 
     // Scope guard: verify the ticket exists and belongs to the caller's tenant.
-    const scope = await resolveClientScope(request);
-    const scopeWhere = scopeToWhere(scope);
-    const ticketGuard = await fastify.db.ticket.findFirst({
-      where: { id: request.params.id, ...scopeWhere },
-      select: { id: true },
-    });
-    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+    if (!await assertTicketInScope(request, request.params.id)) {
+      return fastify.httpErrors.notFound('Ticket not found');
+    }
 
     const ticketId = request.params.id;
     const wantArchive = includeArchive === 'true';
@@ -1210,13 +1217,9 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     Params: { id: string };
   }>('/api/tickets/:id/cost-summary', async (request) => {
     // Scope guard: verify the ticket exists and belongs to the caller's tenant.
-    const scope = await resolveClientScope(request);
-    const scopeWhere = scopeToWhere(scope);
-    const ticketGuard = await fastify.db.ticket.findFirst({
-      where: { id: request.params.id, ...scopeWhere },
-      select: { id: true },
-    });
-    if (!ticketGuard) return fastify.httpErrors.notFound('Ticket not found');
+    if (!await assertTicketInScope(request, request.params.id)) {
+      return fastify.httpErrors.notFound('Ticket not found');
+    }
 
     const ticketId = request.params.id;
 


### PR DESCRIPTION
## Summary

Add `resolveClientScope` + `scopeToWhere` gating to all `/api/tickets/:id/*` side routes. This is Critical item 1 of 11 from #407 (Phase 2 of the #296 security audit).

**Before this PR:** any authenticated operator could read or write any ticket by ID — real IDOR-style cross-tenant access. Chat-tab was the only already-scoped exception.

Fixes #407 Critical #1.

## Scope

9 routes now gated on the caller's resolved client scope:

- `GET /api/tickets/:id` — `findFirst({ ...scopeWhere })` replaces unscoped `findUnique`
- `PATCH /api/tickets/:id` — `findFirst({ ...scopeWhere })` as unconditional guard (previously only when certain body fields were present; pure priority/category/knowledgeDoc updates had zero lookup)
- `POST /api/tickets/:id/events` — narrow scope-gated `findFirst({ select: { id: true } })` before event create
- `POST /api/tickets/:id/ai-help` — scoped `findFirst`
- `POST /api/tickets/:id/reanalyze` — scoped `findFirst`
- `GET /api/tickets/:id/logs` — narrow scope-gated guard before log query
- `GET /api/tickets/:id/ai-usage` — narrow scope-gated guard
- `GET /api/tickets/:id/unified-logs` — narrow scope-gated guard
- `GET /api/tickets/:id/cost-summary` — narrow scope-gated guard before aggregate

**404 (not 403)** on out-of-scope — prevents ticket-ID enumeration, matches the chat-tab pattern.

**Platform ADMIN + API-key callers continue to see all tickets** (`scope.type === 'all'` → empty where-clause → no change in behavior for existing users).

Chat-tab routes (`POST /chat-message`, `POST /chat-message/:eventId/pick-mode`) were already correctly scoped — no changes made there.

## What this PR does NOT do

Remaining #407 items tracked separately:

- Critical 2 — client-scoped entity route groups (systems/repos/integrations/client-memory/...) skip handler-level scope
- Critical 3 — MCP platform has no per-caller scoping
- High 4 — ADMIN role gates on `/api/system-status/control`, global `/api/settings/*` writes, `/api/ai-config` APP_WIDE writes
- High 5 — `POST /api/tickets` body `clientId` not cross-checked
- Medium 6-11 — Person mutation gate, assignedOperatorId check, artifact upload scoping, portal USER-tier actor equality, class-3 Person-include audit, class-4 findFirst ordering sweep

Each of those ships as a separate focused PR from the #407 tracker.

## Changes

Single file: `services/copilot-api/src/routes/tickets.ts` (+68/-14).

## Test plan

- [ ] CI passes on push to staging
- [ ] After merge + deploy: as ADMIN operator, confirm you can still read/write any ticket (no regression)
- [ ] When a second operator exists or a client-scoped operator is added: confirm they can only read/write tickets in their scope; out-of-scope tickets return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
