### PR TITLE
fix(people): restrict existing-Person mutation to caller's scope (#407 Medium 6)

### DIFF
--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -328,15 +328,20 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
     const passwordHash = shouldSetPassword ? await bcrypt.hash(password!, 10) : undefined;
 
     const result = await fastify.db.$transaction(async (tx) => {
+      // #407 Medium 6 — cross-tenant Person mutation gap.
+      //
+      // When an existing Person is matched by email, do NOT mutate their global
+      // Person fields (name, isActive, passwordHash). Person is a shared-identity
+      // record: any field change propagates to every tenant and Operator session
+      // linked to that Person. A client-scoped caller at Client A has no authority
+      // over a Person's global state — they may only extend the Person into their
+      // own client by adding a ClientUser row.
+      //
+      // If the caller needs to update global Person fields (name, isActive,
+      // passwordHash), they should use PATCH /api/people/:id, which enforces
+      // assertPersonMutationScope before touching Person-level data.
       const person = existingPerson
-        ? await tx.person.update({
-            where: { id: existingPerson.id },
-            data: {
-              name: name.trim(),
-              ...(isActive !== undefined && { isActive }),
-              ...(passwordHash !== undefined && { passwordHash }),
-            },
-          })
+        ? existingPerson
         : await tx.person.create({
             data: {
               name: name.trim(),

--- a/services/copilot-api/src/routes/people.ts
+++ b/services/copilot-api/src/routes/people.ts
@@ -325,7 +325,6 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
     }
 
     const shouldSetPassword = (hasPortalAccess === true || !!password) && !!password;
-    const passwordHash = shouldSetPassword ? await bcrypt.hash(password!, 10) : undefined;
 
     const result = await fastify.db.$transaction(async (tx) => {
       // #407 Medium 6 — cross-tenant Person mutation gap.
@@ -340,6 +339,10 @@ export async function peopleRoutes(fastify: FastifyInstance): Promise<void> {
       // If the caller needs to update global Person fields (name, isActive,
       // passwordHash), they should use PATCH /api/people/:id, which enforces
       // assertPersonMutationScope before touching Person-level data.
+      //
+      // Bcrypt hashing is deferred to here so we only pay the CPU cost on the
+      // new-Person path — the hash is never needed when re-using an existing Person.
+      const passwordHash = shouldSetPassword && !existingPerson ? await bcrypt.hash(password!, 10) : undefined;
       const person = existingPerson
         ? existingPerson
         : await tx.person.create({


### PR DESCRIPTION
## Summary

`POST /api/people` existing-Person branch was globally mutating Person fields (`name`, `isActive`, `passwordHash`) on email match. A client-scoped caller at Client A could reset the password of a Person who also has access to Client B — real cross-tenant Person mutation (Class 2 + Class 6 of the #296 audit).

Fixes #407 Medium #6.

## Fix

On existing-Person match, handler now uses `existingPerson` directly (no `person.update` call) and proceeds straight to `ClientUser` creation for the caller's `clientId`. The three sensitive fields are never touched on the existing-Person path.

**New-Person path unchanged** — those fields are still written on creation (no cross-tenant concern since the Person doesn't exist yet).

Added inline comment pointing callers to `PATCH /api/people/:id` (which already enforces `assertPersonMutationScope`) for intentional global-field updates.

## Test plan

- [ ] CI passes on staging push
- [ ] As client-scoped caller at Client A: POST /api/people with email of a Person who exists at Client B
  - Verify: new `ClientUser` row created at Client A
  - Verify: Person.name / isActive / passwordHash on that Person unchanged
- [ ] As ADMIN: POST /api/people with an existing email — behavior: still doesn't mutate Person fields on the existing-Person path (intentional — use PATCH for that)

## Notes

Option A chosen (restrict mutation outright) over Option B (dynamic per-tenant check) because it's semantically cleaner — client-scoped endpoints should never mutate global Person fields. Consistent with how the audit documents intent.

Part of #407 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
