### PR TITLE
fix(tickets): validate clientId scope on create + assignedOperatorId membership on PATCH (#407 High 5 + Medium 7)

### DIFF
--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -506,26 +506,35 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       }
       let resolvedOperatorName: string | null = null;
       if (assignedOperatorId !== undefined && assignedOperatorId !== null) {
+        // existing is guaranteed non-null here — line 491 already returned 404 when null.
+        const ticketClientId = existing!.clientId;
         const operator = await fastify.db.operator.findUnique({
           where: { id: assignedOperatorId },
           select: {
             id: true,
             clientId: true,
+            role: true,
             person: { select: { name: true, isActive: true } },
-            assignedClients: { select: { clientId: true } },
+            // Use a filtered relation to avoid pulling all OperatorClient rows into memory.
+            // We only need to know whether a membership row exists for ticketClientId.
+            assignedClients: { where: { clientId: ticketClientId }, select: { clientId: true }, take: 1 },
           },
         });
         if (!operator) return fastify.httpErrors.badRequest('Referenced operator not found');
         if (!operator.person.isActive) return fastify.httpErrors.badRequest('Cannot assign to an inactive operator');
         // Medium 7 (#407): validate the operator is authorized for this ticket's client.
-        // Authorized when: platform operator (clientId === null), operator pinned to this
-        // client, or operator has an OperatorClient membership for this client.
-        // existing is guaranteed non-null here — line 491 already returned 404 when null.
-        const ticketClientId = existing!.clientId;
-        const isPlatformOperator = operator.clientId === null;
-        const isPinnedToClient = operator.clientId === ticketClientId;
-        const hasClientMembership = operator.assignedClients.some((ac) => ac.clientId === ticketClientId);
-        if (!isPlatformOperator && !isPinnedToClient && !hasClientMembership) {
+        // Authorization mirrors resolveClientScope() exactly:
+        //   - client-scoped operator (clientId !== null) → must match ticketClientId exactly
+        //   - platform ADMIN (clientId === null, role === ADMIN) → allowed for all clients
+        //   - platform STANDARD (clientId === null, role !== ADMIN) → requires OperatorClient membership
+        const hasClientMembership = operator.assignedClients.length > 0;
+        const isAuthorizedForTicketClient =
+          operator.clientId !== null
+            ? operator.clientId === ticketClientId
+            : operator.role === 'ADMIN'
+              ? true
+              : hasClientMembership;
+        if (!isAuthorizedForTicketClient) {
           return fastify.httpErrors.badRequest("Operator not authorized for this ticket's client");
         }
         resolvedOperatorName = operator.person.name;

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -319,6 +319,18 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     if (source && !VALID_SOURCES.has(source)) return fastify.httpErrors.badRequest(`Invalid source: ${source}`);
     if (category && !VALID_CATEGORIES.has(category)) return fastify.httpErrors.badRequest(`Invalid category: ${category}`);
 
+    // High 5 (#407): validate that the caller is authorized to create a ticket
+    // for the requested clientId. A client-scoped STANDARD operator at Client A
+    // must not be able to create a ticket with clientId = Client B.
+    const createScope = await resolveClientScope(request);
+    if (createScope.type === 'single' && clientId !== createScope.clientId) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
+    if (createScope.type === 'assigned' && !createScope.clientIds.includes(clientId)) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
+    // scope.type === 'all' → platform ADMIN or API-key: any clientId is OK.
+
     if (requesterId) {
       // Tenant validation: the requester must be linked to the target
       // client via a ClientUser row, OR be a platform operator
@@ -487,7 +499,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
         if (env.clientId !== existing.clientId) return fastify.httpErrors.forbidden('environmentId belongs to a different client');
       }
 
-      // Validate operator exists and is active
+      // Validate operator exists, is active, and is authorized for the ticket's client.
       const UUID_PATCH_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       if (assignedOperatorId !== undefined && assignedOperatorId !== null && !UUID_PATCH_RE.test(assignedOperatorId)) {
         return fastify.httpErrors.badRequest('assignedOperatorId must be a valid UUID');
@@ -496,10 +508,26 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       if (assignedOperatorId !== undefined && assignedOperatorId !== null) {
         const operator = await fastify.db.operator.findUnique({
           where: { id: assignedOperatorId },
-          select: { id: true, person: { select: { name: true, isActive: true } } },
+          select: {
+            id: true,
+            clientId: true,
+            person: { select: { name: true, isActive: true } },
+            assignedClients: { select: { clientId: true } },
+          },
         });
         if (!operator) return fastify.httpErrors.badRequest('Referenced operator not found');
         if (!operator.person.isActive) return fastify.httpErrors.badRequest('Cannot assign to an inactive operator');
+        // Medium 7 (#407): validate the operator is authorized for this ticket's client.
+        // Authorized when: platform operator (clientId === null), operator pinned to this
+        // client, or operator has an OperatorClient membership for this client.
+        // existing is guaranteed non-null here — line 491 already returned 404 when null.
+        const ticketClientId = existing!.clientId;
+        const isPlatformOperator = operator.clientId === null;
+        const isPinnedToClient = operator.clientId === ticketClientId;
+        const hasClientMembership = operator.assignedClients.some((ac) => ac.clientId === ticketClientId);
+        if (!isPlatformOperator && !isPinnedToClient && !hasClientMembership) {
+          return fastify.httpErrors.badRequest("Operator not authorized for this ticket's client");
+        }
         resolvedOperatorName = operator.person.name;
       }
 


### PR DESCRIPTION
## Summary

Bundle two related `tickets.ts` fixes from #407 Phase 2 into one PR.

**High 5:** `POST /api/tickets` accepted body `clientId` without verifying caller authorization — a client-scoped operator at Client A could create a ticket with `clientId = Client B`.

**Medium 7:** `PATCH /api/tickets/:id` accepted `assignedOperatorId` but didn't verify the operator is authorized for the ticket's client — cross-tenant assignments possible.

Fixes #407 High #5 + Medium #7.

## Changes — 1 file

`services/copilot-api/src/routes/tickets.ts`

### High 5 — POST scope check

After body validation, resolve caller scope and validate `body.clientId`:
- `scope.type === 'single'` → `clientId` must match `scope.clientId`
- `scope.type === 'assigned'` → `scope.clientIds.includes(clientId)`
- `scope.type === 'all'` (ADMIN + API-key) → unrestricted

Returns **403** on mismatch.

### Medium 7 — PATCH assignedOperatorId membership check

The operator lookup now selects `clientId` and `assignedClients { clientId }` alongside `person`. After existence + active check, validates operator↔ticket-client:
- `operator.clientId === null` — platform operator (any client) OK
- `operator.clientId === ticket.clientId` — pinned to this client
- `operator.assignedClients.some(ac => ac.clientId === ticket.clientId)` — `OperatorClient` join membership

Returns **400** on mismatch (semantically invalid assignment, not an authz failure against the caller).

Same membership model as `resolveClientScope` itself.

## Test plan

- [ ] CI passes on staging push
- [ ] ADMIN can POST /api/tickets with any clientId (no regression)
- [ ] Client-scoped STANDARD → POST with own clientId succeeds; another clientId → 403
- [ ] PATCH /api/tickets/:id with assignedOperatorId:
  - Platform operator (null clientId) → 200 any ticket
  - Operator pinned to ticket.clientId → 200
  - Operator with OperatorClient membership for ticket.clientId → 200
  - Operator not in any of the above → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
