### PR TITLE
feat(status-monitor): cloudflared tunnel drift detection via /ready poller

### DIFF
--- a/services/control-panel/src/app/features/system-status/system-status.component.ts
+++ b/services/control-panel/src/app/features/system-status/system-status.component.ts
@@ -866,6 +866,7 @@ export class SystemStatusComponent implements OnInit, OnDestroy {
       'Scheduler Worker': 'scheduler-worker',
       'MCP Platform': 'mcp-platform',
       'MCP Repo': 'mcp-repo',
+      'Cloudflared Tunnel': 'cloudflared',
       'Caddy (Reverse Proxy)': 'caddy',
     };
     return map[name] ?? name.toLowerCase().replace(/\s+/g, '-');

--- a/services/copilot-api/src/config.ts
+++ b/services/copilot-api/src/config.ts
@@ -24,6 +24,8 @@ const configSchema = z.object({
   SCHEDULER_WORKER_HEALTH_URL: z.string().url().optional().default('http://scheduler-worker:3109'),
   MCP_PLATFORM_URL: z.string().url().optional().default('http://mcp-platform:3110'),
   MCP_REPO_URL: z.string().url().optional().default('http://mcp-repo:3111'),
+  // Cloudflared metrics server (inside Docker network) — used by system-status to show tunnel state
+  CLOUDFLARED_METRICS_URL: z.string().url().optional().default('http://cloudflared:2000'),
   // Invoice storage
   INVOICE_STORAGE_PATH: z.string().default('/var/lib/copilot-api/invoices'),
   // GitHub (optional — required for manual release notes backfill)

--- a/services/copilot-api/src/routes/system-status.ts
+++ b/services/copilot-api/src/routes/system-status.ts
@@ -695,6 +695,88 @@ async function checkLlmProvider(
   }
 }
 
+/**
+ * Check the cloudflared tunnel via its metrics /ready endpoint.
+ * Returns a service-type component so it appears in the Services section of
+ * the control panel status page alongside the other workers.
+ *
+ * The /ready endpoint returns HTTP 200 + {"readyConnections": N} when at least
+ * one tunnel is healthy, non-200 or readyConnections===0 means drift.
+ */
+async function checkCloudflaredTunnel(metricsUrl: string, timeoutMs = 5000): Promise<ComponentStatus> {
+  const url = `${metricsUrl}/ready`;
+  const start = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    const latencyMs = Date.now() - start;
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      return {
+        name: 'Cloudflared Tunnel',
+        type: 'service',
+        status: ServiceStatus.DEGRADED,
+        endpoint: metricsUrl,
+        latencyMs,
+        details: { error: `HTTP ${response.status} from /ready`, httpStatus: response.status },
+        controllable: true,
+      };
+    }
+
+    let readyConnections: number | null = null;
+    try {
+      const body = await response.json() as { readyConnections?: number };
+      readyConnections = typeof body.readyConnections === 'number' ? body.readyConnections : null;
+    } catch {
+      return {
+        name: 'Cloudflared Tunnel',
+        type: 'service',
+        status: ServiceStatus.DEGRADED,
+        endpoint: metricsUrl,
+        latencyMs,
+        details: { error: 'Failed to parse /ready response JSON' },
+        controllable: true,
+      };
+    }
+
+    if (readyConnections !== null && readyConnections === 0) {
+      return {
+        name: 'Cloudflared Tunnel',
+        type: 'service',
+        status: ServiceStatus.DEGRADED,
+        endpoint: metricsUrl,
+        latencyMs,
+        details: { readyConnections, note: 'No active tunnel connections' },
+        controllable: true,
+      };
+    }
+
+    return {
+      name: 'Cloudflared Tunnel',
+      type: 'service',
+      status: ServiceStatus.UP,
+      endpoint: metricsUrl,
+      latencyMs,
+      details: { readyConnections: readyConnections ?? 'unknown' },
+      controllable: true,
+    };
+  } catch (err) {
+    clearTimeout(timeout);
+    return {
+      name: 'Cloudflared Tunnel',
+      type: 'service',
+      status: ServiceStatus.DOWN,
+      endpoint: metricsUrl,
+      latencyMs: Date.now() - start,
+      details: { error: (err as Error).message },
+      controllable: true,
+    };
+  }
+}
+
 interface SystemStatusOpts {
   config: Config;
 }
