### PR TITLE
feat(attachments): Phase 1 — schema + persistence (probe, MCP, email, operator) (#424)

### DIFF
--- a/packages/db/prisma/migrations/20260424000000_add_artifact_attachment_metadata/migration.sql
+++ b/packages/db/prisma/migrations/20260424000000_add_artifact_attachment_metadata/migration.sql
@@ -1,0 +1,25 @@
+-- Migration: 20260424000000_add_artifact_attachment_metadata
+-- Adds ArtifactKind enum and attachment-metadata columns to the artifacts table.
+-- All new columns are nullable for full backward compatibility.
+-- Backfills display_name from filename for existing rows.
+
+-- Create the artifact_kind enum
+CREATE TYPE "artifact_kind" AS ENUM (
+  'PROBE_RESULT',
+  'EMAIL_ATTACHMENT',
+  'MCP_TOOL_RESULT',
+  'OPERATOR_UPLOAD'
+);
+
+-- Add new columns to artifacts
+ALTER TABLE "artifacts"
+  ADD COLUMN "kind"                   "artifact_kind",
+  ADD COLUMN "display_name"           TEXT,
+  ADD COLUMN "source"                 TEXT,
+  ADD COLUMN "added_by_person_id"     UUID REFERENCES "people"("id") ON DELETE SET NULL,
+  ADD COLUMN "added_by_system"        TEXT,
+  ADD COLUMN "originating_event_id"   TEXT,
+  ADD COLUMN "originating_event_type" TEXT;
+
+-- Backfill: set display_name to filename for rows that have no display_name yet
+UPDATE "artifacts" SET "display_name" = "filename" WHERE "display_name" IS NULL AND "filename" IS NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -472,7 +472,7 @@ model Artifact {
 
   ticket        Ticket?  @relation(fields: [ticketId], references: [id])
   finding       Finding? @relation(fields: [findingId], references: [id])
-  addedByPerson Person?  @relation(fields: [addedByPersonId], references: [id])
+  addedByPerson Person?  @relation(fields: [addedByPersonId], references: [id], onDelete: SetNull)
 
   @@map("artifacts")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Person {
   clientUsers     ClientUser[]
   refreshTokens   PersonRefreshToken[]
   ticketFollowers TicketFollower[]
+  uploadedArtifacts Artifact[]
 
   @@unique([emailLower])
   @@index([email])
@@ -451,18 +452,27 @@ model DevOpsSyncState {
 // --- Artifacts & Findings ---
 
 model Artifact {
-  id          String   @id @default(uuid()) @db.Uuid
-  ticketId    String?  @map("ticket_id") @db.Uuid
-  findingId   String?  @map("finding_id") @db.Uuid
-  filename    String
-  mimeType    String   @map("mime_type")
-  sizeBytes   Int      @map("size_bytes")
-  storagePath String   @map("storage_path")
-  description String?
-  createdAt   DateTime @default(now()) @map("created_at")
+  id                   String        @id @default(uuid()) @db.Uuid
+  ticketId             String?       @map("ticket_id") @db.Uuid
+  findingId            String?       @map("finding_id") @db.Uuid
+  filename             String
+  mimeType             String        @map("mime_type")
+  sizeBytes            Int           @map("size_bytes")
+  storagePath          String        @map("storage_path")
+  description          String?
+  createdAt            DateTime      @default(now()) @map("created_at")
+  // Phase 1 enrichment — all nullable for backward compatibility
+  kind                 ArtifactKind? @map("kind")
+  displayName          String?       @map("display_name")
+  source               String?       @map("source")
+  addedByPersonId      String?       @map("added_by_person_id") @db.Uuid
+  addedBySystem        String?       @map("added_by_system")
+  originatingEventId   String?       @map("originating_event_id")
+  originatingEventType String?       @map("originating_event_type")
 
-  ticket  Ticket?  @relation(fields: [ticketId], references: [id])
-  finding Finding? @relation(fields: [findingId], references: [id])
+  ticket        Ticket?  @relation(fields: [ticketId], references: [id])
+  finding       Finding? @relation(fields: [findingId], references: [id])
+  addedByPerson Person?  @relation(fields: [addedByPersonId], references: [id])
 
   @@map("artifacts")
 }
@@ -1688,6 +1698,15 @@ enum ToolRequestKind {
   IMPROVE_TOOL
 
   @@map("tool_request_kind")
+}
+
+enum ArtifactKind {
+  PROBE_RESULT
+  EMAIL_ATTACHMENT
+  MCP_TOOL_RESULT
+  OPERATOR_UPLOAD
+
+  @@map("artifact_kind")
 }
 
 model ToolRequest {

--- a/packages/shared-types/src/artifact.ts
+++ b/packages/shared-types/src/artifact.ts
@@ -1,3 +1,11 @@
+export const ArtifactKind = {
+  PROBE_RESULT: 'PROBE_RESULT',
+  EMAIL_ATTACHMENT: 'EMAIL_ATTACHMENT',
+  MCP_TOOL_RESULT: 'MCP_TOOL_RESULT',
+  OPERATOR_UPLOAD: 'OPERATOR_UPLOAD',
+} as const;
+export type ArtifactKind = (typeof ArtifactKind)[keyof typeof ArtifactKind];
+
 export const Severity = {
   LOW: 'LOW',
   MEDIUM: 'MEDIUM',
@@ -25,6 +33,14 @@ export interface Artifact {
   storagePath: string;
   description: string | null;
   createdAt: Date;
+  // Phase 1 enrichment fields (all nullable for backward compatibility)
+  kind: ArtifactKind | null;
+  displayName: string | null;
+  source: string | null;
+  addedByPersonId: string | null;
+  addedBySystem: string | null;
+  originatingEventId: string | null;
+  originatingEventType: string | null;
 }
 
 export interface Finding {

--- a/packages/shared-types/src/ingestion.ts
+++ b/packages/shared-types/src/ingestion.ts
@@ -12,6 +12,18 @@ export interface IngestionJob {
 
 // --- Typed payload shapes per source ---
 
+/** A single email attachment forwarded via the ingestion payload. */
+export interface EmailAttachmentPayload {
+  /** Original filename from the email. */
+  filename: string;
+  /** MIME type reported by the email (e.g. "application/pdf"). */
+  contentType: string;
+  /** File size in bytes. */
+  size: number;
+  /** Base64-encoded content. Only present when size <= 25 MB. */
+  content: string;
+}
+
 /** Email payload submitted by imap-worker. */
 export interface EmailIngestionPayload {
   from: string;
@@ -30,6 +42,12 @@ export interface EmailIngestionPayload {
   emailHash?: string;
   /** Pre-resolved Person ID for the sender (if matched by imap-worker). */
   personId?: string;
+  /**
+   * Attachments extracted from the email. Each attachment is base64-encoded and
+   * capped at 25 MB. Oversized attachments are skipped (WARN-logged by imap-worker).
+   * The ingestion engine persists these as Artifact rows after ticket creation.
+   */
+  attachments?: EmailAttachmentPayload[];
 }
 
 /** Probe result payload submitted by probe-worker. */

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -6,6 +6,35 @@ import { pipeline } from 'node:stream/promises';
 import type { Config } from '../config.js';
 import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
+/** Fields projected on Artifact rows returned by the list/get endpoints. */
+const ARTIFACT_SELECT = {
+  id: true,
+  ticketId: true,
+  findingId: true,
+  filename: true,
+  mimeType: true,
+  sizeBytes: true,
+  storagePath: true,
+  description: true,
+  createdAt: true,
+  // Phase 1 enrichment fields
+  kind: true,
+  displayName: true,
+  source: true,
+  addedByPersonId: true,
+  addedBySystem: true,
+  originatingEventId: true,
+  originatingEventType: true,
+  // Person join: project only safe fields (id, name, email — no passwordHash etc.)
+  addedByPerson: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+} as const;
+
 export async function artifactRoutes(fastify: FastifyInstance, opts: { config: Config }): Promise<void> {
   const storagePath = opts.config.ARTIFACT_STORAGE_PATH;
 
@@ -21,6 +50,7 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
     const artifacts = await fastify.db.artifact.findMany({
       where: { ticketId: request.params.ticketId },
       orderBy: { createdAt: 'desc' },
+      select: ARTIFACT_SELECT,
     });
     return artifacts;
   });
@@ -38,6 +68,7 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
           { ticketId: null },
         ],
       },
+      select: ARTIFACT_SELECT,
     });
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
     return artifact;
@@ -53,6 +84,11 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
           { ticket: { ...scopeToWhere(scope) } },
           { ticketId: null },
         ],
+      },
+      select: {
+        storagePath: true,
+        filename: true,
+        mimeType: true,
       },
     });
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
@@ -76,15 +112,15 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
     return reply.send(createReadStream(filePath));
   });
 
