### PR TITLE
feat(probes): operator ticket body + Haiku augmentation on probe-created tickets (#424)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ System prompts for each task are registered in `packages/ai-provider/src/prompts
 - `DETECT_TOOL_GAPS` — Post-hoc review of a completed analysis to detect capability gaps; upserts tool requests into the registry (default: Claude Haiku for cheap review)
 - `ANALYZE_TOOL_REQUESTS` — Admin-triggered dedupe agent: compares a client's PROPOSED/APPROVED tool requests against each other and against the live MCP tool catalog (platform + repo + database + per-client integrations) and writes `suggestedDuplicateOf*` / `suggestedImprovesExisting*` fields on rows (default: Claude Sonnet)
 - `GENERATE_ARTIFACT_NAME` — Async post-save worker that fills `displayName` + `description` on system-generated artifacts (PROBE_RESULT, MCP_TOOL_RESULT) by reading the first 500 chars of the raw output. Strict JSON output, one generation per artifact lifetime, falls back silently to Phase 1 templated defaults on parse failure (default: Claude Haiku)
+- `COMPOSE_PROBE_TICKET_BODY` — Composes the kick-off `Ticket.description` for tickets created by scheduled probes (`action: create_ticket`). Weaves the operator-supplied `actionConfig.ticketDescription` body (when present) with the probe's meta description, tool name + timeframe params, and the head of the probe result into 1-3 short paragraphs of plain prose. Falls back to the legacy truncated-result behavior on AI failure (default: Claude Haiku)
 
 ### Task Type Discipline (CRITICAL)
 

--- a/packages/ai-provider/src/model-config-resolver.ts
+++ b/packages/ai-provider/src/model-config-resolver.ts
@@ -63,6 +63,7 @@ const DEFAULT_CLAUDE_HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 const CLAUDE_HAIKU_TASK_TYPES = new Set<string>([
   TaskType.DETECT_TOOL_GAPS,
   TaskType.GENERATE_ARTIFACT_NAME,
+  TaskType.COMPOSE_PROBE_TICKET_BODY,
 ]);
 
 function defaultProviderAndModel(taskType: string): { provider: AIProvider; model: string } {

--- a/packages/ai-provider/src/prompts/index.ts
+++ b/packages/ai-provider/src/prompts/index.ts
@@ -36,6 +36,9 @@ export * from './chat-classify-reply.js';
 export { ARTIFACT_NAME_PROMPTS } from './artifact-name.js';
 export * from './artifact-name.js';
 
+export { PROBE_TICKET_BODY_PROMPTS } from './probe-ticket-body.js';
+export * from './probe-ticket-body.js';
+
 // Re-export individual prompts for direct import convenience
 import { IMAP_PROMPTS } from './imap.js';
 import { DEVOPS_PROMPTS } from './devops.js';
@@ -49,6 +52,7 @@ import { DETECT_TOOL_GAPS_PROMPTS } from './detect-tool-gaps.js';
 import { ANALYZE_TOOL_REQUESTS_PROMPTS } from './analyze-tool-requests.js';
 import { CHAT_PROMPTS } from './chat-classify-reply.js';
 import { ARTIFACT_NAME_PROMPTS } from './artifact-name.js';
+import { PROBE_TICKET_BODY_PROMPTS } from './probe-ticket-body.js';
 import type { PromptDefinition } from './types.js';
 
 /**
@@ -72,6 +76,7 @@ export const ALL_PROMPTS: PromptDefinition[] = [
   ...ANALYZE_TOOL_REQUESTS_PROMPTS,
   ...CHAT_PROMPTS,
   ...ARTIFACT_NAME_PROMPTS,
+  ...PROBE_TICKET_BODY_PROMPTS,
 ];
 
 /**

--- a/packages/ai-provider/src/prompts/probe-ticket-body.ts
+++ b/packages/ai-provider/src/prompts/probe-ticket-body.ts
@@ -1,0 +1,38 @@
+import type { PromptDefinition } from './types.js';
+
+export const PROBE_TICKET_BODY_SYSTEM: PromptDefinition = {
+  key: 'probe.ticket-body.system',
+  name: 'Probe Ticket Body Composer',
+  description:
+    'Composes the kick-off ticket description for tickets created by scheduled probes. Weaves the operator-supplied intent (when present) with probe metadata, tool name + timeframe, and the head of the probe result into 1-3 short paragraphs of plain prose that becomes Ticket.description.',
+  taskType: 'COMPOSE_PROBE_TICKET_BODY',
+  role: 'SYSTEM',
+  content: [
+    'You compose the kick-off ticket description for support tickets that are auto-created when a scheduled monitoring probe fires.',
+    '',
+    'Output PLAIN PROSE only — no JSON, no markdown headers, no code fences, no bullet lists, no preamble like "Here\'s the description". Just the body text exactly as it should appear in the ticket.',
+    '',
+    'Length: 1-3 short paragraphs. Cap your full response at roughly 1500 characters. Aim for tight, scannable prose an analyst can read in 10 seconds.',
+    '',
+    'You will be given these inputs in the user message:',
+    '- Operator body (may be empty): the operator\'s authoritative intent for tickets created by this probe.',
+    '- Probe description (may be empty): a short note describing what the probe does in general.',
+    '- Client name: the client this probe runs against.',
+    '- Tool name: the MCP or built-in tool the probe invoked.',
+    '- Tool params: a small object of timeframe / scope params the tool was called with.',
+    '- Probe result head: the first ~1.5 KB of the raw probe output.',
+    '',
+    'Composition rules:',
+    '- If the operator body is non-empty, treat it as authoritative intent and weave it into the opener naturally — it sets the framing.',
+    '- If the operator body is empty, lead with what the probe is and what it just observed (use the probe description if provided).',
+    '- Always state the tool name explicitly (e.g. "via scan_app_logs") and the time window if extractable from the params (e.g. "over the last 6 hours").',
+    '- Always surface the top-level finding or scope from the probe result head — counts, severity, names of impacted services / sessions / objects, anything the analyst should know up front. Do NOT paste raw JSON or log lines verbatim; describe them.',
+    '- Never invent details that are not in the inputs. If a field is missing, omit it.',
+    '- Do not reference any specific artifact ID. End with a sentence like "Probe artifact attached for full detail." so the reader knows the raw output is available.',
+    '- Write in neutral, professional voice. Past tense for what the probe observed, present tense for current state.',
+  ].join('\n'),
+  temperature: 0.2,
+  maxTokens: 600,
+};
+
+export const PROBE_TICKET_BODY_PROMPTS: PromptDefinition[] = [PROBE_TICKET_BODY_SYSTEM];

--- a/packages/ai-provider/src/task-capabilities.ts
+++ b/packages/ai-provider/src/task-capabilities.ts
@@ -19,6 +19,7 @@ export const TASK_CAPABILITY_REQUIREMENTS: Record<string, string> = {
   [TaskType.CLASSIFY_EMAIL]: CapabilityLevel.SIMPLE,
   [TaskType.DETECT_TOOL_GAPS]: CapabilityLevel.BASIC,
   [TaskType.GENERATE_ARTIFACT_NAME]: CapabilityLevel.BASIC,
+  [TaskType.COMPOSE_PROBE_TICKET_BODY]: CapabilityLevel.BASIC,
 
   // STANDARD — mid-tier (drafting, analysis, summarization)
   [TaskType.SUMMARIZE]: CapabilityLevel.STANDARD,

--- a/packages/shared-types/src/ai.ts
+++ b/packages/shared-types/src/ai.ts
@@ -50,6 +50,8 @@ export const TaskType = {
   ANALYZE_TOOL_REQUESTS: 'ANALYZE_TOOL_REQUESTS',
   // Friendly display name + description for system-generated artifacts (Claude Haiku)
   GENERATE_ARTIFACT_NAME: 'GENERATE_ARTIFACT_NAME',
+  // Compose the kick-off ticket description for tickets created by scheduled probes (Claude Haiku)
+  COMPOSE_PROBE_TICKET_BODY: 'COMPOSE_PROBE_TICKET_BODY',
 } as const;
 export type TaskType = (typeof TaskType)[keyof typeof TaskType];
 
@@ -128,6 +130,9 @@ export const TASK_APP_SCOPE: Record<TaskType, AppScope> = {
 
   // Friendly artifact display name generation
   [TaskType.GENERATE_ARTIFACT_NAME]: AppScope.CORE,
+
+  // Probe-created ticket description body (Claude Haiku)
+  [TaskType.COMPOSE_PROBE_TICKET_BODY]: AppScope.CORE,
 
 } satisfies Record<TaskType, AppScope>;
 

--- a/packages/shared-types/src/scheduled-probe.ts
+++ b/packages/shared-types/src/scheduled-probe.ts
@@ -55,6 +55,38 @@ export const BUILTIN_PROBE_TOOLS: BuiltinToolDefinition[] = [
 
 export const BUILTIN_PROBE_TOOL_NAMES = new Set(BUILTIN_PROBE_TOOLS.map((t) => t.name));
 
+// ---------------------------------------------------------------------------
+// ProbeActionConfig — typed shapes for the per-action `actionConfig` blob
+// ---------------------------------------------------------------------------
+//
+// Persisted as `Record<string, unknown> | null` (Prisma JSON column), but
+// callers that build/consume the config should prefer these typed shapes.
+
+/** Action config when `action === 'create_ticket'` or `action === 'silent'`. */
+export interface ProbeActionConfigCreateTicket {
+  /** Operator email — used to resolve the ticket requester / follower. */
+  operatorEmail?: string;
+  /**
+   * Optional operator-supplied seed body for tickets created by this probe.
+   * Augmented at ticket-creation time by the COMPOSE_PROBE_TICKET_BODY task
+   * (Haiku) into a 1-3 paragraph kick-off description that combines this
+   * intent with probe metadata, tool name/params/timeframe, and the head of
+   * the probe result.
+   */
+  ticketDescription?: string;
+}
+
+/** Action config when `action === 'email_direct'`. */
+export interface ProbeActionConfigEmailDirect {
+  emailTo?: string;
+  emailSubject?: string;
+}
+
+export type ProbeActionConfig =
+  | ProbeActionConfigCreateTicket
+  | ProbeActionConfigEmailDirect
+  | null;
+
 export interface ScheduledProbe {
   id: string;
   clientId: string;

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -85,6 +85,20 @@ const ACTIONS = [
           </app-form-field>
         }
 
+        @if (action === 'create_ticket') {
+          <app-form-field
+            label="Ticket description body"
+            hint="Optional. Used as the seed for tickets created by this probe. Haiku will fill in tool, timeframe, and result context automatically."
+          >
+            <app-textarea
+              [value]="ticketDescription"
+              (valueChange)="ticketDescription = $event"
+              [rows]="5"
+              placeholder="e.g. We've been seeing intermittent timeouts on the reporting service — pay attention to repeated tenants and time-of-day clustering."
+            ></app-textarea>
+          </app-form-field>
+        }
+
         @if (action === 'email_direct') {
           <app-form-field label="Email To">
             <app-text-input [value]="emailTo" (valueChange)="emailTo = $event" type="email" placeholder="recipient@example.com"></app-text-input>
@@ -168,6 +182,7 @@ export class ProbeDialogComponent implements OnInit {
   category: string | null = null;
   action = 'create_ticket';
   operatorEmail = '';
+  ticketDescription = '';
   emailTo = '';
   emailSubject = '';
   retentionDays = 30;
@@ -250,6 +265,7 @@ export class ProbeDialogComponent implements OnInit {
       if (p.actionConfig) {
         const cfg = p.actionConfig;
         this.operatorEmail = typeof cfg['operatorEmail'] === 'string' ? cfg['operatorEmail'] : '';
+        this.ticketDescription = typeof cfg['ticketDescription'] === 'string' ? cfg['ticketDescription'] : '';
         this.emailTo = typeof cfg['emailTo'] === 'string' ? cfg['emailTo'] : '';
         this.emailSubject = typeof cfg['emailSubject'] === 'string' ? cfg['emailSubject'] : '';
       }
@@ -368,9 +384,14 @@ export class ProbeDialogComponent implements OnInit {
       if (this.emailTo) actionConfig['emailTo'] = this.emailTo;
       if (this.emailSubject) actionConfig['emailSubject'] = this.emailSubject;
     } else if (this.action === 'create_ticket' || this.action === 'silent') {
-      if (this.operatorEmail) {
-        actionConfig = { operatorEmail: this.operatorEmail };
+      const cfg: Record<string, unknown> = {};
+      if (this.operatorEmail) cfg['operatorEmail'] = this.operatorEmail;
+      // Only persist `ticketDescription` for create_ticket — irrelevant for silent.
+      if (this.action === 'create_ticket') {
+        const trimmedBody = this.ticketDescription.trim();
+        if (trimmedBody) cfg['ticketDescription'] = trimmedBody;
       }
+      if (Object.keys(cfg).length > 0) actionConfig = cfg;
     }
 
     // Strip empty string params

--- a/services/probe-worker/src/probe-worker.ts
+++ b/services/probe-worker/src/probe-worker.ts
@@ -551,11 +551,15 @@ async function executeProbe(
 }
 
 // ---------------------------------------------------------------------------
-// Phase 4 — Compose ticket description body via Haiku for create_ticket probes
+// Phase 4 — Compose probe ticket description body via Haiku for create_ticket and silent probes
 // ---------------------------------------------------------------------------
 
-/** Regex matching `toolParams` keys that are useful to surface as timeframe/scope context. */
-const TIMEFRAME_PARAM_KEY_REGEX = /time|date|hours|window|range|from|to|since|until|start|end|day|interval|threshold/i;
+/**
+ * Regex matching `toolParams` keys that are useful to surface as timeframe/scope context.
+ * Uses word boundaries on `from`/`to` so we don't accidentally match `timeoutMs`, `toolName`,
+ * `total`, etc. Substring matches are fine for the longer descriptive fragments below.
+ */
+const TIMEFRAME_PARAM_KEY_REGEX = /time|date|hours|window|range|since|until|start|end|day|interval|threshold|\bfrom\b|\bto\b/i;
 
 /** Additional explicit keys to always pass through if present (small, common scope keys). */
 const ALLOWLIST_PARAM_KEYS = new Set<string>([
@@ -572,7 +576,53 @@ const ALLOWLIST_PARAM_KEYS = new Set<string>([
   'table',
   'objectName',
   'sessionId',
+  'from',
+  'to',
 ]);
+
+/** Caps for sanitizing forwarded param values — keeps prompt budget predictable. */
+const MAX_TIMEFRAME_PARAM_STRING_LENGTH = 200;
+const MAX_TIMEFRAME_PARAM_ARRAY_ITEMS = 10;
+const MAX_TIMEFRAME_PARAM_OBJECT_JSON_LENGTH = 400;
+
+/** Truncate a string to a max length, adding an ellipsis if clipped. */
+function truncateString(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}…` : s;
+}
+
+/** Sanitize a single value: primitives pass through, strings/arrays/objects bounded, others dropped. */
+function sanitizeParamValue(v: unknown): unknown {
+  if (v === null || v === undefined) return undefined;
+  if (typeof v === 'number' || typeof v === 'boolean') return v;
+  if (typeof v === 'string') return truncateString(v, MAX_TIMEFRAME_PARAM_STRING_LENGTH);
+  if (Array.isArray(v)) {
+    const limited = v.slice(0, MAX_TIMEFRAME_PARAM_ARRAY_ITEMS);
+    const sanitized: unknown[] = [];
+    for (const item of limited) {
+      if (item === null || item === undefined) continue;
+      if (typeof item === 'number' || typeof item === 'boolean') {
+        sanitized.push(item);
+      } else if (typeof item === 'string') {
+        sanitized.push(truncateString(item, MAX_TIMEFRAME_PARAM_STRING_LENGTH));
+      } else {
+        try {
+          sanitized.push(truncateString(JSON.stringify(item), MAX_TIMEFRAME_PARAM_STRING_LENGTH));
+        } catch {
+          // skip un-stringifiable items
+        }
+      }
+    }
+    return sanitized;
+  }
+  if (typeof v === 'object') {
+    try {
+      return truncateString(JSON.stringify(v), MAX_TIMEFRAME_PARAM_OBJECT_JSON_LENGTH);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
 
 /** Filter `toolParams` down to a small object useful as analyst context. */
 function pickTimeframeAndScopeParams(params: Record<string, unknown>): Record<string, unknown> {
@@ -580,7 +630,10 @@ function pickTimeframeAndScopeParams(params: Record<string, unknown>): Record<st
   for (const [k, v] of Object.entries(params)) {
     if (v === null || v === undefined) continue;
     if (TIMEFRAME_PARAM_KEY_REGEX.test(k) || ALLOWLIST_PARAM_KEYS.has(k)) {
-      out[k] = v;
+      const sanitized = sanitizeParamValue(v);
+      if (sanitized !== undefined) {
+        out[k] = sanitized;
+      }
     }
   }
   return out;
@@ -588,14 +641,19 @@ function pickTimeframeAndScopeParams(params: Record<string, unknown>): Record<st
 
 /**
  * Slice the head of an in-memory string by Buffer-byte length so we don't split
- * a multibyte UTF-8 sequence. Probe results are already in memory at compose
- * time, so no fs.read is needed here — but the byte-bounded slice keeps the
- * prompt budget predictable independent of the source's character width.
+ * a multibyte UTF-8 sequence. Avoids materializing the full string into a Buffer
+ * by sampling a char-bounded prefix first (UTF-8 is at most 4 bytes per code unit),
+ * then byte-trimming on a code-point boundary.
  */
 function readHeadFromString(content: string, bytes: number): string {
-  if (!content) return '';
-  const buf = Buffer.from(content, 'utf-8');
-  return buf.subarray(0, Math.min(bytes, buf.length)).toString('utf-8');
+  if (!content || bytes <= 0) return '';
+  // UTF-8 chars are at most 4 bytes; slice 4x the byte budget worth of chars
+  // so the encoded prefix is guaranteed to cover `bytes` (or the full content).
+  const charSlice = content.slice(0, bytes * 4);
+  const buf = Buffer.from(charSlice, 'utf-8');
+  if (buf.length <= bytes) return charSlice;
+  // Trim to byte budget on a code-point boundary (Buffer.toString respects boundaries).
+  return buf.subarray(0, bytes).toString('utf-8');
 }
 
 /**

--- a/services/probe-worker/src/probe-worker.ts
+++ b/services/probe-worker/src/probe-worker.ts
@@ -348,6 +348,17 @@ async function executeProbe(
         // CREATE_TICKET steps configured by the operator). Falls back to the
         // legacy inline path when no ingest queue is wired up.
         if (deps.ingestQueue) {
+          // Phase 4: compose ticket description body via Haiku before enqueueing.
+          // Best-effort — null result triggers fallback to truncated raw result
+          // in the ingestion engine.
+          stepId = await tracker.startStep('Compose ticket body (Haiku)');
+          const composedBody = await composeProbeTicketBody(ai, db, probe, toolResult);
+          if (composedBody) {
+            await tracker.completeStep(stepId, composedBody.slice(0, 2000));
+          } else {
+            await tracker.skipStep(stepId, 'Compose failed or returned empty — falling back to truncated raw result');
+          }
+
           stepId = await tracker.startStep('Enqueue to ingestion engine');
           const operatorEmail = (probe.actionConfig as Record<string, unknown> | null)?.['operatorEmail'];
           await deps.ingestQueue.add('ticket-ingest', {
@@ -358,6 +369,7 @@ async function executeProbe(
               probeName: probe.name,
               toolName: probe.toolName,
               toolResult: toolResult.slice(0, 50000),
+              ...(composedBody && { body: composedBody }),
               ...(probe.category && { category: probe.category }),
               ...(probe.integrationId && { integrationId: probe.integrationId }),
               ...(typeof operatorEmail === 'string' && operatorEmail.trim() && { operatorEmail }),
@@ -372,9 +384,10 @@ async function executeProbe(
           await tracker.completeRun('success', `Ingestion queued. Result: ${truncatedResult.slice(0, 500)}`);
           await updateProbeRun(db, probe.id, 'success', `Ingestion queued. Result: ${truncatedResult.slice(0, 500)}`);
         } else {
-          // Legacy path: AI summarize + title + create ticket inline
-          stepId = await tracker.startStep('AI summarize for ticket');
-          const summary = await summarizeForTicket(ai, probe, truncatedResult);
+          // Legacy path: AI compose body + title + create ticket inline
+          stepId = await tracker.startStep('Compose ticket body (Haiku)');
+          const composedBody = await composeProbeTicketBody(ai, db, probe, toolResult);
+          const summary = composedBody ?? await summarizeForTicket(ai, probe, truncatedResult);
           await tracker.completeStep(stepId, summary.slice(0, 4000));
 
           stepId = await tracker.startStep('AI generate title');
@@ -449,6 +462,15 @@ async function executeProbe(
 
         if (actionable) {
           if (deps.ingestQueue) {
+            // Phase 4: compose ticket description body via Haiku.
+            stepId = await tracker.startStep('Compose ticket body (Haiku)');
+            const composedBody = await composeProbeTicketBody(ai, db, probe, toolResult);
+            if (composedBody) {
+              await tracker.completeStep(stepId, composedBody.slice(0, 2000));
+            } else {
+              await tracker.skipStep(stepId, 'Compose failed or returned empty — falling back to truncated raw result');
+            }
+
             stepId = await tracker.startStep('Enqueue to ingestion engine');
             const operatorEmail = (probe.actionConfig as Record<string, unknown> | null)?.['operatorEmail'];
             await deps.ingestQueue.add('ticket-ingest', {
@@ -459,6 +481,7 @@ async function executeProbe(
                 probeName: probe.name,
                 toolName: probe.toolName,
                 toolResult: toolResult.slice(0, 50000),
+                ...(composedBody && { body: composedBody }),
                 ...(probe.category && { category: probe.category }),
                 ...(probe.integrationId && { integrationId: probe.integrationId }),
                 ...(typeof operatorEmail === 'string' && operatorEmail.trim() && { operatorEmail }),
@@ -474,8 +497,9 @@ async function executeProbe(
             await updateProbeRun(db, probe.id, 'success', `Silent probe — ingestion queued. Result: ${truncatedResult.slice(0, 500)}`);
           } else {
             // Legacy path
-            stepId = await tracker.startStep('AI summarize for ticket');
-            const silentSummary = await summarizeForTicket(ai, probe, truncatedResult);
+            stepId = await tracker.startStep('Compose ticket body (Haiku)');
+            const composedBodyLegacy = await composeProbeTicketBody(ai, db, probe, toolResult);
+            const silentSummary = composedBodyLegacy ?? await summarizeForTicket(ai, probe, truncatedResult);
             await tracker.completeStep(stepId, silentSummary.slice(0, 4000));
 
             stepId = await tracker.startStep('AI generate title');
@@ -523,6 +547,137 @@ async function executeProbe(
     }
   } finally {
     await cleanupRetention(db, probe.id, probe.retentionDays, probe.retentionMaxRuns);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4 — Compose ticket description body via Haiku for create_ticket probes
+// ---------------------------------------------------------------------------
+
+/** Regex matching `toolParams` keys that are useful to surface as timeframe/scope context. */
+const TIMEFRAME_PARAM_KEY_REGEX = /time|date|hours|window|range|from|to|since|until|start|end|day|interval|threshold/i;
+
+/** Additional explicit keys to always pass through if present (small, common scope keys). */
+const ALLOWLIST_PARAM_KEYS = new Set<string>([
+  'services',
+  'minLevel',
+  'level',
+  'severity',
+  'category',
+  'lookbackDays',
+  'limit',
+  'topN',
+  'database',
+  'schema',
+  'table',
+  'objectName',
+  'sessionId',
+]);
+
+/** Filter `toolParams` down to a small object useful as analyst context. */
+function pickTimeframeAndScopeParams(params: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (v === null || v === undefined) continue;
+    if (TIMEFRAME_PARAM_KEY_REGEX.test(k) || ALLOWLIST_PARAM_KEYS.has(k)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Slice the head of an in-memory string by Buffer-byte length so we don't split
+ * a multibyte UTF-8 sequence. Probe results are already in memory at compose
+ * time, so no fs.read is needed here — but the byte-bounded slice keeps the
+ * prompt budget predictable independent of the source's character width.
+ */
+function readHeadFromString(content: string, bytes: number): string {
+  if (!content) return '';
+  const buf = Buffer.from(content, 'utf-8');
+  return buf.subarray(0, Math.min(bytes, buf.length)).toString('utf-8');
+}
+
+/**
+ * Compose the kick-off ticket description body for a probe-created ticket via
+ * Claude Haiku (COMPOSE_PROBE_TICKET_BODY). Best-effort — returns null on AI
+ * failure so callers can fall back to the existing truncated-result behavior.
+ *
+ * Does NOT itself save the artifact or apply the artifact-ref marker; the
+ * caller is responsible for either using this output as Ticket.description
+ * or stitching it together with truncation context.
+ */
+async function composeProbeTicketBody(
+  ai: AIRouter,
+  db: PrismaClient,
+  probe: ProbeConfig,
+  rawResult: string,
+): Promise<string | null> {
+  try {
+    const operatorBody = (() => {
+      const cfg = probe.actionConfig as Record<string, unknown> | null;
+      const v = cfg?.['ticketDescription'];
+      return typeof v === 'string' ? v.trim() : '';
+    })();
+
+    // Look up client name (one-hop join).
+    let clientName = '';
+    try {
+      const client = await db.client.findUnique({
+        where: { id: probe.clientId },
+        select: { name: true },
+      });
+      clientName = client?.name ?? '';
+    } catch (err) {
+      logger.warn({ err, probeId: probe.id, clientId: probe.clientId }, 'Failed to load client name for probe ticket body — continuing');
+    }
+
+    // Probe meta description — pulled fresh from DB to pick up the most current
+    // value (probe.description isn't carried on ProbeConfig).
+    let probeDescription = '';
+    try {
+      const row = await db.scheduledProbe.findUnique({
+        where: { id: probe.id },
+        select: { description: true },
+      });
+      probeDescription = row?.description?.trim() ?? '';
+    } catch (err) {
+      logger.warn({ err, probeId: probe.id }, 'Failed to load probe description for ticket body — continuing');
+    }
+
+    const timeframeParams = pickTimeframeAndScopeParams(probe.toolParams ?? {});
+    const probeResultHead = readHeadFromString(rawResult, 1500);
+
+    // Compose the user message with all inputs labelled so the system prompt
+    // can reason over them without any ambiguity.
+    const userPrompt = [
+      `Operator body: ${operatorBody || '(empty)'}`,
+      `Probe description: ${probeDescription || '(empty)'}`,
+      `Client name: ${clientName || '(unknown)'}`,
+      `Tool name: ${probe.toolName}`,
+      `Tool params (timeframe + scope): ${Object.keys(timeframeParams).length > 0 ? JSON.stringify(timeframeParams) : '(none)'}`,
+      '',
+      'Probe result head (first ~1.5 KB):',
+      probeResultHead || '(empty)',
+    ].join('\n');
+
+    const res = await ai.generate({
+      taskType: TaskType.COMPOSE_PROBE_TICKET_BODY,
+      promptKey: 'probe.ticket-body.system',
+      prompt: userPrompt,
+      context: {
+        clientId: probe.clientId,
+        entityId: probe.id,
+        entityType: 'probe',
+      },
+    });
+
+    const text = (res.content ?? '').trim();
+    if (!text) return null;
+    return text.slice(0, 1500);
+  } catch (err) {
+    logger.warn({ err, probeId: probe.id }, 'composeProbeTicketBody failed — falling back to truncated raw result');
+    return null;
   }
 }
 

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -771,11 +771,27 @@ async function executeIngestionPipeline(
                 typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
                   ? (metadata as Record<string, unknown>)
                   : {};
+
+              // Phase 4: when the description was composed by Haiku (probe-worker passed
+              // `body`), append the artifact-ref marker so the analyzer can pick the full
+              // probe output up by ID. The marker is short and tolerant of being clipped
+              // — the analyzer also reads probeArtifactId from metadata.
+              const updateData: Prisma.TicketUpdateInput = {
+                metadata: { ...safeMeta, probeArtifactId } as Prisma.InputJsonValue,
+              };
+              const usedHaikuBody = typeof payload['body'] === 'string' && payload['body'].trim().length > 0;
+              if (usedHaikuBody) {
+                const trimmedDesc = description.trimEnd();
+                const marker = `\n\n[probe artifact: ${probeArtifactId}]`;
+                const composed = `${trimmedDesc}${marker}`;
+                updateData.description = composed.slice(0, 2000);
+              }
+
               await db.ticket.update({
                 where: { id: ctx.ticketId },
-                data: { metadata: { ...safeMeta, probeArtifactId } as Prisma.InputJsonValue },
+                data: updateData,
               });
-              logger.info({ ticketId: ctx.ticketId, probeArtifactId }, 'Probe artifact ID stored in ticket metadata');
+              logger.info({ ticketId: ctx.ticketId, probeArtifactId, descriptionUpdated: !!updateData.description }, 'Probe artifact ID stored in ticket metadata');
             } catch (metaErr) {
               logger.warn({ metaErr, ticketId: ctx.ticketId }, 'Failed to store probe artifact ID in ticket metadata — continuing');
             }

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -783,8 +783,10 @@ async function executeIngestionPipeline(
               if (usedHaikuBody) {
                 const trimmedDesc = description.trimEnd();
                 const marker = `\n\n[probe artifact: ${probeArtifactId}]`;
-                const composed = `${trimmedDesc}${marker}`;
-                updateData.description = composed.slice(0, 2000);
+                // Reserve marker length so it isn't truncated off when the body is near 2000 chars.
+                const maxBodyLen = 2000 - marker.length;
+                const truncatedBody = trimmedDesc.length > maxBodyLen ? trimmedDesc.slice(0, maxBodyLen) : trimmedDesc;
+                updateData.description = `${truncatedBody}${marker}`;
               }
 
               await db.ticket.update({


### PR DESCRIPTION
## Summary

**Phase 4 of #424.** Operator-supplied ticket body on probes (when `action === 'create_ticket'`), augmented at fire time by Claude Haiku into a coherent kick-off description for the analyzer.

Refs #424.

## The gap

Pre-Phase-4: probe-fired tickets had `description = <truncated probe result + artifact ref>`. The operator had no way to express *intent* or *scope* to the analyzer. The analyzer started cold from raw output.

Post-Phase-4: probe edit form has a "Ticket description body" textarea (visible only when `action === 'create_ticket'`). On fire, the probe-worker calls `COMPOSE_PROBE_TICKET_BODY` with the operator body + probe meta description + tool name/params (timeframe-relevant) + probe result head bytes. Haiku returns a 1-3 short paragraphs summary that becomes `Ticket.description` (capped at 2000 chars, with the existing artifact-ref marker preserved).

Best-effort: Haiku failure logs WARN and falls back to the previous truncated-result behaviour.

## What lands

| File | Change |
|---|---|
| `packages/shared-types/src/ai.ts` | Added `COMPOSE_PROBE_TICKET_BODY` task type + AppScope mapping |
| `packages/shared-types/src/scheduled-probe.ts` | Typed `ProbeActionConfigCreateTicket` / `EmailDirect` shapes |
| `packages/ai-provider/src/model-config-resolver.ts` | Default: Claude Haiku |
| `packages/ai-provider/src/task-capabilities.ts` | `BASIC` (no tools, no streaming) |
| `packages/ai-provider/src/prompts/probe-ticket-body.ts` | New prompt key `probe.ticket-body.system` |
| `packages/ai-provider/src/prompts/index.ts` | Registry wiring |
| `services/probe-worker/src/probe-worker.ts` | `composeProbeTicketBody()` wired into the ingest-queue and legacy paths for `create_ticket` and `silent` actions |
| `services/ticket-analyzer/src/ingestion-engine.ts` | Appends `[probe artifact: <id>]` ref to description after artifact save when payload `body` came from Haiku |
| `services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts` | Textarea for `actionConfig.ticketDescription`, conditional on `action === 'create_ticket'` |
| `CLAUDE.md` | Added `COMPOSE_PROBE_TICKET_BODY` to the Claude API task list |

## Verification

- `pnpm build` — clean
- `pnpm typecheck` — clean
- `pnpm --filter @bronco/ai-provider test` — **51 passed** (existing model-config-resolver tests still green)
- `pnpm --filter @bronco/ticket-analyzer test` — **175 passed** (existing ingestion-engine tests still green)

## Per-source defaults preserved

Phase 1's per-source defaults still apply for the *artifact's* `displayName` / `source` / `addedBySystem`. Phase 4 only changes the **ticket** description for probe-created tickets — does not touch artifact creation.

## Test plan

- [ ] CI passes on push to staging
- [ ] After deploy: edit any probe with `action: create_ticket` → "Ticket description body" textarea visible; save round-trips
- [ ] Switch action to `email_direct` or `silent` → textarea is hidden
- [ ] Trigger that probe (manual run or wait for schedule) → resulting ticket has Haiku-augmented description that includes operator's body, tool name, timeframe, and a 1-line headline finding
- [ ] Probe with empty `actionConfig.ticketDescription` → ticket description leads with the probe meta description, then the augmented context (no operator body block)
- [ ] Force a Haiku failure (e.g. invalid client API key) → ticket description falls back to current truncated-result format with artifact ref; WARN log emitted
- [ ] Spot-check `ai_usage_logs` for `task_type: COMPOSE_PROBE_TICKET_BODY` rows on probe fires
- [ ] Verify the artifact-ref marker `[probe artifact: <id>]` is preserved at the end of the composed description so the analyzer can still pivot to the full file

## Notes

No MCP probe create/update tool exists today, so no MCP platform sync was needed. The copilot-api Zod schema for probes already passes through arbitrary `actionConfig` JSON, so `ticketDescription` round-trips without route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
