### PR TITLE
fix(ingestion): WARN-log + tracker entry on unhandled route step types (fixes #430)

### DIFF
--- a/services/ticket-analyzer/src/ingestion-engine.test.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.test.ts
@@ -25,15 +25,25 @@ import type { PrismaClient } from '@bronco/db';
 // hoist them to the top of the transformed module.
 // ---------------------------------------------------------------------------
 
+// Shared logger spies — exposed so individual tests can assert on logger.warn
+// calls (e.g. the "not implemented in ingestion phase" branch). Use
+// `vi.hoisted` so the spies exist before `vi.mock` factories run.
+const { loggerWarnSpy, loggerInfoSpy, loggerErrorSpy, loggerDebugSpy } = vi.hoisted(() => ({
+  loggerWarnSpy: vi.fn(),
+  loggerInfoSpy: vi.fn(),
+  loggerErrorSpy: vi.fn(),
+  loggerDebugSpy: vi.fn(),
+}));
+
 vi.mock('@bronco/shared-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@bronco/shared-utils')>();
   return {
     ...actual,
     createLogger: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
+      info: loggerInfoSpy,
+      warn: loggerWarnSpy,
+      error: loggerErrorSpy,
+      debug: loggerDebugSpy,
     }),
   };
 });
@@ -935,6 +945,80 @@ describe('ingestion-engine: unknown step type', () => {
     ).resolves.toBeUndefined();
 
     // Pipeline continued to CREATE_TICKET
+    expect(db.ticket.create).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unhandled-but-known step types — analysis-phase steps that have no ingestion
+// implementation must skip with a WARN log + tracker entry whose reason flags
+// "not implemented in ingestion phase", NOT fall through to the unknown/default
+// case path. (PR #451 — Copilot review feedback for issue #430.)
+// ---------------------------------------------------------------------------
+
+describe('ingestion-engine: unhandled-but-known step types skip with WARN + tracker entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'LOAD_CLIENT_CONTEXT',
+    'LOAD_ENVIRONMENT_CONTEXT',
+    'DISPATCH_TO_ROUTE',
+    'NOTIFY_OPERATOR',
+  ])('%s: emits logger.warn + tracker.skipStep with "not implemented in ingestion phase" reason', async (stepType) => {
+    const db = makeMockDb();
+    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute([stepType, 'CREATE_TICKET']));
+
+    const ai = makeMockAI('GENERAL');
+    const ticketCreatedQueue = makeMockQueue();
+
+    const processor = createIngestionProcessor({
+      db,
+      ai: ai as never,
+      mailer: null,
+      ticketCreatedQueue: ticketCreatedQueue as never,
+      senderSignature: 'Test',
+      smtpFrom: 'test@example.com',
+    });
+
+    await processor(makeJob({
+      source: TicketSource.MANUAL,
+      clientId: 'client-1',
+      payload: { description: 'Something' },
+    }) as never);
+
+    // 1. tracker.skipStep was called with status=skipped + reason matching
+    //    "not implemented in ingestion phase" (skipStep updates the
+    //    ingestionRunStep row to status=skipped with output=reason).
+    const skipUpdateCalls = (db.ingestionRunStep.update as ReturnType<typeof vi.fn>).mock.calls
+      .filter((call) => (call[0] as { data?: { status?: string } }).data?.status === 'skipped');
+    expect(skipUpdateCalls.length).toBeGreaterThan(0);
+
+    const reasonMatch = skipUpdateCalls.some((call) => {
+      const data = (call[0] as { data?: { output?: string } }).data;
+      return typeof data?.output === 'string' && data.output.includes('not implemented in ingestion phase');
+    });
+    expect(reasonMatch).toBe(true);
+
+    // 2. logger.warn was invoked with the same "not implemented" message.
+    const warnMatch = loggerWarnSpy.mock.calls.some((call) => {
+      // Logger calls follow Pino shape: (obj, message)
+      const message = call[1];
+      return typeof message === 'string' && message.includes('not implemented in ingestion phase');
+    });
+    expect(warnMatch).toBe(true);
+
+    // 3. Did NOT fall through to the unknown/default case path. The default
+    //    case logs "Unknown ingestion step type: <type>" — assert that
+    //    message was never emitted for our known-but-unhandled step.
+    const fellThroughToUnknown = loggerWarnSpy.mock.calls.some((call) => {
+      const message = call[1];
+      return typeof message === 'string' && message.startsWith('Unknown ingestion step type:');
+    });
+    expect(fellThroughToUnknown).toBe(false);
+
+    // Pipeline still continued — CREATE_TICKET ran after the skip.
     expect(db.ticket.create).toHaveBeenCalled();
   });
 });

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1018,8 +1018,43 @@ async function executeIngestionPipeline(
         break;
       }
 
+      // Known route step types that are valid in the analysis phase but have
+      // no ingestion-phase implementation. Operators wire these into routes
+      // expecting them to do something here; surface the skip so it's visible
+      // in WARN logs and in ingestion_run_steps history rather than failing
+      // silently. Implementing the actual handlers is a separate scope (#430).
+      case RouteStepType.LOAD_CLIENT_CONTEXT:
+      case RouteStepType.LOAD_ENVIRONMENT_CONTEXT:
+      case RouteStepType.DISPATCH_TO_ROUTE:
+      case RouteStepType.NOTIFY_OPERATOR: {
+        logger.warn(
+          {
+            stepType: step.stepType,
+            stepName: step.name,
+            clientId,
+            ticketId: ctx.ticketId,
+            routeId: route!.id,
+            routeName: route!.name,
+          },
+          'Step skipped — not implemented in ingestion phase',
+        );
+        await safeTracker.skipStep(stepId, `Step skipped — ${step.stepType} not implemented in ingestion phase`);
+        stepsSkipped++;
+        break;
+      }
+
       default:
-        logger.warn({ stepType: step.stepType, clientId }, `Unknown ingestion step type: ${step.stepType} — skipping`);
+        logger.warn(
+          {
+            stepType: step.stepType,
+            stepName: step.name,
+            clientId,
+            ticketId: ctx.ticketId,
+            routeId: route!.id,
+            routeName: route!.name,
+          },
+          `Unknown ingestion step type: ${step.stepType} — skipping`,
+        );
         await safeTracker.skipStep(stepId, `Unknown step type: ${step.stepType}`);
         stepsSkipped++;
         break;


### PR DESCRIPTION
## Summary

Four step types in the route-step registry (`LOAD_CLIENT_CONTEXT`, `LOAD_ENVIRONMENT_CONTEXT`, `DISPATCH_TO_ROUTE`, `NOTIFY_OPERATOR`) silently hit the `default` case in `services/ticket-analyzer/src/ingestion-engine.ts` and were skipped without operator-visible feedback.

Fix (option 3 — cheapest mitigation): explicit `case` for each of the four types that emits `logger.warn` ("Step skipped — not implemented in ingestion phase") + a `safeTracker.skipStep` entry on `ingestion_run_steps` so the run trace shows the skip in the UI / `/api/ingest/runs/:id`. Default case retained for truly unknown types, also enriched with route context.

Implementing the actual handlers for these step types remains a separate scope (#430 option 1).

## Test plan
- [ ] CI passes
- [ ] Wire any of the four steps into a route → trigger ingestion → run trace shows "Step skipped — not implemented in ingestion phase"
- [ ] Hugo logs show `logger.warn` with ticketId, routeId, routeName, step type
- [ ] Other (handled) step types still execute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)