### PR TITLE
fix(config): scope remaining client-scoped route groups (#407 Critical 2 remaining)

### DIFF
--- a/services/copilot-api/src/routes/email-logs.ts
+++ b/services/copilot-api/src/routes/email-logs.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { EmailClassification, EmailProcessingStatus } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 const VALID_CLASSIFICATIONS = new Set<string>(Object.values(EmailClassification));
 const VALID_STATUSES = new Set<string>(Object.values(EmailProcessingStatus));
@@ -34,7 +35,16 @@ export async function emailLogRoutes(fastify: FastifyInstance): Promise<void> {
       return fastify.httpErrors.badRequest('limit and offset must be non-negative integers');
     }
 
-    const where: Record<string, unknown> = {};
+    // Scope enforcement: restrict to caller's client(s)
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+
+    const where: Record<string, unknown> = {
+      // Apply scope — for 'assigned'/'single' callers, restrict to their clientId(s).
+      // Note: some email logs may have clientId=null (emails that couldn't be matched to a client).
+      // Those are only visible to 'all' scope callers.
+      ...scopeWhere,
+    };
 
     if (classification) {
       if (!VALID_CLASSIFICATIONS.has(classification)) {
@@ -54,7 +64,15 @@ export async function emailLogRoutes(fastify: FastifyInstance): Promise<void> {
       where.status = status;
     }
 
-    if (clientId) where.clientId = clientId;
+    // If a clientId filter is requested, validate it is within the caller's scope
+    const effectiveClientId =
+      clientId &&
+      (callerScope.type === 'all' ||
+        (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+        (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId)))
+        ? clientId
+        : undefined;
+    if (effectiveClientId) where.clientId = effectiveClientId;
 
     if (fromDate || toDate) {
       const receivedAt: Record<string, Date> = {};
@@ -138,7 +156,11 @@ export async function emailLogRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.post<{ Params: { id: string } }>('/api/email-logs/:id/retry', async (request) => {
     const { id } = request.params;
 
-    const log = await fastify.db.emailProcessingLog.findUnique({ where: { id } });
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+    const log = await fastify.db.emailProcessingLog.findFirst({
+      where: { id, ...scopeWhere },
+    });
     if (!log) return fastify.httpErrors.notFound('Email processing log not found');
 
     if (log.status !== EmailProcessingStatus.FAILED && log.classification !== EmailClassification.NOISE && log.classification !== EmailClassification.AUTO_REPLY) {
@@ -168,7 +190,11 @@ export async function emailLogRoutes(fastify: FastifyInstance): Promise<void> {
       );
     }
 
-    const log = await fastify.db.emailProcessingLog.findUnique({ where: { id } });
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+    const log = await fastify.db.emailProcessingLog.findFirst({
+      where: { id, ...scopeWhere },
+    });
     if (!log) return fastify.httpErrors.notFound('Email processing log not found');
 
     const updated = await fastify.db.emailProcessingLog.update({

--- a/services/copilot-api/src/routes/invoices.ts
+++ b/services/copilot-api/src/routes/invoices.ts
@@ -15,13 +15,13 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
   ensureInvoiceDir(invoiceStoragePath);
 
   // GET /api/clients/:id/invoices — list invoices for client
-  fastify.get<{ Params: { id: string } }>('/api/clients/:id/invoices', async (request) => {
+  fastify.get<{ Params: { id: string } }>('/api/clients/:id/invoices', async (request, reply) => {
     const scope = await resolveClientScope(request);
     if (
       (scope.type === 'single' && scope.clientId !== request.params.id) ||
       (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
     ) {
-      return fastify.httpErrors.forbidden('clientId not in your scope');
+      return reply.code(403).send({ error: 'clientId not in your scope' });
     }
 
     const rows = await fastify.db.invoice.findMany({

--- a/services/copilot-api/src/routes/invoices.ts
+++ b/services/copilot-api/src/routes/invoices.ts
@@ -4,6 +4,7 @@ import { createReadStream, existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import { Prisma } from '@bronco/db';
 import { aggregateDailyUsage, generateInvoicePdf, nextInvoiceNumber, ensureInvoiceDir } from '../services/invoice-generator.js';
+import { resolveClientScope } from '../plugins/client-scope.js';
 
 interface InvoiceRouteOpts {
   invoiceStoragePath: string;
@@ -15,6 +16,14 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
 
   // GET /api/clients/:id/invoices — list invoices for client
   fastify.get<{ Params: { id: string } }>('/api/clients/:id/invoices', async (request) => {
+    const scope = await resolveClientScope(request);
+    if (
+      (scope.type === 'single' && scope.clientId !== request.params.id) ||
+      (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
+
     const rows = await fastify.db.invoice.findMany({
       where: { clientId: request.params.id },
       orderBy: { invoiceNumber: 'desc' },
@@ -33,6 +42,14 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
     Params: { id: string };
     Body: { periodStart: string; periodEnd: string; finalize?: boolean };
   }>('/api/clients/:id/invoices/generate', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    if (
+      (scope.type === 'single' && scope.clientId !== request.params.id) ||
+      (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
+    ) {
+      return reply.code(403).send({ error: 'clientId not in your scope' });
+    }
+
     const client = await fastify.db.client.findUnique({
       where: { id: request.params.id },
       select: { name: true, billingMarkupPercent: true },
@@ -112,6 +129,14 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
   fastify.get<{ Params: { id: string; invoiceId: string } }>(
     '/api/clients/:id/invoices/:invoiceId/download',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        (scope.type === 'single' && scope.clientId !== request.params.id) ||
+        (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
+
       const invoice = await fastify.db.invoice.findFirst({
         where: { id: request.params.invoiceId, clientId: request.params.id },
       });
@@ -129,6 +154,14 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
   fastify.patch<{ Params: { id: string; invoiceId: string }; Body: { status: string } }>(
     '/api/clients/:id/invoices/:invoiceId',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        (scope.type === 'single' && scope.clientId !== request.params.id) ||
+        (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
+
       const { status } = request.body;
       if (status !== 'draft' && status !== 'final') {
         return reply.code(400).send({ error: 'status must be "draft" or "final"' });
@@ -149,6 +182,14 @@ export async function invoiceRoutes(fastify: FastifyInstance, opts: InvoiceRoute
   fastify.delete<{ Params: { id: string; invoiceId: string } }>(
     '/api/clients/:id/invoices/:invoiceId',
     async (request, reply) => {
+      const scope = await resolveClientScope(request);
+      if (
+        (scope.type === 'single' && scope.clientId !== request.params.id) ||
+        (scope.type === 'assigned' && !scope.clientIds.includes(request.params.id))
+      ) {
+        return reply.code(403).send({ error: 'clientId not in your scope' });
+      }
+
       const invoice = await fastify.db.invoice.findFirst({
         where: { id: request.params.invoiceId, clientId: request.params.id },
       });

--- a/services/copilot-api/src/routes/issue-jobs.ts
+++ b/services/copilot-api/src/routes/issue-jobs.ts
@@ -108,21 +108,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
     const { ticketId, repoId } = request.body;
     const force = request.query.force === 'true';
 
-    // Validate ticket exists
-    const ticket = await fastify.db.ticket.findUnique({
-      where: { id: ticketId },
+    // Scope-gated ticket lookup: merge scope into the query so out-of-scope ticket IDs
+    // return 404 (not 403), preventing cross-tenant existence enumeration.
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
+    const ticket = await fastify.db.ticket.findFirst({
+      where: { id: ticketId, ...scopeWhere },
       select: { id: true, subject: true, description: true, category: true, clientId: true, sufficiencyStatus: true },
     });
     if (!ticket) return fastify.httpErrors.notFound('Ticket not found');
-
-    // Scope enforcement: validate the caller is authorized for the ticket's client
-    const scope = await resolveClientScope(request);
-    if (
-      (scope.type === 'single' && scope.clientId !== ticket.clientId) ||
-      (scope.type === 'assigned' && !scope.clientIds.includes(ticket.clientId))
-    ) {
-      return fastify.httpErrors.forbidden('clientId not in your scope');
-    }
 
     // Sufficiency gate
     if (!force) {

--- a/services/copilot-api/src/routes/issue-jobs.ts
+++ b/services/copilot-api/src/routes/issue-jobs.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { Queue } from 'bullmq';
 import { PROTECTED_BRANCH_NAMES, SufficiencyStatus } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 /** Matches the payload shape expected by the issue-resolver worker. */
 interface IssueResolvePayload {
@@ -21,8 +22,19 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
     '/api/issue-jobs',
     async (request) => {
       const { ticketId, repoId, status, limit = 50, offset = 0 } = request.query;
+
+      // Scope enforcement: filter jobs to only those whose ticket belongs to the caller's client(s)
+      const scope = await resolveClientScope(request);
+      const clientScopeWhere = scopeToWhere(scope);
+      // IssueJob has no direct clientId; scope via the ticket relation
+      const ticketClientWhere =
+        Object.keys(clientScopeWhere).length > 0
+          ? { ticket: { clientId: clientScopeWhere.clientId as string | { in: string[] } } }
+          : {};
+
       return fastify.db.issueJob.findMany({
         where: {
+          ...ticketClientWhere,
           ...(ticketId && { ticketId }),
           ...(repoId && { repoId }),
           ...(status && { status: status as never }),
@@ -40,8 +52,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
 
   // Get a single issue job by ID
   fastify.get<{ Params: { id: string } }>('/api/issue-jobs/:id', async (request) => {
-    const job = await fastify.db.issueJob.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const clientScopeWhere = scopeToWhere(scope);
+    const ticketClientWhere =
+      Object.keys(clientScopeWhere).length > 0
+        ? { ticket: { clientId: clientScopeWhere.clientId as string | { in: string[] } } }
+        : {};
+
+    const job = await fastify.db.issueJob.findFirst({
+      where: { id: request.params.id, ...ticketClientWhere },
       include: {
         ticket: { select: { subject: true, description: true, category: true, clientId: true } },
         repo: { select: { name: true, repoUrl: true, branchPrefix: true, defaultBranch: true } },
@@ -53,8 +72,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
 
   // Get the plan for an issue job
   fastify.get<{ Params: { id: string } }>('/api/issue-jobs/:id/plan', async (request) => {
-    const job = await fastify.db.issueJob.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const clientScopeWhere = scopeToWhere(scope);
+    const ticketClientWhere =
+      Object.keys(clientScopeWhere).length > 0
+        ? { ticket: { clientId: clientScopeWhere.clientId as string | { in: string[] } } }
+        : {};
+
+    const job = await fastify.db.issueJob.findFirst({
+      where: { id: request.params.id, ...ticketClientWhere },
       select: {
         id: true,
         status: true,
@@ -88,6 +114,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
       select: { id: true, subject: true, description: true, category: true, clientId: true, sufficiencyStatus: true },
     });
     if (!ticket) return fastify.httpErrors.notFound('Ticket not found');
+
+    // Scope enforcement: validate the caller is authorized for the ticket's client
+    const scope = await resolveClientScope(request);
+    if (
+      (scope.type === 'single' && scope.clientId !== ticket.clientId) ||
+      (scope.type === 'assigned' && !scope.clientIds.includes(ticket.clientId))
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
 
     // Sufficiency gate
     if (!force) {
@@ -158,8 +193,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
       operatorId?: string;
     };
   }>('/api/issue-jobs/:id/approve', async (request) => {
-    const job = await fastify.db.issueJob.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const clientScopeWhere = scopeToWhere(scope);
+    const ticketClientWhere =
+      Object.keys(clientScopeWhere).length > 0
+        ? { ticket: { clientId: clientScopeWhere.clientId as string | { in: string[] } } }
+        : {};
+
+    const job = await fastify.db.issueJob.findFirst({
+      where: { id: request.params.id, ...ticketClientWhere },
       select: { id: true, status: true, plan: true, ticketId: true },
     });
     if (!job) return fastify.httpErrors.notFound('Issue job not found');
@@ -234,8 +276,15 @@ export async function issueJobRoutes(fastify: FastifyInstance, opts: IssueJobRou
       feedback: string;
     };
   }>('/api/issue-jobs/:id/reject', async (request) => {
-    const job = await fastify.db.issueJob.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const clientScopeWhere = scopeToWhere(scope);
+    const ticketClientWhere =
+      Object.keys(clientScopeWhere).length > 0
+        ? { ticket: { clientId: clientScopeWhere.clientId as string | { in: string[] } } }
+        : {};
+
+    const job = await fastify.db.issueJob.findFirst({
+      where: { id: request.params.id, ...ticketClientWhere },
       select: { id: true, status: true, plan: true },
     });
     if (!job) return fastify.httpErrors.notFound('Issue job not found');

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -167,12 +167,24 @@ export async function scheduledProbeRoutes(
   fastify.get<{
     Querystring: { clientId?: string };
   }>('/api/scheduled-probes', async (request) => {
+    const scope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(scope);
     const { clientId } = request.query;
-    const where: Record<string, unknown> = {};
-    if (clientId) where.clientId = clientId;
+
+    // If a clientId filter is requested, validate it is within the caller's scope
+    const effectiveClientId =
+      clientId &&
+      (scope.type === 'all' ||
+        (scope.type === 'single' && scope.clientId === clientId) ||
+        (scope.type === 'assigned' && scope.clientIds.includes(clientId)))
+        ? clientId
+        : undefined;
 
     return fastify.db.scheduledProbe.findMany({
-      where,
+      where: {
+        ...scopeWhere,
+        ...(effectiveClientId && { clientId: effectiveClientId }),
+      },
       orderBy: [{ createdAt: 'desc' }],
       include: {
         client: { select: { id: true, name: true, shortCode: true } },
@@ -188,8 +200,9 @@ export async function scheduledProbeRoutes(
 
   // Get single probe
   fastify.get<{ Params: { id: string } }>('/api/scheduled-probes/:id', async (request) => {
-    const probe = await fastify.db.scheduledProbe.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const probe = await fastify.db.scheduledProbe.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
       include: {
         client: { select: { id: true, name: true, shortCode: true } },
         integration: { select: { id: true, label: true, type: true, config: true, metadata: true } },
@@ -207,6 +220,15 @@ export async function scheduledProbeRoutes(
     }
 
     const data = parsed.data;
+
+    // Scope enforcement: validate the caller is authorized for the target client
+    const scope = await resolveClientScope(request);
+    if (
+      (scope.type === 'single' && scope.clientId !== data.clientId) ||
+      (scope.type === 'assigned' && !scope.clientIds.includes(data.clientId))
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
 
     // Timezone-based schedule validation
     if (data.scheduleTimezone) {
@@ -334,15 +356,19 @@ export async function scheduledProbeRoutes(
       updates.scheduleDaysOfWeek !== undefined ||
       updates.cronExpression !== undefined;
 
+    // Scope guard: ensure the caller is authorized for this probe's client
+    const scope = await resolveClientScope(request);
+    const probeForScope = await fastify.db.scheduledProbe.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true, scheduleHour: true, scheduleMinute: true, scheduleDaysOfWeek: true, scheduleTimezone: true },
+    });
+    if (!probeForScope) return fastify.httpErrors.notFound('Scheduled probe not found');
+
     // If any schedule fields changed and the probe uses timezone scheduling, we must
     // fetch the existing record to merge with the incoming partial update before recomputing cron
     let existingProbe: { scheduleHour: number | null; scheduleMinute: number | null; scheduleDaysOfWeek: string | null; scheduleTimezone: string | null } | null = null;
     if (scheduleFieldsChanged) {
-      existingProbe = await fastify.db.scheduledProbe.findUnique({
-        where: { id: request.params.id },
-        select: { scheduleHour: true, scheduleMinute: true, scheduleDaysOfWeek: true, scheduleTimezone: true },
-      });
-      if (!existingProbe) return fastify.httpErrors.notFound('Scheduled probe not found');
+      existingProbe = probeForScope;
     }
 
     // Resolve effective timezone schedule fields by merging incoming updates with existing values
@@ -433,8 +459,15 @@ export async function scheduledProbeRoutes(
 
   // Delete probe
   fastify.delete<{ Params: { id: string } }>('/api/scheduled-probes/:id', async (request, reply) => {
+    const scope = await resolveClientScope(request);
+    const probe = await fastify.db.scheduledProbe.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!probe) return fastify.httpErrors.notFound('Scheduled probe not found');
+
     try {
-      await fastify.db.scheduledProbe.delete({ where: { id: request.params.id } });
+      await fastify.db.scheduledProbe.delete({ where: { id: probe.id } });
     } catch (err) {
       if (isPrismaError(err, 'P2025')) {
         return fastify.httpErrors.notFound('Scheduled probe not found');
@@ -446,8 +479,9 @@ export async function scheduledProbeRoutes(
 
   // Trigger immediate execution
   fastify.post<{ Params: { id: string } }>('/api/scheduled-probes/:id/run', async (request) => {
-    const probe = await fastify.db.scheduledProbe.findUnique({
-      where: { id: request.params.id },
+    const scope = await resolveClientScope(request);
+    const probe = await fastify.db.scheduledProbe.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
     });
     if (!probe) return fastify.httpErrors.notFound('Scheduled probe not found');
 
@@ -467,7 +501,11 @@ export async function scheduledProbeRoutes(
     const offset = Math.max(parseInt(request.query.offset ?? '0', 10) || 0, 0);
     const statusFilter = request.query.status;
 
-    const probe = await fastify.db.scheduledProbe.findUnique({ where: { id: probeId }, select: { id: true } });
+    const scope = await resolveClientScope(request);
+    const probe = await fastify.db.scheduledProbe.findFirst({
+      where: { id: probeId, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
     if (!probe) return fastify.httpErrors.notFound('Scheduled probe not found');
 
     const where: Record<string, unknown> = { probeId };
@@ -500,6 +538,14 @@ export async function scheduledProbeRoutes(
   // Get current running probe run
   fastify.get<{ Params: { id: string } }>('/api/scheduled-probes/:id/runs/current', async (request) => {
     const probeId = request.params.id;
+    // Scope guard: verify caller can access this probe before returning its runs
+    const scope = await resolveClientScope(request);
+    const probeExists = await fastify.db.scheduledProbe.findFirst({
+      where: { id: probeId, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!probeExists) return fastify.httpErrors.notFound('Scheduled probe not found');
+
     const run = await fastify.db.probeRun.findFirst({
       where: { probeId, status: 'running' },
       orderBy: { startedAt: 'desc' },
@@ -510,6 +556,14 @@ export async function scheduledProbeRoutes(
 
   // Get single run with steps
   fastify.get<{ Params: { id: string; runId: string } }>('/api/scheduled-probes/:id/runs/:runId', async (request) => {
+    // Scope guard: verify caller can access the parent probe
+    const scope = await resolveClientScope(request);
+    const probeExists = await fastify.db.scheduledProbe.findFirst({
+      where: { id: request.params.id, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
+    if (!probeExists) return fastify.httpErrors.notFound('Scheduled probe not found');
+
     const run = await fastify.db.probeRun.findUnique({
       where: { id: request.params.runId },
       include: { steps: { orderBy: { stepOrder: 'asc' } } },
@@ -523,7 +577,11 @@ export async function scheduledProbeRoutes(
   // Purge run history (keep most recent 5)
   fastify.delete<{ Params: { id: string } }>('/api/scheduled-probes/:id/runs', async (request) => {
     const probeId = request.params.id;
-    const probe = await fastify.db.scheduledProbe.findUnique({ where: { id: probeId }, select: { id: true } });
+    const scope = await resolveClientScope(request);
+    const probe = await fastify.db.scheduledProbe.findFirst({
+      where: { id: probeId, ...scopeToWhere(scope) },
+      select: { id: true },
+    });
     if (!probe) return fastify.httpErrors.notFound('Scheduled probe not found');
 
     const recentRuns = await fastify.db.probeRun.findMany({

--- a/services/copilot-api/src/routes/slack-conversations.ts
+++ b/services/copilot-api/src/routes/slack-conversations.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 export async function slackConversationRoutes(fastify: FastifyInstance): Promise<void> {
   // --- List conversations ---
@@ -28,9 +29,25 @@ export async function slackConversationRoutes(fastify: FastifyInstance): Promise
       return fastify.httpErrors.badRequest('limit and offset must be non-negative integers');
     }
 
-    const where: Record<string, unknown> = {};
+    // Scope enforcement: restrict to caller's client(s)
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+
+    const where: Record<string, unknown> = {
+      // Apply scope — conversations with clientId=null are only visible to 'all' callers
+      ...scopeWhere,
+    };
     if (operatorId) where.operatorId = operatorId;
-    if (clientId) where.clientId = clientId;
+
+    // If a clientId filter is requested, validate it is within the caller's scope
+    const effectiveClientId =
+      clientId &&
+      (callerScope.type === 'all' ||
+        (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+        (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId)))
+        ? clientId
+        : undefined;
+    if (effectiveClientId) where.clientId = effectiveClientId;
 
     if (startDate || endDate) {
       const createdAt: Record<string, Date> = {};
@@ -77,8 +94,11 @@ export async function slackConversationRoutes(fastify: FastifyInstance): Promise
   fastify.get<{ Params: { id: string } }>('/api/slack-conversations/:id', async (request) => {
     const { id } = request.params;
 
-    const conversation = await fastify.db.slackConversationLog.findUnique({
-      where: { id },
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+
+    const conversation = await fastify.db.slackConversationLog.findFirst({
+      where: { id, ...scopeWhere },
       include: {
         operator: { select: { id: true, person: { select: { name: true } } } },
         client: { select: { id: true, name: true, shortCode: true } },

--- a/services/copilot-api/src/routes/system-analyses.ts
+++ b/services/copilot-api/src/routes/system-analyses.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import type { Queue } from 'bullmq';
 import { SystemAnalysisStatus } from '@bronco/shared-types';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
 const VALID_STATUSES: Set<string> = new Set(Object.values(SystemAnalysisStatus));
 
@@ -38,9 +39,23 @@ export async function systemAnalysisRoutes(
       return fastify.httpErrors.badRequest(`Invalid status: ${status}`);
     }
 
+    // Scope enforcement: restrict to caller's client(s)
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+
+    // If a clientId filter is requested, validate it is within the caller's scope
+    const effectiveClientId =
+      clientId &&
+      (callerScope.type === 'all' ||
+        (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+        (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId)))
+        ? clientId
+        : undefined;
+
     const where = {
+      ...scopeWhere,
       ...(status && { status: status as SystemAnalysisStatus }),
-      ...(clientId && { clientId }),
+      ...(effectiveClientId && { clientId: effectiveClientId }),
     };
 
     const [total, analyses] = await Promise.all([
@@ -57,9 +72,13 @@ export async function systemAnalysisRoutes(
   });
 
   // GET /api/system-analyses/stats — counts by status
-  fastify.get('/api/system-analyses/stats', async () => {
+  fastify.get('/api/system-analyses/stats', async (request) => {
+    const callerScope = await resolveClientScope(request);
+    const scopeWhere = scopeToWhere(callerScope);
+
     const byStatus = await fastify.db.systemAnalysis.groupBy({
       by: ['status'],
+      where: scopeWhere,
       _count: true,
     });
 
@@ -77,6 +96,15 @@ export async function systemAnalysisRoutes(
     const { clientId } = request.query;
     if (!clientId) {
       return fastify.httpErrors.badRequest('clientId query parameter is required');
+    }
+
+    // Scope enforcement: validate the caller is authorized for the requested client
+    const callerScope = await resolveClientScope(request);
+    if (
+      (callerScope.type === 'single' && callerScope.clientId !== clientId) ||
+      (callerScope.type === 'assigned' && !callerScope.clientIds.includes(clientId))
+    ) {
+      return fastify.httpErrors.forbidden('clientId not in your scope');
     }
 
     const [pending, rejected] = await Promise.all([
@@ -101,8 +129,9 @@ export async function systemAnalysisRoutes(
   fastify.get<{ Params: { id: string } }>(
     '/api/system-analyses/:id',
     async (request) => {
-      const analysis = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const analysis = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
       });
       if (!analysis) return fastify.httpErrors.notFound('Analysis not found');
       return analysis;
@@ -113,8 +142,9 @@ export async function systemAnalysisRoutes(
   fastify.patch<{ Params: { id: string } }>(
     '/api/system-analyses/:id/acknowledge',
     async (request) => {
-      const existing = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const existing = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
         select: { status: true },
       });
       if (!existing) return fastify.httpErrors.notFound('Analysis not found');
@@ -141,8 +171,9 @@ export async function systemAnalysisRoutes(
         return fastify.httpErrors.badRequest('Rejection reason is required');
       }
 
-      const existing = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const existing = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
         select: { status: true },
       });
       if (!existing) return fastify.httpErrors.notFound('Analysis not found');
@@ -161,8 +192,9 @@ export async function systemAnalysisRoutes(
   fastify.post<{ Params: { id: string } }>(
     '/api/system-analyses/:id/regenerate',
     async (request, reply) => {
-      const existing = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const existing = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
         select: { ticketId: true },
       });
       if (!existing) return fastify.httpErrors.notFound('Analysis not found');
@@ -182,8 +214,9 @@ export async function systemAnalysisRoutes(
   fastify.patch<{ Params: { id: string } }>(
     '/api/system-analyses/:id/reopen',
     async (request) => {
-      const existing = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const existing = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
         select: { status: true },
       });
       if (!existing) return fastify.httpErrors.notFound('Analysis not found');
@@ -202,8 +235,9 @@ export async function systemAnalysisRoutes(
   fastify.delete<{ Params: { id: string } }>(
     '/api/system-analyses/:id',
     async (request, reply) => {
-      const existing = await fastify.db.systemAnalysis.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const existing = await fastify.db.systemAnalysis.findFirst({
+        where: { id: request.params.id, ...scopeToWhere(callerScope) },
         select: { id: true },
       });
       if (!existing) return fastify.httpErrors.notFound('Analysis not found');

--- a/services/copilot-api/src/routes/ticket-routes.ts
+++ b/services/copilot-api/src/routes/ticket-routes.ts
@@ -4,7 +4,7 @@ import type { PrismaClient, PrismaRouteStepType, PrismaRouteType } from '@bronco
 import { TaskType, TicketCategory, TicketSource, RouteStepType, RouteType } from '@bronco/shared-types';
 import type { RouteStepTypeInfo } from '@bronco/shared-types';
 import type { AIRouter } from '@bronco/ai-provider';
-import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
+import { resolveClientScope } from '../plugins/client-scope.js';
 import type { ClientScope } from '../plugins/client-scope.js';
 
 const VALID_CATEGORIES = new Set<string>(Object.values(TicketCategory));
@@ -418,6 +418,16 @@ export async function ticketRouteRoutes(
   }>('/api/ticket-routes/dispatch-preview', async (request) => {
     const { clientId, routeId } = request.query;
     if (!routeId) return fastify.httpErrors.badRequest('routeId is required');
+
+    // Scope guard: if a clientId was provided, validate the caller can access it
+    if (clientId) {
+      const callerScope = await resolveClientScope(request);
+      const inScope =
+        callerScope.type === 'all' ||
+        (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+        (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId));
+      if (!inScope) return fastify.httpErrors.forbidden('clientId not in your scope');
+    }
 
     const allCategories = Object.values(TicketCategory);
 
@@ -840,8 +850,13 @@ export async function ticketRouteRoutes(
     const scopeFilter = ticketRouteScopeFilter(callerScope);
     const route = await fastify.db.ticketRoute.findFirst({
       where: { id: request.params.id, ...scopeFilter },
+      select: { id: true, clientId: true, routeType: true },
     });
     if (!route) return fastify.httpErrors.notFound('Ticket route not found');
+    // Platform-scoped routes can only be mutated by admin/API-key callers
+    if (route.clientId === null && callerScope.type !== 'all') {
+      return fastify.httpErrors.forbidden('Platform-scoped routes can only be modified by global administrators');
+    }
 
     try {
       const step = await fastify.db.ticketRouteStep.create({
@@ -908,10 +923,14 @@ export async function ticketRouteRoutes(
         }),
         fastify.db.ticketRoute.findFirst({
           where: { id: request.params.id, ...scopeFilter },
-          select: { routeType: true },
+          select: { routeType: true, clientId: true },
         }),
       ]);
       if (!parentRoute || !existing) return fastify.httpErrors.notFound('Route step not found');
+      // Platform-scoped routes can only be mutated by admin/API-key callers
+      if (parentRoute.clientId === null && callerScope.type !== 'all') {
+        return fastify.httpErrors.forbidden('Platform-scoped routes can only be modified by global administrators');
+      }
 
       const effectiveStepType = stepType ?? existing.stepType;
       if (effectiveStepType === RouteStepType.DISPATCH_TO_ROUTE && config) {
@@ -978,9 +997,13 @@ export async function ticketRouteRoutes(
       const scopeFilter = ticketRouteScopeFilter(callerScope);
       const parentRoute = await fastify.db.ticketRoute.findFirst({
         where: { id: request.params.id, ...scopeFilter },
-        select: { id: true },
+        select: { id: true, clientId: true },
       });
       if (!parentRoute) return fastify.httpErrors.notFound('Ticket route not found');
+      // Platform-scoped routes can only be mutated by admin/API-key callers
+      if (parentRoute.clientId === null && callerScope.type !== 'all') {
+        return fastify.httpErrors.forbidden('Platform-scoped routes can only be modified by global administrators');
+      }
 
       try {
         const deleteResult = await fastify.db.ticketRouteStep.deleteMany({

--- a/services/copilot-api/src/routes/ticket-routes.ts
+++ b/services/copilot-api/src/routes/ticket-routes.ts
@@ -4,6 +4,8 @@ import type { PrismaClient, PrismaRouteStepType, PrismaRouteType } from '@bronco
 import { TaskType, TicketCategory, TicketSource, RouteStepType, RouteType } from '@bronco/shared-types';
 import type { RouteStepTypeInfo } from '@bronco/shared-types';
 import type { AIRouter } from '@bronco/ai-provider';
+import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
+import type { ClientScope } from '../plugins/client-scope.js';
 
 const VALID_CATEGORIES = new Set<string>(Object.values(TicketCategory));
 const VALID_STEP_TYPES = new Set<string>(Object.values(RouteStepType));
@@ -371,6 +373,22 @@ function validateCustomAiQueryConfig(config: Record<string, unknown>): string | 
   return null;
 }
 
+/**
+ * Build a Prisma where-clause fragment for TicketRoute that respects caller scope.
+ *
+ * Platform-scoped routes (clientId IS NULL) are shared infrastructure visible to all
+ * authenticated callers — same pattern as ClientIntegration in integrations.ts.
+ * Client-scoped routes are restricted to the caller's tenant(s).
+ */
+function ticketRouteScopeFilter(scope: ClientScope): Record<string, unknown> {
+  if (scope.type === 'all') return {};
+  if (scope.type === 'single') {
+    return { OR: [{ clientId: null }, { clientId: scope.clientId }] };
+  }
+  // assigned
+  return { OR: [{ clientId: null }, { clientId: { in: scope.clientIds } }] };
+}
+
 interface TicketRouteOpts {
   ai: AIRouter;
 }
@@ -458,10 +476,24 @@ export async function ticketRouteRoutes(
     if (routeType && !VALID_ROUTE_TYPES.has(routeType)) {
       return fastify.httpErrors.badRequest(`Invalid routeType "${routeType}". Valid values: ${[...VALID_ROUTE_TYPES].join(', ')}`);
     }
+
+    const callerScope = await resolveClientScope(request);
+    const scopeFilter = ticketRouteScopeFilter(callerScope);
+
+    // If a clientId filter is requested, validate it is within the caller's scope
+    const effectiveClientId =
+      clientId &&
+      (callerScope.type === 'all' ||
+        (callerScope.type === 'single' && callerScope.clientId === clientId) ||
+        (callerScope.type === 'assigned' && callerScope.clientIds.includes(clientId)))
+        ? clientId
+        : undefined;
+
     return fastify.db.ticketRoute.findMany({
       where: {
+        ...scopeFilter,
         ...(category && { category: category as never }),
-        ...(clientId && { clientId }),
+        ...(effectiveClientId && { clientId: effectiveClientId }),
         ...(isActive !== undefined && { isActive: isActive === 'true' }),
         ...(routeType && { routeType: routeType as never }),
       },
@@ -478,8 +510,10 @@ export async function ticketRouteRoutes(
   fastify.get<{ Params: { id: string } }>(
     '/api/ticket-routes/:id',
     async (request) => {
-      const route = await fastify.db.ticketRoute.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const scopeFilter = ticketRouteScopeFilter(callerScope);
+      const route = await fastify.db.ticketRoute.findFirst({
+        where: { id: request.params.id, ...scopeFilter },
         include: {
           steps: { orderBy: { stepOrder: 'asc' } },
           client: { select: { name: true, shortCode: true } },
@@ -533,6 +567,24 @@ export async function ticketRouteRoutes(
     if (source && !VALID_SOURCES.has(source)) {
       return fastify.httpErrors.badRequest(`Invalid source "${source}". Valid values: ${[...VALID_SOURCES].join(', ')}`);
     }
+
+    // Scope enforcement: validate the caller is authorized for the target client.
+    // Platform-scoped (null clientId) routes require 'all' scope — only ADMIN/API-key.
+    const callerScope = await resolveClientScope(request);
+    if (trimmedClientId === null) {
+      // Platform-scoped creation restricted to admin/API-key callers
+      if (callerScope.type !== 'all') {
+        return fastify.httpErrors.forbidden('Creating platform-scoped routes requires admin access');
+      }
+    } else if (trimmedClientId !== null) {
+      if (
+        (callerScope.type === 'single' && callerScope.clientId !== trimmedClientId) ||
+        (callerScope.type === 'assigned' && !callerScope.clientIds.includes(trimmedClientId))
+      ) {
+        return fastify.httpErrors.forbidden('clientId not in your scope');
+      }
+    }
+
     if (steps) {
       for (const s of steps) {
         if (!VALID_STEP_TYPES.has(s.stepType)) {
@@ -645,6 +697,19 @@ export async function ticketRouteRoutes(
       return fastify.httpErrors.badRequest(`Invalid source "${trimmedSource}". Valid values: ${[...VALID_SOURCES].join(', ')}`);
     }
 
+    // Scope guard: ensure the caller is authorized for this route's client (or platform-scoped)
+    const callerScope = await resolveClientScope(request);
+    const scopeFilter = ticketRouteScopeFilter(callerScope);
+    const existingRoute = await fastify.db.ticketRoute.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
+      select: { id: true, clientId: true },
+    });
+    if (!existingRoute) return fastify.httpErrors.notFound('Ticket route not found');
+    // Platform-scoped routes can only be mutated by admin/API-key callers
+    if (existingRoute.clientId === null && callerScope.type !== 'all') {
+      return fastify.httpErrors.forbidden('Platform-scoped routes can only be modified by global administrators');
+    }
+
     try {
       const route = await fastify.db.ticketRoute.update({
         where: { id: request.params.id },
@@ -697,6 +762,18 @@ export async function ticketRouteRoutes(
   fastify.delete<{ Params: { id: string } }>(
     '/api/ticket-routes/:id',
     async (request, reply) => {
+      const callerScope = await resolveClientScope(request);
+      const scopeFilter = ticketRouteScopeFilter(callerScope);
+      const existingRoute = await fastify.db.ticketRoute.findFirst({
+        where: { id: request.params.id, ...scopeFilter },
+        select: { id: true, clientId: true },
+      });
+      if (!existingRoute) return fastify.httpErrors.notFound('Ticket route not found');
+      // Platform-scoped routes can only be deleted by admin/API-key callers
+      if (existingRoute.clientId === null && callerScope.type !== 'all') {
+        return fastify.httpErrors.forbidden('Platform-scoped routes can only be deleted by global administrators');
+      }
+
       try {
         await fastify.db.ticketRoute.delete({ where: { id: request.params.id } });
         reply.code(204);
@@ -714,8 +791,10 @@ export async function ticketRouteRoutes(
   fastify.post<{ Params: { id: string } }>(
     '/api/ticket-routes/:id/regenerate-summary',
     async (request) => {
-      const route = await fastify.db.ticketRoute.findUnique({
-        where: { id: request.params.id },
+      const callerScope = await resolveClientScope(request);
+      const scopeFilter = ticketRouteScopeFilter(callerScope);
+      const route = await fastify.db.ticketRoute.findFirst({
+        where: { id: request.params.id, ...scopeFilter },
         include: { steps: { where: { isActive: true }, orderBy: { stepOrder: 'asc' } } },
       });
       if (!route) return fastify.httpErrors.notFound('Ticket route not found');
@@ -757,7 +836,11 @@ export async function ticketRouteRoutes(
       if (cfgErr) return fastify.httpErrors.badRequest(cfgErr);
     }
 
-    const route = await fastify.db.ticketRoute.findUnique({ where: { id: request.params.id } });
+    const callerScope = await resolveClientScope(request);
+    const scopeFilter = ticketRouteScopeFilter(callerScope);
+    const route = await fastify.db.ticketRoute.findFirst({
+      where: { id: request.params.id, ...scopeFilter },
+    });
     if (!route) return fastify.httpErrors.notFound('Ticket route not found');
 
     try {
@@ -816,17 +899,19 @@ export async function ticketRouteRoutes(
     }
 
     try {
+      const callerScope = await resolveClientScope(request);
+      const scopeFilter = ticketRouteScopeFilter(callerScope);
       const [existing, parentRoute] = await Promise.all([
         fastify.db.ticketRouteStep.findFirst({
           where: { id: request.params.stepId, routeId: request.params.id },
           select: { id: true, stepType: true },
         }),
-        fastify.db.ticketRoute.findUnique({
-          where: { id: request.params.id },
+        fastify.db.ticketRoute.findFirst({
+          where: { id: request.params.id, ...scopeFilter },
           select: { routeType: true },
         }),
       ]);
-      if (!existing) return fastify.httpErrors.notFound('Route step not found');
+      if (!parentRoute || !existing) return fastify.httpErrors.notFound('Route step not found');
 
       const effectiveStepType = stepType ?? existing.stepType;
       if (effectiveStepType === RouteStepType.DISPATCH_TO_ROUTE && config) {
@@ -888,6 +973,15 @@ export async function ticketRouteRoutes(
   fastify.delete<{ Params: { id: string; stepId: string } }>(
     '/api/ticket-routes/:id/steps/:stepId',
     async (request, reply) => {
+      // Scope guard: verify the parent route is accessible before deleting its step
+      const callerScope = await resolveClientScope(request);
+      const scopeFilter = ticketRouteScopeFilter(callerScope);
+      const parentRoute = await fastify.db.ticketRoute.findFirst({
+        where: { id: request.params.id, ...scopeFilter },
+        select: { id: true },
+      });
+      if (!parentRoute) return fastify.httpErrors.notFound('Ticket route not found');
+
       try {
         const deleteResult = await fastify.db.ticketRouteStep.deleteMany({
           where: { id: request.params.stepId, routeId: request.params.id },


### PR DESCRIPTION
## Summary

Complete the Critical 2 scoping sweep started in #410. Applies the same `resolveClientScope` + `scopeToWhere` pattern to the 8 remaining client-scoped route groups that accepted `clientId` without verifying caller authorization.

Fixes #407 Critical #2 (remainder — subset already shipped in #410).

## Changes — 7 files (8th `operational-tasks.ts` correctly skipped)

| File | Endpoints scoped |
|---|---|
| `scheduled-probes.ts` | LIST, GET/:id, POST, PATCH/:id, DELETE/:id, /:id/run, /:id/runs, /:id/runs/current, /:id/runs/:runId, purge-runs DELETE. PATCH's existing conditional `findUnique` replaced with unified scope-guard fetch. |
| `issue-jobs.ts` | LIST, GET/:id, GET/:id/plan, POST, /:id/approve, /:id/reject. `IssueJob` has no direct `clientId`; scope applied via `ticket.clientId` relation filter. |
| `invoices.ts` | All 5 routes (LIST, generate POST, download GET, PATCH, DELETE). Routes nest under `/api/clients/:id/invoices`; path-param `:id` is the clientId — scope validates it against caller. |
| `system-analyses.ts` | LIST, stats, context, GET/:id, acknowledge, reject, regenerate, reopen, DELETE. `stats` also scoped so counts are caller-specific. |
| `ticket-routes.ts` | LIST, GET/:id, POST, PATCH/:id, DELETE/:id, regenerate-summary, POST steps, PATCH steps, DELETE steps. Platform-scoped rows (`clientId IS NULL`) visible to all; creation/mutation restricted to `scope.type === 'all'` — same pattern as integrations.ts from #410. |
| `email-logs.ts` | LIST, /:id/retry, PATCH /:id (reclassify). `clientId` is nullable; null-client logs only visible to `all`-scope callers. |
| `slack-conversations.ts` | LIST, GET/:id. Same nullable-client handling. |

**`operational-tasks.ts`** — skipped. `OperationalTask` has no `clientId` field in the schema; it's a platform-level entity (DevOps workflow tasks) with no per-client scoping axis.

## Pattern (same as #410)

- **LIST:** `scopeToWhere(resolveClientScope(request))` applied to where
- **GET /:id:** `findFirst({ where: { id, ...scopeToWhere(...) } })`; 404 on miss
- **POST:** `body.clientId` validated; 403 on mismatch (where applicable)
- **PATCH / DELETE /:id:** scope-gated `findFirst` guard; 404 on miss
- ADMIN + API-key (`scope.type === 'all'`) unchanged — empty where = no filter

## With this PR

Combined with #410's first tranche, **every client-scoped REST surface** now has per-caller tenant enforcement. Critical 2 closed.

## Test plan

- [ ] CI passes on staging push
- [ ] ADMIN / API-key callers continue to see all clients' data on each endpoint (no regression)
- [ ] Client-scoped operator at Client A: LIST returns only Client A rows; cross-tenant IDs return 404
- [ ] Platform-scoped rows in `ticket-routes` (clientId IS NULL) remain visible to client-scoped callers but cannot be mutated by them
- [ ] email-logs / slack-conversations: null-client rows only visible to `all`-scope callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
