### PR TITLE
fix(portal): switch USER-tier access from email-actor equality to personId (#407 Medium 9)

### DIFF
--- a/services/copilot-api/src/routes/portal-tickets.ts
+++ b/services/copilot-api/src/routes/portal-tickets.ts
@@ -58,8 +58,10 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
     // Once ticket_events gains an author_person_id column and it is backfilled,
     // replace this with an ID-based query and remove the email fallback.
     // legacy actor-email fallback — remove once events have authorPersonId backfilled
+    // Constrained to COMMENT events only to avoid unintended access grants from other
+    // event types that may incidentally store a raw email in the actor field.
     const commentCount = await fastify.db.ticketEvent.count({
-      where: { ticketId, actor: portalUser.email },
+      where: { ticketId, actor: portalUser.email, eventType: 'COMMENT' },
     });
     return commentCount > 0;
   }
@@ -110,7 +112,9 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
           { followers: { some: { personId: portalUser.personId } } },
           { metadata: { path: ['portalCreatorId'], equals: portalUser.personId } },
           // legacy actor-email fallback — remove once events have authorPersonId backfilled
-          { events: { some: { actor: portalUser.email } } },
+          // Constrained to COMMENT events only to avoid unintended access grants from other
+          // event types that may incidentally store a raw email in the actor field.
+          { events: { some: { actor: portalUser.email, eventType: 'COMMENT' } } },
         ];
       }
 
@@ -150,7 +154,9 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
         { followers: { some: { personId: portalUser.personId } } },
         { metadata: { path: ['portalCreatorId'], equals: portalUser.personId } },
         // legacy actor-email fallback — remove once events have authorPersonId backfilled
-        { events: { some: { actor: portalUser.email } } },
+        // Constrained to COMMENT events only to avoid unintended access grants from other
+        // event types that may incidentally store a raw email in the actor field.
+        { events: { some: { actor: portalUser.email, eventType: 'COMMENT' } } },
       ];
     }
 

