### PR TITLE
fix(migration): make parent_log_pointers idempotent (CI hotfix)

### DIFF
--- a/packages/db/prisma/migrations/20260410020000_add_parent_log_pointers/migration.sql
+++ b/packages/db/prisma/migrations/20260410020000_add_parent_log_pointers/migration.sql
@@ -1,7 +1,17 @@
-ALTER TABLE "ai_usage_logs" ADD COLUMN "parent_log_id" UUID;
-ALTER TABLE "ai_usage_logs" ADD COLUMN "parent_log_type" TEXT;
-CREATE INDEX "ai_usage_logs_parent_log_id_idx" ON "ai_usage_logs"("parent_log_id");
+-- Idempotent version of this migration: the preceding migration
+-- 20260409010000_add_parent_log_lineage added the same columns and indexes
+-- to both ai_usage_logs and app_logs (same feature, issue #187). On a fresh
+-- database this migration was a duplicate and failed with
+-- "column already exists" (error 42701). Production already has both
+-- migrations marked applied — Prisma does not re-verify checksums on
+-- already-applied migrations, so the drift here is a no-op for existing
+-- deploys. Only fresh deploys (dev resets, test DBs, new environments)
+-- benefit from the IF NOT EXISTS guards below.
 
-ALTER TABLE "app_logs" ADD COLUMN "parent_log_id" UUID;
-ALTER TABLE "app_logs" ADD COLUMN "parent_log_type" TEXT;
-CREATE INDEX "app_logs_parent_log_id_idx" ON "app_logs"("parent_log_id");
+ALTER TABLE "ai_usage_logs" ADD COLUMN IF NOT EXISTS "parent_log_id" UUID;
+ALTER TABLE "ai_usage_logs" ADD COLUMN IF NOT EXISTS "parent_log_type" TEXT;
+CREATE INDEX IF NOT EXISTS "ai_usage_logs_parent_log_id_idx" ON "ai_usage_logs"("parent_log_id");
+
+ALTER TABLE "app_logs" ADD COLUMN IF NOT EXISTS "parent_log_id" UUID;
+ALTER TABLE "app_logs" ADD COLUMN IF NOT EXISTS "parent_log_type" TEXT;
+CREATE INDEX IF NOT EXISTS "app_logs_parent_log_id_idx" ON "app_logs"("parent_log_id");


### PR DESCRIPTION
## Summary

CI hotfix. After merging #433 (testing infrastructure), the new `prisma migrate deploy` step in CI exposed a latent duplicate-migration bug that's been sitting in `staging` since #188. Run on `staging` failed with:

```
ERROR: column "parent_log_id" of relation "ai_usage_logs" already exists
Migration name: 20260410020000_add_parent_log_pointers
```

## Root cause

`20260410020000_add_parent_log_pointers` and `20260409010000_add_parent_log_lineage` both add the same columns and indexes to `ai_usage_logs` and `app_logs` (same feature, refs #187, committed a day apart). Prod already has both marked applied (Prisma doesn't re-checksum applied migrations) so deployed environments are unaffected. Every fresh database (CI, dev resets, test DBs, new envs) fails on the second one.

## Fix

Same pattern as commit `6673242` (`fix(migration): two latent bugs in auth_model_unification`): add `IF NOT EXISTS` guards. No-op on already-applied environments; fresh deploys now succeed.

## Why this didn't ship with #433

I discovered and fixed this locally during the initial testing buildout, but the file edit never made it into PR #433 — the migration file was bumped out of my staging set when I rebuilt the branch on a worktree. The fix is a one-file change so re-applying as a hotfix is the cleanest path forward (vs. force-pushing the merged commit).

## Test plan

- [x] Verified locally — `prisma migrate deploy` against a freshly-created `bronco_test` runs all 138 migrations clean
- [ ] CI run on `staging` after merge confirms the integration suite gets past the migrate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
