### PR TITLE
fix(control-panel): PWA iOS safe-area + dialog body-scroll-lock

### DIFF
--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, effect, input, output, viewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, effect, input, output, viewChild } from '@angular/core';
 
 @Component({
   selector: 'app-dialog',
@@ -129,6 +129,9 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
         border-radius: 0;
         animation: slideUp 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
       }
+      .dialog-header {
+        padding-top: max(16px, calc(env(safe-area-inset-top) + 8px));
+      }
       .dialog-close {
         width: 44px;
         height: 44px;
@@ -142,7 +145,7 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
     }
   `],
 })
-export class DialogComponent {
+export class DialogComponent implements OnDestroy {
   title = input<string>('');
   open = input<boolean>(false);
   maxWidth = input<string>('480px');
@@ -152,10 +155,52 @@ export class DialogComponent {
   private panelRef = viewChild<ElementRef<HTMLElement>>('panel');
   private previouslyFocused: HTMLElement | null = null;
 
+  // ── Body-scroll-lock (static counter so stacked dialogs work correctly) ──
+  private static openCount = 0;
+  private static savedScrollY = 0;
+  private scrollLocked = false;
+
+  private lockBodyScroll(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (DialogComponent.openCount === 0) {
+      DialogComponent.savedScrollY = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${DialogComponent.savedScrollY}px`;
+      document.body.style.width = '100%';
+      document.body.style.left = '0';
+      document.body.style.right = '0';
+    }
+    DialogComponent.openCount++;
+    this.scrollLocked = true;
+  }
+
+  private unlockBodyScroll(): void {
+    if (!this.scrollLocked) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    this.scrollLocked = false;
+    DialogComponent.openCount--;
+    if (DialogComponent.openCount < 0) DialogComponent.openCount = 0;
+    if (DialogComponent.openCount === 0) {
+      const scrollY = DialogComponent.savedScrollY;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      window.scrollTo(0, scrollY);
+      DialogComponent.savedScrollY = 0;
+    }
+  }
+
   constructor() {
-    // Manage Escape key + focus restore while the dialog is open.
+    // Manage Escape key + focus restore + body-scroll-lock while dialog is open.
     effect((onCleanup) => {
-      if (!this.open()) return;
+      if (!this.open()) {
+        this.unlockBodyScroll();
+        return;
+      }
+
+      this.lockBodyScroll();
 
       this.previouslyFocused = (typeof document !== 'undefined'
         ? (document.activeElement as HTMLElement | null)
@@ -171,6 +216,7 @@ export class DialogComponent {
 
       onCleanup(() => {
         document.removeEventListener('keydown', onKeyDown);
+        this.unlockBodyScroll();
         // Restore focus to whatever was focused before the dialog opened.
         if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
           this.previouslyFocused.focus();
@@ -191,6 +237,11 @@ export class DialogComponent {
         focusable?.focus();
       });
     });
+  }
+
+  ngOnDestroy(): void {
+    // Guard against component teardown while open (e.g. route navigation).
+    this.unlockBodyScroll();
   }
 
   close(): void {

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -158,12 +158,22 @@ export class DialogComponent implements OnDestroy {
   // ── Body-scroll-lock (static counter so stacked dialogs work correctly) ──
   private static openCount = 0;
   private static savedScrollY = 0;
+  // Captured inline style values from before the first dialog locks — restored
+  // exactly when the last dialog closes so pre-existing inline styles survive.
+  private static savedBodyStyles: { position: string; top: string; width: string; left: string; right: string } | null = null;
   private scrollLocked = false;
 
   private lockBodyScroll(): void {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
     if (DialogComponent.openCount === 0) {
       DialogComponent.savedScrollY = window.scrollY;
+      DialogComponent.savedBodyStyles = {
+        position: document.body.style.position,
+        top: document.body.style.top,
+        width: document.body.style.width,
+        left: document.body.style.left,
+        right: document.body.style.right,
+      };
       document.body.style.position = 'fixed';
       document.body.style.top = `-${DialogComponent.savedScrollY}px`;
       document.body.style.width = '100%';
@@ -182,13 +192,15 @@ export class DialogComponent implements OnDestroy {
     if (DialogComponent.openCount < 0) DialogComponent.openCount = 0;
     if (DialogComponent.openCount === 0) {
       const scrollY = DialogComponent.savedScrollY;
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.left = '';
-      document.body.style.right = '';
+      const prev = DialogComponent.savedBodyStyles;
+      document.body.style.position = prev?.position ?? '';
+      document.body.style.top = prev?.top ?? '';
+      document.body.style.width = prev?.width ?? '';
+      document.body.style.left = prev?.left ?? '';
+      document.body.style.right = prev?.right ?? '';
       window.scrollTo(0, scrollY);
       DialogComponent.savedScrollY = 0;
+      DialogComponent.savedBodyStyles = null;
     }
   }
 

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -36,8 +36,8 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
   `,
   styles: [`
     .header-bar {
-      height: var(--header-height);
-      min-height: var(--header-height);
+      height: calc(var(--header-height) + env(safe-area-inset-top));
+      min-height: calc(var(--header-height) + env(safe-area-inset-top));
       background: var(--bg-header);
       backdrop-filter: saturate(180%) blur(20px);
       -webkit-backdrop-filter: saturate(180%) blur(20px);


### PR DESCRIPTION
## Summary

Three related fixes for the iOS Home Screen PWA experience plus defense-in-depth body-scroll-lock when any dialog is open.

## Background

User installed `itrack.siirial.com/cp/` to iOS Home Screen and saw:
1. Status bar overlapping the app header content
2. Dialog close-X partially hidden under the iOS status bar — and tapping in that zone would trigger iOS's native "tap status bar to scroll to top" behavior on the underlying page

Both stem from `apple-mobile-web-app-status-bar-style: black-translucent` + `viewport-fit=cover` (correctly set in `index.html`) requiring the app to manually account for `env(safe-area-inset-top)` — which the header and dialog header weren't doing.

## Changes — 2 files

**`services/control-panel/src/app/shell/header-bar.component.ts`** — header now grows for the safe-area inset:

```diff
.header-bar {
- height: var(--header-height);
- min-height: var(--header-height);
+ height: calc(var(--header-height) + env(safe-area-inset-top));
+ min-height: calc(var(--header-height) + env(safe-area-inset-top));
  padding-top: env(safe-area-inset-top);
}
```

**`services/control-panel/src/app/shared/components/dialog.component.ts`**:
1. Mobile media query — added `padding-top: max(16px, calc(env(safe-area-inset-top) + 8px))` to `.dialog-header`. The `max()` keeps non-PWA mobile at the existing 16px floor; PWA mode gets the inset + 8px gap so the X clears the status bar.
2. **Body-scroll-lock** when any dialog is open:
   - Static `openCount` counter handles stacked dialogs
   - On open: capture `window.scrollY`, set body `position: fixed; top: -<scrollY>px; width: 100%; left/right: 0`
   - On close: restore styles, `scrollTo(0, savedScrollY)`
   - Wired via the existing Angular `effect()` lifecycle (lock on `open()` signal true, unlock on cleanup), with `ngOnDestroy()` safety net for route-navigation teardown
   - `scrollLocked` instance guard prevents double-unlock

## Non-PWA contexts unaffected

`env(safe-area-inset-top)` resolves to `0` in mobile Safari (URL bar visible) and desktop browsers — every `calc()` / `max()` expression degrades to the existing values. No regression.

| Context | `env(safe-area-inset-top)` | Header height after fix |
|---|---|---|
| Mobile Safari (browser, URL bar) | `0` | `52 + 0 = 52px` (unchanged) |
| Standalone PWA (home screen) | `~59px` | `52 + 59 = 111px` (fixes overlap) |
| Desktop | `0` | `52px` (unchanged) |

## Scroll-lock scope

Only applies to `DialogComponent` (the shared base used app-wide). `ai-help-dialog` and `command-palette` use CDK overlays directly and are unaffected — no cross-contamination from the static `openCount`.

## Pre-existing typecheck error noted

The subagent flagged a pre-existing `TS2353` error on `mcp-servers/platform/src/tools/request-tool.ts:208` that's already on staging. Not introduced by this branch. Worth investigating separately — staging shouldn't have a typecheck error.

## Test plan

- [ ] CI passes on staging push
- [ ] PWA install on iOS, open ticket → header content not behind status bar
- [ ] Open a dialog from PWA → close-X is below the status bar zone, tappable cleanly
- [ ] Open a dialog → body doesn't scroll while dialog is up; close → scroll position preserved (no jump-to-top)
- [ ] Stacked dialogs (open A → open B → close B → close A) → unlock only on final close, scroll restored
- [ ] Non-PWA mobile Safari and desktop — no visual or behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
