### PR TITLE
hotfix(cloudflared): liveness-only healthcheck for distroless image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -384,14 +384,14 @@ services:
     image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:latest}
     restart: unless-stopped
     command: tunnel --no-autoupdate --metrics 0.0.0.0:2000 run --token ${CLOUDFLARE_TUNNEL_TOKEN:?CLOUDFLARE_TUNNEL_TOKEN must be set in .env — create a tunnel at one.dash.cloudflare.com}
-    # Healthcheck uses the cloudflared metrics /ready endpoint (exposed on port 2000 via --metrics).
-    # /ready returns HTTP 200 when at least one tunnel connection is registered and non-200 when all
-    # connections are down, allowing Docker to restart the container when QUIC drift causes the
-    # tunnel to go stale.
-    # Uses CMD (not CMD-SHELL) so the healthcheck only depends on wget being in the image PATH
-    # and does not require /bin/sh or grep. wget is present in the cloudflared image base layer.
+    # Liveness-only healthcheck: the cloudflared image is distroless — no sh, no wget, no curl.
+    # The only binary available on PATH is cloudflared itself, so `--version` is used as a
+    # shallow "is the process alive" probe. This is NOT a drift-detection probe (the tunnel
+    # could be registered-but-stale and this would still return 0). Drift detection against
+    # the metrics /ready endpoint (exposed on port 2000 via --metrics) is tracked as a
+    # follow-up — would need a sidecar probe or a variant cloudflared image with wget/curl.
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:2000/ready"]
+      test: ["CMD", "cloudflared", "--version"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Hotfix — direct to master

**Observed on Hugo post v0.2.4 deploy:**

```
bronco-cloudflared-1  Up 2 minutes (unhealthy)
```

`docker inspect` output:
```
"Output":"OCI runtime exec failed: exec failed: unable to start container process: exec: \"wget\": executable file not found in $PATH"
```

The v0.2.4 healthcheck `CMD wget -q --spider http://localhost:2000/ready` (added in #382, refined in the v0.2.4 sweep) fails on every probe because `cloudflare/cloudflared:latest` is a **distroless image** — no `sh`, no `wget`, no `curl`. Only the `cloudflared` binary itself is on PATH.

**The tunnel is not broken** — `curl -I https://itrack.siirial.com` still returns `HTTP/2 302` to Cloudflare Access as expected. This is purely a broken health probe reporting `unhealthy` while everything functions normally.

## Fix

Swap the probe to the only executable available in the image: `cloudflared --version`. This is a **liveness-only** check — it confirms the process is alive and the binary runs, but does NOT detect tunnel-connection drift (which was #381's original goal).

```yaml
healthcheck:
  test: ["CMD", "cloudflared", "--version"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 30s
```

## What we lose

Drift detection against the `/ready` metrics endpoint (what #381 tried to build). Fix captured as a follow-up (new issue opened) — options:
- Sidecar container with `curl`/`wget` that probes `/ready` and reports
- Switch to a cloudflared image variant that includes busybox / wget
- External poller (e.g. status-monitor) that hits `/ready` via network and alerts if it fails

## Why direct to master

Healthcheck noise is visible on every `docker compose ps` and is continuously failing (30s interval, 3 retries). Quick one-line fix that should land on Hugo today.

## Test plan

- [ ] After deploy: `ssh hugo-app "docker ps --format '{{.Names}} {{.Status}}' | grep cloudflared"` — shows `(healthy)` not `(unhealthy)`
- [ ] `ssh hugo-app "docker exec bronco-cloudflared-1 cloudflared --version"` — prints version string (it already does)
- [ ] Tunnel still serving: `curl -I https://itrack.siirial.com` returns 302 to Cloudflare Access

🤖 Generated with [Claude Code](https://claude.com/claude-code)
