### PR TITLE
fix(build): exclude *.test.ts from prod tsc output (unblocks v0.2.7 deploy)

### DIFF
--- a/packages/ai-provider/tsconfig.json
+++ b/packages/ai-provider/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/packages/shared-utils/tsconfig.json
+++ b/packages/shared-utils/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/services/ticket-analyzer/tsconfig.json
+++ b/services/ticket-analyzer/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }


### PR DESCRIPTION
## Summary

The v0.2.7 deploy-hugo run failed at the Docker build step. `pnpm --filter @bronco/ai-provider run build` crashed with **TS2307 `Cannot find module '@bronco/test-utils'`** because `tsc` tried to compile the new `*.integration.test.ts` files (added by #433 / #443), which import from the `@bronco/test-utils` workspace devDependency. Production Docker stages don't install devDeps, so the workspace isn't on disk → tsc fails.

Fix: add an `exclude` pattern to the three tsconfigs with test files in `src/`:
- `packages/ai-provider/tsconfig.json`
- `packages/shared-utils/tsconfig.json`
- `services/ticket-analyzer/tsconfig.json`

```json
"exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
```

Vitest discovers tests via its own glob (`**/*.test.ts`), so this only affects `tsc` output. Verified locally:
- `pnpm build` — clean across all 19 workspace packages
- `pnpm --filter @bronco/ai-provider --filter @bronco/ticket-analyzer test` — 216 tests pass, 2 todo

## Why direct-to-master

Hugo is currently still on v0.2.6 (the deploy never reached the deploy step). master is already at v0.2.7's promotion commit. This hotfix needs to land on master to retrigger `tag-release.yml` → `deploy-hugo.yml`. Same pattern as the v0.2.5 cloudflared distroless hotfix. Will sync staging back from master after merge.

## Test plan

- [ ] CI passes (`Typecheck & Build`)
- [ ] After merge: `tag-release.yml` cuts `v0.2.8` → `deploy-hugo.yml` runs → all 16 services healthy on Hugo
- [ ] copilot-api `/api/health` reports `version: v0.2.8`

## Related
- v0.2.7 deploy run: https://github.com/siir/bronco/actions/runs/24937398170
- Pre-deploy migration checksum fix from this session: applied to Hugo `_prisma_migrations` row earlier (no further action needed)
- Process-improvement issue: #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)