@@ -794,6 +876,7 @@ export async function systemStatusRoutes(
       schedulerWorker,
       mcpPlatform,
       mcpRepo,
+      cloudflaredTunnel,
       queueStats,
       ...externalResults
     ] = await Promise.all([
@@ -810,6 +893,7 @@ export async function systemStatusRoutes(
       checkWorkerHealth('Scheduler Worker', opts.config.SCHEDULER_WORKER_HEALTH_URL, 'scheduler-worker', containers),
       checkWorkerHealth('MCP Platform', opts.config.MCP_PLATFORM_URL, 'mcp-platform', containers),
       checkWorkerHealth('MCP Repo', opts.config.MCP_REPO_URL, 'mcp-repo', containers),
+      checkCloudflaredTunnel(opts.config.CLOUDFLARED_METRICS_URL),
       getBullMQQueueStats(opts.config.REDIS_URL),
       ...externalServices.map(svc => checkExternalService(svc, containers)),
     ]);
@@ -841,6 +925,7 @@ export async function systemStatusRoutes(
       schedulerWorker,
       mcpPlatform,
       mcpRepo,
+      cloudflaredTunnel,
       ...externalResults,
     ];
 
@@ -888,6 +973,7 @@ export async function systemStatusRoutes(
       'scheduler-worker': 'scheduler-worker',
       'mcp-platform': 'mcp-platform',
       'mcp-repo': 'mcp-repo',
+      'cloudflared': 'cloudflared',
       'caddy': 'caddy',
       'postgres': 'postgres',
       'redis': 'redis',

--- a/services/status-monitor/src/cloudflared-poller.ts
+++ b/services/status-monitor/src/cloudflared-poller.ts
@@ -33,17 +33,28 @@ export class CloudflaredDriftPoller {
   private db: PrismaClient;
   private config: Config;
   private interval: ReturnType<typeof setInterval> | null = null;
+  private inFlight = false;
 
   constructor(db: PrismaClient, config: Config) {
     this.db = db;
     this.config = config;
   }
 
+  private async runProbe(): Promise<void> {
+    if (this.inFlight) return;
+    this.inFlight = true;
+    try {
+      await this.probe();
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
   start(): void {
     // Run immediately at startup, then on interval
-    void this.probe();
+    void this.runProbe();
     this.interval = setInterval(() => {
-      void this.probe();
+      void this.runProbe();
     }, this.config.CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS * 1000);
 
     logger.info(
@@ -134,7 +145,8 @@ export class CloudflaredDriftPoller {
         );
       }
     } else {
-      // Probe failed
+      // Probe failed — clear cached readyConnections so the UI doesn't show stale data
+      this.lastReadyConnections = null;
       this.consecutiveFailures++;
       this.healthy = false;
 
@@ -169,7 +181,8 @@ export class CloudflaredDriftPoller {
       `Endpoint: ${this.config.CLOUDFLARED_METRICS_URL}/ready`,
       ``,
       `Suggested operator action:`,
-      `  ssh hugo-app "docker restart bronco-cloudflared-1"`,
+      `  Restart the cloudflared service via /api/system-status/control when available,`,
+      `  or run: docker compose restart cloudflared`,
       ``,
       `Monitor: check status-monitor /health for current state`,
       `Time: ${new Date().toISOString()}`,
@@ -188,24 +201,10 @@ export class CloudflaredDriftPoller {
 
     if (channels.length === 0) {
       logger.warn('Cloudflared drift alert: no active notification channels configured');
-      return;
     }
 
-    // Record the alert in the database
-    try {
-      await this.db.serviceAlert.create({
-        data: {
-          componentName: 'cloudflared',
-          previousStatus: 'UP',
-          newStatus: 'DEGRADED',
-          notifiedVia: [],
-          message,
-        },
-      });
-    } catch (err) {
-      logger.error({ err }, 'Failed to record cloudflared alert in database');
-    }
-
+    // Dispatch first so we can record the actual notifiedVia values on the ServiceAlert row.
+    // Matches StatusMonitor.notify() ordering in monitor.ts.
     const notifiedVia: string[] = [];
 
     for (const channel of channels) {
@@ -220,6 +219,22 @@ export class CloudflaredDriftPoller {
       } catch (err) {
         logger.error({ err, channel: channel.name, type: channel.type }, 'Failed to send cloudflared drift alert via channel');
       }
+    }
+
+    // Always record the alert in the database (even when no channels are configured)
+    // so we have a durable history of drift events.
+    try {
+      await this.db.serviceAlert.create({
+        data: {
+          componentName: 'cloudflared',
+          previousStatus: 'UP',
+          newStatus: 'DEGRADED',
+          notifiedVia,
+          message,
+        },
+      });
+    } catch (err) {
+      logger.error({ err }, 'Failed to record cloudflared alert in database');
     }
 
     logger.info({ notifiedVia }, 'Cloudflared drift alert dispatched');

--- a/services/status-monitor/src/cloudflared-poller.ts
+++ b/services/status-monitor/src/cloudflared-poller.ts
@@ -1,0 +1,264 @@
+import { createLogger, decrypt, looksEncrypted } from '@bronco/shared-utils';
+import type { PrismaClient } from '@bronco/db';
+import type { Config } from './config.js';
+import { EmailNotifier } from './notifiers/email.js';
+import { PushoverNotifier } from './notifiers/pushover.js';
+
+const logger = createLogger('cloudflared-poller');
+
+export interface CloudflaredTunnelState {
+  healthy: boolean;
+  readyConnections: number | null;
+  consecutiveFailures: number;
+  lastChecked: string | null;
+  lastError: string | null;
+}
+
+interface ChannelRow {
+  id: string;
+  name: string;
+  type: string;
+  config: Record<string, unknown>;
+  isActive: boolean;
+}
+
+export class CloudflaredDriftPoller {
+  private consecutiveFailures = 0;
+  private alertFired = false;
+  private lastReadyConnections: number | null = null;
+  private lastChecked: string | null = null;
+  private lastError: string | null = null;
+  private healthy = true;
+
+  private db: PrismaClient;
+  private config: Config;
+  private interval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(db: PrismaClient, config: Config) {
+    this.db = db;
+    this.config = config;
+  }
+
+  start(): void {
+    // Run immediately at startup, then on interval
+    void this.probe();
+    this.interval = setInterval(() => {
+      void this.probe();
+    }, this.config.CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS * 1000);
+
+    logger.info(
+      {
+        metricsUrl: this.config.CLOUDFLARED_METRICS_URL,
+        intervalSeconds: this.config.CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS,
+        failThreshold: this.config.CLOUDFLARED_DRIFT_FAIL_THRESHOLD,
+      },
+      'Cloudflared drift poller started',
+    );
+  }
+
+  stop(): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  getState(): CloudflaredTunnelState {
+    return {
+      healthy: this.healthy,
+      readyConnections: this.lastReadyConnections,
+      consecutiveFailures: this.consecutiveFailures,
+      lastChecked: this.lastChecked,
+      lastError: this.lastError,
+    };
+  }
+
+  private async probe(): Promise<void> {
+    const url = `${this.config.CLOUDFLARED_METRICS_URL}/ready`;
+    const wasHealthy = this.healthy;
+    this.lastChecked = new Date().toISOString();
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    let driftReason: string | null = null;
+
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        driftReason = `HTTP ${res.status} ${res.statusText}`;
+        this.lastError = driftReason;
+      } else {
+        // 200 OK — parse readyConnections
+        let readyConnections: number | null = null;
+        try {
+          const body = await res.json() as { readyConnections?: number };
+          readyConnections = typeof body.readyConnections === 'number' ? body.readyConnections : null;
+          this.lastReadyConnections = readyConnections;
+        } catch {
+          driftReason = 'Failed to parse /ready JSON response';
+          this.lastError = driftReason;
+        }
+
+        if (driftReason === null && readyConnections !== null && readyConnections === 0) {
+          driftReason = 'readyConnections === 0 (no active tunnel connections)';
+          this.lastError = driftReason;
+        }
+      }
+    } catch (err) {
+      clearTimeout(timeout);
+      const message = err instanceof Error ? err.message : String(err);
+      driftReason = `Request failed: ${message}`;
+      this.lastError = driftReason;
+    }
+
+    if (driftReason === null) {
+      // Probe succeeded
+      const wasUnhealthy = !wasHealthy;
+      this.consecutiveFailures = 0;
+      this.healthy = true;
+      this.alertFired = false;
+      this.lastError = null;
+
+      if (wasUnhealthy) {
+        logger.info(
+          { readyConnections: this.lastReadyConnections },
+          'Cloudflared tunnel: DEGRADED → HEALTHY',
+        );
+      } else {
+        logger.debug(
+          { readyConnections: this.lastReadyConnections },
+          'Cloudflared tunnel: probe OK',
+        );
+      }
+    } else {
+      // Probe failed
+      this.consecutiveFailures++;
+      this.healthy = false;
+
+      const threshold = this.config.CLOUDFLARED_DRIFT_FAIL_THRESHOLD;
+      logger.warn(
+        {
+          consecutiveFailures: this.consecutiveFailures,
+          threshold,
+          reason: driftReason,
+          url,
+        },
+        'Cloudflared /ready probe failed',
+      );
+
+      if (this.consecutiveFailures >= threshold && !this.alertFired) {
+        this.alertFired = true;
+        logger.error(
+          { consecutiveFailures: this.consecutiveFailures, threshold, reason: driftReason },
+          'Cloudflared tunnel drift detected — emitting operational alert',
+        );
+        await this.emitAlert(driftReason);
+      }
+    }
+  }
+
+  private async emitAlert(lastError: string): Promise<void> {
+    const subject = '[DEGRADED] cloudflared tunnel drift detected';
+    const message = [
+      `Service: cloudflared`,
+      `State: DEGRADED — ${this.consecutiveFailures} consecutive /ready failures`,
+      `Last error: ${lastError}`,
+      `Endpoint: ${this.config.CLOUDFLARED_METRICS_URL}/ready`,
+      ``,
+      `Suggested operator action:`,
+      `  ssh hugo-app "docker restart bronco-cloudflared-1"`,
+      ``,
+      `Monitor: check status-monitor /health for current state`,
+      `Time: ${new Date().toISOString()}`,
+    ].join('\n');
+
+    // Load active notification channels from DB (same pattern as StatusMonitor.notify)
+    let channels: ChannelRow[];
+    try {
+      channels = (await this.db.notificationChannel.findMany({
+        where: { isActive: true },
+      })) as unknown as ChannelRow[];
+    } catch (err) {
+      logger.error({ err }, 'Failed to load notification channels from DB for cloudflared alert');
+      channels = [];
+    }
+
+    if (channels.length === 0) {
+      logger.warn('Cloudflared drift alert: no active notification channels configured');
+      return;
+    }
+
+    // Record the alert in the database
+    try {
+      await this.db.serviceAlert.create({
+        data: {
+          componentName: 'cloudflared',
+          previousStatus: 'UP',
+          newStatus: 'DEGRADED',
+          notifiedVia: [],
+          message,
+        },
+      });
+    } catch (err) {
+      logger.error({ err }, 'Failed to record cloudflared alert in database');
+    }
+
+    const notifiedVia: string[] = [];
+
+    for (const channel of channels) {
+      try {
+        if (channel.type === 'EMAIL') {
+          await this.sendEmail(channel.config, subject, message);
+          notifiedVia.push(`email:${channel.name}`);
+        } else if (channel.type === 'PUSHOVER') {
+          await this.sendPushover(channel.config, subject, message, 1);
+          notifiedVia.push(`pushover:${channel.name}`);
+        }
+      } catch (err) {
+        logger.error({ err, channel: channel.name, type: channel.type }, 'Failed to send cloudflared drift alert via channel');
+      }
+    }
+
+    logger.info({ notifiedVia }, 'Cloudflared drift alert dispatched');
+  }
+
+  private decryptIfNeeded(value: string): string {
+    if (looksEncrypted(value)) {
+      return decrypt(value, this.config.ENCRYPTION_KEY);
+    }
+    return value;
+  }
+
+  private async sendEmail(
+    config: Record<string, unknown>,
+    subject: string,
+    body: string,
+  ): Promise<void> {
+    const notifier = new EmailNotifier({
+      host: config.host as string,
+      port: (config.port as number) ?? 587,
+      user: config.user as string,
+      password: this.decryptIfNeeded(config.password as string),
+      from: config.from as string,
+      to: config.to as string,
+    });
+    await notifier.send(`Bronco ${subject}`, body);
+    notifier.close();
+  }
+
+  private async sendPushover(
+    config: Record<string, unknown>,
+    title: string,
+    message: string,
+    priority: -1 | 0 | 1,
+  ): Promise<void> {
+    const notifier = new PushoverNotifier({
+      appToken: this.decryptIfNeeded(config.appToken as string),
+      userKey: this.decryptIfNeeded(config.userKey as string),
+    });
+    await notifier.send(title, message, priority);
+  }
+}

--- a/services/status-monitor/src/config.ts
+++ b/services/status-monitor/src/config.ts
@@ -16,6 +16,13 @@ const configSchema = z.object({
   NOTIFY_ON_FIRST_POLL: z.string().optional().default('false'),
   // Health server
   HEALTH_PORT: z.coerce.number().default(3105),
+  // Cloudflared tunnel drift detection
+  // Base URL of the cloudflared metrics server (inside Docker network)
+  CLOUDFLARED_METRICS_URL: z.string().url().optional().default('http://cloudflared:2000'),
+  // Number of consecutive /ready failures before emitting an operational alert
+  CLOUDFLARED_DRIFT_FAIL_THRESHOLD: z.coerce.number().min(1).default(3),
+  // How often to probe /ready (seconds)
+  CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS: z.coerce.number().min(5).default(30),
 });
 
 export type Config = z.output<typeof configSchema>;

--- a/services/status-monitor/src/index.ts
+++ b/services/status-monitor/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@bronco/shared-utils';
 import { getConfig } from './config.js';
 import { StatusMonitor } from './monitor.js';
+import { CloudflaredDriftPoller } from './cloudflared-poller.js';
 
 const logger = createLogger('status-monitor');
 
@@ -21,6 +22,9 @@ async function main(): Promise<void> {
   // --- Monitor (channels are loaded from DB on each notification) ---
   const monitor = new StatusMonitor(db, config);
 
+  // --- Cloudflared drift poller ---
+  const cloudflaredPoller = new CloudflaredDriftPoller(db, config);
+
   // --- Health server ---
   const health = createHealthServer('status-monitor', config.HEALTH_PORT, {
     getDetails: () => ({
@@ -30,11 +34,15 @@ async function main(): Promise<void> {
       pollIntervalSeconds: config.POLL_INTERVAL_SECONDS,
       cooldownSeconds: config.COOLDOWN_SECONDS,
       activeChannels: monitor.activeChannelCount,
+      cloudflaredTunnel: cloudflaredPoller.getState(),
     }),
   });
 
   // --- Initial poll ---
   await monitor.poll();
+
+  // --- Start cloudflared drift poller (independent interval, non-blocking) ---
+  cloudflaredPoller.start();
 
   // --- Recurring polls (serialized — next poll only starts after previous completes) ---
   let pollRunning = false;
@@ -55,6 +63,7 @@ async function main(): Promise<void> {
 
   createGracefulShutdown(logger, [
     { interval },
+    { fn: () => cloudflaredPoller.stop() },
     health,
     { fn: disconnectDb },
   ]);


### PR DESCRIPTION
## Summary

Restore cloudflared tunnel-drift detection via an external poller in `status-monitor`. The v0.2.5 hotfix replaced the in-container `/ready` probe with a liveness-only `cloudflared --version` check (the distroless image has no shell or wget/curl). This PR brings back the drift signal that #381 / #382 were trying to provide — without a sidecar container, without auto-restart authority — by polling cloudflared's metrics endpoint from inside the docker network.

Fixes #423.

## How it works

- `CloudflaredDriftPoller` (status-monitor) probes `http://cloudflared:2000/ready` every 30s (configurable)
- Counts consecutive failures
- After threshold (default 3), emits an operational alert via the existing notification channels (Email + Pushover)
- Alert fires once per degraded episode (gated by `alertFired` flag) — resets on first successful probe
- Records a `ServiceAlert` row for history
- Surfaces state on:
  - `status-monitor /health` (`cloudflaredTunnel: { healthy, readyConnections, consecutiveFailures, lastChecked, lastError }`)
  - `GET /api/system-status` — new "Cloudflared Tunnel" component row with readyConnections + restart/start/stop controls wired to existing docker-compose control endpoint
  - Control-panel system-status component grid

## Why Option 3 (poller) over Option 1 (sidecar)

Sidecar would need Docker socket access to restart cloudflared on its own, which is a privilege-escalation surface. Operator-initiated restart (via the existing `/api/system-status/control` endpoint, gated to ADMIN per #409) is safer. Alert + runbook covers the gap.

## Changes — 6 files

- `services/status-monitor/src/cloudflared-poller.ts` — **new** — `CloudflaredDriftPoller` class
- `services/status-monitor/src/config.ts` — 3 new env vars with defaults: `CLOUDFLARED_METRICS_URL` (default `http://cloudflared:2000`), `CLOUDFLARED_DRIFT_FAIL_THRESHOLD` (3), `CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS` (30)
- `services/status-monitor/src/index.ts` — wires poller into startup + graceful shutdown + health response
- `services/copilot-api/src/config.ts` — `CLOUDFLARED_METRICS_URL` env var
- `services/copilot-api/src/routes/system-status.ts` — `checkCloudflaredTunnel()` helper + Promise.all + `allowedServices` whitelist
- `services/control-panel/src/app/features/system-status/system-status.component.ts` — adds `Cloudflared Tunnel` to `serviceKey()` map

## Hugo deploy

**No operator action required.** All env vars have defaults that resolve to the docker-compose network address (`http://cloudflared:2000`). Feature is live on next deploy. Optionally tune via Hugo `.env`:

```
CLOUDFLARED_DRIFT_FAIL_THRESHOLD=3
CLOUDFLARED_DRIFT_POLL_INTERVAL_SECONDS=30
```

## Test plan

- [ ] CI passes on push to staging
- [ ] After deploy: `ssh hugo-app "curl -sf http://localhost:3105/health | jq .cloudflaredTunnel"` returns `{healthy: true, readyConnections: 4, ...}` (or however many connections cloudflared has registered)
- [ ] Open System Status page in control-panel → "Cloudflared Tunnel" appears with healthy state + ready connections count
- [ ] Force a drift simulation: temporarily block UDP outbound from Hugo to Cloudflare edge → poller should detect failures, after 3 consecutive a notification fires, ServiceAlert row created
- [ ] Restore connectivity → poller transitions back to healthy, alert state resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
