### PR TITLE
fix(probes): allow editing toolParams on existing probes (was silently dropped)

### DIFF
--- a/services/control-panel/src/app/core/services/scheduled-probe.service.ts
+++ b/services/control-panel/src/app/core/services/scheduled-probe.service.ts
@@ -63,6 +63,7 @@ export interface UpdateProbeRequest {
   category?: string | null;
   action?: string;
   actionConfig?: Record<string, unknown> | null;
+  toolParams?: Record<string, unknown>;
   isActive?: boolean;
   scheduleHour?: number | null;
   scheduleMinute?: number | null;

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -412,6 +412,7 @@ export class ProbeDialogComponent implements OnInit {
         category: this.category,
         action: this.action,
         actionConfig,
+        toolParams: cleanParams,
         retentionDays: this.isValidRetention(this.retentionDays, 1, 365)
           ? Math.round(this.retentionDays) : undefined,
         retentionMaxRuns: this.isValidRetention(this.retentionMaxRuns, 5, 10000)

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -234,6 +234,12 @@ export class ProbeDialogComponent implements OnInit {
   }
 
   setToolParam(name: string, val: string, type: string): void {
+    if (val === '' || val === undefined || val === null) {
+      const next = { ...this.toolParams };
+      delete next[name];
+      this.toolParams = next;
+      return;
+    }
     this.toolParams = { ...this.toolParams, [name]: type === 'number' ? +val : val };
   }
 

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -410,11 +410,12 @@ export async function scheduledProbeRoutes(
       return fastify.httpErrors.badRequest(`Invalid category. Must be one of: ${[...VALID_CATEGORIES].join(', ')}`);
     }
 
-    // toolName and toolParams are immutable via PATCH to avoid persisting
-    // probes that reference invalid or disabled tools
-    if (updates.toolName !== undefined || updates.toolParams !== undefined) {
+    // toolName is immutable via PATCH — changing the tool changes the probe
+    // identity. Create a new probe instead. toolParams remains editable so
+    // operators can adjust tool inputs (e.g. lookback windows) on existing probes.
+    if (updates.toolName !== undefined) {
       return fastify.httpErrors.badRequest(
-        'Updating toolName or toolParams is not supported; create a new probe instead',
+        'Updating toolName is not supported; create a new probe instead',
       );
     }
 
@@ -443,6 +444,9 @@ export async function scheduledProbeRoutes(
     if (updates.scheduleDaysOfWeek !== undefined) data.scheduleDaysOfWeek = updates.scheduleDaysOfWeek;
     if (updates.retentionDays !== undefined) data.retentionDays = updates.retentionDays;
     if (updates.retentionMaxRuns !== undefined) data.retentionMaxRuns = updates.retentionMaxRuns;
+    if (updates.toolParams !== undefined) {
+      data.toolParams = updates.toolParams as Prisma.InputJsonValue;
+    }
 
     try {
       return await fastify.db.scheduledProbe.update({


### PR DESCRIPTION
## Summary

When editing a scheduled probe, changes to **Tool Parameters** (e.g., bumping the deadlock probe's `hours` from 24 to 48) showed a success toast but never persisted. Confirmed against Hugo: `scheduled_probes.tool_params` stays at the old value despite the UI accepting the change.

## Root cause — two layers

1. **Backend** (`services/copilot-api/src/routes/scheduled-probes.ts:413`): the PATCH route explicitly rejected `toolParams` in the update payload (`Updating toolName or toolParams is not supported; create a new probe instead`). The original concern was about `toolName` (changing the tool changes probe identity), but `toolParams` was lumped in incorrectly.
2. **Frontend** (`services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts:408`): the edit-save path's `updateData` payload omitted `toolParams` entirely. So the user's edit never even reached the API — the rejection above never fired. They got a clean success response with the old value preserved.

## Fix

- Backend: relax the immutability guard to `toolName` only. Wire `toolParams` into the update `data` object alongside other fields. Error message updated to `'Updating toolName is not supported; create a new probe instead'`.
- Frontend: include `toolParams: cleanParams` in the edit-branch `updateData`, matching the create-branch pattern at line 446.
- Type definition: `UpdateProbeRequest` interface adds `toolParams?: Record<string, unknown>` (was missing).

`toolName` remains immutable — changing the tool changes probe identity; create a new probe instead.

## Test plan

- [ ] CI passes
- [ ] Open the Altman "Daily Deadlock Check" probe → change `hours` from 24 to 48 → save → reopen → value shows 48
- [ ] Trigger probe manually → result includes deadlocks from the past 48 hours (id 7579 from 4-24 14:34 UTC should reappear)
- [ ] Try to change `toolName` via direct API call → gets 400 with the updated error message
- [ ] DB confirms: `SELECT tool_params FROM scheduled_probes WHERE id = '372909c9-…'` returns `{"hours": "48"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)