### PR TITLE
fix(ingestion): pass probe artifact through to analyzer initial prompt

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
@@ -14,6 +14,7 @@ import { executeRecommendations } from './recommendation-executor.js';
 import type { ParsedAction } from './recommendation-executor.js';
 import {
   buildAgenticTools,
+  buildTruncatedPreview,
   DEFAULT_REPO_FILE_EXTENSIONS,
   parseSufficiencyEvaluation,
   resolveAnalysisStrategy,
@@ -324,8 +325,8 @@ async function loadAnalysisContext(
 
     if (probeArtifactId && artifactStoragePath) {
       try {
-        const artifact = await db.artifact.findUnique({
-          where: { id: probeArtifactId },
+        const artifact = await db.artifact.findFirst({
+          where: { id: probeArtifactId, ticketId },
           select: { storagePath: true, sizeBytes: true },
         });
         if (artifact) {
@@ -333,28 +334,32 @@ async function loadAnalysisContext(
           const absPath = resolve(resolvedStorage, artifact.storagePath);
           const rel = relative(resolvedStorage, absPath);
           if (!rel.startsWith('..') && rel !== '' && !rel.startsWith('/')) {
-            const rawContent = await readFile(absPath, 'utf-8');
             if (artifact.sizeBytes <= PROBE_ARTIFACT_INLINE_BYTES) {
-              // Small enough to inline — Claude sees the full probe result immediately
+              // Small enough to inline — read the full file; Claude sees the full probe result immediately
+              const rawContent = await readFile(absPath, 'utf-8');
               emailBody = rawContent;
               logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact inlined in analysis context');
             } else {
-              // Too large to inline — build head+tail preview so Claude knows the
-              // full data is available via platform__read_tool_result_artifact
-              const head = rawContent.slice(0, 2000);
-              const tail = rawContent.slice(-500);
-              emailBody = [
-                '[truncated — full probe result saved as artifact]',
-                `artifactId: ${probeArtifactId}`,
-                `size: ${rawContent.length} chars`,
-                'Use platform__read_tool_result_artifact to retrieve the full content.',
-                '---',
-                head,
-                '',
-                '...',
-                '',
-                tail,
-              ].join('\n');
+              // Too large to inline — read only head and tail bytes to avoid loading the
+              // entire file into memory, then build a canonical truncated preview so
+              // Claude can page the rest via platform__read_tool_result_artifact.
+              const HEAD_BYTES = 1500;
+              const TAIL_BYTES = 500;
+              const fh = await open(absPath, 'r');
+              try {
+                const headBuf = Buffer.alloc(HEAD_BYTES);
+                const { bytesRead: headRead } = await fh.read(headBuf, 0, HEAD_BYTES, 0);
+                const tailOffset = Math.max(HEAD_BYTES, artifact.sizeBytes - TAIL_BYTES);
+                const tailBuf = Buffer.alloc(TAIL_BYTES);
+                const { bytesRead: tailRead } = await fh.read(tailBuf, 0, TAIL_BYTES, tailOffset);
+                const head = headBuf.subarray(0, headRead).toString('utf-8');
+                const tail = tailBuf.subarray(0, tailRead).toString('utf-8');
+                const approxChars = artifact.sizeBytes; // byte count ≈ char count for UTF-8 text
+                emailBody = buildTruncatedPreview(head + '\n...\n' + tail, probeArtifactId)
+                  .replace(/^size: \d+ chars$/m, `size: ~${approxChars} bytes`);
+              } finally {
+                await fh.close();
+              }
               logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact preview-with-ref added to analysis context');
             }
           } else {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
@@ -257,15 +257,23 @@ export interface AnalyzerDeps {
 // (email metadata, body, and general ticket fields used by the pipeline)
 // ---------------------------------------------------------------------------
 
+/**
+ * Inline threshold: probe artifacts ≤ this many bytes are included verbatim in
+ * the initial emailBody; larger ones are included as a 2000-char preview plus
+ * an artifact-ref footer so Claude knows to call platform__read_tool_result_artifact.
+ */
+const PROBE_ARTIFACT_INLINE_BYTES = 8 * 1024; // 8 KB
+
 async function loadAnalysisContext(
   db: PrismaClient,
   job: AnalysisJob,
+  artifactStoragePath?: string,
 ): Promise<AnalysisContext> {
   const { ticketId, reanalysis, triggerEventId } = job;
 
   const ticket = await db.ticket.findUnique({
     where: { id: ticketId },
-    select: { clientId: true, subject: true, source: true, description: true, followers: { where: { followerType: 'REQUESTER' }, select: { person: { select: { email: true } } }, orderBy: { createdAt: 'asc' }, take: 1 } },
+    select: { clientId: true, subject: true, source: true, description: true, metadata: true, followers: { where: { followerType: 'REQUESTER' }, select: { person: { select: { email: true } } }, orderBy: { createdAt: 'asc' }, take: 1 } },
   });
 
   if (!ticket) {
@@ -307,12 +315,71 @@ async function loadAnalysisContext(
   if (!inboundEvent) {
     // Non-email ticket (probe, manual, AI-detected) — fall back to requester email for notifications
     logger.info({ ticketId, source: ticket.source }, 'No EMAIL_INBOUND event found — loading non-email context');
+
+    // If a probe artifact was saved at ingestion time, use its full content (or a
+    // preview-with-artifact-ref) instead of the 2000-char truncated description.
+    let emailBody = ticket.description ?? '';
+    const ticketMeta = ticket.metadata as Record<string, unknown> | null;
+    const probeArtifactId = typeof ticketMeta?.['probeArtifactId'] === 'string' ? ticketMeta['probeArtifactId'] : null;
+
+    if (probeArtifactId && artifactStoragePath) {
+      try {
+        const artifact = await db.artifact.findUnique({
+          where: { id: probeArtifactId },
+          select: { storagePath: true, sizeBytes: true },
+        });
+        if (artifact) {
+          const resolvedStorage = resolve(artifactStoragePath);
+          const absPath = resolve(resolvedStorage, artifact.storagePath);
+          const rel = relative(resolvedStorage, absPath);
+          if (!rel.startsWith('..') && rel !== '' && !rel.startsWith('/')) {
+            const rawContent = await readFile(absPath, 'utf-8');
+            if (artifact.sizeBytes <= PROBE_ARTIFACT_INLINE_BYTES) {
+              // Small enough to inline — Claude sees the full probe result immediately
+              emailBody = rawContent;
+              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact inlined in analysis context');
+            } else {
+              // Too large to inline — build head+tail preview so Claude knows the
+              // full data is available via platform__read_tool_result_artifact
+              const head = rawContent.slice(0, 2000);
+              const tail = rawContent.slice(-500);
+              emailBody = [
+                '[truncated — full probe result saved as artifact]',
+                `artifactId: ${probeArtifactId}`,
+                `size: ${rawContent.length} chars`,
+                'Use platform__read_tool_result_artifact to retrieve the full content.',
+                '---',
+                head,
+                '',
+                '...',
+                '',
+                tail,
+              ].join('\n');
+              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact preview-with-ref added to analysis context');
+            }
+          } else {
+            logger.warn({ ticketId, probeArtifactId }, 'Probe artifact path escaped storage root — falling back to description');
+          }
+        }
+      } catch (artifactErr) {
+        logger.warn({ artifactErr, ticketId, probeArtifactId }, 'Failed to load probe artifact for analysis context — falling back to description');
+      }
+    } else if (probeArtifactId && !artifactStoragePath) {
+      // Artifact exists but no storage path — append a reference so Claude knows to fetch it
+      emailBody = [
+        ticket.description ?? '',
+        '',
+        `[Full probe result available at artifact ${probeArtifactId}. Use platform__read_tool_result_artifact to retrieve.]`,
+      ].join('\n').trim();
+      logger.info({ ticketId, probeArtifactId }, 'Probe artifact ID appended to analysis context (no storage path available)');
+    }
+
     return {
       ticketId,
       clientId: ticket.clientId,
       emailFrom: ticket.followers[0]?.person?.email ?? undefined,
       emailSubject: ticket.subject ?? '(No subject)',
-      emailBody: ticket.description ?? '',
+      emailBody,
       emailMessageId: undefined,
       ticketSource: ticket.source,
     };
@@ -3352,8 +3419,9 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
   return async function processAnalysis(job: Job<AnalysisJob>): Promise<void> {
     const { ticketId, reanalysis, triggerEventId, chatReanalysisMode } = job.data;
 
-    // Resolve ticket context from the DB instead of carrying it on the job payload
-    const ctx = await loadAnalysisContext(deps.db, job.data);
+    // Resolve ticket context from the DB instead of carrying it on the job payload.
+    // Pass artifactStoragePath so probe-sourced tickets can inline or reference their full result.
+    const ctx = await loadAnalysisContext(deps.db, job.data, deps.artifactStoragePath);
 
     appLog.info(
       reanalysis ? 'Starting re-analysis pipeline (reply-triggered)' : 'Starting ticket analysis pipeline',

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -758,14 +758,16 @@ async function executeIngestionPipeline(
             try {
               // Patch ticket.metadata to include the probe artifact ID so the analyzer
               // can build a full-content or preview-with-ref context without re-querying.
-              const existing = await db.ticket.findUnique({
-                where: { id: ctx.ticketId },
-                select: { metadata: true },
-              });
-              const existingMeta = (existing?.metadata as Record<string, unknown> | null) ?? {};
+              // Use the in-scope `metadata` object (built above during ticket creation) to
+              // avoid a round-trip `findUnique`. Guard against any non-object value in case
+              // the DB column was written externally with a non-object JSON value.
+              const safeMeta: Record<string, unknown> =
+                typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+                  ? (metadata as Record<string, unknown>)
+                  : {};
               await db.ticket.update({
                 where: { id: ctx.ticketId },
-                data: { metadata: { ...existingMeta, probeArtifactId } as Prisma.InputJsonValue },
+                data: { metadata: { ...safeMeta, probeArtifactId } as Prisma.InputJsonValue },
               });
               logger.info({ ticketId: ctx.ticketId, probeArtifactId }, 'Probe artifact ID stored in ticket metadata');
             } catch (metaErr) {

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -747,12 +747,31 @@ async function executeIngestionPipeline(
           }
         }
 
-        // Save raw probe result artifact when available
+        // Save raw probe result artifact when available, then stash the artifact ID
+        // in ticket.metadata so the analyzer can reference it without re-fetching.
         const toolResult = payloadStr(payload, 'toolResult');
         const probeName = payloadStr(payload, 'probeName');
         const toolName = payloadStr(payload, 'toolName');
         if (toolResult && probeName && deps.artifactStoragePath) {
-          await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
+          const probeArtifactId = await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
+          if (probeArtifactId) {
+            try {
+              // Patch ticket.metadata to include the probe artifact ID so the analyzer
+              // can build a full-content or preview-with-ref context without re-querying.
+              const existing = await db.ticket.findUnique({
+                where: { id: ctx.ticketId },
+                select: { metadata: true },
+              });
+              const existingMeta = (existing?.metadata as Record<string, unknown> | null) ?? {};
+              await db.ticket.update({
+                where: { id: ctx.ticketId },
+                data: { metadata: { ...existingMeta, probeArtifactId } as Prisma.InputJsonValue },
+              });
+              logger.info({ ticketId: ctx.ticketId, probeArtifactId }, 'Probe artifact ID stored in ticket metadata');
+            } catch (metaErr) {
+              logger.warn({ metaErr, ticketId: ctx.ticketId }, 'Failed to store probe artifact ID in ticket metadata — continuing');
+            }
+          }
         }
 
         const stepDuration = Date.now() - stepStart;
@@ -1154,6 +1173,10 @@ function sanitizeFilenameSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64);
 }
 
+/**
+ * Save the raw probe tool result as a file artifact and return the artifact ID.
+ * Returns null on any error so callers can always proceed without blocking ticket creation.
+ */
 async function saveProbeArtifact(
   db: PrismaClient,
   ticketId: string,
@@ -1161,7 +1184,7 @@ async function saveProbeArtifact(
   toolName: string,
   rawResult: string,
   storagePath: string,
-): Promise<void> {
+): Promise<string | null> {
   try {
     let isJson = false;
     try { JSON.parse(rawResult); isJson = true; } catch { /* not JSON */ }
@@ -1177,13 +1200,13 @@ async function saveProbeArtifact(
     const rel = relative(resolvedStorage, ticketDir);
     if (rel.startsWith('..') || rel === '') {
       logger.warn({ ticketId, ticketDir, resolvedStorage }, 'Probe artifact path escaped storage root — skipping');
-      return;
+      return null;
     }
     const fullPath = join(ticketDir, filename);
     await mkdir(ticketDir, { recursive: true });
     await writeFile(fullPath, rawResult, 'utf-8');
     const relativePath = `tickets/${ticketId}/${filename}`;
-    await db.artifact.create({
+    const artifact = await db.artifact.create({
       data: {
         ticketId,
         filename,
@@ -1192,10 +1215,13 @@ async function saveProbeArtifact(
         storagePath: relativePath,
         description: `Raw MCP tool output from probe "${probeName}" (${toolName})`,
       },
+      select: { id: true },
     });
-    logger.info({ ticketId, filename }, 'Probe artifact saved via ingestion engine');
+    logger.info({ ticketId, filename, artifactId: artifact.id }, 'Probe artifact saved via ingestion engine');
+    return artifact.id;
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save probe artifact — continuing');
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

Close the loop on probe-sourced ticket analysis: the analyzer's initial prompt now references the full probe artifact instead of starting blind to truncated data.

**Observed on ticket `f5f81c87`** (Altman Plants deadlock probe, 2026-04-24): probe result was 3436 bytes, `ticket.description` was hard-capped at 2000 chars, and the analyzer read the truncated description as `emailBody`. Claude had to **re-query** the same `deadlock_events` MCP tool just to recover the full payload that had already been saved as an artifact.

## Approach — Option B (no schema change)

Stash artifact ID on the existing `Ticket.metadata` JSON column (`probeArtifactId` key). No Prisma migration needed.

## Changes — 2 files

**`services/ticket-analyzer/src/ingestion-engine.ts`**:
- `saveProbeArtifact()` now returns `Promise<string | null>` (the artifact UUID) instead of `void`
- After save, the ticket's `metadata` is patched with `{ probeArtifactId: '<uuid>' }`

**`services/ticket-analyzer/src/analyzer.ts`** (non-email path in `loadAnalysisContext`):
- Reads `ticket.metadata.probeArtifactId`
- If present, fetches the Artifact row + reads file content
- **≤ 8 KB**: inlines full raw content as `emailBody` — Claude sees everything immediately
- **> 8 KB**: head (2000 chars) + tail (500 chars) preview + artifact-ref footer with `artifactId: <uuid>` and instructions to call `platform__read_tool_result_artifact` — same pattern as the agentic `buildTruncatedPreview` used for in-run tool results
- Falls back to `ticket.description` on any read error (non-blocking)

`ticket.description` cap stays at 2000 chars — it's the UI-visible preview field. Artifact is the canonical full source.

## Why this matters

Every probe-triggered ticket today wastes Claude tokens + ~5-10 seconds re-fetching data we already have. With this fix the analyzer sees the full probe payload in its first prompt and can reason about it directly. Costs drop, latency drops, and the agent's first iteration is more substantive.

## Related

- #424 — unified ticket attachments (longer-term UI work to surface every Artifact on ticket-detail; this PR is the analyzer-side complement)
- The `Artifact` model + scope-gated endpoints from #411 are unchanged — this PR just leverages them

## Test plan

- [ ] CI passes on staging push
- [ ] After merge + deploy: trigger a scheduled probe ticket on Altman Plants (or any client). Verify:
  - `Ticket.metadata` has `probeArtifactId` populated
  - The first DEEP_ANALYSIS request_text in `ai_usage_logs` for that ticket contains the full probe data (or the preview + artifact-ref) — NOT just a 2000-char truncation
- [ ] Compare cost / duration vs prior probe-sourced runs (cbcc4dde was $0.34 stuck-loop, 0dba035c was $1.05 good run, f5f81c87 was $1.38 good run with re-query). Should see a reduction in input tokens + duration on the first iteration
- [ ] Email-sourced tickets unaffected (the new path only activates when `metadata.probeArtifactId` is present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
