### PR TITLE
feat(ticket-detail): pill header + edit dialog + manual refresh + sticky-on-scroll

### DIFF
--- a/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
@@ -1,12 +1,25 @@
-import { Component, input } from '@angular/core';
+import { Component, input, output } from '@angular/core';
+import { BroncoButtonComponent, IconComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-ticket-detail-resolution',
   standalone: true,
+  imports: [BroncoButtonComponent, IconComponent],
   template: `
-    <p class="summary-text">{{ summary() }}</p>
+    @if (summary(); as s) {
+      <p class="summary-text">{{ s }}</p>
+    } @else {
+      <p class="summary-empty">No resolution summary yet — analysis has not completed or no summary was produced.</p>
+    }
+
+    <div class="resolution-actions">
+      <app-bronco-button variant="secondary" (click)="reanalyze.emit()" [disabled]="reanalyzing()">
+        <app-icon name="refresh" size="sm" /> Re-run Analysis
+      </app-bronco-button>
+    </div>
   `,
   styles: [`
+    :host { display: block; }
     .summary-text {
       white-space: pre-wrap;
       line-height: 1.6;
@@ -15,8 +28,24 @@ import { Component, input } from '@angular/core';
       font-family: var(--font-primary);
       font-size: 14px;
     }
+    .summary-empty {
+      margin: 0;
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-style: italic;
+    }
+    .resolution-actions {
+      margin-top: 20px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
+      display: flex;
+      justify-content: flex-start;
+    }
   `],
 })
 export class TicketDetailResolutionComponent {
-  summary = input.required<string>();
+  summary = input<string | null>(null);
+  reanalyzing = input<boolean>(false);
+  reanalyze = output<void>();
 }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -9,17 +9,47 @@
   position: relative;
 }
 
-.page-header {
+/*
+ * Sticky header: keeps title + ticket number + meta pills + edit/refresh
+ * buttons pinned at the top of the viewport while the operator scrolls
+ * through long log/analysis tabs. Background must be opaque so content
+ * scrolling beneath does not bleed through. A subtle bottom shadow
+ * separates it visually from the scrolling content. Z-index sits above
+ * tab content but below the AI-help FAB (z-index: 100) and any modal
+ * dialogs (z-index: 1000).
+ */
+.ticket-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg-page, var(--bg-card));
+  padding-bottom: 8px;
   margin-bottom: 16px;
+  box-shadow: 0 1px 0 var(--border-light);
+}
+
+.page-header {
+  margin-bottom: 8px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-top: 8px;
 }
 
 .header-left {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.page-subline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 2px;
 }
 
 .back-link {
@@ -45,25 +75,33 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 24px;
+  flex-wrap: wrap;
+  padding-bottom: 4px;
+}
+.ticket-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
 }
