### PR TITLE
fix(mcp-platform): consolidate Person selects via SAFE_PERSON_SELECT (#407 Medium 10)

### DIFF
--- a/mcp-servers/platform/src/tools/clients.ts
+++ b/mcp-servers/platform/src/tools/clients.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
+import { SAFE_PERSON_SELECT } from './selects.js';
 
 export function registerClientTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
@@ -97,7 +98,7 @@ export function registerClientTools(server: McpServer, { db }: ServerDeps): void
               id: true,
               userType: true,
               isPrimary: true,
-              person: { select: { id: true, name: true, email: true, phone: true } },
+              person: { select: SAFE_PERSON_SELECT },
             },
           },
           integrations: {

--- a/mcp-servers/platform/src/tools/operators.ts
+++ b/mcp-servers/platform/src/tools/operators.ts
@@ -2,9 +2,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
 import { OperatorRole } from '@bronco/shared-types';
+import { SAFE_PERSON_SELECT } from './selects.js';
 
-// Explicit Person select — never expose passwordHash or emailLower to MCP callers.
-const PERSON_SELECT = { id: true, name: true, email: true, phone: true, isActive: true } as const;
+const PERSON_SELECT = SAFE_PERSON_SELECT;
 
 const OPERATOR_SELECT = {
   id: true,

--- a/mcp-servers/platform/src/tools/people.ts
+++ b/mcp-servers/platform/src/tools/people.ts
@@ -2,9 +2,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ServerDeps } from '../server.js';
 import { ClientUserType } from '@bronco/shared-types';
+import { SAFE_PERSON_SELECT } from './selects.js';
 
-// Explicit Person select — never expose passwordHash or emailLower to MCP callers.
-const PERSON_SELECT = { id: true, name: true, email: true, phone: true, isActive: true } as const;
+const PERSON_SELECT = SAFE_PERSON_SELECT;
 
 const CLIENT_USER_SELECT = {
   id: true,

--- a/mcp-servers/platform/src/tools/selects.ts
+++ b/mcp-servers/platform/src/tools/selects.ts
@@ -2,9 +2,9 @@
  * Shared Prisma select projections for MCP platform tools.
  *
  * SAFE_PERSON_SELECT — explicit allowlist for Person fields returned to MCP callers.
- * Deliberately excludes: passwordHash, emailLower, resetToken*, and any future
- * credential-adjacent columns.  Import and reuse this constant in every tool that
- * joins or queries a Person so the allowlist is maintained in one place.
+ * Deliberately excludes sensitive fields such as passwordHash, emailLower, and any
+ * future credential-adjacent columns.  Import and reuse this constant in every tool
+ * that joins or queries a Person so the allowlist is maintained in one place.
  */
 export const SAFE_PERSON_SELECT = {
   id: true,

--- a/mcp-servers/platform/src/tools/selects.ts
+++ b/mcp-servers/platform/src/tools/selects.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared Prisma select projections for MCP platform tools.
+ *
+ * SAFE_PERSON_SELECT — explicit allowlist for Person fields returned to MCP callers.
+ * Deliberately excludes: passwordHash, emailLower, resetToken*, and any future
+ * credential-adjacent columns.  Import and reuse this constant in every tool that
+ * joins or queries a Person so the allowlist is maintained in one place.
+ */
+export const SAFE_PERSON_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  phone: true,
+  isActive: true,
+} as const;

--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -149,6 +149,8 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
           followers: {
             select: {
               id: true,
+              ticketId: true,
+              personId: true,
               followerType: true,
               createdAt: true,
               person: { select: SAFE_PERSON_SELECT },

--- a/mcp-servers/platform/src/tools/tickets.ts
+++ b/mcp-servers/platform/src/tools/tickets.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { Prisma } from '@bronco/db';
 import type { ServerDeps } from '../server.js';
+import { SAFE_PERSON_SELECT } from './selects.js';
 
 export function registerTicketTools(server: McpServer, { db }: ServerDeps): void {
   server.tool(
@@ -145,7 +146,14 @@ export function registerTicketTools(server: McpServer, { db }: ServerDeps): void
           client: { select: { id: true, name: true, shortCode: true } },
           system: { select: { id: true, name: true, host: true } },
           assignedOperator: { select: { id: true, person: { select: { name: true, email: true } } } },
-          followers: { include: { person: { select: { id: true, name: true, email: true } } } },
+          followers: {
+            select: {
+              id: true,
+              followerType: true,
+              createdAt: true,
+              person: { select: SAFE_PERSON_SELECT },
+            },
+          },
           events: { orderBy: { createdAt: 'desc' }, take: 50 },
           pendingActions: { where: { status: 'pending' } },
         },


### PR DESCRIPTION
## Summary

Consolidate Person projections across MCP platform tools behind a shared `SAFE_PERSON_SELECT` constant. Class-3 audit from #407 Phase 2 — verify no `passwordHash` / `emailLower` / other sensitive Person fields are leaked through MCP tool responses.

**Finding:** no actual leaks existed — each tool had its own explicit select. But selects were duplicated and divergent (some excluded `isActive`, one used a wrapping `include` instead of `select`). Consolidation + audit.

Fixes #407 Medium #10.

## Changes — 5 files

- **New:** `mcp-servers/platform/src/tools/selects.ts` — exports `SAFE_PERSON_SELECT = { id, name, email, phone, isActive }`
- `mcp-servers/platform/src/tools/people.ts` — `get_person` / `list_people` / `search_people` wired to shared constant (replaces local `PERSON_SELECT` literal)
- `mcp-servers/platform/src/tools/operators.ts` — `OPERATOR_SELECT` nests `SAFE_PERSON_SELECT`
- `mcp-servers/platform/src/tools/clients.ts` — `get_client` → `clientUsers.person` select updated to `SAFE_PERSON_SELECT` (adds `isActive` which was missing)
- `mcp-servers/platform/src/tools/tickets.ts` — `get_ticket` → `followers` converted from `include: { person: { select: ... } }` to a full `select:` block using `SAFE_PERSON_SELECT`. Eliminates the outer bare `include` on `TicketFollower` that was spreading all follower columns.

## Audit summary (per tool)

| Tool | State before | Action |
|---|---|---|
| `get_person`, `list_people`, `search_people` | Explicit local `PERSON_SELECT` (safe) | Rewired to shared constant |
| `list_operators`, `search_operators`, `get_operator` | Explicit via `OPERATOR_SELECT` (safe) | Rewired to nest shared constant |
| `search_users` | Explicit inline select (safe — `id, name, email, isActive`) | No change |
| `get_client` → `clientUsers.person` | Explicit but missing `isActive` | Added; now uses shared constant |
| `get_ticket` → `followers.person` | Inner select safe, but outer `include` spread all `TicketFollower` columns | Converted to `select:` block |

**No remaining `include: { person: true }` sites** across MCP platform tools.

## Test plan

- [ ] CI passes on staging push
- [ ] Manual: call `get_person` / `list_people` / `search_people` / `list_operators` / `get_client` / `get_ticket` via MCP and inspect the response — no `passwordHash`, `emailLower`, or other undocumented Person fields in any response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
