### PR TITLE
fix(auth): require ADMIN role on platform-admin surfaces (#407 High 4)

### DIFF
--- a/services/copilot-api/src/routes/ai-config.ts
+++ b/services/copilot-api/src/routes/ai-config.ts
@@ -149,7 +149,9 @@ export async function aiConfigRoutes(
 
     // APP_WIDE configs affect every client — restrict to ADMIN operators.
     // CLIENT-scoped configs are allowed for STANDARD operators within their assigned scope.
-    if (scope === 'APP_WIDE' && request.user?.role !== OperatorRole.ADMIN) {
+    // API-key callers have no request.user (trusted service-to-service); only enforce for
+    // operator-authenticated requests, consistent with the requireRole() helper contract.
+    if (scope === 'APP_WIDE' && request.user && request.user.role !== OperatorRole.ADMIN) {
       return reply.code(403).send({ error: 'APP_WIDE AI config changes require ADMIN role' });
     }
     if (!VALID_PROVIDERS.has(provider)) {
@@ -212,7 +214,9 @@ export async function aiConfigRoutes(
     }
 
     // APP_WIDE configs affect every client — restrict updates to ADMIN operators.
-    if (request.user?.role !== OperatorRole.ADMIN) {
+    // API-key callers have no request.user (trusted service-to-service); only enforce for
+    // operator-authenticated requests, consistent with the requireRole() helper contract.
+    if (request.user && request.user.role !== OperatorRole.ADMIN) {
       const existing = await fastify.db.aiModelConfig.findUnique({
         where: { id: request.params.id },
         select: { scope: true },
@@ -247,7 +251,9 @@ export async function aiConfigRoutes(
     '/api/ai-config/:id',
     async (request, reply) => {
       // APP_WIDE configs affect every client — restrict deletes to ADMIN operators.
-      if (request.user?.role !== OperatorRole.ADMIN) {
+      // API-key callers have no request.user (trusted service-to-service); only enforce for
+      // operator-authenticated requests, consistent with the requireRole() helper contract.
+      if (request.user && request.user.role !== OperatorRole.ADMIN) {
         const existing = await fastify.db.aiModelConfig.findUnique({
           where: { id: request.params.id },
           select: { scope: true },

--- a/services/copilot-api/src/routes/ai-config.ts
+++ b/services/copilot-api/src/routes/ai-config.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { TaskType, AIProvider, AppScope, TASK_APP_SCOPE } from '@bronco/shared-types';
+import { TaskType, AIProvider, AppScope, TASK_APP_SCOPE, OperatorRole } from '@bronco/shared-types';
 import { getTaskTypeDefaults } from '@bronco/ai-provider';
 import type { AIRouter, ModelConfigResolver } from '@bronco/ai-provider';
 
@@ -146,6 +146,12 @@ export async function aiConfigRoutes(
     if (!VALID_SCOPES.has(scope)) {
       return fastify.httpErrors.badRequest(`Invalid scope "${scope}". Must be APP_WIDE or CLIENT.`);
     }
+
+    // APP_WIDE configs affect every client — restrict to ADMIN operators.
+    // CLIENT-scoped configs are allowed for STANDARD operators within their assigned scope.
+    if (scope === 'APP_WIDE' && request.user?.role !== OperatorRole.ADMIN) {
+      return reply.code(403).send({ error: 'APP_WIDE AI config changes require ADMIN role' });
+    }
     if (!VALID_PROVIDERS.has(provider)) {
       return fastify.httpErrors.badRequest(`Invalid provider "${provider}". Must be LOCAL or CLAUDE.`);
     }
@@ -195,7 +201,7 @@ export async function aiConfigRoutes(
       maxTokens?: number | null;
       isActive?: boolean;
     };
-  }>('/api/ai-config/:id', async (request) => {
+  }>('/api/ai-config/:id', async (request, reply) => {
     const { provider, model, maxTokens, isActive } = request.body;
 
     if (provider && !VALID_PROVIDERS.has(provider)) {
@@ -203,6 +209,17 @@ export async function aiConfigRoutes(
     }
     if (model !== undefined && !model.trim()) {
       return fastify.httpErrors.badRequest('model cannot be empty.');
+    }
+
+    // APP_WIDE configs affect every client — restrict updates to ADMIN operators.
+    if (request.user?.role !== OperatorRole.ADMIN) {
+      const existing = await fastify.db.aiModelConfig.findUnique({
+        where: { id: request.params.id },
+        select: { scope: true },
+      });
+      if (existing?.scope === 'APP_WIDE') {
+        return reply.code(403).send({ error: 'APP_WIDE AI config changes require ADMIN role' });
+      }
     }
 
     try {
@@ -229,6 +246,17 @@ export async function aiConfigRoutes(
   fastify.delete<{ Params: { id: string } }>(
     '/api/ai-config/:id',
     async (request, reply) => {
+      // APP_WIDE configs affect every client — restrict deletes to ADMIN operators.
+      if (request.user?.role !== OperatorRole.ADMIN) {
+        const existing = await fastify.db.aiModelConfig.findUnique({
+          where: { id: request.params.id },
+          select: { scope: true },
+        });
+        if (existing?.scope === 'APP_WIDE') {
+          return reply.code(403).send({ error: 'APP_WIDE AI config changes require ADMIN role' });
+        }
+      }
+
       try {
         await fastify.db.aiModelConfig.delete({
           where: { id: request.params.id },

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -142,6 +142,11 @@ interface SettingsRouteOpts {
 }
 
 export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRouteOpts): Promise<void> {
+  // Inner preHandler for endpoints that must be restricted to ADMIN operators only.
+  // The outer operatorControlPanelGuard (applied in routes/index.ts) allows both ADMIN
+  // and STANDARD; this inner guard tightens specific routes to ADMIN-only.
+  const adminOnly = requireRole(OperatorRole.ADMIN);
+
   // ─── Ticket Statuses ───
 
   // GET /api/settings/statuses — list all status configs (auto-seed missing defaults)
@@ -416,9 +421,10 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return row.value as unknown as OperationalAlertConfig;
   });
 
-  // PUT /api/settings/operational-alerts — save alert config
+  // PUT /api/settings/operational-alerts — save alert config (ADMIN-only)
   fastify.put<{ Body: OperationalAlertConfig }>(
     '/api/settings/operational-alerts',
+    { preHandler: adminOnly },
     async (request) => {
       const parsed = operationalAlertConfigSchema.safeParse(request.body);
       if (!parsed.success) {
@@ -438,8 +444,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     },
   );
 
-  // POST /api/settings/operational-alerts/test — send a test alert email
-  fastify.post('/api/settings/operational-alerts/test', async (request) => {
+  // POST /api/settings/operational-alerts/test — send a test alert email (ADMIN-only)
+  fastify.post('/api/settings/operational-alerts/test', { preHandler: adminOnly }, async (request) => {
     // Load alert config
     const settingRow = await fastify.db.appSetting.findUnique({
       where: { key: SETTINGS_KEY_OPERATIONAL_ALERTS },
@@ -503,8 +509,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...config, password: REDACTED };
   });
 
-  // PUT /api/settings/smtp — save SMTP config
-  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/smtp', async (request) => {
+  // PUT /api/settings/smtp — save SMTP config (ADMIN-only)
+  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/smtp', { preHandler: adminOnly }, async (request) => {
     const parsed = smtpConfigSchema.safeParse(request.body);
     if (!parsed.success) {
       const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -533,8 +539,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...saved, password: REDACTED };
   });
 
-  // POST /api/settings/smtp/test — verify SMTP connectivity
-  fastify.post('/api/settings/smtp/test', async () => {
+  // POST /api/settings/smtp/test — verify SMTP connectivity (ADMIN-only)
+  fastify.post('/api/settings/smtp/test', { preHandler: adminOnly }, async () => {
     const row = await fastify.db.appSetting.findUnique({ where: { key: SETTINGS_KEY_SMTP } });
     if (!row) return fastify.httpErrors.badRequest('SMTP not configured');
 
@@ -574,8 +580,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...config, pat: REDACTED };
   });
 
-  // PUT /api/settings/devops — save DevOps config
-  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/devops', async (request) => {
+  // PUT /api/settings/devops — save DevOps config (ADMIN-only)
+  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/devops', { preHandler: adminOnly }, async (request) => {
     const parsed = devopsConfigSchema.safeParse(request.body);
     if (!parsed.success) {
       const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -604,8 +610,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...saved, pat: REDACTED };
   });
 
-  // POST /api/settings/devops/test — verify DevOps PAT + org/project access
-  fastify.post('/api/settings/devops/test', async () => {
+  // POST /api/settings/devops/test — verify DevOps PAT + org/project access (ADMIN-only)
+  fastify.post('/api/settings/devops/test', { preHandler: adminOnly }, async () => {
     const row = await fastify.db.appSetting.findUnique({ where: { key: SETTINGS_KEY_DEVOPS } });
     if (!row) return fastify.httpErrors.badRequest('Azure DevOps not configured');
 
@@ -640,8 +646,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...config, token: REDACTED };
   });
 
-  // PUT /api/settings/github — save GitHub config
-  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/github', async (request) => {
+  // PUT /api/settings/github — save GitHub config (ADMIN-only)
+  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/github', { preHandler: adminOnly }, async (request) => {
     const parsed = githubConfigSchema.safeParse(request.body);
     if (!parsed.success) {
       const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -670,8 +676,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...saved, token: REDACTED };
   });
 
-  // POST /api/settings/github/test — verify GitHub token
-  fastify.post('/api/settings/github/test', async () => {
+  // POST /api/settings/github/test — verify GitHub token (ADMIN-only)
+  fastify.post('/api/settings/github/test', { preHandler: adminOnly }, async () => {
     const row = await fastify.db.appSetting.findUnique({ where: { key: SETTINGS_KEY_GITHUB } });
     if (!row) return fastify.httpErrors.badRequest('GitHub not configured');
 
@@ -706,8 +712,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...config, password: REDACTED };
   });
 
-  // PUT /api/settings/imap — save IMAP config
-  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/imap', async (request) => {
+  // PUT /api/settings/imap — save IMAP config (ADMIN-only)
+  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/imap', { preHandler: adminOnly }, async (request) => {
     const parsed = imapConfigSchema.safeParse(request.body);
     if (!parsed.success) {
       const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -736,8 +742,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...saved, password: REDACTED };
   });
 
-  // POST /api/settings/imap/test — verify IMAP connectivity
-  fastify.post('/api/settings/imap/test', async () => {
+  // POST /api/settings/imap/test — verify IMAP connectivity (ADMIN-only)
+  fastify.post('/api/settings/imap/test', { preHandler: adminOnly }, async () => {
     const row = await fastify.db.appSetting.findUnique({ where: { key: SETTINGS_KEY_IMAP } });
     if (!row) return fastify.httpErrors.badRequest('IMAP not configured');
 
@@ -783,8 +789,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...config, botToken: REDACTED, appToken: REDACTED };
   });
 
-  // PUT /api/settings/slack — save Slack config
-  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/slack', async (request) => {
+  // PUT /api/settings/slack — save Slack config (ADMIN-only)
+  fastify.put<{ Body: Record<string, unknown> }>('/api/settings/slack', { preHandler: adminOnly }, async (request) => {
     const parsed = slackConfigSchema.safeParse(request.body);
     if (!parsed.success) {
       const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
@@ -830,8 +836,8 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return { ...saved, botToken: REDACTED, appToken: REDACTED };
   });
 
-  // POST /api/settings/slack/test — test Slack connectivity
-  fastify.post('/api/settings/slack/test', async () => {
+  // POST /api/settings/slack/test — test Slack connectivity (ADMIN-only)
+  fastify.post('/api/settings/slack/test', { preHandler: adminOnly }, async () => {
     const row = await fastify.db.appSetting.findUnique({ where: { key: SETTINGS_KEY_SLACK } });
     if (!row) return fastify.httpErrors.badRequest('Slack not configured');
 
@@ -886,9 +892,10 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
     return parsed.success ? parsed.data : DEFAULT_PROMPT_RETENTION;
   });
 
-  // PUT /api/settings/prompt-retention — save prompt retention config
+  // PUT /api/settings/prompt-retention — save prompt retention config (ADMIN-only)
   fastify.put<{ Body: { fullRetentionDays?: number; summaryRetentionDays?: number } }>(
     '/api/settings/prompt-retention',
+    { preHandler: adminOnly },
     async (request) => {
       const parsed = promptRetentionSchema.safeParse(request.body);
       if (!parsed.success) {
@@ -915,11 +922,6 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
   });
 
   const DEFAULT_TOOL_REQUEST_RATE_LIMIT = { limit: 5 };
-
-  // These endpoints touch admin-only surface (Gap Requests triage + GitHub PAT usage),
-  // so gate them with ADMIN-only preHandlers instead of relying on the outer
-  // operatorControlPanelGuard which allows STANDARD operators as well.
-  const adminOnly = requireRole(OperatorRole.ADMIN);
 
   // GET /api/settings/tool-request-rate-limit — max `request_tool` calls per analysis run
   fastify.get(

--- a/services/copilot-api/src/routes/system-status.ts
+++ b/services/copilot-api/src/routes/system-status.ts
@@ -1,8 +1,9 @@
 import type { FastifyInstance } from 'fastify';
 import { createLogger, decrypt, looksEncrypted } from '@bronco/shared-utils';
-import { ExternalServiceCheckType, IntegrationType } from '@bronco/shared-types';
+import { ExternalServiceCheckType, IntegrationType, OperatorRole } from '@bronco/shared-types';
 import { normalizeUrl } from '../services/mcp-discovery.js';
 import { sendRedisCommand } from '../services/redis.js';
+import { requireRole } from '../plugins/auth.js';
 import type { Config } from '../config.js';
 
 const logger = createLogger('system-status');
@@ -864,13 +865,13 @@ export async function systemStatusRoutes(
     };
   });
 
-  // POST /api/system-status/control — start/stop/restart a Docker service
+  // POST /api/system-status/control — start/stop/restart a Docker service (ADMIN-only)
   fastify.post<{
     Body: {
       service: string;
       action: 'start' | 'stop' | 'restart';
     };
-  }>('/api/system-status/control', async (request, reply) => {
+  }>('/api/system-status/control', { preHandler: requireRole(OperatorRole.ADMIN) }, async (request, reply) => {
     const { service, action } = request.body;
 
     // Whitelist of controllable Docker Compose services


### PR DESCRIPTION
## Summary

Tighten role guards on platform-admin surfaces that were reachable by STANDARD operators. Part of #407 Phase 2 (High item 4).

Fixes #407 High #4.

## Changes — 3 files

**`system-status.ts`**
- `POST /api/system-status/control` — now `preHandler: requireRole(OperatorRole.ADMIN)`. Service restart should not be STANDARD-operator reachable.

**`settings.ts`**
- 7 global settings PUTs + their companion `/test` POSTs → ADMIN-only via a shared `adminOnly` preHandler: `operational-alerts`, `smtp`, `devops`, `github`, `imap`, `slack`, `prompt-retention`
- Already ADMIN-only (correctly skipped): `tool-request-rate-limit`, `analysis-strategy-version`
- Explicitly out of scope per issue body: `self-analysis` (Phase 1 doc flagged separately)

**`ai-config.ts`** — runtime check based on scope field
- `POST /api/ai-config` — if `scope === 'APP_WIDE'` and caller is not ADMIN → 403
- `PATCH /api/ai-config/:id` — fetches existing record; if `APP_WIDE` and caller is not ADMIN → 403
- `DELETE /api/ai-config/:id` — same pattern
- **CLIENT-scoped creates/updates/deletes still allowed for STANDARD operators** (they already have tenant access; this is the correct tier for per-client config)

STANDARD operators continue to have full access to per-client settings and all their tenant's data. ADMIN and API-key callers unchanged.

## Test plan

- [ ] CI passes on staging push
- [ ] Post-deploy: as STANDARD operator, confirm `POST /api/system-status/control` returns 403 (or deny via role guard)
- [ ] As STANDARD, attempting `PUT /api/settings/smtp` returns 403
- [ ] As STANDARD, `POST /api/ai-config` with `scope: 'CLIENT', clientId: <your-tenant>` still works
- [ ] As STANDARD, `POST /api/ai-config` with `scope: 'APP_WIDE'` returns 403
- [ ] As ADMIN, all of the above still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