-.ticket-meta app-select {
-  display: inline-block;
-  min-width: 140px;
+.ticket-meta-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
 }
 
 /*
- * Mobile (< 768px): the ticket meta row has 3 form-field selects plus
- * source/date/analysis chips. The 140px select min-width overflows
- * 375px screens. Stretch each app-form-field to fill the row so Priority,
- * Status, Category stack vertically. The metadata chips keep flex-wrap
- * so they pile below.
+ * Mobile (< 768px): pills + actions row stays inline but wraps. Title
+ * shrinks; back link + meta pills + buttons all fit on screen. The
+ * sticky header keeps a tight footprint so it doesn't dominate the
+ * viewport while the operator scrolls.
  */
 @media (max-width: 767.98px) {
   .page-header {
     align-items: flex-start;
     gap: 8px;
+    padding-top: 4px;
   }
   .page-title {
     font-size: 18px;
@@ -72,14 +110,12 @@
   }
   .ticket-meta {
     gap: 8px;
-    margin-bottom: 16px;
   }
-  .ticket-meta app-form-field {
-    flex: 1 1 100%;
+  .ticket-meta-actions {
+    margin-left: 0;
   }
-  .ticket-meta app-select {
-    width: 100%;
-    min-width: 0;
+  .ticket-sticky-header {
+    margin-bottom: 12px;
   }
 }
 .source {
@@ -681,11 +717,6 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 12px;
-}
-
-/* Re-run analysis bar */
-.reanalyze-bar {
-  margin-bottom: 16px;
 }
 
 /* Floating AI help button */

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -13,11 +13,19 @@
  * Sticky header: keeps title + ticket number + meta pills + edit/refresh
  * buttons pinned at the top of the viewport while the operator scrolls
  * through long log/analysis tabs. Background must be opaque so content
- * scrolling beneath does not bleed through. A subtle bottom shadow
- * separates it visually from the scrolling content. Z-index sits above
- * tab content but below the AI-help FAB (z-index: 100) and any modal
- * dialogs (z-index: 1000).
+ * scrolling beneath does not bleed through. The bottom shadow is only
+ * applied once the page has actually scrolled (.scrolled is toggled by an
+ * IntersectionObserver on .ticket-sticky-sentinel just above), so an
+ * un-scrolled page doesn't show a stray hairline. Z-index sits above tab
+ * content but below the AI-help FAB (z-index: 100) and any modal dialogs
+ * (z-index: 1000).
  */
+.ticket-sticky-sentinel {
+  /* Zero-height marker observed by IntersectionObserver. */
+  height: 1px;
+  width: 100%;
+  pointer-events: none;
+}
 .ticket-sticky-header {
   position: sticky;
   top: 0;
@@ -25,6 +33,9 @@
   background: var(--bg-page, var(--bg-card));
   padding-bottom: 8px;
   margin-bottom: 16px;
+  transition: box-shadow 120ms ease-out;
+}
+.ticket-sticky-header.scrolled {
   box-shadow: 0 1px 0 var(--border-light);
 }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1,10 +1,11 @@
-import { Component, DestroyRef, inject, OnInit, signal, input, computed } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, ElementRef, inject, OnInit, signal, input, computed, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule, DatePipe, DecimalPipe, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse } from '../../core/services/ticket.service.js';
 import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service.js';
 import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service.js';
@@ -99,7 +100,15 @@ interface ConvTreeNode {
   template: `
     @if (ticket(); as t) {
       <div class="page-wrapper">
-        <div class="ticket-sticky-header">
+        <!--
+          Sentinel sits at the very top of the page-wrapper. While it is
+          visible (intersecting the viewport) the page is not scrolled, so we
+          omit the sticky-header drop shadow. Once the sentinel scrolls
+          out of view, we toggle .scrolled on the sticky header to draw the
+          shadow — keeps the visual cue meaningful instead of always-on.
+        -->
+        <div #stickySentinel class="ticket-sticky-sentinel" aria-hidden="true"></div>
+        <div class="ticket-sticky-header" [class.scrolled]="stickyScrolled()">
           <div class="page-header">
             <div class="header-left">
               <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
@@ -126,7 +135,7 @@ interface ConvTreeNode {
           <div class="ticket-meta">
             <div class="ticket-pills">
               <app-priority-pill [priority]="$any(t.priority)" />
-              <app-status-badge [status]="$any(t.status.toLowerCase())" />
+              <app-status-badge [status]="t.status" />
               @if (t.category) {
                 <app-category-chip [category]="t.category" />
               }
@@ -728,7 +737,7 @@ interface ConvTreeNode {
   `,
   styleUrl: './ticket-detail.component.css',
 })
