### PR TITLE
merge: staging → master (v0.2.6)

### DIFF
--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, effect, input, output, viewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, effect, input, output, viewChild } from '@angular/core';
 
 @Component({
   selector: 'app-dialog',
@@ -129,6 +129,9 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
         border-radius: 0;
         animation: slideUp 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
       }
+      .dialog-header {
+        padding-top: max(16px, calc(env(safe-area-inset-top) + 8px));
+      }
       .dialog-close {
         width: 44px;
         height: 44px;
@@ -142,7 +145,7 @@ import { Component, ElementRef, effect, input, output, viewChild } from '@angula
     }
   `],
 })
-export class DialogComponent {
+export class DialogComponent implements OnDestroy {
   title = input<string>('');
   open = input<boolean>(false);
   maxWidth = input<string>('480px');
@@ -152,10 +155,52 @@ export class DialogComponent {
   private panelRef = viewChild<ElementRef<HTMLElement>>('panel');
   private previouslyFocused: HTMLElement | null = null;
 
+  // ── Body-scroll-lock (static counter so stacked dialogs work correctly) ──
+  private static openCount = 0;
+  private static savedScrollY = 0;
+  private scrollLocked = false;
+
+  private lockBodyScroll(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    if (DialogComponent.openCount === 0) {
+      DialogComponent.savedScrollY = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${DialogComponent.savedScrollY}px`;
+      document.body.style.width = '100%';
+      document.body.style.left = '0';
+      document.body.style.right = '0';
+    }
+    DialogComponent.openCount++;
+    this.scrollLocked = true;
+  }
+
+  private unlockBodyScroll(): void {
+    if (!this.scrollLocked) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    this.scrollLocked = false;
+    DialogComponent.openCount--;
+    if (DialogComponent.openCount < 0) DialogComponent.openCount = 0;
+    if (DialogComponent.openCount === 0) {
+      const scrollY = DialogComponent.savedScrollY;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      window.scrollTo(0, scrollY);
+      DialogComponent.savedScrollY = 0;
+    }
+  }
+
   constructor() {
-    // Manage Escape key + focus restore while the dialog is open.
+    // Manage Escape key + focus restore + body-scroll-lock while dialog is open.
     effect((onCleanup) => {
-      if (!this.open()) return;
+      if (!this.open()) {
+        this.unlockBodyScroll();
+        return;
+      }
+
+      this.lockBodyScroll();
 
       this.previouslyFocused = (typeof document !== 'undefined'
         ? (document.activeElement as HTMLElement | null)
@@ -171,6 +216,7 @@ export class DialogComponent {
 
       onCleanup(() => {
         document.removeEventListener('keydown', onKeyDown);
+        this.unlockBodyScroll();
         // Restore focus to whatever was focused before the dialog opened.
         if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
           this.previouslyFocused.focus();
@@ -191,6 +237,11 @@ export class DialogComponent {
         focusable?.focus();
       });
     });
+  }
+
+  ngOnDestroy(): void {
+    // Guard against component teardown while open (e.g. route navigation).
+    this.unlockBodyScroll();
   }
 
   close(): void {

--- a/services/control-panel/src/app/shared/components/dialog.component.ts
+++ b/services/control-panel/src/app/shared/components/dialog.component.ts
@@ -158,12 +158,22 @@ export class DialogComponent implements OnDestroy {
   // ── Body-scroll-lock (static counter so stacked dialogs work correctly) ──
   private static openCount = 0;
   private static savedScrollY = 0;
+  // Captured inline style values from before the first dialog locks — restored
+  // exactly when the last dialog closes so pre-existing inline styles survive.
+  private static savedBodyStyles: { position: string; top: string; width: string; left: string; right: string } | null = null;
   private scrollLocked = false;
 
   private lockBodyScroll(): void {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
     if (DialogComponent.openCount === 0) {
       DialogComponent.savedScrollY = window.scrollY;
+      DialogComponent.savedBodyStyles = {
+        position: document.body.style.position,
+        top: document.body.style.top,
+        width: document.body.style.width,
+        left: document.body.style.left,
+        right: document.body.style.right,
+      };
       document.body.style.position = 'fixed';
       document.body.style.top = `-${DialogComponent.savedScrollY}px`;
       document.body.style.width = '100%';
@@ -182,13 +192,15 @@ export class DialogComponent implements OnDestroy {
     if (DialogComponent.openCount < 0) DialogComponent.openCount = 0;
     if (DialogComponent.openCount === 0) {
       const scrollY = DialogComponent.savedScrollY;
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.left = '';
-      document.body.style.right = '';
+      const prev = DialogComponent.savedBodyStyles;
+      document.body.style.position = prev?.position ?? '';
+      document.body.style.top = prev?.top ?? '';
+      document.body.style.width = prev?.width ?? '';
+      document.body.style.left = prev?.left ?? '';
+      document.body.style.right = prev?.right ?? '';
       window.scrollTo(0, scrollY);
       DialogComponent.savedScrollY = 0;
+      DialogComponent.savedBodyStyles = null;
     }
   }
 

--- a/services/control-panel/src/app/shell/header-bar.component.ts
+++ b/services/control-panel/src/app/shell/header-bar.component.ts
@@ -36,8 +36,8 @@ const isMac = /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
   `,
   styles: [`
     .header-bar {
-      height: var(--header-height);
-      min-height: var(--header-height);
+      height: calc(var(--header-height) + env(safe-area-inset-top));
+      min-height: calc(var(--header-height) + env(safe-area-inset-top));
       background: var(--bg-header);
       backdrop-filter: saturate(180%) blur(20px);
       -webkit-backdrop-filter: saturate(180%) blur(20px);

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
@@ -14,6 +14,7 @@ import { executeRecommendations } from './recommendation-executor.js';
 import type { ParsedAction } from './recommendation-executor.js';
 import {
   buildAgenticTools,
+  buildTruncatedPreview,
   DEFAULT_REPO_FILE_EXTENSIONS,
   parseSufficiencyEvaluation,
   resolveAnalysisStrategy,
@@ -324,8 +325,8 @@ async function loadAnalysisContext(
 
     if (probeArtifactId && artifactStoragePath) {
       try {
-        const artifact = await db.artifact.findUnique({
-          where: { id: probeArtifactId },
+        const artifact = await db.artifact.findFirst({
+          where: { id: probeArtifactId, ticketId },
           select: { storagePath: true, sizeBytes: true },
         });
         if (artifact) {
@@ -333,28 +334,32 @@ async function loadAnalysisContext(
           const absPath = resolve(resolvedStorage, artifact.storagePath);
           const rel = relative(resolvedStorage, absPath);
           if (!rel.startsWith('..') && rel !== '' && !rel.startsWith('/')) {
-            const rawContent = await readFile(absPath, 'utf-8');
             if (artifact.sizeBytes <= PROBE_ARTIFACT_INLINE_BYTES) {
-              // Small enough to inline — Claude sees the full probe result immediately
+              // Small enough to inline — read the full file; Claude sees the full probe result immediately
+              const rawContent = await readFile(absPath, 'utf-8');
               emailBody = rawContent;
               logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact inlined in analysis context');
             } else {
-              // Too large to inline — build head+tail preview so Claude knows the
-              // full data is available via platform__read_tool_result_artifact
-              const head = rawContent.slice(0, 2000);
-              const tail = rawContent.slice(-500);
-              emailBody = [
-                '[truncated — full probe result saved as artifact]',
-                `artifactId: ${probeArtifactId}`,
-                `size: ${rawContent.length} chars`,
-                'Use platform__read_tool_result_artifact to retrieve the full content.',
-                '---',
-                head,
-                '',
-                '...',
-                '',
-                tail,
-              ].join('\n');
+              // Too large to inline — read only head and tail bytes to avoid loading the
+              // entire file into memory, then build a canonical truncated preview so
+              // Claude can page the rest via platform__read_tool_result_artifact.
+              const HEAD_BYTES = 1500;
+              const TAIL_BYTES = 500;
+              const fh = await open(absPath, 'r');
+              try {
+                const headBuf = Buffer.alloc(HEAD_BYTES);
+                const { bytesRead: headRead } = await fh.read(headBuf, 0, HEAD_BYTES, 0);
+                const tailOffset = Math.max(HEAD_BYTES, artifact.sizeBytes - TAIL_BYTES);
+                const tailBuf = Buffer.alloc(TAIL_BYTES);
+                const { bytesRead: tailRead } = await fh.read(tailBuf, 0, TAIL_BYTES, tailOffset);
+                const head = headBuf.subarray(0, headRead).toString('utf-8');
+                const tail = tailBuf.subarray(0, tailRead).toString('utf-8');
+                const approxChars = artifact.sizeBytes; // byte count ≈ char count for UTF-8 text
+                emailBody = buildTruncatedPreview(head + '\n...\n' + tail, probeArtifactId)
+                  .replace(/^size: \d+ chars$/m, `size: ~${approxChars} bytes`);
+              } finally {
+                await fh.close();
+              }
               logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact preview-with-ref added to analysis context');
             }
           } else {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
@@ -257,15 +257,23 @@ export interface AnalyzerDeps {
 // (email metadata, body, and general ticket fields used by the pipeline)
 // ---------------------------------------------------------------------------
 
+/**
+ * Inline threshold: probe artifacts ≤ this many bytes are included verbatim in
+ * the initial emailBody; larger ones are included as a 2000-char preview plus
+ * an artifact-ref footer so Claude knows to call platform__read_tool_result_artifact.
+ */
+const PROBE_ARTIFACT_INLINE_BYTES = 8 * 1024; // 8 KB
+
 async function loadAnalysisContext(
   db: PrismaClient,
   job: AnalysisJob,
+  artifactStoragePath?: string,
 ): Promise<AnalysisContext> {
   const { ticketId, reanalysis, triggerEventId } = job;
 
   const ticket = await db.ticket.findUnique({
     where: { id: ticketId },
-    select: { clientId: true, subject: true, source: true, description: true, followers: { where: { followerType: 'REQUESTER' }, select: { person: { select: { email: true } } }, orderBy: { createdAt: 'asc' }, take: 1 } },
+    select: { clientId: true, subject: true, source: true, description: true, metadata: true, followers: { where: { followerType: 'REQUESTER' }, select: { person: { select: { email: true } } }, orderBy: { createdAt: 'asc' }, take: 1 } },
   });
 
   if (!ticket) {
@@ -307,12 +315,71 @@ async function loadAnalysisContext(
   if (!inboundEvent) {
     // Non-email ticket (probe, manual, AI-detected) — fall back to requester email for notifications
     logger.info({ ticketId, source: ticket.source }, 'No EMAIL_INBOUND event found — loading non-email context');
+
+    // If a probe artifact was saved at ingestion time, use its full content (or a
+    // preview-with-artifact-ref) instead of the 2000-char truncated description.
+    let emailBody = ticket.description ?? '';
+    const ticketMeta = ticket.metadata as Record<string, unknown> | null;
+    const probeArtifactId = typeof ticketMeta?.['probeArtifactId'] === 'string' ? ticketMeta['probeArtifactId'] : null;
+
+    if (probeArtifactId && artifactStoragePath) {
+      try {
+        const artifact = await db.artifact.findUnique({
+          where: { id: probeArtifactId },
+          select: { storagePath: true, sizeBytes: true },
+        });
+        if (artifact) {
+          const resolvedStorage = resolve(artifactStoragePath);
+          const absPath = resolve(resolvedStorage, artifact.storagePath);
+          const rel = relative(resolvedStorage, absPath);
+          if (!rel.startsWith('..') && rel !== '' && !rel.startsWith('/')) {
+            const rawContent = await readFile(absPath, 'utf-8');
+            if (artifact.sizeBytes <= PROBE_ARTIFACT_INLINE_BYTES) {
+              // Small enough to inline — Claude sees the full probe result immediately
+              emailBody = rawContent;
+              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact inlined in analysis context');
+            } else {
+              // Too large to inline — build head+tail preview so Claude knows the
+              // full data is available via platform__read_tool_result_artifact
+              const head = rawContent.slice(0, 2000);
+              const tail = rawContent.slice(-500);
+              emailBody = [
+                '[truncated — full probe result saved as artifact]',
+                `artifactId: ${probeArtifactId}`,
+                `size: ${rawContent.length} chars`,
+                'Use platform__read_tool_result_artifact to retrieve the full content.',
+                '---',
+                head,
+                '',
+                '...',
+                '',
+                tail,
+              ].join('\n');
+              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact preview-with-ref added to analysis context');
+            }
+          } else {
+            logger.warn({ ticketId, probeArtifactId }, 'Probe artifact path escaped storage root — falling back to description');
+          }
+        }
+      } catch (artifactErr) {
+        logger.warn({ artifactErr, ticketId, probeArtifactId }, 'Failed to load probe artifact for analysis context — falling back to description');
+      }
+    } else if (probeArtifactId && !artifactStoragePath) {
+      // Artifact exists but no storage path — append a reference so Claude knows to fetch it
+      emailBody = [
+        ticket.description ?? '',
+        '',
+        `[Full probe result available at artifact ${probeArtifactId}. Use platform__read_tool_result_artifact to retrieve.]`,
+      ].join('\n').trim();
+      logger.info({ ticketId, probeArtifactId }, 'Probe artifact ID appended to analysis context (no storage path available)');
+    }
+
     return {
       ticketId,
       clientId: ticket.clientId,
       emailFrom: ticket.followers[0]?.person?.email ?? undefined,
       emailSubject: ticket.subject ?? '(No subject)',
-      emailBody: ticket.description ?? '',
+      emailBody,
       emailMessageId: undefined,
       ticketSource: ticket.source,
     };
@@ -3352,8 +3419,9 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
   return async function processAnalysis(job: Job<AnalysisJob>): Promise<void> {
     const { ticketId, reanalysis, triggerEventId, chatReanalysisMode } = job.data;
 
-    // Resolve ticket context from the DB instead of carrying it on the job payload
-    const ctx = await loadAnalysisContext(deps.db, job.data);
+    // Resolve ticket context from the DB instead of carrying it on the job payload.
+    // Pass artifactStoragePath so probe-sourced tickets can inline or reference their full result.
+    const ctx = await loadAnalysisContext(deps.db, job.data, deps.artifactStoragePath);
 
     appLog.info(
       reanalysis ? 'Starting re-analysis pipeline (reply-triggered)' : 'Starting ticket analysis pipeline',

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -758,14 +758,16 @@ async function executeIngestionPipeline(
             try {
               // Patch ticket.metadata to include the probe artifact ID so the analyzer
               // can build a full-content or preview-with-ref context without re-querying.
-              const existing = await db.ticket.findUnique({
-                where: { id: ctx.ticketId },
-                select: { metadata: true },
-              });
-              const existingMeta = (existing?.metadata as Record<string, unknown> | null) ?? {};
+              // Use the in-scope `metadata` object (built above during ticket creation) to
+              // avoid a round-trip `findUnique`. Guard against any non-object value in case
+              // the DB column was written externally with a non-object JSON value.
+              const safeMeta: Record<string, unknown> =
+                typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+                  ? (metadata as Record<string, unknown>)
+                  : {};
               await db.ticket.update({
                 where: { id: ctx.ticketId },
-                data: { metadata: { ...existingMeta, probeArtifactId } as Prisma.InputJsonValue },
+                data: { metadata: { ...safeMeta, probeArtifactId } as Prisma.InputJsonValue },
               });
               logger.info({ ticketId: ctx.ticketId, probeArtifactId }, 'Probe artifact ID stored in ticket metadata');
             } catch (metaErr) {

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -747,12 +747,31 @@ async function executeIngestionPipeline(
           }
         }
 
-        // Save raw probe result artifact when available
+        // Save raw probe result artifact when available, then stash the artifact ID
+        // in ticket.metadata so the analyzer can reference it without re-fetching.
         const toolResult = payloadStr(payload, 'toolResult');
         const probeName = payloadStr(payload, 'probeName');
         const toolName = payloadStr(payload, 'toolName');
         if (toolResult && probeName && deps.artifactStoragePath) {
-          await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
+          const probeArtifactId = await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
+          if (probeArtifactId) {
+            try {
+              // Patch ticket.metadata to include the probe artifact ID so the analyzer
+              // can build a full-content or preview-with-ref context without re-querying.
+              const existing = await db.ticket.findUnique({
+                where: { id: ctx.ticketId },
+                select: { metadata: true },
+              });
+              const existingMeta = (existing?.metadata as Record<string, unknown> | null) ?? {};
+              await db.ticket.update({
+                where: { id: ctx.ticketId },
+                data: { metadata: { ...existingMeta, probeArtifactId } as Prisma.InputJsonValue },
+              });
+              logger.info({ ticketId: ctx.ticketId, probeArtifactId }, 'Probe artifact ID stored in ticket metadata');
+            } catch (metaErr) {
+              logger.warn({ metaErr, ticketId: ctx.ticketId }, 'Failed to store probe artifact ID in ticket metadata — continuing');
+            }
+          }
         }
 
         const stepDuration = Date.now() - stepStart;
@@ -1154,6 +1173,10 @@ function sanitizeFilenameSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64);
 }
 
+/**
+ * Save the raw probe tool result as a file artifact and return the artifact ID.
+ * Returns null on any error so callers can always proceed without blocking ticket creation.
+ */
 async function saveProbeArtifact(
   db: PrismaClient,
   ticketId: string,
@@ -1161,7 +1184,7 @@ async function saveProbeArtifact(
   toolName: string,
   rawResult: string,
   storagePath: string,
-): Promise<void> {
+): Promise<string | null> {
   try {
     let isJson = false;
     try { JSON.parse(rawResult); isJson = true; } catch { /* not JSON */ }
@@ -1177,13 +1200,13 @@ async function saveProbeArtifact(
     const rel = relative(resolvedStorage, ticketDir);
     if (rel.startsWith('..') || rel === '') {
       logger.warn({ ticketId, ticketDir, resolvedStorage }, 'Probe artifact path escaped storage root — skipping');
-      return;
+      return null;
     }
     const fullPath = join(ticketDir, filename);
     await mkdir(ticketDir, { recursive: true });
     await writeFile(fullPath, rawResult, 'utf-8');
     const relativePath = `tickets/${ticketId}/${filename}`;
-    await db.artifact.create({
+    const artifact = await db.artifact.create({
       data: {
         ticketId,
         filename,
@@ -1192,10 +1215,13 @@ async function saveProbeArtifact(
         storagePath: relativePath,
         description: `Raw MCP tool output from probe "${probeName}" (${toolName})`,
       },
+      select: { id: true },
     });
-    logger.info({ ticketId, filename }, 'Probe artifact saved via ingestion engine');
+    logger.info({ ticketId, filename, artifactId: artifact.id }, 'Probe artifact saved via ingestion engine');
+    return artifact.id;
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save probe artifact — continuing');
+    return null;
   }
 }
 


### PR DESCRIPTION
## v0.2.6 — Promotion: staging → master

Small-batch release: two targeted fixes for iOS PWA UX and probe-artifact analysis efficiency.

### Highlights

**PWA / Mobile UX — #425**
- iOS Home Screen PWA: header now accounts for `env(safe-area-inset-top)` so status bar no longer overlaps app chrome
- Dialog close-X padded to clear the status bar zone on iOS standalone mode
- Body-scroll-lock on all dialogs: page can't scroll while a dialog is open; scroll position is restored on close (handles stacked dialogs via static `openCount`)
- All `calc()` / `max()` expressions degrade to existing values on non-PWA contexts — no regression

**Probe Artifact Handoff to Analyzer — #426**
- Analyzer initial prompt now sees the full probe artifact instead of the 2000-char truncated `ticket.description`
- Artifact ID stashed on `Ticket.metadata.probeArtifactId` (no schema migration)
- ≤ 8 KB: full content inlined; > 8 KB: head+tail preview + artifact-ref footer for agent follow-up
- Eliminates redundant re-fetch of probe data Claude already had — lower cost, lower latency, more substantive first iteration
- Falls back to `ticket.description` on any artifact read error (non-blocking)

### Commits (4, no merges)

- `60dbf07` fix(control-panel): PWA iOS safe-area + body-scroll-lock on dialogs
- `93e2b80` fix: address PR #425 review feedback — capture/restore pre-existing body inline styles
- `0a6cfd8` fix(ingestion): pass probe artifact through to analyzer initial prompt
- `b556232` fix: address PR #426 review feedback

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
