### PR TITLE
feat(attachments): Phase 2 — Haiku-generated friendly artifact names (#424)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ System prompts for each task are registered in `packages/ai-provider/src/prompts
 - `ANALYZE_APP_HEALTH` — Scheduled platform health analysis — ticket patterns, AI usage trends, error logs, and codebase review
 - `DETECT_TOOL_GAPS` — Post-hoc review of a completed analysis to detect capability gaps; upserts tool requests into the registry (default: Claude Haiku for cheap review)
 - `ANALYZE_TOOL_REQUESTS` — Admin-triggered dedupe agent: compares a client's PROPOSED/APPROVED tool requests against each other and against the live MCP tool catalog (platform + repo + database + per-client integrations) and writes `suggestedDuplicateOf*` / `suggestedImprovesExisting*` fields on rows (default: Claude Sonnet)
+- `GENERATE_ARTIFACT_NAME` — Async post-save worker that fills `displayName` + `description` on system-generated artifacts (PROBE_RESULT, MCP_TOOL_RESULT) by reading the first 500 chars of the raw output. Strict JSON output, one generation per artifact lifetime, falls back silently to Phase 1 templated defaults on parse failure (default: Claude Haiku)
 
 ### Task Type Discipline (CRITICAL)
 

--- a/packages/ai-provider/src/model-config-resolver.ts
+++ b/packages/ai-provider/src/model-config-resolver.ts
@@ -62,6 +62,7 @@ const DEFAULT_CLAUDE_HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 /** Task types that default to Claude Haiku (cheap, fast) instead of Sonnet. */
 const CLAUDE_HAIKU_TASK_TYPES = new Set<string>([
   TaskType.DETECT_TOOL_GAPS,
+  TaskType.GENERATE_ARTIFACT_NAME,
 ]);
 
 function defaultProviderAndModel(taskType: string): { provider: AIProvider; model: string } {

--- a/packages/ai-provider/src/prompts/artifact-name.ts
+++ b/packages/ai-provider/src/prompts/artifact-name.ts
@@ -1,0 +1,27 @@
+import type { PromptDefinition } from './types.js';
+
+export const ARTIFACT_NAME_SYSTEM: PromptDefinition = {
+  key: 'artifact.name.system',
+  name: 'Artifact Name Generator',
+  description:
+    'Generates a short human-friendly displayName and one-to-two-sentence description for a system-generated artifact (probe result or MCP tool output) based on its raw content.',
+  taskType: 'GENERATE_ARTIFACT_NAME',
+  role: 'SYSTEM',
+  content:
+    'You generate short, human-friendly names and descriptions for system-generated ' +
+    'artifact files (probe results, MCP tool outputs) based on a small content preview.\n\n' +
+    'Output STRICT JSON ONLY — no prose, no code fences, no commentary:\n' +
+    '{"displayName":"<3-8 word title>","description":"<1-2 sentence summary>"}\n\n' +
+    'Rules:\n' +
+    '- displayName: 3-8 words. Bias toward verbs + specific nouns (e.g. ' +
+    '"Top blocking sessions snapshot", "Index fragmentation scan", "Failed login audit").\n' +
+    '- Avoid generic words like "result", "output", "data", "file", "artifact".\n' +
+    '- description: 1-2 sentences. Describe what the artifact contains and why it matters.\n' +
+    '- If content is empty, malformed, or unparseable, still return JSON with a best-effort title ' +
+    'derived from the tool name supplied in the prompt.\n' +
+    '- Never include markdown, backticks, or surrounding text — JSON only.',
+  temperature: 0.2,
+  maxTokens: 200,
+};
+
+export const ARTIFACT_NAME_PROMPTS: PromptDefinition[] = [ARTIFACT_NAME_SYSTEM];

--- a/packages/ai-provider/src/prompts/index.ts
+++ b/packages/ai-provider/src/prompts/index.ts
@@ -33,6 +33,9 @@ export * from './analyze-tool-requests.js';
 export { CHAT_PROMPTS } from './chat-classify-reply.js';
 export * from './chat-classify-reply.js';
 
+export { ARTIFACT_NAME_PROMPTS } from './artifact-name.js';
+export * from './artifact-name.js';
+
 // Re-export individual prompts for direct import convenience
 import { IMAP_PROMPTS } from './imap.js';
 import { DEVOPS_PROMPTS } from './devops.js';
@@ -45,6 +48,7 @@ import { CLIENT_MEMORY_PROMPTS } from './client-memory.js';
 import { DETECT_TOOL_GAPS_PROMPTS } from './detect-tool-gaps.js';
 import { ANALYZE_TOOL_REQUESTS_PROMPTS } from './analyze-tool-requests.js';
 import { CHAT_PROMPTS } from './chat-classify-reply.js';
+import { ARTIFACT_NAME_PROMPTS } from './artifact-name.js';
 import type { PromptDefinition } from './types.js';
 
 /**
@@ -67,6 +71,7 @@ export const ALL_PROMPTS: PromptDefinition[] = [
   ...DETECT_TOOL_GAPS_PROMPTS,
   ...ANALYZE_TOOL_REQUESTS_PROMPTS,
   ...CHAT_PROMPTS,
+  ...ARTIFACT_NAME_PROMPTS,
 ];
 
 /**

--- a/packages/ai-provider/src/task-capabilities.ts
+++ b/packages/ai-provider/src/task-capabilities.ts
@@ -18,6 +18,7 @@ export const TASK_CAPABILITY_REQUIREMENTS: Record<string, string> = {
   [TaskType.GENERATE_TITLE]: CapabilityLevel.SIMPLE,
   [TaskType.CLASSIFY_EMAIL]: CapabilityLevel.SIMPLE,
   [TaskType.DETECT_TOOL_GAPS]: CapabilityLevel.BASIC,
+  [TaskType.GENERATE_ARTIFACT_NAME]: CapabilityLevel.BASIC,
 
   // STANDARD — mid-tier (drafting, analysis, summarization)
   [TaskType.SUMMARIZE]: CapabilityLevel.STANDARD,

--- a/packages/shared-types/src/ai.ts
+++ b/packages/shared-types/src/ai.ts
@@ -48,6 +48,8 @@ export const TaskType = {
   DETECT_TOOL_GAPS: 'DETECT_TOOL_GAPS',
   // Admin dedupe pass over pending ToolRequest rows (Claude Sonnet)
   ANALYZE_TOOL_REQUESTS: 'ANALYZE_TOOL_REQUESTS',
+  // Friendly display name + description for system-generated artifacts (Claude Haiku)
+  GENERATE_ARTIFACT_NAME: 'GENERATE_ARTIFACT_NAME',
 } as const;
 export type TaskType = (typeof TaskType)[keyof typeof TaskType];
 
@@ -123,6 +125,9 @@ export const TASK_APP_SCOPE: Record<TaskType, AppScope> = {
 
   // Admin dedupe pass
   [TaskType.ANALYZE_TOOL_REQUESTS]: AppScope.CORE,
+
+  // Friendly artifact display name generation
+  [TaskType.GENERATE_ARTIFACT_NAME]: AppScope.CORE,
 
 } satisfies Record<TaskType, AppScope>;
 

--- a/packages/shared-types/src/log.ts
+++ b/packages/shared-types/src/log.ts
@@ -14,6 +14,7 @@ export const EntityType = {
   SYSTEM: 'system',
   OPERATOR: 'operator',
   CLIENT: 'client',
+  ARTIFACT: 'artifact',
 } as const;
 export type EntityType = (typeof EntityType)[keyof typeof EntityType];
 

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -1069,7 +1069,9 @@ export async function saveMcpToolArtifact(
     });
     logger.info({ ticketId, filename }, 'MCP tool artifact saved');
     // Phase 2: best-effort enqueue Haiku friendly-name generation. No-op if queue not registered.
-    await enqueueArtifactNameGeneration(created.id);
+    void enqueueArtifactNameGeneration(created.id).catch((err) => {
+      logger.warn({ err, ticketId, artifactId: created.id }, 'Failed to enqueue artifact friendly-name generation — continuing');
+    });
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save MCP tool artifact — continuing');
   }

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -16,6 +16,7 @@ import {
   looksEncrypted,
   callMcpToolViaSdk,
 } from '@bronco/shared-utils';
+import { enqueueArtifactNameGeneration } from '../artifact-name-queue.js';
 
 const logger = createLogger('ticket-analyzer');
 
@@ -1049,7 +1050,7 @@ export async function saveMcpToolArtifact(
     await mkdir(ticketDir, { recursive: true });
     await writeFile(fullPath, rawResult, 'utf-8');
     const relativePath = `tickets/${ticketId}/${filename}`;
-    await db.artifact.create({
+    const created = await db.artifact.create({
       data: {
         ...(artifactId ? { id: artifactId } : {}),
         ticketId,
@@ -1064,8 +1065,11 @@ export async function saveMcpToolArtifact(
         addedBySystem: 'ticket-analyzer:agentic',
         addedByPersonId: null,
       },
+      select: { id: true },
     });
     logger.info({ ticketId, filename }, 'MCP tool artifact saved');
+    // Phase 2: best-effort enqueue Haiku friendly-name generation. No-op if queue not registered.
+    await enqueueArtifactNameGeneration(created.id);
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save MCP tool artifact — continuing');
   }

--- a/services/ticket-analyzer/src/artifact-name-queue.ts
+++ b/services/ticket-analyzer/src/artifact-name-queue.ts
@@ -1,0 +1,39 @@
+import type { Queue } from 'bullmq';
+import { createLogger } from '@bronco/shared-utils';
+
+const logger = createLogger('artifact-name-queue');
+
+/** BullMQ queue name for artifact display-name generation jobs. */
+export const ARTIFACT_NAME_QUEUE_NAME = 'artifact-name-generation';
+
+export interface ArtifactNameJob {
+  artifactId: string;
+}
+
+let activeQueue: Queue<ArtifactNameJob> | null = null;
+
+/** Register the queue at service startup so the trigger sites can enqueue lazily. */
+export function registerArtifactNameQueue(queue: Queue<ArtifactNameJob>): void {
+  activeQueue = queue;
+}
+
+/**
+ * Enqueue a friendly-name generation job for an artifact. Best-effort —
+ * never throws. Skips silently if the queue hasn't been registered yet
+ * (e.g., during tests or pre-startup) so callers can drop this in safely.
+ */
+export async function enqueueArtifactNameGeneration(artifactId: string): Promise<void> {
+  if (!activeQueue) {
+    // Queue not yet registered — no-op. Phase 1 templated default remains.
+    return;
+  }
+  try {
+    await activeQueue.add(
+      'generate',
+      { artifactId },
+      { removeOnComplete: 100, removeOnFail: 50 },
+    );
+  } catch (err) {
+    logger.warn({ err, artifactId }, 'Failed to enqueue artifact-name generation — continuing');
+  }
+}

--- a/services/ticket-analyzer/src/artifact-name-worker.test.ts
+++ b/services/ticket-analyzer/src/artifact-name-worker.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for services/ticket-analyzer/src/artifact-name-worker.ts
+ *
+ * Mocks @bronco/shared-utils (createLogger), node:fs/promises (open),
+ * and constructs in-memory PrismaClient + AIRouter doubles to exercise
+ * the processor returned by createArtifactNameProcessor.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock shared-utils so module-level createLogger() in SUT doesn't blow up.
+// ---------------------------------------------------------------------------
+vi.mock('@bronco/shared-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@bronco/shared-utils')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock node:fs/promises#open so we don't touch the real disk. The processor
+// only calls open(...).read(...).close().
+// ---------------------------------------------------------------------------
+const fhRead = vi.fn();
+const fhClose = vi.fn();
+const open = vi.fn();
+vi.mock('node:fs/promises', () => ({
+  open: (...args: unknown[]) => open(...args),
+}));
+
+import { createArtifactNameProcessor } from './artifact-name-worker.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal Prisma + AIRouter doubles
+// ---------------------------------------------------------------------------
+type ArtifactRow = {
+  id: string;
+  ticketId: string;
+  kind: string | null;
+  displayName: string | null;
+  filename: string;
+  storagePath: string | null;
+  sizeBytes: number;
+  source: string | null;
+  ticket: { clientId: string | null };
+};
+
+interface DbDouble {
+  artifact: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+interface AiDouble {
+  generate: ReturnType<typeof vi.fn>;
+}
+
+function makeDb(): DbDouble {
+  return {
+    artifact: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+}
+
+function makeAi(): AiDouble {
+  return { generate: vi.fn() };
+}
+
+function eligibleArtifact(overrides: Partial<ArtifactRow> = {}): ArtifactRow {
+  return {
+    id: 'art-1',
+    ticketId: 'tkt-1',
+    kind: 'PROBE_RESULT',
+    displayName: 'Probe: dm_exec_requests',
+    filename: 'probe-1.json',
+    storagePath: 'tickets/tkt-1/probe-1.json',
+    sizeBytes: 1234,
+    source: 'probe:dm_exec_requests',
+    ticket: { clientId: 'client-1' },
+    ...overrides,
+  };
+}
+
+function setupOpenStub(content = '{"foo":"bar"}'): void {
+  fhRead.mockReset();
+  fhClose.mockReset();
+  open.mockReset();
+  open.mockImplementation(async () => ({
+    read: fhRead.mockImplementation(async (buf: Buffer) => {
+      const bytes = Buffer.from(content, 'utf-8');
+      bytes.copy(buf);
+      return { bytesRead: bytes.length, buffer: buf };
+    }),
+    close: fhClose.mockResolvedValue(undefined),
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Skip when ineligible
+// ---------------------------------------------------------------------------
+describe('createArtifactNameProcessor — ineligibility', () => {
+  it('skips when artifact.kind is EMAIL_ATTACHMENT (not in ELIGIBLE_KINDS)', async () => {
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique.mockResolvedValueOnce(
+      eligibleArtifact({ kind: 'EMAIL_ATTACHMENT' }),
+    );
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    expect(ai.generate).not.toHaveBeenCalled();
+    expect(db.artifact.update).not.toHaveBeenCalled();
+  });
+
+  it('skips when displayName is non-templated (e.g. "My uploaded file.pdf")', async () => {
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique.mockResolvedValueOnce(
+      eligibleArtifact({ displayName: 'My uploaded file.pdf' }),
+    );
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    expect(ai.generate).not.toHaveBeenCalled();
+    expect(db.artifact.update).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Strict JSON parsing
+// ---------------------------------------------------------------------------
+describe('createArtifactNameProcessor — strict JSON parsing', () => {
+  it('updates the row given a clean JSON response', async () => {
+    setupOpenStub('{"some":"preview"}');
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique
+      .mockResolvedValueOnce(eligibleArtifact()) // initial load
+      .mockResolvedValueOnce({ displayName: 'Probe: dm_exec_requests' }); // re-check
+    ai.generate.mockResolvedValueOnce({
+      content: '{"displayName":"Active query snapshot","description":"Snapshot of currently-running SQL queries from sys.dm_exec_requests."}',
+    });
+    db.artifact.update.mockResolvedValueOnce({});
+
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    expect(ai.generate).toHaveBeenCalledTimes(1);
+    expect(db.artifact.update).toHaveBeenCalledTimes(1);
+    expect(db.artifact.update).toHaveBeenCalledWith({
+      where: { id: 'art-1' },
+      data: {
+        displayName: 'Active query snapshot',
+        description: 'Snapshot of currently-running SQL queries from sys.dm_exec_requests.',
+      },
+    });
+  });
+
+  it('does NOT update the row given non-JSON garbage', async () => {
+    setupOpenStub();
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique.mockResolvedValueOnce(eligibleArtifact());
+    ai.generate.mockResolvedValueOnce({ content: 'this is not json at all' });
+
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    expect(ai.generate).toHaveBeenCalledTimes(1);
+    expect(db.artifact.update).not.toHaveBeenCalled();
+  });
+
+  it('handles fenced ```json blocks by stripping fences before parsing', async () => {
+    setupOpenStub();
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique
+      .mockResolvedValueOnce(eligibleArtifact())
+      .mockResolvedValueOnce({ displayName: 'Probe: dm_exec_requests' });
+    ai.generate.mockResolvedValueOnce({
+      content: '```json\n{"displayName":"Q snapshot","description":"A description."}\n```',
+    });
+    db.artifact.update.mockResolvedValueOnce({});
+
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    // Fenced JSON is currently accepted by the parser, so update IS called.
+    expect(db.artifact.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. No-clobber on stale read
+// ---------------------------------------------------------------------------
+describe('createArtifactNameProcessor — no-clobber on stale read', () => {
+  it('skips update if displayName changed during generation', async () => {
+    setupOpenStub();
+    const db = makeDb();
+    const ai = makeAi();
+    db.artifact.findUnique
+      .mockResolvedValueOnce(eligibleArtifact()) // initial load — templated
+      .mockResolvedValueOnce({ displayName: 'Operator-renamed thing' }); // re-check — operator edited
+    ai.generate.mockResolvedValueOnce({
+      content: '{"displayName":"AI Name","description":"AI desc."}',
+    });
+
+    const processor = createArtifactNameProcessor({
+      db: db as unknown as Parameters<typeof createArtifactNameProcessor>[0]['db'],
+      ai: ai as unknown as Parameters<typeof createArtifactNameProcessor>[0]['ai'],
+      artifactStoragePath: '/tmp/storage',
+    });
+
+    await processor({ data: { artifactId: 'art-1' } });
+
+    expect(ai.generate).toHaveBeenCalledTimes(1);
+    expect(db.artifact.update).not.toHaveBeenCalled();
+  });
+});

--- a/services/ticket-analyzer/src/artifact-name-worker.ts
+++ b/services/ticket-analyzer/src/artifact-name-worker.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { resolve as pathResolve, relative } from 'node:path';
 import type { PrismaClient } from '@bronco/db';
 import type { AIRouter } from '@bronco/ai-provider';
@@ -111,9 +111,16 @@ export function createArtifactNameProcessor(deps: ProcessorDeps) {
           logger.warn({ artifactId, storagePath: artifact.storagePath }, 'Artifact path escaped storage root — skipping');
           return;
         }
-        // Read only up to PREVIEW_BYTES; using a buffer + slice keeps us safe on large files.
-        const buf = await readFile(fullPath);
-        preview = buf.subarray(0, PREVIEW_BYTES).toString('utf-8');
+        // Positional read of the first PREVIEW_BYTES — avoids loading large
+        // artifacts entirely into memory.
+        const fh = await open(fullPath, 'r');
+        try {
+          const buf = Buffer.alloc(PREVIEW_BYTES);
+          const { bytesRead } = await fh.read(buf, 0, PREVIEW_BYTES, 0);
+          preview = buf.subarray(0, bytesRead).toString('utf-8');
+        } finally {
+          await fh.close();
+        }
       } catch (err) {
         logger.warn({ err, artifactId, storagePath: artifact.storagePath }, 'Failed to read artifact preview — skipping');
         return;

--- a/services/ticket-analyzer/src/artifact-name-worker.ts
+++ b/services/ticket-analyzer/src/artifact-name-worker.ts
@@ -1,0 +1,189 @@
+import { readFile } from 'node:fs/promises';
+import { resolve as pathResolve, relative } from 'node:path';
+import type { PrismaClient } from '@bronco/db';
+import type { AIRouter } from '@bronco/ai-provider';
+import { createLogger } from '@bronco/shared-utils';
+import { TaskType } from '@bronco/shared-types';
+
+const logger = createLogger('artifact-name-worker');
+
+export interface ArtifactNameJob {
+  artifactId: string;
+}
+
+/** Templated displayName prefixes from Phase 1 — only artifacts with these are eligible for friendly-name generation. */
+const TEMPLATED_PREFIXES = ['Probe: ', 'Tool result: '];
+
+/** Artifact kinds eligible for AI-generated friendly names. */
+const ELIGIBLE_KINDS = new Set(['PROBE_RESULT', 'MCP_TOOL_RESULT']);
+
+/** Max bytes of file content to read into the prompt preview. */
+const PREVIEW_BYTES = 500;
+
+interface ProcessorDeps {
+  db: PrismaClient;
+  ai: AIRouter;
+  artifactStoragePath?: string;
+}
+
+function looksLikeTemplatedDefault(displayName: string | null): boolean {
+  if (!displayName) return false;
+  return TEMPLATED_PREFIXES.some((p) => displayName.startsWith(p));
+}
+
+function parseAiJson(text: string): { displayName: string; description: string } | null {
+  // Strip code fences if present, then try parse.
+  const cleaned = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+  try {
+    const obj = JSON.parse(cleaned) as Record<string, unknown>;
+    const displayName = typeof obj.displayName === 'string' ? obj.displayName.trim() : '';
+    const description = typeof obj.description === 'string' ? obj.description.trim() : '';
+    if (!displayName || !description) return null;
+    // Sanity caps to keep DB clean.
+    return {
+      displayName: displayName.slice(0, 200),
+      description: description.slice(0, 1000),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create the BullMQ processor for the `artifact-name-generation` queue.
+ * One generation per artifact lifetime — bails if the displayName is no
+ * longer a Phase 1 templated default. Best-effort: parse failures and
+ * non-infra errors leave the templated default in place.
+ */
+export function createArtifactNameProcessor(deps: ProcessorDeps) {
+  const { db, ai, artifactStoragePath } = deps;
+
+  return async function processArtifactNameJob(job: { data: ArtifactNameJob }): Promise<void> {
+    const { artifactId } = job.data;
+    if (!artifactId) {
+      logger.warn('artifact-name job missing artifactId — skipping');
+      return;
+    }
+
+    // Load artifact + ticket clientId
+    const artifact = await db.artifact.findUnique({
+      where: { id: artifactId },
+      select: {
+        id: true,
+        ticketId: true,
+        kind: true,
+        displayName: true,
+        filename: true,
+        storagePath: true,
+        sizeBytes: true,
+        source: true,
+        ticket: { select: { clientId: true } },
+      },
+    });
+
+    if (!artifact) {
+      logger.warn({ artifactId }, 'Artifact not found — skipping');
+      return;
+    }
+
+    // Defensive: only PROBE_RESULT and MCP_TOOL_RESULT are eligible.
+    if (!artifact.kind || !ELIGIBLE_KINDS.has(artifact.kind)) {
+      logger.debug({ artifactId, kind: artifact.kind }, 'Artifact kind not eligible — skipping');
+      return;
+    }
+
+    // One-shot guard: skip if displayName has already been replaced (operator edit
+    // or previous successful run) — only replace Phase 1 templated defaults.
+    if (!looksLikeTemplatedDefault(artifact.displayName)) {
+      logger.debug({ artifactId, displayName: artifact.displayName }, 'displayName not templated — skipping');
+      return;
+    }
+
+    // Read up to PREVIEW_BYTES of file content
+    let preview = '';
+    if (artifactStoragePath && artifact.storagePath) {
+      try {
+        const resolvedRoot = pathResolve(artifactStoragePath);
+        const fullPath = pathResolve(resolvedRoot, artifact.storagePath);
+        // Path-traversal guard: keep within storage root.
+        const rel = relative(resolvedRoot, fullPath);
+        if (rel.startsWith('..')) {
+          logger.warn({ artifactId, storagePath: artifact.storagePath }, 'Artifact path escaped storage root — skipping');
+          return;
+        }
+        // Read only up to PREVIEW_BYTES; using a buffer + slice keeps us safe on large files.
+        const buf = await readFile(fullPath);
+        preview = buf.subarray(0, PREVIEW_BYTES).toString('utf-8');
+      } catch (err) {
+        logger.warn({ err, artifactId, storagePath: artifact.storagePath }, 'Failed to read artifact preview — skipping');
+        return;
+      }
+    }
+
+    // Derive a tool name hint from `source` (e.g. "probe:dm_exec_requests" or "mcp_tool:list_tickets").
+    const toolNameHint = artifact.source?.includes(':') ? artifact.source.split(':').slice(1).join(':') : (artifact.source ?? 'unknown');
+
+    const userPrompt = [
+      `Artifact kind: ${artifact.kind}`,
+      `Tool/source: ${toolNameHint}`,
+      `Filename: ${artifact.filename}`,
+      `Size: ${artifact.sizeBytes} bytes`,
+      '',
+      'Content preview (first 500 chars):',
+      preview || '(empty or unreadable)',
+    ].join('\n');
+
+    let responseText: string;
+    try {
+      const result = await ai.generate({
+        taskType: TaskType.GENERATE_ARTIFACT_NAME,
+        promptKey: 'artifact.name.system',
+        prompt: userPrompt,
+        context: {
+          entityType: 'artifact',
+          entityId: artifactId,
+          clientId: artifact.ticket?.clientId ?? null,
+          skipClientMemory: true,
+        },
+      });
+      responseText = result.content;
+    } catch (err) {
+      // True infra failure — log and let BullMQ decide via default retry policy. We don't add
+      // explicit retries; default queue config (no retries) keeps this best-effort.
+      logger.warn({ err, artifactId }, 'AI generate failed for artifact name — leaving Phase 1 default in place');
+      return;
+    }
+
+    const parsed = parseAiJson(responseText);
+    if (!parsed) {
+      logger.warn({ artifactId, responseText: responseText.slice(0, 300) }, 'Failed to parse JSON for artifact name — leaving Phase 1 default in place');
+      return;
+    }
+
+    // Re-check the row: an operator edit between dispatch and completion shouldn't be clobbered.
+    const fresh = await db.artifact.findUnique({
+      where: { id: artifactId },
+      select: { displayName: true },
+    });
+    if (!fresh || !looksLikeTemplatedDefault(fresh.displayName)) {
+      logger.debug({ artifactId }, 'displayName changed during generation — skipping update');
+      return;
+    }
+
+    try {
+      await db.artifact.update({
+        where: { id: artifactId },
+        data: {
+          displayName: parsed.displayName,
+          description: parsed.description,
+        },
+      });
+      logger.info({ artifactId, displayName: parsed.displayName }, 'Artifact display name updated');
+    } catch (err) {
+      logger.warn({ err, artifactId }, 'Failed to persist artifact display name — leaving Phase 1 default in place');
+    }
+  };
+}
+
+// Re-export the queue name for convenience so callers don't need two imports.
+export { ARTIFACT_NAME_QUEUE_NAME } from './artifact-name-queue.js';

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -9,6 +9,8 @@ import { createRouteDispatcher } from './route-dispatcher.js';
 import { createIngestionProcessor } from './ingestion-engine.js';
 import { processClientLearningJob } from './client-learning-worker.js';
 import type { ClientLearningJob } from './client-learning-worker.js';
+import { createArtifactNameProcessor } from './artifact-name-worker.js';
+import { ARTIFACT_NAME_QUEUE_NAME, registerArtifactNameQueue, type ArtifactNameJob } from './artifact-name-queue.js';
 
 const logger = createLogger('ticket-analyzer');
 const appLog = new AppLogger('ticket-analyzer');
@@ -169,6 +171,28 @@ async function main(): Promise<void> {
     appLog.error(`Client learning extraction failed: ${err.message}`, { err, ticketId: job?.data.ticketId, clientId: job?.data.clientId }, job?.data.ticketId, 'ticket');
   });
 
+  // --- Artifact name generation worker (Haiku-friendly names for system artifacts) ---
+  const artifactNameQueue = createQueue<ArtifactNameJob>(ARTIFACT_NAME_QUEUE_NAME, config.REDIS_URL);
+  registerArtifactNameQueue(artifactNameQueue);
+  const artifactNameProcessor = createArtifactNameProcessor({
+    db,
+    ai,
+    artifactStoragePath: config.ARTIFACT_STORAGE_PATH,
+  });
+  const artifactNameWorker = createWorker<ArtifactNameJob>(
+    ARTIFACT_NAME_QUEUE_NAME,
+    config.REDIS_URL,
+    artifactNameProcessor,
+  );
+
+  artifactNameWorker.on('completed', (job) => {
+    appLog.info('Artifact name generation completed', { artifactId: job.data.artifactId }, job.data.artifactId, 'ticket');
+  });
+
+  artifactNameWorker.on('failed', (job, err) => {
+    appLog.warn(`Artifact name generation failed: ${err.message}`, { err, artifactId: job?.data.artifactId });
+  });
+
   // Health tracking state
   let lastAnalysisAt: Date | undefined;
   let analysisCount = 0;
@@ -199,6 +223,8 @@ async function main(): Promise<void> {
   createGracefulShutdown(logger, [
     { interval: cleanupInterval },
     health,
+    artifactNameWorker,
+    artifactNameQueue,
     clientLearningWorker,
     ingestionWorker,
     ticketCreatedWorker,

--- a/services/ticket-analyzer/src/index.ts
+++ b/services/ticket-analyzer/src/index.ts
@@ -186,11 +186,11 @@ async function main(): Promise<void> {
   );
 
   artifactNameWorker.on('completed', (job) => {
-    appLog.info('Artifact name generation completed', { artifactId: job.data.artifactId }, job.data.artifactId, 'ticket');
+    appLog.info('Artifact name generation completed', { artifactId: job.data.artifactId }, job.data.artifactId, 'artifact');
   });
 
   artifactNameWorker.on('failed', (job, err) => {
-    appLog.warn(`Artifact name generation failed: ${err.message}`, { err, artifactId: job?.data.artifactId });
+    appLog.warn(`Artifact name generation failed: ${err.message}`, { err, artifactId: job?.data.artifactId }, job?.data.artifactId, 'artifact');
   });
 
   // Health tracking state

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1259,7 +1259,9 @@ async function saveProbeArtifact(
     });
     logger.info({ ticketId, filename, artifactId: artifact.id }, 'Probe artifact saved via ingestion engine');
     // Phase 2: best-effort enqueue Haiku friendly-name generation. No-op if queue not registered.
-    await enqueueArtifactNameGeneration(artifact.id);
+    void enqueueArtifactNameGeneration(artifact.id).catch((err) => {
+      logger.warn({ err, ticketId, artifactId: artifact.id }, 'Failed to enqueue artifact friendly-name generation — continuing');
+    });
     return artifact.id;
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save probe artifact — continuing');

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -22,6 +22,7 @@ import { createLogger } from '@bronco/shared-utils';
 import type { AppLogger, Mailer, ReplyOptions } from '@bronco/shared-utils';
 import { createIngestionRunTracker } from './ingestion-tracker.js';
 import type { IngestionRunTracker } from './ingestion-tracker.js';
+import { enqueueArtifactNameGeneration } from './artifact-name-queue.js';
 
 const logger = createLogger('ingestion-engine');
 
@@ -1257,6 +1258,8 @@ async function saveProbeArtifact(
       select: { id: true },
     });
     logger.info({ ticketId, filename, artifactId: artifact.id }, 'Probe artifact saved via ingestion engine');
+    // Phase 2: best-effort enqueue Haiku friendly-name generation. No-op if queue not registered.
+    await enqueueArtifactNameGeneration(artifact.id);
     return artifact.id;
   } catch (err) {
     logger.warn({ err, ticketId }, 'Failed to save probe artifact — continuing');


### PR DESCRIPTION
## Summary

**Phase 2 of #424.** Backend-only — Haiku worker that swaps Phase 1's templated `displayName` defaults (`Probe: <name>` / `Tool result: <name>`) for AI-generated friendly names + a 1–2 sentence description. Runs async after `saveProbeArtifact()` / `saveMcpToolArtifact()`; never blocks ticket analysis. Phase 3 (UI panel) ships in a separate PR.

Refs #424.

## What lands

| Layer | Change |
|---|---|
| Task type | New `GENERATE_ARTIFACT_NAME` in `packages/shared-types/src/ai.ts` |
| Routing default | `claude-haiku-4-5-20251001` in `packages/ai-provider/src/model-config-resolver.ts` |
| Capabilities | `BASIC` in `packages/ai-provider/src/task-capabilities.ts` (no tools, no streaming) |
| Prompt | New `artifact.name.system` registered in `packages/ai-provider/src/prompts/artifact-name.ts` (strict JSON output) |
| Worker | `services/ticket-analyzer/src/artifact-name-worker.ts` — BullMQ queue `artifact-name-generation` |
| Queue helper | `services/ticket-analyzer/src/artifact-name-queue.ts` |
| Service wiring | `services/ticket-analyzer/src/index.ts` — register queue + worker, graceful shutdown |
| Trigger | Single `enqueueArtifactNameGeneration(artifact.id)` line at the end of `saveProbeArtifact` and `saveMcpToolArtifact` |
| EntityType | `EntityType.ARTIFACT` added to `packages/shared-types/src/log.ts` so `ai_usage_logs` rows are queryable per artifact |
| Docs | `CLAUDE.md` task-types table updated |

## Behaviour

- Prompt asks for strict JSON `{"displayName":"<3-8 words>","description":"<1-2 sentences>"}`.
- Worker bails early if `kind ∉ (PROBE_RESULT, MCP_TOOL_RESULT)` or if `displayName` already looks non-templated (`displayName` does not start with `Probe: ` / `Tool result: `).
- Reads up to 500 chars of artifact content from `storagePath` for context.
- AI usage logged with `entityType: 'artifact'`, `entityId: artifactId`, `clientId` from parent ticket.
- Parse / read failures: WARN log, no row update — Phase 1 templated default stands.

## Cost

Haiku, ~500 input tokens, ~30 output tokens, sub-second. Once-per-artifact lifetime — never regenerates if `displayName` is already AI-generated.

## Test plan

- [ ] CI passes on push to staging
- [ ] Trigger a probe-sourced ticket → after Phase 1's `Probe: <name>` lands, the worker fires and the Artifact row's `displayName` is replaced with a 3–8 word AI title; `description` populated
- [ ] Run an analysis with a large MCP tool output → `MCP_TOOL_RESULT` artifact's `displayName` flips from `Tool result: <toolName>` to a Haiku-generated label within ~5s
- [ ] Email attachment + operator upload artifacts NEVER hit the worker (filename is the displayName by design)
- [ ] Spot-check `ai_usage_logs` for `task_type: GENERATE_ARTIFACT_NAME` rows with correct `entity_type/entity_id/client_id`
- [ ] Worker handles malformed JSON / truncated artifact content gracefully (WARN log, no update)
- [ ] After Hugo deploy: `bronco-ticket-analyzer-1` logs show worker startup line; Redis shows `artifact-name-generation` queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