-export class TicketDetailComponent implements OnInit {
+export class TicketDetailComponent implements OnInit, AfterViewInit {
   id = input.required<string>();
 
   readonly ticketService = inject(TicketService);
@@ -743,6 +752,13 @@ export class TicketDetailComponent implements OnInit {
   aiHelpTitle = signal('');
   aiHelpSubmitFn: (params: { question?: string; provider?: string; model?: string }) => Promise<AiHelpResponse> = () => Promise.reject(new Error('not initialized'));
   showQuickActionsDialog = signal(false);
+
+  // Sentinel + IntersectionObserver drive the sticky-header bottom shadow:
+  // the shadow only appears once the page has actually scrolled past the
+  // top, instead of being permanently rendered.
+  @ViewChild('stickySentinel', { static: false }) private stickySentinel?: ElementRef<HTMLElement>;
+  stickyScrolled = signal(false);
+  private stickyObserver?: IntersectionObserver;
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
@@ -964,8 +980,30 @@ export class TicketDetailComponent implements OnInit {
     this.loadUnifiedLogs();
     this.loadCostSummary();
     this.loadPendingActions();
-    this.destroyRef.onDestroy(() => this.stopPolling());
+    this.destroyRef.onDestroy(() => {
+      this.stopPolling();
+      this.stickyObserver?.disconnect();
+      this.stickyObserver = undefined;
+    });
+  }
 
+  ngAfterViewInit(): void {
+    // The sentinel lives inside an `@if (ticket(); as t)` block, so on the
+    // first AfterViewInit it likely isn't in the DOM yet. Try once now and
+    // retry on a microtask if not — `load()` will also kick this off again
+    // via `tryInitStickyObserver()` once the ticket signal is populated.
+    this.tryInitStickyObserver();
+  }
+
+  private tryInitStickyObserver(): void {
+    if (this.stickyObserver || typeof IntersectionObserver === 'undefined') return;
+    const el = this.stickySentinel?.nativeElement;
+    if (!el) return;
+    this.stickyObserver = new IntersectionObserver(
+      ([entry]) => this.stickyScrolled.set(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    this.stickyObserver.observe(el);
   }
 
   loadPendingActions(): void {
@@ -983,6 +1021,11 @@ export class TicketDetailComponent implements OnInit {
   load(): void {
     this.ticketService.getTicket(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => {
       this.ticket.set(t);
+
+      // Sentinel only renders once the ticket signal is populated, so wire up
+      // the IntersectionObserver after the next microtask to ensure the DOM
+      // has caught up with the signal.
+      queueMicrotask(() => this.tryInitStickyObserver());
 
       // Restore tab from query param on first load (after ticket is available so tabsInOrder is correct)
       if (!this.tabRestored) {
@@ -1230,8 +1273,16 @@ export class TicketDetailComponent implements OnInit {
     return this.conversationEntries().some(e => !!e.parentLogId);
   }
 
-  loadConversationEntries(): void {
-    if (this.conversationLoaded()) return;
+  /**
+   * Load (or reload) the Conversation tab's unified-log entries.
+   *
+   * @param force When true, bypass the `conversationLoaded` guard and
+   *   re-fetch — used by manual refresh so the operator's click on the
+   *   refresh button always pulls fresh data, even if the conversation
+   *   was already loaded once.
+   */
+  loadConversationEntries(force = false): void {
+    if (!force && this.conversationLoaded()) return;
     const ticketId = this.ticket()?.id;
     if (!ticketId) return;
     this.conversationLoading.set(true);
@@ -1489,27 +1540,101 @@ export class TicketDetailComponent implements OnInit {
   }
 
   onQuickActionsSaved(): void {
+    // Note: app-ticket-quick-actions-content already shows a 'Ticket updated'
+    // toast on successful save — don't double-toast here.
     this.showQuickActionsDialog.set(false);
-    this.toast.success('Ticket updated');
     this.load();
   }
 
   /**
    * Manually refresh ticket data + cost summaries without scrolling to top.
-   * Captures window.scrollY before re-fetching and restores it on the next
-   * macrotask once the new data has rendered.
+   *
+   * Captures `window.scrollY` before re-fetching, runs all loads in parallel
+   * via forkJoin, and restores the scroll position only after every fetch
+   * has resolved AND the view has had a chance to paint
+   * (`requestAnimationFrame`). This avoids the prior `setTimeout(0)` race
+   * where the restore could fire before async fetches inside the load
+   * methods had finished re-rendering, defeating the purpose.
+   *
+   * Also force-reloads the Conversation tab's entries — the regular
+   * `loadConversationEntries()` is guarded by `conversationLoaded()` so a
+   * manual refresh on the Conversation tab would otherwise be a no-op.
    */
   refreshTicket(): void {
+    const ticketId = this.id();
     const savedScrollY = typeof window !== 'undefined' ? window.scrollY : 0;
-    this.load();
-    this.loadTicketCost();
-    this.loadCostSummary();
-    this.loadUnifiedLogs();
-    if (typeof window !== 'undefined') {
-      // Restore after Angular flushes the resulting view updates. setTimeout(0)
-      // queues the restore behind the change detection pass triggered by load().
-      setTimeout(() => window.scrollTo(0, savedScrollY), 0);
-    }
+
+    const ticket$ = this.ticketService
+      .getTicket(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+    const cost$ = this.aiUsageService
+      .getTicketCost(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+    const costSummary$ = this.ticketService
+      .getCostSummary(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    const filters: Record<string, string | number> = { limit: 200 };
+    const type = this.unifiedTypeFilter();
+    const level = this.logsLevelFilter();
+    const search = this.logsSearchFilter();
+    if (type) filters['type'] = type;
+    if (level) filters['level'] = level;
+    if (search) filters['search'] = search;
+    this.unifiedLogsLoading.set(true);
+    const unifiedLogs$ = this.ticketService
+      .getUnifiedLogs(ticketId, filters as never)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    // Conversation entries — force a reload regardless of `conversationLoaded`.
+    this.conversationLoading.set(true);
+    const conv$ = this.ticketService
+      .getUnifiedLogs(ticketId, { limit: 200 })
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    forkJoin({
+      ticket: ticket$,
+      cost: cost$,
+      costSummary: costSummary$,
+      unifiedLogs: unifiedLogs$,
+      conv: conv$,
+    }).subscribe(({ ticket, cost, costSummary, unifiedLogs, conv }) => {
+      if (ticket) {
+        this.ticket.set(ticket);
+        const incoming = ticket.events ?? [];
+        const newEvents = incoming.filter(e => !this.knownEventIds.has(e.id));
+        if (newEvents.length > 0) {
+          this.events.update(current => [...current, ...newEvents]);
+          for (const e of newEvents) this.knownEventIds.add(e.id);
+        }
+        this.managePoll(ticket.analysisStatus);
+      }
+      if (cost) this.ticketCost.set(cost);
+      if (costSummary) this.costSummary.set(costSummary);
+      if (unifiedLogs) {
+        this.unifiedLogs.set(unifiedLogs.entries);
+        this.buildStepGroups(unifiedLogs.entries);
+        this.unifiedLogsTotal.set(unifiedLogs.total);
+        this.knownUnifiedLogIds.clear();
+        for (const e of unifiedLogs.entries) this.knownUnifiedLogIds.add(e.id);
+        if (unifiedLogs.entries.length > 0) {
+          this.lastUnifiedLogAt = unifiedLogs.entries[unifiedLogs.entries.length - 1].timestamp;
+        }
+      }
+      this.unifiedLogsLoading.set(false);
+      if (conv) {
+        this.conversationEntries.set(conv.entries);
+        this.buildConvGroups(conv.entries);
+        this.conversationLoaded.set(true);
+      }
+      this.conversationLoading.set(false);
+
+      // Restore scroll on the next paint, after Angular has flushed change
+      // detection from the signal updates above.
+      if (typeof window !== 'undefined') {
+        requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
+      }
+    });
   }
 
   onAiHelpClosed(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -25,6 +25,12 @@ import { AnalysisTraceComponent } from './analysis-trace/analysis-trace.componen
 import { computeStrategyStamp, formatStrategyStamp } from './analysis-strategy-stamp.js';
 import { TicketDetailSummaryComponent } from './ticket-detail-summary.component.js';
 import { TicketDetailResolutionComponent } from './ticket-detail-resolution.component.js';
+import { TicketQuickActionsDialogComponent } from './ticket-quick-actions-dialog.component.js';
+import {
+  PriorityPillComponent,
+  StatusBadgeComponent,
+  CategoryChipComponent,
+} from '../../shared/components/index.js';
 import { TicketDetailDetailsComponent } from './ticket-detail-details.component.js';
 import { TicketDetailKnowledgeComponent } from './ticket-detail-knowledge.component.js';
 import { ChatTabComponent } from './chat/chat-tab.component.js';
@@ -85,55 +91,68 @@ interface ConvTreeNode {
     TicketDetailTimelineComponent,
     AttachmentsListComponent,
     IconComponent,
+    TicketQuickActionsDialogComponent,
+    PriorityPillComponent,
+    StatusBadgeComponent,
+    CategoryChipComponent,
   ],
   template: `
     @if (ticket(); as t) {
       <div class="page-wrapper">
-        <div class="page-header">
-          <div class="header-left">
-            <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
-            <h1 class="page-title">
-              @if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> }
-              {{ t.subject }}
-            </h1>
+        <div class="ticket-sticky-header">
+          <div class="page-header">
+            <div class="header-left">
+              <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
+              <h1 class="page-title">
+                @if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> }
+                {{ t.subject }}
+              </h1>
+              <div class="page-subline">
+                <span class="source">via {{ t.source }}</span>
+                <span class="date">{{ t.createdAt | date:'medium' }}</span>
+                <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
+                  @if (t.analysisStatus === 'IN_PROGRESS') {
+                    <app-icon name="spinner" size="sm" class="spin-icon" />
+                  }
+                  {{ formatAnalysisStatus(t.analysisStatus) }}
+                  @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
+                    <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
+                  }
+                </span>
+              </div>
+            </div>
           </div>
-        </div>
 
-        <div class="ticket-meta">
-          <app-form-field label="Priority">
-            <app-select
-              [value]="t.priority"
-              [options]="priorityOptions"
-              (valueChange)="updateField('priority', $event)" />
-          </app-form-field>
-          <app-form-field label="Status">
-            <app-select
-              [value]="t.status"
-              [options]="statusOptions"
-              (valueChange)="updateStatus($event)" />
-          </app-form-field>
-          <app-form-field label="Category">
-            <app-select
-              [value]="t.category ?? ''"
-              [options]="categoryOptions"
-              (valueChange)="updateField('category', $event || null)" />
-          </app-form-field>
-          <span class="source">via {{ t.source }}</span>
-          <span class="date">{{ t.createdAt | date:'medium' }}</span>
-          <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
-            @if (t.analysisStatus === 'IN_PROGRESS') {
-              <app-icon name="spinner" size="sm" class="spin-icon" />
-            }
-            {{ formatAnalysisStatus(t.analysisStatus) }}
-            @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
-              <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
-            }
-          </span>
-          @if (t.analysisStatus === 'FAILED') {
-            <app-bronco-button variant="destructive" size="sm" (click)="reanalyze()" [disabled]="reanalyzing()">
-              <app-icon name="refresh" size="sm" /> Retry Analysis
-            </app-bronco-button>
-          }
+          <div class="ticket-meta">
+            <div class="ticket-pills">
+              <app-priority-pill [priority]="$any(t.priority)" />
+              <app-status-badge [status]="$any(t.status.toLowerCase())" />
+              @if (t.category) {
+                <app-category-chip [category]="t.category" />
+              }
+            </div>
+            <div class="ticket-meta-actions">
+              <app-bronco-button
+                variant="icon"
+                size="sm"
+                ariaLabel="Edit ticket attributes"
+                (click)="openQuickActionsDialog()">
+                <app-icon name="edit" size="sm" />
+              </app-bronco-button>
+              <app-bronco-button
+                variant="icon"
+                size="sm"
+                ariaLabel="Refresh ticket"
+                (click)="refreshTicket()">
+                <app-icon name="refresh" size="sm" />
+              </app-bronco-button>
+              @if (t.analysisStatus === 'FAILED') {
+                <app-bronco-button variant="destructive" size="sm" (click)="reanalyze()" [disabled]="reanalyzing()">
+                  <app-icon name="refresh" size="sm" /> Retry Analysis
+                </app-bronco-button>
+              }
+            </div>
+          </div>
         </div>
 
         @if (t.analysisStatus === 'FAILED' && t.analysisError) {
@@ -159,11 +178,12 @@ interface ConvTreeNode {
               <app-ticket-detail-summary [emailBlurb]="emailBlurb()!" />
             </app-tab>
           }
-          @if (t.summary) {
-            <app-tab label="Resolution Summary">
-              <app-ticket-detail-resolution [summary]="t.summary" />
-            </app-tab>
-          }
+          <app-tab label="Resolution">
+            <app-ticket-detail-resolution
+              [summary]="t.summary"
+              [reanalyzing]="reanalyzing()"
+              (reanalyze)="reanalyze()" />
+          </app-tab>
           <app-tab label="Details">
             <app-ticket-detail-details
               [description]="t.description"
@@ -677,12 +697,6 @@ interface ConvTreeNode {
           </app-tab>
         </app-tab-group>
 
-        <div class="reanalyze-bar">
-          <app-bronco-button variant="secondary" (click)="reanalyze()" [disabled]="reanalyzing()">
-            <app-icon name="refresh" size="sm" /> Re-run Analysis
-          </app-bronco-button>
-        </div>
-
         <button class="ai-fab" type="button" aria-label="Ask AI for Help" (click)="openAiHelp()">
           <app-icon name="sparkles" size="md" />
         </button>
@@ -696,6 +710,19 @@ interface ConvTreeNode {
         <app-ai-help-dialog-content
           [submitFn]="aiHelpSubmitFn"
           (closed)="onAiHelpClosed()" />
+      </app-dialog>
+    }
+
+    @if (showQuickActionsDialog() && ticket(); as t) {
+      <app-dialog
+        [open]="true"
+        title="Edit ticket attributes"
+        maxWidth="420px"
+        (openChange)="closeQuickActionsDialog()">
+        <app-ticket-quick-actions-content
+          [ticket]="t"
+          (saved)="onQuickActionsSaved()"
+          (cancelled)="closeQuickActionsDialog()" />
       </app-dialog>
     }
   `,
@@ -715,6 +742,7 @@ export class TicketDetailComponent implements OnInit {
   showAiHelpDialog = signal(false);
   aiHelpTitle = signal('');
   aiHelpSubmitFn: (params: { question?: string; provider?: string; model?: string }) => Promise<AiHelpResponse> = () => Promise.reject(new Error('not initialized'));
+  showQuickActionsDialog = signal(false);
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
@@ -774,7 +802,7 @@ export class TicketDetailComponent implements OnInit {
     const labels: string[] = [];
     labels.push('AI Cost');
     if (this.emailBlurb()) labels.push('AI Summary');
-    if (t?.summary) labels.push('Resolution Summary');
+    labels.push('Resolution');
     labels.push('Details');
     labels.push('Attachments');
     if (t?.knowledgeDoc || this.editingKnowledgeDoc()) labels.push('Knowledge');
@@ -1450,6 +1478,38 @@ export class TicketDetailComponent implements OnInit {
     this.aiHelpTitle.set(`Ask AI — ${ticketSubject}`);
     this.aiHelpSubmitFn = (params) => firstValueFrom(this.ticketService.askAi(ticketId, params));
     this.showAiHelpDialog.set(true);
+  }
+
+  openQuickActionsDialog(): void {
+    this.showQuickActionsDialog.set(true);
+  }
+
+  closeQuickActionsDialog(): void {
+    this.showQuickActionsDialog.set(false);
+  }
+
+  onQuickActionsSaved(): void {
+    this.showQuickActionsDialog.set(false);
+    this.toast.success('Ticket updated');
+    this.load();
+  }
+
+  /**
+   * Manually refresh ticket data + cost summaries without scrolling to top.
+   * Captures window.scrollY before re-fetching and restores it on the next
+   * macrotask once the new data has rendered.
+   */
+  refreshTicket(): void {
+    const savedScrollY = typeof window !== 'undefined' ? window.scrollY : 0;
+    this.load();
+    this.loadTicketCost();
+    this.loadCostSummary();
+    this.loadUnifiedLogs();
+    if (typeof window !== 'undefined') {
+      // Restore after Angular flushes the resulting view updates. setTimeout(0)
+      // queues the restore behind the change detection pass triggered by load().
+      setTimeout(() => window.scrollTo(0, savedScrollY), 0);
+    }
   }
 
   onAiHelpClosed(): void {

--- a/services/control-panel/src/app/shared/components/status-badge.component.ts
+++ b/services/control-panel/src/app/shared/components/status-badge.component.ts
@@ -1,11 +1,20 @@
 import { Component, computed, input } from '@angular/core';
 
+export type StatusBadgeValue =
+  | 'new'
+  | 'open'
+  | 'in_progress'
+  | 'waiting'
+  | 'analyzing'
+  | 'resolved'
+  | 'closed';
+
 @Component({
   selector: 'app-status-badge',
   standalone: true,
   template: `
     <span class="status-badge">
-      <span [class]="'status-dot dot-' + status()"></span>
+      <span [class]="'status-dot dot-' + normalizedStatus()"></span>
       <span class="status-label">{{ displayLabel() }}</span>
     </span>
   `,
@@ -23,8 +32,10 @@ import { Component, computed, input } from '@angular/core';
       flex-shrink: 0;
     }
 
+    .dot-new { background: var(--color-info); }
     .dot-open { background: var(--color-info); }
     .dot-in_progress { background: var(--color-warning); }
+    .dot-waiting { background: var(--color-warning); }
     .dot-analyzing { background: var(--accent); }
     .dot-resolved { background: var(--color-success); }
     .dot-closed { background: var(--text-tertiary); }
@@ -38,16 +49,24 @@ import { Component, computed, input } from '@angular/core';
   `],
 })
 export class StatusBadgeComponent {
-  status = input.required<'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'>();
+  // Accept any string so callers passing the raw API enum (e.g. 'WAITING')
+  // don't need to lowercase or cast at the call site.
+  status = input.required<StatusBadgeValue | string>();
+
+  /** Lowercased status for use in dot-* class lookup. */
+  normalizedStatus = computed(() => (this.status() ?? '').toLowerCase());
 
   displayLabel = computed(() => {
     const labels: Record<string, string> = {
+      new: 'New',
       open: 'Open',
       in_progress: 'In Progress',
+      waiting: 'Waiting',
       analyzing: 'Analyzing',
       resolved: 'Resolved',
       closed: 'Closed',
     };
-    return labels[this.status()] ?? this.status();
+    const key = this.normalizedStatus();
+    return labels[key] ?? this.status();
   });
 }


### PR DESCRIPTION
## Summary

UX overhaul on the ticket-detail page header, driven by mobile screenshot feedback. Five linked changes:

| Change | Detail |
|---|---|
| 1. Pills replace dropdowns | The three Priority / Status / Category dropdowns at the top of the page are now compact inline pills (`app-priority-pill` + `app-status-badge` + `app-category-chip`). Saves 2-3 rows of vertical space, much cleaner on mobile. |
| 2. Pencil edit dialog | Adjacent pencil icon opens a small edit dialog containing the three dropdowns (reuses the existing `app-ticket-quick-actions-content` component, so all save/validate logic stays unchanged). |
| 3. Manual refresh button | New `arrows-rotate` icon next to the pencil. Calls a new `refreshTicket()` method that **captures `window.scrollY` pre-fetch and restores via `setTimeout(0)` after data lands** — so refreshing while scrolled deep into AI logs doesn't kick the page back to top. |
| 4. Sticky header | The title + pills + edit + refresh row now `position: sticky; top: 0` with a subtle bottom shadow once scrolled. Stays pinned while operators dig through logs / analysis trace below. |
| 5. Re-run Analysis moved to Resolution tab | The floating bottom-left button is gone. The action now lives inside `TicketDetailResolutionComponent` where it belongs contextually. The Resolution tab is also now always-visible (was conditionally rendered). |

## Files

- `services/control-panel/src/app/features/tickets/ticket-detail.component.ts`
- `services/control-panel/src/app/features/tickets/ticket-detail.component.css`
- `services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts`

Reused existing `edit` (pencil) and `refresh` (arrows-rotate) icons from the FA Pro registry — no new icon registrations.

## Test plan

- [ ] CI passes
- [ ] Open any ticket → header shows three pills + pencil + refresh icon (no dropdowns inline)
- [ ] Pencil → edit dialog with the three dropdowns; Save → values update + dialog closes; pills update accordingly
- [ ] Scroll to the AI Cost or Analysis Trace tab content → click refresh → ticket data updates without scroll jumping back to top
- [ ] Continue scrolling — header (title + pills + edit + refresh) stays pinned to the top of the viewport
- [ ] Resolution tab → "Re-run Analysis" button is now inside the tab body; bottom-left floating button is gone
- [ ] Mobile (≤767px) — header still sticky, pills wrap reasonably, dialog renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)