-  fastify.post<{ Querystring: { ticketId?: string; findingId?: string; description?: string } }>(
+  fastify.post<{ Querystring: { ticketId?: string; findingId?: string; description?: string; kind?: string } }>(
     '/api/artifacts/upload',
     async (request, reply) => {
       const file = await request.file();
       if (!file) return fastify.httpErrors.badRequest('No file provided');
 
-      // ticketId, findingId, and description are passed as querystring params so
+      // ticketId, findingId, description, and kind are passed as querystring params so
       // they can accompany a multipart/form-data upload without a JSON body.
-      const { ticketId, findingId, description } = request.query;
+      const { ticketId, findingId, description, kind } = request.query;
 
       // Scope checks: resolve once if either parent is provided.
       if (ticketId || findingId) {
@@ -127,6 +163,18 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
       await mkdir(dirname(fullPath), { recursive: true });
       await pipeline(file.file, createWriteStream(fullPath));
 
+      // Resolve the operator's Person ID from the JWT (present for authenticated callers).
+      const callerPersonId = request.user?.personId ?? null;
+
+      // Determine the artifact kind: default to OPERATOR_UPLOAD unless caller explicitly
+      // passes a recognised kind value (guards against free-form strings).
+      const VALID_KINDS = ['PROBE_RESULT', 'EMAIL_ATTACHMENT', 'MCP_TOOL_RESULT', 'OPERATOR_UPLOAD'] as const;
+      type ValidKind = typeof VALID_KINDS[number];
+      const resolvedKind: ValidKind =
+        (kind && (VALID_KINDS as readonly string[]).includes(kind))
+          ? kind as ValidKind
+          : 'OPERATOR_UPLOAD';
+
       const artifact = await fastify.db.artifact.create({
         data: {
           ticketId: ticketId ?? null,
@@ -136,7 +184,13 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
           sizeBytes: file.file.bytesRead,
           storagePath: relativePath,
           description: description ?? null,
+          kind: resolvedKind,
+          displayName: sanitizedFilename,
+          source: 'upload',
+          addedByPersonId: callerPersonId,
+          addedBySystem: 'copilot-api:upload',
         },
+        select: ARTIFACT_SELECT,
       });
 
       reply.code(201);

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -112,15 +112,18 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
     return reply.send(createReadStream(filePath));
   });
 
-  fastify.post<{ Querystring: { ticketId?: string; findingId?: string; description?: string; kind?: string } }>(
+  fastify.post<{ Querystring: { ticketId?: string; findingId?: string; description?: string } }>(
     '/api/artifacts/upload',
     async (request, reply) => {
       const file = await request.file();
       if (!file) return fastify.httpErrors.badRequest('No file provided');
 
-      // ticketId, findingId, description, and kind are passed as querystring params so
+      // ticketId, findingId, and description are passed as querystring params so
       // they can accompany a multipart/form-data upload without a JSON body.
-      const { ticketId, findingId, description, kind } = request.query;
+      // The artifact kind is hardcoded to OPERATOR_UPLOAD — callers cannot mislabel
+      // operator uploads as PROBE_RESULT / EMAIL_ATTACHMENT / MCP_TOOL_RESULT (those
+      // kinds are written exclusively by their respective worker pipelines).
+      const { ticketId, findingId, description } = request.query;
 
       // Scope checks: resolve once if either parent is provided.
       if (ticketId || findingId) {
@@ -166,15 +169,6 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
       // Resolve the operator's Person ID from the JWT (present for authenticated callers).
       const callerPersonId = request.user?.personId ?? null;
 
-      // Determine the artifact kind: default to OPERATOR_UPLOAD unless caller explicitly
-      // passes a recognised kind value (guards against free-form strings).
-      const VALID_KINDS = ['PROBE_RESULT', 'EMAIL_ATTACHMENT', 'MCP_TOOL_RESULT', 'OPERATOR_UPLOAD'] as const;
-      type ValidKind = typeof VALID_KINDS[number];
-      const resolvedKind: ValidKind =
-        (kind && (VALID_KINDS as readonly string[]).includes(kind))
-          ? kind as ValidKind
-          : 'OPERATOR_UPLOAD';
-
       const artifact = await fastify.db.artifact.create({
         data: {
           ticketId: ticketId ?? null,
@@ -184,7 +178,7 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
           sizeBytes: file.file.bytesRead,
           storagePath: relativePath,
           description: description ?? null,
-          kind: resolvedKind,
+          kind: 'OPERATOR_UPLOAD',
           displayName: sanitizedFilename,
           source: 'upload',
           addedByPersonId: callerPersonId,

--- a/services/imap-worker/src/processor.ts
+++ b/services/imap-worker/src/processor.ts
@@ -3,9 +3,12 @@ import { simpleParser } from 'mailparser';
 import type { Job, Queue } from 'bullmq';
 import { type PrismaClient } from '@bronco/db';
 import { TaskType, EmailClassification, EmailProcessingStatus, TicketSource } from '@bronco/shared-types';
-import type { IngestionJob, EmailIngestionPayload } from '@bronco/shared-types';
+import type { IngestionJob, EmailIngestionPayload, EmailAttachmentPayload } from '@bronco/shared-types';
 import type { AIRouter } from '@bronco/ai-provider';
 import { AppLogger, createPrismaLogWriter } from '@bronco/shared-utils';
+
+/** Maximum per-attachment size in bytes before we skip (and WARN-log). */
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024; // 25 MB
 
 export const appLog = new AppLogger('email-processor');
 
@@ -259,6 +262,31 @@ Respond with ONLY one word: ACTIONABLE or NOISE`,
       classification = EmailClassification.THREAD_REPLY;
     }
 
+    // --- Collect attachments for ingestion payload ---
+    const attachmentPayloads: EmailAttachmentPayload[] = [];
+    if (parsed.attachments && parsed.attachments.length > 0) {
+      for (const att of parsed.attachments) {
+        const attSize = att.size ?? att.content?.length ?? 0;
+        if (attSize > MAX_ATTACHMENT_BYTES) {
+          appLog.warn(`Skipping oversized email attachment (${attSize} bytes > 25 MB limit)`, {
+            filename: att.filename,
+            contentType: att.contentType,
+            size: attSize,
+            messageId,
+          });
+          continue;
+        }
+        const content = att.content;
+        if (!content || content.length === 0) continue;
+        attachmentPayloads.push({
+          filename: att.filename || 'attachment',
+          contentType: att.contentType || 'application/octet-stream',
+          size: attSize,
+          content: content.toString('base64'),
+        });
+      }
+    }
+
     // --- Build payload and push to ingestion queue ---
     const refsArray = Array.isArray(references) ? references : references ? [references] : [];
     const emailPayload: EmailIngestionPayload = {
@@ -274,6 +302,7 @@ Respond with ONLY one word: ACTIONABLE or NOISE`,
       hasAttachments: hasAttachments || undefined,
       emailHash,
       personId: person?.id,
+      ...(attachmentPayloads.length > 0 && { attachments: attachmentPayloads }),
     };
 
     const ingestionJob: IngestionJob = {

--- a/services/imap-worker/src/processor.ts
+++ b/services/imap-worker/src/processor.ts
@@ -7,8 +7,15 @@ import type { IngestionJob, EmailIngestionPayload, EmailAttachmentPayload } from
 import type { AIRouter } from '@bronco/ai-provider';
 import { AppLogger, createPrismaLogWriter } from '@bronco/shared-utils';
 
-/** Maximum per-attachment size in bytes before we skip (and WARN-log). */
-const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024; // 25 MB
+/**
+ * Maximum per-attachment RAW size in bytes before we skip (and WARN-log).
+ *
+ * The ingestion BullMQ payload carries attachment bytes as base64 inside JSON,
+ * which inflates payload size by ~33% (4 base64 chars per 3 raw bytes). To keep
+ * the encoded Redis payload ≤ ~25 MB per attachment, we cap RAW at ~18.75 MB.
+ * 18.75 MB raw → ~25 MB base64 ≤ Redis-friendly payload size.
+ */
+const RAW_ATTACHMENT_LIMIT_BYTES = Math.floor(18.75 * 1024 * 1024); // ~18.75 MB raw → ~25 MB base64
 
 export const appLog = new AppLogger('email-processor');
 
@@ -267,13 +274,17 @@ Respond with ONLY one word: ACTIONABLE or NOISE`,
     if (parsed.attachments && parsed.attachments.length > 0) {
       for (const att of parsed.attachments) {
         const attSize = att.size ?? att.content?.length ?? 0;
-        if (attSize > MAX_ATTACHMENT_BYTES) {
-          appLog.warn(`Skipping oversized email attachment (${attSize} bytes > 25 MB limit)`, {
-            filename: att.filename,
-            contentType: att.contentType,
-            size: attSize,
-            messageId,
-          });
+        if (attSize > RAW_ATTACHMENT_LIMIT_BYTES) {
+          appLog.warn(
+            `Skipping oversized email attachment (${attSize} raw bytes > ${RAW_ATTACHMENT_LIMIT_BYTES} raw-byte limit; base64-encoded payload would exceed ~25 MB)`,
+            {
+              filename: att.filename,
+              contentType: att.contentType,
+              size: attSize,
+              rawLimit: RAW_ATTACHMENT_LIMIT_BYTES,
+              messageId,
+            },
+          );
           continue;
         }
         const content = att.content;

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -1058,6 +1058,11 @@ export async function saveMcpToolArtifact(
         sizeBytes: Buffer.byteLength(rawResult, 'utf-8'),
         storagePath: relativePath,
         description: `Raw MCP tool output from agentic analysis (${toolName})`,
+        kind: 'MCP_TOOL_RESULT',
+        displayName: `Tool result: ${toolName}`,
+        source: `mcp_tool:${toolName}`,
+        addedBySystem: 'ticket-analyzer:agentic',
+        addedByPersonId: null,
       },
     });
     logger.info({ ticketId, filename }, 'MCP tool artifact saved');

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1,5 +1,6 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import type { Job, Queue } from 'bullmq';
 import type { PrismaClient } from '@bronco/db';
 import { Prisma } from '@bronco/db';
@@ -700,9 +701,11 @@ async function executeIngestionPipeline(
           throw new Error('Failed to create ticket after max retries');
         }
 
-        // Record initial inbound event based on source
+        // Record initial inbound event based on source. For EMAIL we capture the event
+        // id so attachments below can stamp originatingEventId without an extra query.
+        let inboundEventId: string | null = null;
         if (source === TicketSource.EMAIL) {
-          await db.ticketEvent.create({
+          const inboundEvent = await db.ticketEvent.create({
             data: {
               ticketId: ctx.ticketId,
               eventType: 'EMAIL_INBOUND',
@@ -720,7 +723,9 @@ async function executeIngestionPipeline(
               ...(typeof payload['messageId'] === 'string' && !payload['messageId'].startsWith('uid-') ? { emailMessageId: payload['messageId'] as string } : {}),
               ...(typeof payload['emailHash'] === 'string' && payload['emailHash'].trim() !== '' ? { emailHash: payload['emailHash'] as string } : {}),
             },
+            select: { id: true },
           });
+          inboundEventId = inboundEvent.id;
         } else {
           await db.ticketEvent.create({
             data: {
@@ -755,18 +760,14 @@ async function executeIngestionPipeline(
           await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
         }
 
-        // Save email attachments when present in the payload (EMAIL source only)
+        // Save email attachments when present in the payload (EMAIL source only).
+        // We reuse the inboundEventId captured from the create() above instead of
+        // re-querying ticketEvent for the row we just inserted.
         if (source === TicketSource.EMAIL && deps.artifactStoragePath) {
           const rawAttachments = payload['attachments'];
           if (Array.isArray(rawAttachments) && rawAttachments.length > 0) {
             const subject = payloadStr(payload, 'subject');
             const personId = typeof payload['personId'] === 'string' ? payload['personId'] : null;
-            // Find the EMAIL_INBOUND event we just created so we can store originatingEventId
-            const inboundEvent = await db.ticketEvent.findFirst({
-              where: { ticketId: ctx.ticketId, eventType: 'EMAIL_INBOUND' },
-              orderBy: { createdAt: 'desc' },
-              select: { id: true },
-            });
             for (const att of rawAttachments) {
               if (
                 typeof att !== 'object' || att === null ||
@@ -779,7 +780,7 @@ async function executeIngestionPipeline(
                 att as { filename: string; contentType: string; size: number; content: string },
                 subject,
                 personId,
-                inboundEvent?.id ?? null,
+                inboundEventId,
                 deps.artifactStoragePath,
               );
             }
@@ -1246,7 +1247,9 @@ async function saveEmailAttachmentArtifact(
 ): Promise<void> {
   try {
     const safeFilename = sanitizeFilenameSegment(att.filename || 'attachment');
-    const filename = `email-${Date.now()}-${safeFilename}`;
+    // Append a randomUUID() segment so two attachments saved in the same millisecond
+    // (same ticket, multiple parts) cannot collide on disk. Matches saveMcpToolArtifact.
+    const filename = `email-${Date.now()}-${randomUUID()}-${safeFilename}`;
     const resolvedStorage = resolve(storagePath);
     const ticketDir = resolve(resolvedStorage, 'tickets', ticketId);
     const rel = relative(resolvedStorage, ticketDir);

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -755,6 +755,37 @@ async function executeIngestionPipeline(
           await saveProbeArtifact(db, ctx.ticketId, probeName, toolName, toolResult, deps.artifactStoragePath);
         }
 
+        // Save email attachments when present in the payload (EMAIL source only)
+        if (source === TicketSource.EMAIL && deps.artifactStoragePath) {
+          const rawAttachments = payload['attachments'];
+          if (Array.isArray(rawAttachments) && rawAttachments.length > 0) {
+            const subject = payloadStr(payload, 'subject');
+            const personId = typeof payload['personId'] === 'string' ? payload['personId'] : null;
+            // Find the EMAIL_INBOUND event we just created so we can store originatingEventId
+            const inboundEvent = await db.ticketEvent.findFirst({
+              where: { ticketId: ctx.ticketId, eventType: 'EMAIL_INBOUND' },
+              orderBy: { createdAt: 'desc' },
+              select: { id: true },
+            });
+            for (const att of rawAttachments) {
+              if (
+                typeof att !== 'object' || att === null ||
+                typeof att['filename'] !== 'string' ||
+                typeof att['content'] !== 'string'
+              ) continue;
+              await saveEmailAttachmentArtifact(
+                db,
+                ctx.ticketId,
+                att as { filename: string; contentType: string; size: number; content: string },
+                subject,
+                personId,
+                inboundEvent?.id ?? null,
+                deps.artifactStoragePath,
+              );
+            }
+          }
+        }
+
         const stepDuration = Date.now() - stepStart;
         deps.appLog?.info(
           `Ticket created: ${ctx.ticketId} (${source}, ${ctx.category}/${ctx.priority}) (${(stepDuration / 1000).toFixed(1)}s)`,
@@ -1191,11 +1222,64 @@ async function saveProbeArtifact(
         sizeBytes: Buffer.byteLength(rawResult, 'utf-8'),
         storagePath: relativePath,
         description: `Raw MCP tool output from probe "${probeName}" (${toolName})`,
+        kind: 'PROBE_RESULT',
+        displayName: `Probe: ${probeName}`,
+        source: `probe:${toolName}`,
+        addedBySystem: 'probe-worker',
+        addedByPersonId: null,
       },
     });
     logger.info({ ticketId, filename }, 'Probe artifact saved via ingestion engine');
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save probe artifact — continuing');
+  }
+}
+
+async function saveEmailAttachmentArtifact(
+  db: PrismaClient,
+  ticketId: string,
+  att: { filename: string; contentType: string; size: number; content: string },
+  emailSubject: string,
+  personId: string | null,
+  originatingEventId: string | null,
+  storagePath: string,
+): Promise<void> {
+  try {
+    const safeFilename = sanitizeFilenameSegment(att.filename || 'attachment');
+    const filename = `email-${Date.now()}-${safeFilename}`;
+    const resolvedStorage = resolve(storagePath);
+    const ticketDir = resolve(resolvedStorage, 'tickets', ticketId);
+    const rel = relative(resolvedStorage, ticketDir);
+    if (rel.startsWith('..') || rel === '') {
+      logger.warn({ ticketId, ticketDir, resolvedStorage }, 'Email attachment path escaped storage root — skipping');
+      return;
+    }
+    const fullPath = join(ticketDir, filename);
+    await mkdir(ticketDir, { recursive: true });
+    const contentBuffer = Buffer.from(att.content, 'base64');
+    await writeFile(fullPath, contentBuffer);
+    const relativePath = `tickets/${ticketId}/${filename}`;
+    const sourceTag = `email:${emailSubject.slice(0, 80)}`;
+    await db.artifact.create({
+      data: {
+        ticketId,
+        filename: att.filename || 'attachment',
+        mimeType: att.contentType || 'application/octet-stream',
+        sizeBytes: contentBuffer.length,
+        storagePath: relativePath,
+        description: null,
+        kind: 'EMAIL_ATTACHMENT',
+        displayName: att.filename || 'attachment',
+        source: sourceTag,
+        addedByPersonId: personId,
+        addedBySystem: 'imap-worker',
+        originatingEventId: originatingEventId,
+        originatingEventType: originatingEventId ? 'ticket_event' : null,
+      },
+    });
+    logger.info({ ticketId, filename: att.filename }, 'Email attachment artifact saved');
+  } catch (err) {
+    logger.warn({ err, ticketId, filename: att.filename }, 'Failed to save email attachment artifact — continuing');
   }
 }
 


### PR DESCRIPTION
## Summary

**Phase 1 of #424** — schema enrichment + persistence backbone for unified ticket attachments. Phase 2 (Haiku friendly-name worker) and Phase 3 (Finder-style UI panel) ship as follow-up PRs.

Refs #424. Closes the email-attachment persistence gap (`imap-worker/processor.ts:120` — previously only set `hasAttachments: boolean`, dropped the bytes).

## Migration

`packages/db/prisma/migrations/20260424000000_add_artifact_attachment_metadata/migration.sql` — single-transaction, all additive:

- New enum `ArtifactKind`: `PROBE_RESULT`, `EMAIL_ATTACHMENT`, `MCP_TOOL_RESULT`, `OPERATOR_UPLOAD`
- 7 new nullable columns on `artifacts`:
  - `kind: ArtifactKind?`
  - `display_name: String?`
  - `source: String?`
  - `added_by_person_id: String?` (FK → `people`, `ON DELETE SET NULL`)
  - `added_by_system: String?`
  - `originating_event_id: String?` (plain string — flexible across TicketEvent / Email / AiUsageLog)
  - `originating_event_type: String?` (discriminator for the above)
- Backfill: `UPDATE artifacts SET display_name = filename WHERE display_name IS NULL AND filename IS NOT NULL`

Safe rollout — all columns nullable, no FK constraints that would fail on existing data, `Person.uploadedArtifacts` reverse relation added.

## Per-source defaults Phase 1 sets

| Source | `kind` | `displayName` | `source` | `addedBySystem` |
|---|---|---|---|---|
| Probe artifact | `PROBE_RESULT` | `Probe: <probeName>` | `probe:<toolName>` | `probe-worker` |
| MCP tool result | `MCP_TOOL_RESULT` | `Tool result: <toolName>` | `mcp_tool:<toolName>` | `ticket-analyzer:agentic` |
| Email attachment | `EMAIL_ATTACHMENT` | original filename | `email:<subject 80 chars>` | `imap-worker` |
| Operator upload | `OPERATOR_UPLOAD` | sanitized filename | `upload` | `copilot-api:upload` |

`displayName` is set by Phase 1 with templated defaults for system artifacts. **Phase 2** improves these for `PROBE_RESULT` / `MCP_TOOL_RESULT` via Haiku-generated names.

## Email attachment persistence (the actual gap fix)

Previously: `parsed.attachments` was inspected only for the `hasAttachments` boolean; bytes were dropped.

Now:
1. `imap-worker` collects `parsed.attachments` into a base64-encoded `EmailAttachmentPayload[]` on the `EmailIngestionPayload` (passes through BullMQ `ticket-ingest` queue)
2. Per-attachment 25 MB cap applied in `imap-worker` before queueing — oversized files skipped with WARN log, not an error
3. `CREATE_TICKET` step decodes and writes to `ARTIFACT_STORAGE_PATH/tickets/<ticketId>/email-<timestamp>-<sanitizedFilename>`
4. `Artifact` row created with full metadata, `originatingEventId` set to the `EMAIL_INBOUND` `TicketEvent` id

**Reply emails** flow through the same threading + ingestion path, so reply attachments persist alongside the ticket — operator sees them appearing in the attachments panel as the conversation grows (once Phase 3 lands).

## API: `GET /api/tickets/:id/artifacts` enriched

Returns all new fields + safe `addedByPerson: { id, name, email }` join (per the #415 SAFE_PERSON_SELECT pattern — no `passwordHash` / `emailLower` leak). Phase 3 UI consumes this directly.

## Files changed

| File | Change |
|---|---|
| `packages/db/prisma/schema.prisma` | Enum + 7 columns + reverse relation |
| `packages/db/prisma/migrations/20260424000000_…` | New migration |
| `packages/shared-types/src/artifact.ts` | `ArtifactKind` const+type, extended `Artifact` interface |
| `packages/shared-types/src/ingestion.ts` | `EmailAttachmentPayload` type |
| `services/imap-worker/src/processor.ts` | Collect attachments → base64 payload, 25 MB cap |
| `services/ticket-analyzer/src/ingestion-engine.ts` | `saveProbeArtifact()` populates new fields; new `saveEmailAttachmentArtifact()`; `CREATE_TICKET` iterates email attachments |
| `services/ticket-analyzer/src/analysis/shared.ts` | `saveMcpToolArtifact()` populates new fields |
| `services/copilot-api/src/routes/artifacts.ts` | `ARTIFACT_SELECT` projection; `POST /upload` populates new fields, `kind` defaults to `OPERATOR_UPLOAD` |

## Phase 2 / Phase 3 readiness

- **Phase 2 trigger**: `WHERE kind IN ('PROBE_RESULT', 'MCP_TOOL_RESULT')` — these have templated defaults that Haiku can replace with friendlier names
- **Phase 3 ready**: API returns everything the UI needs; no further backend changes required for the panel itself

## Test plan

- [ ] CI passes on push to staging
- [ ] After deploy: `prisma migrate deploy` applies cleanly; Hugo `_prisma_migrations` table records the row
- [ ] Send an email with an attachment to a configured IMAP inbox → verify `Artifact` row created with `kind: EMAIL_ATTACHMENT`, file content stored on disk under `ARTIFACT_STORAGE_PATH/tickets/<ticketId>/`, `addedBySystem: 'imap-worker'`
- [ ] Reply with another attachment → second row appears for same `ticketId`
- [ ] Trigger a probe-sourced ticket → existing `Artifact` flow now also populates `kind: PROBE_RESULT`, `displayName: 'Probe: <name>'`
- [ ] Trigger an analysis with a large MCP tool output → `MCP_TOOL_RESULT` artifact has correct kind + display name
- [ ] Upload via `POST /api/artifacts/upload?ticketId=<id>` → `OPERATOR_UPLOAD` kind, `addedByPersonId` populated from operator's Person
- [ ] `GET /api/tickets/:id/artifacts` returns all new fields including `addedByPerson` projection
- [ ] No `passwordHash` / `emailLower` leak in artifacts response (response-field sanity)
- [ ] Existing artifacts in DB get `display_name = filename` from backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
