### PR TITLE
ci: block PR edits to already-applied Prisma migration files (fixes #447)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,51 +3,12 @@ name: CI
 on:
   push:
     branches: [staging]
-  pull_request:
-    branches: [staging]
 
 concurrency:
   group: ci-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
-  migration-edit-guard:
-    name: Migration Edit Guard
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Block edits to already-applied Prisma migrations
-        run: |
-          set -euo pipefail
-          git fetch origin master --depth=0 2>/dev/null || git fetch origin master
-          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
-          if [ -z "$DIFF" ]; then
-            echo "No migration file changes vs origin/master."
-            exit 0
-          fi
-          echo "Migration file changes vs origin/master:"
-          echo "$DIFF"
-          BAD=0
-          while IFS=$'\t' read -r STATUS FILE REST; do
-            [ -z "${STATUS:-}" ] && continue
-            FIRST="${STATUS:0:1}"
-            if [ "$FIRST" = "A" ]; then
-              echo "OK   $STATUS  $FILE  (new migration)"
-              continue
-            fi
-            NAME=$(basename "$(dirname "$FILE")")
-            echo "FAIL $STATUS  $FILE"
-            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
-            BAD=1
-          done <<< "$DIFF"
-          if [ "$BAD" -ne 0 ]; then
-            exit 1
-          fi
-
   check:
     name: Typecheck & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,51 @@ name: CI
 on:
   push:
     branches: [staging]
+  pull_request:
+    branches: [staging]
 
 concurrency:
   group: ci-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
+  migration-edit-guard:
+    name: Migration Edit Guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block edits to already-applied Prisma migrations
+        run: |
+          set -euo pipefail
+          git fetch origin master --depth=0 2>/dev/null || git fetch origin master
+          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
+          if [ -z "$DIFF" ]; then
+            echo "No migration file changes vs origin/master."
+            exit 0
+          fi
+          echo "Migration file changes vs origin/master:"
+          echo "$DIFF"
+          BAD=0
+          while IFS=$'\t' read -r STATUS FILE REST; do
+            [ -z "${STATUS:-}" ] && continue
+            FIRST="${STATUS:0:1}"
+            if [ "$FIRST" = "A" ]; then
+              echo "OK   $STATUS  $FILE  (new migration)"
+              continue
+            fi
+            NAME=$(basename "$(dirname "$FILE")")
+            echo "FAIL $STATUS  $FILE"
+            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
+            BAD=1
+          done <<< "$DIFF"
+          if [ "$BAD" -ne 0 ]; then
+            exit 1
+          fi
+
   check:
     name: Typecheck & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -1,0 +1,45 @@
+name: Migration Guard
+
+on:
+  pull_request:
+    branches: [staging]
+
+concurrency:
+  group: migration-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  migration-edit-guard:
+    name: Migration Edit Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block edits to already-applied Prisma migrations
+        run: |
+          set -euo pipefail
+          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
+          if [ -z "$DIFF" ]; then
+            echo "No migration file changes vs origin/master."
+            exit 0
+          fi
+          echo "Migration file changes vs origin/master:"
+          echo "$DIFF"
+          BAD=0
+          while IFS=$'\t' read -r STATUS FILE REST; do
+            [ -z "${STATUS:-}" ] && continue
+            FIRST="${STATUS:0:1}"
+            if [ "$FIRST" = "A" ]; then
+              echo "OK   $STATUS  $FILE  (new migration)"
+              continue
+            fi
+            NAME=$(basename "$(dirname "$FILE")")
+            echo "FAIL $STATUS  $FILE"
+            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
+            BAD=1
+          done <<< "$DIFF"
+          if [ "$BAD" -ne 0 ]; then
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,14 @@ pnpm install
 
 Then include the updated `pnpm-lock.yaml` in the same commit. CI uses `--frozen-lockfile` and will fail if the lockfile is out of sync. This applies to every commit that touches `package.json`, `pnpm-workspace.yaml`, or adds a new workspace directory.
 
+## Migration Discipline (CRITICAL)
+
+**Never edit a Prisma migration file that has already shipped to `master`.** Prisma validates SHA-256 checksums on every `prisma migrate deploy`. Modifying an applied file aborts the deploy with `P3008` and breaks production startup until manually resolved.
+
+If you need to fix or extend an applied migration, write a NEW migration that's idempotent against the prior state (e.g. `IF NOT EXISTS` guards on `ALTER TABLE` / `CREATE INDEX`).
+
+CI enforces this on PRs targeting `staging` — the `migration-edit-guard` job in `.github/workflows/ci.yml` runs `git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql'` and fails the check on any non-Added change (`M`/`D`/`R`) to an existing `migration.sql`. New migrations (status `A`) pass.
+
 ## PR Review Comment Handling
 
 When subscribed to PR activity and review comments arrive, **do not just fix the code silently**. For each review comment:


### PR DESCRIPTION
## Summary

The v0.2.7 deploy crashed because PR #434 edited an already-applied migration file. Prisma's `prisma migrate deploy` validates SHA-256 checksums on every startup; editing an applied file aborts with `P3008` and breaks production until manually resolved.

This adds CI enforcement so the failure mode moves from "loud at production deploy" to "loud at PR review".

## What lands

| File | Change |
|---|---|
| `.github/workflows/migration-guard.yml` | New dedicated workflow with `migration-edit-guard` job: triggers on PRs targeting `staging`, checks out with `fetch-depth: 0`, runs `git diff --name-status origin/master...HEAD -- packages/db/prisma/migrations/*/migration.sql`. Status `A` (added) passes; `M` / `D` / `R` fails with a clear error pointing at #447. Lives in its own file so the existing `ci.yml` push-only `check` job doesn't double-run on every staging-targeted PR. |
| `CLAUDE.md` | New "Migration Discipline (CRITICAL)" section after Lockfile Discipline — codifies the "never edit a shipped migration; write a new idempotent one" rule with the same severity as lockfile rules. |

## Test plan

- [ ] CI passes on this PR (no migration changes in this diff → guard exits 0)
- [ ] Future PR that modifies an existing `migration.sql` file → CI fails with the spec'd error message
- [ ] Future PR that adds a NEW `migration.sql` (status `A`) → CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
