### PR TITLE
fix(config): scope client-config endpoints to caller tenant (#407 Critical 2 subset)

### DIFF
--- a/services/copilot-api/src/routes/client-ai-credentials.ts
+++ b/services/copilot-api/src/routes/client-ai-credentials.ts
@@ -28,13 +28,13 @@ export async function clientAiCredentialRoutes(
   }
 
   // GET /api/clients/:id/ai-credentials
-  fastify.get<{ Params: { id: string } }>('/api/clients/:id/ai-credentials', async (request) => {
+  fastify.get<{ Params: { id: string } }>('/api/clients/:id/ai-credentials', async (request, reply) => {
     const scope = await resolveClientScope(request);
     if (
       scope.type === 'single' && scope.clientId !== request.params.id ||
       scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
     ) {
-      return fastify.httpErrors.forbidden('clientId not in your scope');
+      return reply.code(403).send({ error: 'clientId not in your scope' });
     }
     const rows = await fastify.db.clientAiCredential.findMany({
       where: { clientId: request.params.id },

--- a/services/copilot-api/src/routes/client-ai-credentials.ts
+++ b/services/copilot-api/src/routes/client-ai-credentials.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { encrypt, decrypt } from '@bronco/shared-utils';
 import { AIProvider } from '@bronco/shared-types';
+import { resolveClientScope } from '../plugins/client-scope.js';
 
 /** Providers that support external API keys and can be tested over the network. */
 const BYOK_PROVIDERS = new Set<string>([AIProvider.CLAUDE, AIProvider.OPENAI, AIProvider.GROK]);
@@ -28,6 +29,13 @@ export async function clientAiCredentialRoutes(
 
   // GET /api/clients/:id/ai-credentials
   fastify.get<{ Params: { id: string } }>('/api/clients/:id/ai-credentials', async (request) => {
+    const scope = await resolveClientScope(request);
+    if (
+      scope.type === 'single' && scope.clientId !== request.params.id ||
+      scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
     const rows = await fastify.db.clientAiCredential.findMany({
       where: { clientId: request.params.id },
       orderBy: { createdAt: 'asc' },
@@ -39,6 +47,13 @@ export async function clientAiCredentialRoutes(
   fastify.post<{ Params: { id: string }; Body: { provider: string; apiKey: string; label: string } }>(
     '/api/clients/:id/ai-credentials',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       const { provider, apiKey, label } = request.body;
       if (!BYOK_PROVIDERS.has(provider)) {
         return reply.code(400).send({ error: `Invalid provider: ${provider}. Supported BYOK providers: ${[...BYOK_PROVIDERS].join(', ')}` });
@@ -61,6 +76,13 @@ export async function clientAiCredentialRoutes(
   fastify.patch<{ Params: { id: string; credId: string }; Body: { label?: string; isActive?: boolean; apiKey?: string } }>(
     '/api/clients/:id/ai-credentials/:credId',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       const { label, isActive, apiKey } = request.body;
       const data: Record<string, unknown> = {};
       if (label !== undefined) {
@@ -99,6 +121,13 @@ export async function clientAiCredentialRoutes(
   fastify.delete<{ Params: { id: string; credId: string } }>(
     '/api/clients/:id/ai-credentials/:credId',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       const result = await fastify.db.clientAiCredential.deleteMany({
         where: { id: request.params.credId, clientId: request.params.id },
       });
@@ -111,6 +140,13 @@ export async function clientAiCredentialRoutes(
   fastify.post<{ Params: { id: string; credId: string } }>(
     '/api/clients/:id/ai-credentials/:credId/test',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       const cred = await fastify.db.clientAiCredential.findFirst({
         where: { id: request.params.credId, clientId: request.params.id },
       });

--- a/services/copilot-api/src/routes/client-environments.ts
+++ b/services/copilot-api/src/routes/client-environments.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import { resolveClientScope } from '../plugins/client-scope.js';
 
 const TAG_RE = /^[a-z0-9-]+$/;
 
@@ -11,7 +12,14 @@ export async function clientEnvironmentRoutes(fastify: FastifyInstance): Promise
   // GET /api/clients/:id/environments
   fastify.get<{ Params: { id: string } }>(
     '/api/clients/:id/environments',
-    async (request) => {
+    async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       return fastify.db.clientEnvironment.findMany({
         where: { clientId: request.params.id },
         orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
@@ -31,6 +39,13 @@ export async function clientEnvironmentRoutes(fastify: FastifyInstance): Promise
       sortOrder?: number;
     };
   }>('/api/clients/:id/environments', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    if (
+      scope.type === 'single' && scope.clientId !== request.params.id ||
+      scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+    ) {
+      return reply.code(403).send({ error: 'clientId not in your scope' });
+    }
     const { name, tag, description, operationalInstructions, isDefault, sortOrder } = request.body;
 
     const trimmedName = name?.trim();
@@ -87,6 +102,13 @@ export async function clientEnvironmentRoutes(fastify: FastifyInstance): Promise
       sortOrder?: number;
     };
   }>('/api/clients/:id/environments/:envId', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    if (
+      scope.type === 'single' && scope.clientId !== request.params.id ||
+      scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+    ) {
+      return reply.code(403).send({ error: 'clientId not in your scope' });
+    }
     const { name, tag, description, operationalInstructions, isDefault, isActive, sortOrder } = request.body;
 
     if (name !== undefined && !name.trim()) {
@@ -133,6 +155,13 @@ export async function clientEnvironmentRoutes(fastify: FastifyInstance): Promise
   fastify.delete<{ Params: { id: string; envId: string } }>(
     '/api/clients/:id/environments/:envId',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        scope.type === 'single' && scope.clientId !== request.params.id ||
+        scope.type === 'assigned' && !scope.clientIds.includes(request.params.id)
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
       // Verify the environment belongs to this client before modifying any linked resources
       const env = await fastify.db.clientEnvironment.findFirst({
         where: { id: request.params.envId, clientId: request.params.id },

--- a/services/copilot-api/src/routes/client-memory.ts
+++ b/services/copilot-api/src/routes/client-memory.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import type { ClientMemoryResolver } from '@bronco/ai-provider';
 import { MemoryType, MemorySource, TicketCategory } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 const VALID_MEMORY_TYPES = new Set(Object.values(MemoryType));
 const VALID_SOURCES = new Set(Object.values(MemorySource));
@@ -36,9 +37,19 @@ export async function clientMemoryRoutes(
     if (!parsed.success) {
       throw fastify.httpErrors.badRequest(parsed.error.errors[0]?.message ?? 'Invalid query parameters');
     }
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
     const { clientId, category, memoryType, isActive } = parsed.data;
-    const where: Record<string, unknown> = {};
-    if (clientId) where.clientId = clientId;
+    const where: Record<string, unknown> = { ...scopeWhere };
+    // If a specific clientId is requested, it must fall within the caller's scope
+    if (clientId) {
+      const allowed =
+        scope.type === 'all' ||
+        (scope.type === 'single' && scope.clientId === clientId) ||
+        (scope.type === 'assigned' && scope.clientIds.includes(clientId));
+      if (allowed) where.clientId = clientId;
+      // If not allowed, scopeWhere already constrains results; no additional filter needed
+    }
     if (category) where.category = category;
     if (memoryType) where.memoryType = memoryType;
     if (isActive !== undefined) where.isActive = isActive === 'true';
@@ -52,8 +63,9 @@ export async function clientMemoryRoutes(
 
   // Get single memory entry
   fastify.get<{ Params: { id: string } }>('/api/client-memory/:id', async (request) => {
-    const entry = await fastify.db.clientMemory.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const entry = await fastify.db.clientMemory.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
       include: { client: { select: { id: true, name: true, shortCode: true } } },
     });
     if (!entry) return fastify.httpErrors.notFound('Client memory entry not found');
@@ -77,6 +89,14 @@ export async function clientMemoryRoutes(
 
     if (!clientId || !title?.trim() || !content?.trim()) {
       return fastify.httpErrors.badRequest('clientId, title, and content are required');
+    }
+
+    const scope = await resolveClientScope(request);
+    if (
+      scope.type === 'single' && scope.clientId !== clientId ||
+      scope.type === 'assigned' && !scope.clientIds.includes(clientId)
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
     }
     if (!VALID_MEMORY_TYPES.has(memoryType as MemoryType)) {
       return fastify.httpErrors.badRequest(`Invalid memoryType. Must be one of: ${[...VALID_MEMORY_TYPES].join(', ')}`);
@@ -131,6 +151,14 @@ export async function clientMemoryRoutes(
       source?: string;
     };
   }>('/api/client-memory/:id', async (request) => {
+    // Scope guard: fetch existing entry with scope filter (404 if out of scope)
+    const scope = await resolveClientScope(request);
+    const guard = await fastify.db.clientMemory.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!guard) return fastify.httpErrors.notFound('Client memory entry not found');
+
     const { memoryType, category, source, title, content, ...rest } = request.body;
 
     if (memoryType && !VALID_MEMORY_TYPES.has(memoryType as MemoryType)) {
@@ -180,7 +208,10 @@ export async function clientMemoryRoutes(
 
   // Delete memory entry
   fastify.delete<{ Params: { id: string } }>('/api/client-memory/:id', async (request, reply) => {
-    const entry = await fastify.db.clientMemory.findUnique({ where: { id: request.params.id } });
+    const scope = await resolveClientScope(request);
+    const entry = await fastify.db.clientMemory.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+    });
     if (!entry) return fastify.httpErrors.notFound('Client memory entry not found');
 
     await fastify.db.clientMemory.delete({ where: { id: request.params.id } });

--- a/services/copilot-api/src/routes/integrations.ts
+++ b/services/copilot-api/src/routes/integrations.ts
@@ -162,7 +162,10 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
           callerScope.type === 'all' ||
           (callerScope.type === 'single' && callerScope.clientId === clientId) ||
           (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId));
-        where.clientId = clientIdAllowed ? clientId : '__none__';
+        if (!clientIdAllowed) {
+          return fastify.httpErrors.forbidden('Requested clientId is outside your scope');
+        }
+        where.clientId = clientId;
       } else if (scope === 'platform') {
         where.clientId = null;
       } else if (scope === 'client') {
@@ -327,6 +330,10 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
       select: { type: true, config: true, clientId: true },
     });
     if (!existing) return fastify.httpErrors.notFound('Integration not found');
+    // Platform-scoped integrations are shared infrastructure — only ADMIN/API-key callers may mutate them.
+    if (existing.clientId === null && callerScope.type !== 'all') {
+      return fastify.httpErrors.forbidden('Platform-scoped integrations can only be modified by global administrators');
+    }
     const existingType = existing.type;
     const existingClientId = existing.clientId;
 
@@ -396,9 +403,13 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
         ] };
     const integration = await fastify.db.clientIntegration.findFirst({
       where: { id: request.params.id, ...scopeFilter },
-      select: { id: true, type: true },
+      select: { id: true, type: true, clientId: true },
     });
     if (!integration) return fastify.httpErrors.notFound('Integration not found');
+    // Platform-scoped integrations are shared infrastructure — only ADMIN/API-key callers may trigger operational actions.
+    if (integration.clientId === null && callerScope.type !== 'all') {
+      return fastify.httpErrors.forbidden('Only admin callers can verify platform-scoped integrations');
+    }
     if (integration.type !== IntegrationType.MCP_DATABASE) {
       return fastify.httpErrors.badRequest('Verification is only supported for MCP_DATABASE integrations');
     }
@@ -418,9 +429,13 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
         ] };
     const integration = await fastify.db.clientIntegration.findFirst({
       where: { id: request.params.id, ...scopeFilter },
-      select: { id: true, type: true },
+      select: { id: true, type: true, clientId: true },
     });
     if (!integration) return fastify.httpErrors.notFound('Integration not found');
+    // Platform-scoped integrations are shared infrastructure — only ADMIN/API-key callers may delete them.
+    if (integration.clientId === null && callerScope.type !== 'all') {
+      return fastify.httpErrors.forbidden('Platform-scoped integrations can only be deleted by global administrators');
+    }
 
     try {
       const deleted = await fastify.db.clientIntegration.delete({

--- a/services/copilot-api/src/routes/integrations.ts
+++ b/services/copilot-api/src/routes/integrations.ts
@@ -3,6 +3,7 @@ import type { Queue } from 'bullmq';
 import { z } from 'zod';
 import { IntegrationType } from '@bronco/shared-types';
 import { encrypt, looksEncrypted } from '@bronco/shared-utils';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 const VALID_INTEGRATION_TYPES = Object.values(IntegrationType);
 
@@ -145,16 +146,42 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
           `Invalid type. Must be one of: ${VALID_INTEGRATION_TYPES.join(', ')}`,
         );
       }
+
+      const callerScope = await resolveClientScope(request);
+
       // `scope=platform` narrows to platform-scoped (clientId IS NULL) rows.
       // `scope=client` narrows to client-scoped rows (clientId IS NOT NULL).
       // A `clientId` query param takes precedence when both are set.
+      // For scoped callers: client-scoped rows are filtered to their tenants;
+      // platform-scoped rows (clientId IS NULL) are shared infrastructure and
+      // visible to all authenticated callers.
       const where: Record<string, unknown> = {};
       if (clientId) {
-        where.clientId = clientId;
+        // Validate the requested clientId is within the caller's scope
+        const clientIdAllowed =
+          callerScope.type === 'all' ||
+          (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+          (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId));
+        where.clientId = clientIdAllowed ? clientId : '__none__';
       } else if (scope === 'platform') {
         where.clientId = null;
       } else if (scope === 'client') {
-        where.clientId = { not: null };
+        // Restrict to the caller's tenant(s) when filtering for client-scoped rows
+        const scopeWhere = scopeToWhere(callerScope);
+        if (scopeWhere.clientId !== undefined) {
+          where.clientId = scopeWhere.clientId;
+        } else {
+          where.clientId = { not: null };
+        }
+      } else {
+        // No explicit filter: for scoped callers, show only their tenant's rows
+        // plus platform-scoped (null) rows.
+        if (callerScope.type === 'single') {
+          where.OR = [{ clientId: callerScope.clientId }, { clientId: null }];
+        } else if (callerScope.type === 'assigned') {
+          where.OR = [{ clientId: { in: callerScope.clientIds } }, { clientId: null }];
+        }
+        // type === 'all': no clientId filter — return everything
       }
       if (type) where.type = type;
       return fastify.db.clientIntegration.findMany({
@@ -168,8 +195,19 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
   );
 
   fastify.get<{ Params: { id: string } }>('/api/integrations/:id', async (request) => {
-    const integration = await fastify.db.clientIntegration.findUnique({
-      where: { id: request.params.id },
+    const callerScope = await resolveClientScope(request);
+    // Platform-scoped integrations (clientId IS NULL) are accessible to all callers.
+    // Client-scoped integrations are restricted to the caller's tenant(s).
+    const scopeFilter = callerScope.type === 'all'
+      ? {}
+      : { OR: [
+          { clientId: null },
+          callerScope.type === 'single'
+            ? { clientId: callerScope.clientId }
+            : { clientId: { in: callerScope.clientIds } },
+        ] };
+    const integration = await fastify.db.clientIntegration.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
       include: {
         client: { select: { name: true, shortCode: true } },
       },
@@ -206,6 +244,20 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
       return fastify.httpErrors.badRequest(
         `clientId is required for ${type} integrations. Only GITHUB integrations may be platform-scoped.`,
       );
+    }
+
+    // Scope enforcement: validate the caller is authorized for the target client.
+    // Platform-scoped (null clientId) integrations require 'all' scope — only ADMIN/API-key.
+    const callerScope = await resolveClientScope(request);
+    if (isPlatformScoped) {
+      if (callerScope.type !== 'all') {
+        return fastify.httpErrors.forbidden('clientId not in your scope');
+      }
+    } else if (
+      callerScope.type === 'single' && callerScope.clientId !== clientId ||
+      callerScope.type === 'assigned' && !callerScope.clientIds.includes(clientId!)
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
     }
     if (environmentId !== undefined && environmentId !== null) {
       if (!clientId) {
@@ -257,33 +309,42 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
       notes?: string;
     };
   }>('/api/integrations/:id', async (request) => {
-    let existingType: string | undefined;
-    const needsExisting = request.body.config !== undefined || request.body.environmentId !== undefined;
-    let existingClientId: string | null | undefined;
-    if (needsExisting) {
-      const existing = await fastify.db.clientIntegration.findUnique({
-        where: { id: request.params.id },
-        select: { type: true, config: true, clientId: true },
-      });
-      if (!existing) return fastify.httpErrors.notFound('Integration not found');
-      existingType = existing.type;
-      existingClientId = existing.clientId;
+    const callerScope = await resolveClientScope(request);
+    // Platform-scoped rows (clientId IS NULL) are accessible to all callers.
+    // Client-scoped rows are restricted to the caller's tenant(s).
+    const scopeFilter = callerScope.type === 'all'
+      ? {}
+      : { OR: [
+          { clientId: null },
+          callerScope.type === 'single'
+            ? { clientId: callerScope.clientId }
+            : { clientId: { in: callerScope.clientIds } },
+        ] };
 
-      if (request.body.config !== undefined) {
-        // Merge incoming config with existing so that omitted fields (e.g. secrets) are preserved
-        const existingConfig = typeof existing.config === 'object' && existing.config !== null && !Array.isArray(existing.config)
-          ? existing.config as Record<string, unknown>
-          : {};
-        const mergedConfig = { ...existingConfig, ...request.body.config };
+    // Always fetch the existing row for scope guard and type/config merging
+    const existing = await fastify.db.clientIntegration.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
+      select: { type: true, config: true, clientId: true },
+    });
+    if (!existing) return fastify.httpErrors.notFound('Integration not found');
+    const existingType = existing.type;
+    const existingClientId = existing.clientId;
 
-        const configError = validateIntegrationConfig(existing.type, mergedConfig);
-        if (configError) {
-          return fastify.httpErrors.badRequest(`Invalid config for ${existing.type}: ${configError}`);
-        }
+    if (request.body.config !== undefined) {
+      // Merge incoming config with existing so that omitted fields (e.g. secrets) are preserved
+      const existingConfig = typeof existing.config === 'object' && existing.config !== null && !Array.isArray(existing.config)
+        ? existing.config as Record<string, unknown>
+        : {};
+      const mergedConfig = { ...existingConfig, ...request.body.config };
 
-        request.body.config = encryptConfigSecrets(existing.type, mergedConfig, encryptionKey);
+      const configError = validateIntegrationConfig(existing.type, mergedConfig);
+      if (configError) {
+        return fastify.httpErrors.badRequest(`Invalid config for ${existing.type}: ${configError}`);
       }
+
+      request.body.config = encryptConfigSecrets(existing.type, mergedConfig, encryptionKey);
     }
+
     if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
       if (!existingClientId) {
         return fastify.httpErrors.badRequest('environmentId cannot be set on a platform-scoped integration');
@@ -324,8 +385,17 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
 
   // On-demand re-verification of MCP server discovery
   fastify.post<{ Params: { id: string } }>('/api/integrations/:id/verify', async (request) => {
-    const integration = await fastify.db.clientIntegration.findUnique({
-      where: { id: request.params.id },
+    const callerScope = await resolveClientScope(request);
+    const scopeFilter = callerScope.type === 'all'
+      ? {}
+      : { OR: [
+          { clientId: null },
+          callerScope.type === 'single'
+            ? { clientId: callerScope.clientId }
+            : { clientId: { in: callerScope.clientIds } },
+        ] };
+    const integration = await fastify.db.clientIntegration.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
       select: { id: true, type: true },
     });
     if (!integration) return fastify.httpErrors.notFound('Integration not found');
@@ -337,6 +407,21 @@ export async function integrationRoutes(fastify: FastifyInstance, opts: Integrat
   });
 
   fastify.delete<{ Params: { id: string } }>('/api/integrations/:id', async (request, reply) => {
+    const callerScope = await resolveClientScope(request);
+    const scopeFilter = callerScope.type === 'all'
+      ? {}
+      : { OR: [
+          { clientId: null },
+          callerScope.type === 'single'
+            ? { clientId: callerScope.clientId }
+            : { clientId: { in: callerScope.clientIds } },
+        ] };
+    const integration = await fastify.db.clientIntegration.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
+      select: { id: true, type: true },
+    });
+    if (!integration) return fastify.httpErrors.notFound('Integration not found');
+
     try {
       const deleted = await fastify.db.clientIntegration.delete({
         where: { id: request.params.id },

--- a/services/copilot-api/src/routes/repos.ts
+++ b/services/copilot-api/src/routes/repos.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { IntegrationType, PROTECTED_BRANCH_NAMES } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 class BranchPrefixError extends Error {
   statusCode = 400;
@@ -59,10 +60,18 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get<{ Querystring: { clientId?: string } }>(
     '/api/repos',
     async (request) => {
+      const scope = await resolveClientScope(request);
+      const scopeWhere = scopeToWhere(scope);
       const { clientId } = request.query;
+      const effectiveClientId = clientId && (
+        scope.type === 'all' ||
+        (scope.type === 'single' && scope.clientId === clientId) ||
+        (scope.type === 'assigned' && scope.clientIds.includes(clientId))
+      ) ? clientId : undefined;
       return fastify.db.codeRepo.findMany({
         where: {
-          ...(clientId && { clientId }),
+          ...scopeWhere,
+          ...(effectiveClientId && { clientId: effectiveClientId }),
         },
         include: {
           client: { select: { name: true, shortCode: true } },
@@ -74,8 +83,9 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
   );
 
   fastify.get<{ Params: { id: string } }>('/api/repos/:id', async (request) => {
-    const repo = await fastify.db.codeRepo.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const repo = await fastify.db.codeRepo.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
       include: {
         client: { select: { name: true, shortCode: true } },
         issueJobs: { orderBy: { createdAt: 'desc' }, take: 10 },
@@ -99,7 +109,14 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
   }>('/api/repos', async (request, reply) => {
     validateBranchPrefix(request.body.branchPrefix);
 
+    const scope = await resolveClientScope(request);
     const { clientId, environmentId, githubIntegrationId } = request.body;
+    if (
+      scope.type === 'single' && scope.clientId !== clientId ||
+      scope.type === 'assigned' && !scope.clientIds.includes(clientId)
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
     if (environmentId !== undefined && environmentId !== null) {
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: environmentId },
@@ -146,19 +163,14 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
   }>('/api/repos/:id', async (request) => {
     validateBranchPrefix(request.body.branchPrefix);
 
-    const needsExistingRepo =
-      (request.body.environmentId !== undefined && request.body.environmentId !== null) ||
-      (request.body.githubIntegrationId !== undefined && request.body.githubIntegrationId !== null);
-
-    let existingRepoClientId: string | undefined;
-    if (needsExistingRepo) {
-      const repo = await fastify.db.codeRepo.findUnique({
-        where: { id: request.params.id },
-        select: { clientId: true },
-      });
-      if (!repo) return fastify.httpErrors.notFound('Code repo not found');
-      existingRepoClientId = repo.clientId;
-    }
+    const scope = await resolveClientScope(request);
+    // Always fetch the existing repo to enforce scope guard (404 if out of scope)
+    const existingRepo = await fastify.db.codeRepo.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { clientId: true },
+    });
+    if (!existingRepo) return fastify.httpErrors.notFound('Code repo not found');
+    const existingRepoClientId = existingRepo.clientId;
 
     if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
       const env = await fastify.db.clientEnvironment.findUnique({
@@ -169,7 +181,7 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
       if (env.clientId !== existingRepoClientId) return fastify.httpErrors.forbidden('environmentId belongs to a different client');
     }
 
-    if (request.body.githubIntegrationId !== undefined && request.body.githubIntegrationId !== null && existingRepoClientId) {
+    if (request.body.githubIntegrationId !== undefined && request.body.githubIntegrationId !== null) {
       const err = await validateGithubIntegration(fastify, request.body.githubIntegrationId, existingRepoClientId);
       if (err) return fastify.httpErrors.badRequest(err);
     }
@@ -188,6 +200,13 @@ export async function repoRoutes(fastify: FastifyInstance): Promise<void> {
   });
 
   fastify.delete<{ Params: { id: string } }>('/api/repos/:id', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    const repo = await fastify.db.codeRepo.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!repo) return fastify.httpErrors.notFound('Code repo not found');
+
     // Check for related issue jobs before deleting
     const jobCount = await fastify.db.issueJob.count({
       where: { repoId: request.params.id },

--- a/services/copilot-api/src/routes/systems.ts
+++ b/services/copilot-api/src/routes/systems.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { DbEngine } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 const VALID_DB_ENGINES = Object.values(DbEngine);
 
@@ -11,10 +12,19 @@ export async function systemRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get<{ Querystring: { clientId?: string } }>(
     '/api/systems',
     async (request) => {
+      const scope = await resolveClientScope(request);
+      const scopeWhere = scopeToWhere(scope);
       const { clientId } = request.query;
+      // If a specific clientId is requested, it must fall within the caller's scope
+      const effectiveClientId = clientId && (
+        scope.type === 'all' ||
+        (scope.type === 'single' && scope.clientId === clientId) ||
+        (scope.type === 'assigned' && scope.clientIds.includes(clientId))
+      ) ? clientId : undefined;
       return fastify.db.system.findMany({
         where: {
-          ...(clientId && { clientId }),
+          ...scopeWhere,
+          ...(effectiveClientId && { clientId: effectiveClientId }),
         },
         include: {
           client: { select: { name: true, shortCode: true } },
@@ -26,8 +36,9 @@ export async function systemRoutes(fastify: FastifyInstance): Promise<void> {
   );
 
   fastify.get<{ Params: { id: string } }>('/api/systems/:id', async (request) => {
-    const system = await fastify.db.system.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const system = await fastify.db.system.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
       include: {
         client: { select: { name: true, shortCode: true } },
         findings: { orderBy: { detectedAt: 'desc' }, take: 10 },
@@ -65,7 +76,14 @@ export async function systemRoutes(fastify: FastifyInstance): Promise<void> {
         `Invalid dbEngine. Must be one of: ${VALID_DB_ENGINES.join(', ')}`,
       );
     }
+    const scope = await resolveClientScope(request);
     const { clientId, environmentId } = request.body;
+    if (
+      scope.type === 'single' && scope.clientId !== clientId ||
+      scope.type === 'assigned' && !scope.clientIds.includes(clientId)
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
     if (environmentId !== undefined && environmentId !== null) {
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: environmentId },
@@ -111,12 +129,14 @@ export async function systemRoutes(fastify: FastifyInstance): Promise<void> {
       notes?: string;
     };
   }>('/api/systems/:id', async (request) => {
+    const scope = await resolveClientScope(request);
+    const system = await fastify.db.system.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { clientId: true },
+    });
+    if (!system) return fastify.httpErrors.notFound('System not found');
+
     if (request.body.environmentId !== undefined && request.body.environmentId !== null) {
-      const system = await fastify.db.system.findUnique({
-        where: { id: request.params.id },
-        select: { clientId: true },
-      });
-      if (!system) return fastify.httpErrors.notFound('System not found');
       const env = await fastify.db.clientEnvironment.findUnique({
         where: { id: request.body.environmentId },
         select: { clientId: true },
@@ -138,6 +158,13 @@ export async function systemRoutes(fastify: FastifyInstance): Promise<void> {
   });
 
   fastify.delete<{ Params: { id: string } }>('/api/systems/:id', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    const system = await fastify.db.system.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!system) return fastify.httpErrors.notFound('System not found');
+
     const ticketCount = await fastify.db.ticket.count({
       where: { systemId: request.params.id },
     });


### PR DESCRIPTION
## Summary

Add `resolveClientScope` + `scopeToWhere` gating to the 6 sensitive per-client config endpoints. Previously, a client-scoped STANDARD operator at Client A could read/mutate Client B's database credentials, GitHub PATs, AI API keys, Slack tokens, memory entries, environments, and code repos — real IDOR-style cross-tenant access.

Part of #407 Phase 2 Critical 2 subset. The remaining Critical 2 route groups (scheduled-probes, issue-jobs, invoices, system-analyses, ticket-routes, operational-tasks, email-logs, slack-conversations) ship in a follow-up PR.

Fixes #407 Critical #2 (subset).

## Changes — 6 files

- `services/copilot-api/src/routes/systems.ts` — DB systems + encrypted passwords
- `services/copilot-api/src/routes/repos.ts` — code repo configs
- `services/copilot-api/src/routes/integrations.ts` — IMAP/Slack/GitHub/DevOps/MCP integrations
- `services/copilot-api/src/routes/client-memory.ts` — per-client playbooks
- `services/copilot-api/src/routes/client-ai-credentials.ts` — client AI provider keys
- `services/copilot-api/src/routes/client-environments.ts` — environment config

## Pattern

- **LIST:** `scopeToWhere(resolveClientScope(request))` applied to where clause
- **GET /:id:** scope-gated `findFirst`; 404 if out of scope
- **POST:** `body.clientId` validated against scope (403 on mismatch)
- **PATCH/DELETE /:id:** scope-gated `findFirst` guard, 404 if missing-or-out-of-scope; mutation proceeds only on success

## Notable deviations

- **`integrations.ts` LIST** uses `OR: [{clientId: null}, {clientId: ...in-scope}]` because platform-scoped integrations (`clientId IS NULL`) are shared infrastructure (GITHUB PAT/App credentials) and correctly visible to all authenticated operators. Only client-scoped rows are restricted.
- **`integrations.ts` POST** requires `scope.type === 'all'` (ADMIN/API-key) to create platform-scoped integrations. Client-scoped creations validated against caller's scope.
- **`integrations.ts` PATCH** previously skipped scope checks when body only contained label/notes fields. Now always loads via scope-gated `findFirst` — consistent enforcement.
- **`client-ai-credentials.ts` + `client-environments.ts`** use path `:id` as clientId (not body) — scope check runs before DB access, returns 403 with existing error style.

ADMIN + API-key callers see/mutate everything (scope.type === 'all' → empty where-clause). No regression.

## Test plan

- [ ] CI passes on staging push
- [ ] Post-deploy: ADMIN operator can still see all clients' systems/repos/integrations (no regression)
- [ ] When a second operator is added with `Operator.clientId = X`: confirm they see ONLY Client X's rows on each endpoint
- [ ] Cross-tenant write attempt returns 403 or 404 appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