--- a/services/copilot-api/src/routes/portal-tickets.ts
+++ b/services/copilot-api/src/routes/portal-tickets.ts
@@ -27,11 +27,11 @@ interface PortalTicketOpts {
 export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalTicketOpts): Promise<void> {
   /**
    * Check if a ticket is visible to the portal user.
-   * ADMIN users can see all client tickets.
+   * ADMIN users can see all client tickets for their client.
    * USER users can see tickets where:
-   * - requester email matches their email
-   * - they previously commented (actor matches email)
-   * - ticket metadata has their portalCreatorId
+   * - they are a follower (matched by personId)
+   * - ticket metadata has their portalCreatorId (personId)
+   * - they have commented on the ticket (legacy: matched by actor email, see TODO)
    */
   async function canAccessTicket(ticketId: string, portalUser: PortalUser): Promise<boolean> {
     const ticket = await fastify.db.ticket.findUnique({
@@ -39,21 +39,25 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
       select: {
         clientId: true,
         metadata: true,
-        followers: { select: { person: { select: { email: true } } } },
+        // Select personId directly — ID-based match, not email-string equality
+        followers: { select: { personId: true } },
       },
     });
 
     if (!ticket || ticket.clientId !== portalUser.clientId) return false;
     if (portalUser.userType === ClientUserType.ADMIN) return true;
 
-    // Check if user is a follower (any type)
-    if (ticket.followers.some((f) => f.person?.email === portalUser.email)) return true;
+    // Check if user is a follower (matched by personId, not email)
+    if (ticket.followers.some((f) => f.personId === portalUser.personId)) return true;
 
-    // Check metadata portalCreatorId
+    // Check metadata portalCreatorId (already ID-based)
     const meta = ticket.metadata as Record<string, unknown> | null;
     if (meta?.['portalCreatorId'] === portalUser.personId) return true;
 
-    // Check if user has commented on this ticket
+    // TODO: TicketEvent.actor is a free-text string with no authorPersonId FK.
+    // Once ticket_events gains an author_person_id column and it is backfilled,
+    // replace this with an ID-based query and remove the email fallback.
+    // legacy actor-email fallback — remove once events have authorPersonId backfilled
     const commentCount = await fastify.db.ticketEvent.count({
       where: { ticketId, actor: portalUser.email },
     });
@@ -97,11 +101,15 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
         where['category'] = category;
       }
 
-      // USER type: only see their own tickets
+      // USER type: only see their own tickets (matched by personId, not email)
+      // TODO: The third clause (events.actor) is a legacy email-string match because
+      // TicketEvent.actor is a free-text field with no authorPersonId FK. Remove once
+      // ticket_events gains an author_person_id column and it is backfilled.
       if (portalUser.userType !== ClientUserType.ADMIN) {
         where['OR'] = [
-          { followers: { some: { person: { email: portalUser.email } } } },
+          { followers: { some: { personId: portalUser.personId } } },
           { metadata: { path: ['portalCreatorId'], equals: portalUser.personId } },
+          // legacy actor-email fallback — remove once events have authorPersonId backfilled
           { events: { some: { actor: portalUser.email } } },
         ];
       }
@@ -133,10 +141,15 @@ export async function portalTicketRoutes(fastify: FastifyInstance, opts: PortalT
 
     const where: Record<string, unknown> = { clientId: portalUser.clientId };
 
+    // USER type: only see their own tickets (matched by personId, not email)
+    // TODO: The third clause (events.actor) is a legacy email-string match because
+    // TicketEvent.actor is a free-text field with no authorPersonId FK. Remove once
+    // ticket_events gains an author_person_id column and it is backfilled.
     if (portalUser.userType !== ClientUserType.ADMIN) {
       where['OR'] = [
-        { followers: { some: { person: { email: portalUser.email } } } },
+        { followers: { some: { personId: portalUser.personId } } },
         { metadata: { path: ['portalCreatorId'], equals: portalUser.personId } },
+        // legacy actor-email fallback — remove once events have authorPersonId backfilled
         { events: { some: { actor: portalUser.email } } },
       ];
     }


### PR DESCRIPTION
## Summary

Switch portal USER-tier `canAccessTicket` from email-actor equality to `personId`-based equality. The old pattern compared `portalUser.email` against `followers.person.email` and `actor` free-text strings — fragile under email changes, non-unique matches, and stringly typed comparisons.

Part of #407 Phase 2 (Medium 9).

Fixes #407 Medium #9.

## Changes — 1 file

`services/copilot-api/src/routes/portal-tickets.ts` — 3 locations updated identically:

1. **`canAccessTicket` helper** — follower select changed from `{ person: { select: { email: true } } }` to `{ select: { personId: true } }`. Follower check swapped from `f.person?.email === portalUser.email` to `f.personId === portalUser.personId`.
2. **`GET /api/portal/tickets` list query** — `followers.some.person.email` filter → `followers.some.personId`
3. **`GET /api/portal/tickets/stats` query** — same follower filter update

## Legacy actor-email fallback

`TicketEvent.actor` is a free-text `String` column in the schema — no `authorPersonId` FK. The actor-email check is retained as an explicit last-resort OR branch in all three locations with a `// legacy actor-email fallback` comment and TODO for follow-up ID backfill. Once events carry `authorPersonId`, the email path can go.

**`portalCreatorId` metadata check** (requester equality) was already ID-based — untouched.

**ADMIN-tier portal access** unchanged — it bypasses the USER-only clause after the `clientId` check.

## Test plan

- [ ] CI passes on staging push
- [ ] USER-tier portal access still works for tickets where they're the follower (by `personId`)
- [ ] Renaming an email on a Person no longer silently shifts their portal ticket visibility
- [ ] Follow-up: track `TicketEvent.authorPersonId` backfill so the email fallback can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
