### PR TITLE
merge: staging → master (v0.2.9 — ticket UX overhaul + probe edit fix + ingestion clarity + retry-analysis correctness + migration CI guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,51 +3,12 @@ name: CI
 on:
   push:
     branches: [staging]
-  pull_request:
-    branches: [staging]
 
 concurrency:
   group: ci-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
-  migration-edit-guard:
-    name: Migration Edit Guard
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Block edits to already-applied Prisma migrations
-        run: |
-          set -euo pipefail
-          git fetch origin master --depth=0 2>/dev/null || git fetch origin master
-          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
-          if [ -z "$DIFF" ]; then
-            echo "No migration file changes vs origin/master."
-            exit 0
-          fi
-          echo "Migration file changes vs origin/master:"
-          echo "$DIFF"
-          BAD=0
-          while IFS=$'\t' read -r STATUS FILE REST; do
-            [ -z "${STATUS:-}" ] && continue
-            FIRST="${STATUS:0:1}"
-            if [ "$FIRST" = "A" ]; then
-              echo "OK   $STATUS  $FILE  (new migration)"
-              continue
-            fi
-            NAME=$(basename "$(dirname "$FILE")")
-            echo "FAIL $STATUS  $FILE"
-            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
-            BAD=1
-          done <<< "$DIFF"
-          if [ "$BAD" -ne 0 ]; then
-            exit 1
-          fi
-
   check:
     name: Typecheck & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,51 @@ name: CI
 on:
   push:
     branches: [staging]
+  pull_request:
+    branches: [staging]
 
 concurrency:
   group: ci-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:
+  migration-edit-guard:
+    name: Migration Edit Guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block edits to already-applied Prisma migrations
+        run: |
+          set -euo pipefail
+          git fetch origin master --depth=0 2>/dev/null || git fetch origin master
+          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
+          if [ -z "$DIFF" ]; then
+            echo "No migration file changes vs origin/master."
+            exit 0
+          fi
+          echo "Migration file changes vs origin/master:"
+          echo "$DIFF"
+          BAD=0
+          while IFS=$'\t' read -r STATUS FILE REST; do
+            [ -z "${STATUS:-}" ] && continue
+            FIRST="${STATUS:0:1}"
+            if [ "$FIRST" = "A" ]; then
+              echo "OK   $STATUS  $FILE  (new migration)"
+              continue
+            fi
+            NAME=$(basename "$(dirname "$FILE")")
+            echo "FAIL $STATUS  $FILE"
+            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
+            BAD=1
+          done <<< "$DIFF"
+          if [ "$BAD" -ne 0 ]; then
+            exit 1
+          fi
+
   check:
     name: Typecheck & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -1,0 +1,45 @@
+name: Migration Guard
+
+on:
+  pull_request:
+    branches: [staging]
+
+concurrency:
+  group: migration-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  migration-edit-guard:
+    name: Migration Edit Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Block edits to already-applied Prisma migrations
+        run: |
+          set -euo pipefail
+          DIFF=$(git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql' || true)
+          if [ -z "$DIFF" ]; then
+            echo "No migration file changes vs origin/master."
+            exit 0
+          fi
+          echo "Migration file changes vs origin/master:"
+          echo "$DIFF"
+          BAD=0
+          while IFS=$'\t' read -r STATUS FILE REST; do
+            [ -z "${STATUS:-}" ] && continue
+            FIRST="${STATUS:0:1}"
+            if [ "$FIRST" = "A" ]; then
+              echo "OK   $STATUS  $FILE  (new migration)"
+              continue
+            fi
+            NAME=$(basename "$(dirname "$FILE")")
+            echo "FAIL $STATUS  $FILE"
+            echo "Migration \`$NAME\` is already applied on master. Add a new migration instead of editing this one. Editing applied files breaks \`prisma migrate deploy\` checksum validation. See #447."
+            BAD=1
+          done <<< "$DIFF"
+          if [ "$BAD" -ne 0 ]; then
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,14 @@ pnpm install
 
 Then include the updated `pnpm-lock.yaml` in the same commit. CI uses `--frozen-lockfile` and will fail if the lockfile is out of sync. This applies to every commit that touches `package.json`, `pnpm-workspace.yaml`, or adds a new workspace directory.
 
+## Migration Discipline (CRITICAL)
+
+**Never edit a Prisma migration file that has already shipped to `master`.** Prisma validates SHA-256 checksums on every `prisma migrate deploy`. Modifying an applied file aborts the deploy with `P3008` and breaks production startup until manually resolved.
+
+If you need to fix or extend an applied migration, write a NEW migration that's idempotent against the prior state (e.g. `IF NOT EXISTS` guards on `ALTER TABLE` / `CREATE INDEX`).
+
+CI enforces this on PRs targeting `staging` — the `migration-edit-guard` job in `.github/workflows/ci.yml` runs `git diff --name-status origin/master...HEAD -- 'packages/db/prisma/migrations/*/migration.sql'` and fails the check on any non-Added change (`M`/`D`/`R`) to an existing `migration.sql`. New migrations (status `A`) pass.
+
 ## PR Review Comment Handling
 
 When subscribed to PR activity and review comments arrive, **do not just fix the code silently**. For each review comment:

--- a/services/control-panel/src/app/core/services/scheduled-probe.service.ts
+++ b/services/control-panel/src/app/core/services/scheduled-probe.service.ts
@@ -63,6 +63,7 @@ export interface UpdateProbeRequest {
   category?: string | null;
   action?: string;
   actionConfig?: Record<string, unknown> | null;
+  toolParams?: Record<string, unknown>;
   isActive?: boolean;
   scheduleHour?: number | null;
   scheduleMinute?: number | null;

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -412,6 +412,7 @@ export class ProbeDialogComponent implements OnInit {
         category: this.category,
         action: this.action,
         actionConfig,
+        toolParams: cleanParams,
         retentionDays: this.isValidRetention(this.retentionDays, 1, 365)
           ? Math.round(this.retentionDays) : undefined,
         retentionMaxRuns: this.isValidRetention(this.retentionMaxRuns, 5, 10000)

--- a/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
+++ b/services/control-panel/src/app/features/scheduled-probes/probe-dialog.component.ts
@@ -234,6 +234,12 @@ export class ProbeDialogComponent implements OnInit {
   }
 
   setToolParam(name: string, val: string, type: string): void {
+    if (val === '' || val === undefined || val === null) {
+      const next = { ...this.toolParams };
+      delete next[name];
+      this.toolParams = next;
+      return;
+    }
     this.toolParams = { ...this.toolParams, [name]: type === 'number' ? +val : val };
   }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail-resolution.component.ts
@@ -1,12 +1,25 @@
-import { Component, input } from '@angular/core';
+import { Component, input, output } from '@angular/core';
+import { BroncoButtonComponent, IconComponent } from '../../shared/components/index.js';
 
 @Component({
   selector: 'app-ticket-detail-resolution',
   standalone: true,
+  imports: [BroncoButtonComponent, IconComponent],
   template: `
-    <p class="summary-text">{{ summary() }}</p>
+    @if (summary(); as s) {
+      <p class="summary-text">{{ s }}</p>
+    } @else {
+      <p class="summary-empty">No resolution summary yet — analysis has not completed or no summary was produced.</p>
+    }
+
+    <div class="resolution-actions">
+      <app-bronco-button variant="secondary" (click)="reanalyze.emit()" [disabled]="reanalyzing()">
+        <app-icon name="refresh" size="sm" /> Re-run Analysis
+      </app-bronco-button>
+    </div>
   `,
   styles: [`
+    :host { display: block; }
     .summary-text {
       white-space: pre-wrap;
       line-height: 1.6;
@@ -15,8 +28,24 @@ import { Component, input } from '@angular/core';
       font-family: var(--font-primary);
       font-size: 14px;
     }
+    .summary-empty {
+      margin: 0;
+      color: var(--text-tertiary);
+      font-family: var(--font-primary);
+      font-size: 13px;
+      font-style: italic;
+    }
+    .resolution-actions {
+      margin-top: 20px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border-light);
+      display: flex;
+      justify-content: flex-start;
+    }
   `],
 })
 export class TicketDetailResolutionComponent {
-  summary = input.required<string>();
+  summary = input<string | null>(null);
+  reanalyzing = input<boolean>(false);
+  reanalyze = output<void>();
 }

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -9,17 +9,47 @@
   position: relative;
 }
 
-.page-header {
+/*
+ * Sticky header: keeps title + ticket number + meta pills + edit/refresh
+ * buttons pinned at the top of the viewport while the operator scrolls
+ * through long log/analysis tabs. Background must be opaque so content
+ * scrolling beneath does not bleed through. A subtle bottom shadow
+ * separates it visually from the scrolling content. Z-index sits above
+ * tab content but below the AI-help FAB (z-index: 100) and any modal
+ * dialogs (z-index: 1000).
+ */
+.ticket-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg-page, var(--bg-card));
+  padding-bottom: 8px;
   margin-bottom: 16px;
+  box-shadow: 0 1px 0 var(--border-light);
+}
+
+.page-header {
+  margin-bottom: 8px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding-top: 8px;
 }
 
 .header-left {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.page-subline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 2px;
 }
 
 .back-link {
@@ -45,25 +75,33 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 24px;
+  flex-wrap: wrap;
+  padding-bottom: 4px;
+}
+.ticket-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   flex-wrap: wrap;
 }
-.ticket-meta app-select {
-  display: inline-block;
-  min-width: 140px;
+.ticket-meta-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
 }
 
 /*
- * Mobile (< 768px): the ticket meta row has 3 form-field selects plus
- * source/date/analysis chips. The 140px select min-width overflows
- * 375px screens. Stretch each app-form-field to fill the row so Priority,
- * Status, Category stack vertically. The metadata chips keep flex-wrap
- * so they pile below.
+ * Mobile (< 768px): pills + actions row stays inline but wraps. Title
+ * shrinks; back link + meta pills + buttons all fit on screen. The
+ * sticky header keeps a tight footprint so it doesn't dominate the
+ * viewport while the operator scrolls.
  */
 @media (max-width: 767.98px) {
   .page-header {
     align-items: flex-start;
     gap: 8px;
+    padding-top: 4px;
   }
   .page-title {
     font-size: 18px;
@@ -72,14 +110,12 @@
   }
   .ticket-meta {
     gap: 8px;
-    margin-bottom: 16px;
   }
-  .ticket-meta app-form-field {
-    flex: 1 1 100%;
+  .ticket-meta-actions {
+    margin-left: 0;
   }
-  .ticket-meta app-select {
-    width: 100%;
-    min-width: 0;
+  .ticket-sticky-header {
+    margin-bottom: 12px;
   }
 }
 .source {
@@ -681,11 +717,6 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 12px;
-}
-
-/* Re-run analysis bar */
-.reanalyze-bar {
-  margin-bottom: 16px;
 }
 
 /* Floating AI help button */

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.css
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.css
@@ -13,11 +13,19 @@
  * Sticky header: keeps title + ticket number + meta pills + edit/refresh
  * buttons pinned at the top of the viewport while the operator scrolls
  * through long log/analysis tabs. Background must be opaque so content
- * scrolling beneath does not bleed through. A subtle bottom shadow
- * separates it visually from the scrolling content. Z-index sits above
- * tab content but below the AI-help FAB (z-index: 100) and any modal
- * dialogs (z-index: 1000).
+ * scrolling beneath does not bleed through. The bottom shadow is only
+ * applied once the page has actually scrolled (.scrolled is toggled by an
+ * IntersectionObserver on .ticket-sticky-sentinel just above), so an
+ * un-scrolled page doesn't show a stray hairline. Z-index sits above tab
+ * content but below the AI-help FAB (z-index: 100) and any modal dialogs
+ * (z-index: 1000).
  */
+.ticket-sticky-sentinel {
+  /* Zero-height marker observed by IntersectionObserver. */
+  height: 1px;
+  width: 100%;
+  pointer-events: none;
+}
 .ticket-sticky-header {
   position: sticky;
   top: 0;
@@ -25,6 +33,9 @@
   background: var(--bg-page, var(--bg-card));
   padding-bottom: 8px;
   margin-bottom: 16px;
+  transition: box-shadow 120ms ease-out;
+}
+.ticket-sticky-header.scrolled {
   box-shadow: 0 1px 0 var(--border-light);
 }
 

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -1,10 +1,11 @@
-import { Component, DestroyRef, inject, OnInit, signal, input, computed } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, ElementRef, inject, OnInit, signal, input, computed, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule, DatePipe, DecimalPipe, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { TicketService, Ticket, TicketEvent, type PendingAction, type UnifiedLogEntry, type TicketCostSummary, type AiHelpResponse } from '../../core/services/ticket.service.js';
 import { LogSummaryService, type LogSummary } from '../../core/services/log-summary.service.js';
 import { AiUsageService, type TicketCostResponse } from '../../core/services/ai-usage.service.js';
@@ -99,7 +100,15 @@ interface ConvTreeNode {
   template: `
     @if (ticket(); as t) {
       <div class="page-wrapper">
-        <div class="ticket-sticky-header">
+        <!--
+          Sentinel sits at the very top of the page-wrapper. While it is
+          visible (intersecting the viewport) the page is not scrolled, so we
+          omit the sticky-header drop shadow. Once the sentinel scrolls
+          out of view, we toggle .scrolled on the sticky header to draw the
+          shadow — keeps the visual cue meaningful instead of always-on.
+        -->
+        <div #stickySentinel class="ticket-sticky-sentinel" aria-hidden="true"></div>
+        <div class="ticket-sticky-header" [class.scrolled]="stickyScrolled()">
           <div class="page-header">
             <div class="header-left">
               <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
@@ -126,7 +135,7 @@ interface ConvTreeNode {
           <div class="ticket-meta">
             <div class="ticket-pills">
               <app-priority-pill [priority]="$any(t.priority)" />
-              <app-status-badge [status]="$any(t.status.toLowerCase())" />
+              <app-status-badge [status]="t.status" />
               @if (t.category) {
                 <app-category-chip [category]="t.category" />
               }
@@ -728,7 +737,7 @@ interface ConvTreeNode {
   `,
   styleUrl: './ticket-detail.component.css',
 })
-export class TicketDetailComponent implements OnInit {
+export class TicketDetailComponent implements OnInit, AfterViewInit {
   id = input.required<string>();
 
   readonly ticketService = inject(TicketService);
@@ -743,6 +752,13 @@ export class TicketDetailComponent implements OnInit {
   aiHelpTitle = signal('');
   aiHelpSubmitFn: (params: { question?: string; provider?: string; model?: string }) => Promise<AiHelpResponse> = () => Promise.reject(new Error('not initialized'));
   showQuickActionsDialog = signal(false);
+
+  // Sentinel + IntersectionObserver drive the sticky-header bottom shadow:
+  // the shadow only appears once the page has actually scrolled past the
+  // top, instead of being permanently rendered.
+  @ViewChild('stickySentinel', { static: false }) private stickySentinel?: ElementRef<HTMLElement>;
+  stickyScrolled = signal(false);
+  private stickyObserver?: IntersectionObserver;
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
@@ -964,8 +980,30 @@ export class TicketDetailComponent implements OnInit {
     this.loadUnifiedLogs();
     this.loadCostSummary();
     this.loadPendingActions();
-    this.destroyRef.onDestroy(() => this.stopPolling());
+    this.destroyRef.onDestroy(() => {
+      this.stopPolling();
+      this.stickyObserver?.disconnect();
+      this.stickyObserver = undefined;
+    });
+  }
 
+  ngAfterViewInit(): void {
+    // The sentinel lives inside an `@if (ticket(); as t)` block, so on the
+    // first AfterViewInit it likely isn't in the DOM yet. Try once now and
+    // retry on a microtask if not — `load()` will also kick this off again
+    // via `tryInitStickyObserver()` once the ticket signal is populated.
+    this.tryInitStickyObserver();
+  }
+
+  private tryInitStickyObserver(): void {
+    if (this.stickyObserver || typeof IntersectionObserver === 'undefined') return;
+    const el = this.stickySentinel?.nativeElement;
+    if (!el) return;
+    this.stickyObserver = new IntersectionObserver(
+      ([entry]) => this.stickyScrolled.set(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    this.stickyObserver.observe(el);
   }
 
   loadPendingActions(): void {
@@ -983,6 +1021,11 @@ export class TicketDetailComponent implements OnInit {
   load(): void {
     this.ticketService.getTicket(this.id()).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(t => {
       this.ticket.set(t);
+
+      // Sentinel only renders once the ticket signal is populated, so wire up
+      // the IntersectionObserver after the next microtask to ensure the DOM
+      // has caught up with the signal.
+      queueMicrotask(() => this.tryInitStickyObserver());
 
       // Restore tab from query param on first load (after ticket is available so tabsInOrder is correct)
       if (!this.tabRestored) {
@@ -1230,8 +1273,16 @@ export class TicketDetailComponent implements OnInit {
     return this.conversationEntries().some(e => !!e.parentLogId);
   }
 
-  loadConversationEntries(): void {
-    if (this.conversationLoaded()) return;
+  /**
+   * Load (or reload) the Conversation tab's unified-log entries.
+   *
+   * @param force When true, bypass the `conversationLoaded` guard and
+   *   re-fetch — used by manual refresh so the operator's click on the
+   *   refresh button always pulls fresh data, even if the conversation
+   *   was already loaded once.
+   */
+  loadConversationEntries(force = false): void {
+    if (!force && this.conversationLoaded()) return;
     const ticketId = this.ticket()?.id;
     if (!ticketId) return;
     this.conversationLoading.set(true);
@@ -1489,27 +1540,101 @@ export class TicketDetailComponent implements OnInit {
   }
 
   onQuickActionsSaved(): void {
+    // Note: app-ticket-quick-actions-content already shows a 'Ticket updated'
+    // toast on successful save — don't double-toast here.
     this.showQuickActionsDialog.set(false);
-    this.toast.success('Ticket updated');
     this.load();
   }
 
   /**
    * Manually refresh ticket data + cost summaries without scrolling to top.
-   * Captures window.scrollY before re-fetching and restores it on the next
-   * macrotask once the new data has rendered.
+   *
+   * Captures `window.scrollY` before re-fetching, runs all loads in parallel
+   * via forkJoin, and restores the scroll position only after every fetch
+   * has resolved AND the view has had a chance to paint
+   * (`requestAnimationFrame`). This avoids the prior `setTimeout(0)` race
+   * where the restore could fire before async fetches inside the load
+   * methods had finished re-rendering, defeating the purpose.
+   *
+   * Also force-reloads the Conversation tab's entries — the regular
+   * `loadConversationEntries()` is guarded by `conversationLoaded()` so a
+   * manual refresh on the Conversation tab would otherwise be a no-op.
    */
   refreshTicket(): void {
+    const ticketId = this.id();
     const savedScrollY = typeof window !== 'undefined' ? window.scrollY : 0;
-    this.load();
-    this.loadTicketCost();
-    this.loadCostSummary();
-    this.loadUnifiedLogs();
-    if (typeof window !== 'undefined') {
-      // Restore after Angular flushes the resulting view updates. setTimeout(0)
-      // queues the restore behind the change detection pass triggered by load().
-      setTimeout(() => window.scrollTo(0, savedScrollY), 0);
-    }
+
+    const ticket$ = this.ticketService
+      .getTicket(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+    const cost$ = this.aiUsageService
+      .getTicketCost(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+    const costSummary$ = this.ticketService
+      .getCostSummary(ticketId)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    const filters: Record<string, string | number> = { limit: 200 };
+    const type = this.unifiedTypeFilter();
+    const level = this.logsLevelFilter();
+    const search = this.logsSearchFilter();
+    if (type) filters['type'] = type;
+    if (level) filters['level'] = level;
+    if (search) filters['search'] = search;
+    this.unifiedLogsLoading.set(true);
+    const unifiedLogs$ = this.ticketService
+      .getUnifiedLogs(ticketId, filters as never)
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    // Conversation entries — force a reload regardless of `conversationLoaded`.
+    this.conversationLoading.set(true);
+    const conv$ = this.ticketService
+      .getUnifiedLogs(ticketId, { limit: 200 })
+      .pipe(takeUntilDestroyed(this.destroyRef), catchError(() => of(null)));
+
+    forkJoin({
+      ticket: ticket$,
+      cost: cost$,
+      costSummary: costSummary$,
+      unifiedLogs: unifiedLogs$,
+      conv: conv$,
+    }).subscribe(({ ticket, cost, costSummary, unifiedLogs, conv }) => {
+      if (ticket) {
+        this.ticket.set(ticket);
+        const incoming = ticket.events ?? [];
+        const newEvents = incoming.filter(e => !this.knownEventIds.has(e.id));
+        if (newEvents.length > 0) {
+          this.events.update(current => [...current, ...newEvents]);
+          for (const e of newEvents) this.knownEventIds.add(e.id);
+        }
+        this.managePoll(ticket.analysisStatus);
+      }
+      if (cost) this.ticketCost.set(cost);
+      if (costSummary) this.costSummary.set(costSummary);
+      if (unifiedLogs) {
+        this.unifiedLogs.set(unifiedLogs.entries);
+        this.buildStepGroups(unifiedLogs.entries);
+        this.unifiedLogsTotal.set(unifiedLogs.total);
+        this.knownUnifiedLogIds.clear();
+        for (const e of unifiedLogs.entries) this.knownUnifiedLogIds.add(e.id);
+        if (unifiedLogs.entries.length > 0) {
+          this.lastUnifiedLogAt = unifiedLogs.entries[unifiedLogs.entries.length - 1].timestamp;
+        }
+      }
+      this.unifiedLogsLoading.set(false);
+      if (conv) {
+        this.conversationEntries.set(conv.entries);
+        this.buildConvGroups(conv.entries);
+        this.conversationLoaded.set(true);
+      }
+      this.conversationLoading.set(false);
+
+      // Restore scroll on the next paint, after Angular has flushed change
+      // detection from the signal updates above.
+      if (typeof window !== 'undefined') {
+        requestAnimationFrame(() => window.scrollTo(0, savedScrollY));
+      }
+    });
   }
 
   onAiHelpClosed(): void {

--- a/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
+++ b/services/control-panel/src/app/features/tickets/ticket-detail.component.ts
@@ -25,6 +25,12 @@ import { AnalysisTraceComponent } from './analysis-trace/analysis-trace.componen
 import { computeStrategyStamp, formatStrategyStamp } from './analysis-strategy-stamp.js';
 import { TicketDetailSummaryComponent } from './ticket-detail-summary.component.js';
 import { TicketDetailResolutionComponent } from './ticket-detail-resolution.component.js';
+import { TicketQuickActionsDialogComponent } from './ticket-quick-actions-dialog.component.js';
+import {
+  PriorityPillComponent,
+  StatusBadgeComponent,
+  CategoryChipComponent,
+} from '../../shared/components/index.js';
 import { TicketDetailDetailsComponent } from './ticket-detail-details.component.js';
 import { TicketDetailKnowledgeComponent } from './ticket-detail-knowledge.component.js';
 import { ChatTabComponent } from './chat/chat-tab.component.js';
@@ -85,55 +91,68 @@ interface ConvTreeNode {
     TicketDetailTimelineComponent,
     AttachmentsListComponent,
     IconComponent,
+    TicketQuickActionsDialogComponent,
+    PriorityPillComponent,
+    StatusBadgeComponent,
+    CategoryChipComponent,
   ],
   template: `
     @if (ticket(); as t) {
       <div class="page-wrapper">
-        <div class="page-header">
-          <div class="header-left">
-            <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
-            <h1 class="page-title">
-              @if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> }
-              {{ t.subject }}
-            </h1>
+        <div class="ticket-sticky-header">
+          <div class="page-header">
+            <div class="header-left">
+              <a routerLink="/tickets" class="back-link"><app-icon name="back" size="sm" /> Tickets</a>
+              <h1 class="page-title">
+                @if (t.ticketNumber) { <span class="ticket-number">#{{ t.ticketNumber }}</span> }
+                {{ t.subject }}
+              </h1>
+              <div class="page-subline">
+                <span class="source">via {{ t.source }}</span>
+                <span class="date">{{ t.createdAt | date:'medium' }}</span>
+                <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
+                  @if (t.analysisStatus === 'IN_PROGRESS') {
+                    <app-icon name="spinner" size="sm" class="spin-icon" />
+                  }
+                  {{ formatAnalysisStatus(t.analysisStatus) }}
+                  @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
+                    <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
+                  }
+                </span>
+              </div>
+            </div>
           </div>
-        </div>
 
-        <div class="ticket-meta">
-          <app-form-field label="Priority">
-            <app-select
-              [value]="t.priority"
-              [options]="priorityOptions"
-              (valueChange)="updateField('priority', $event)" />
-          </app-form-field>
-          <app-form-field label="Status">
-            <app-select
-              [value]="t.status"
-              [options]="statusOptions"
-              (valueChange)="updateStatus($event)" />
-          </app-form-field>
-          <app-form-field label="Category">
-            <app-select
-              [value]="t.category ?? ''"
-              [options]="categoryOptions"
-              (valueChange)="updateField('category', $event || null)" />
-          </app-form-field>
-          <span class="source">via {{ t.source }}</span>
-          <span class="date">{{ t.createdAt | date:'medium' }}</span>
-          <span class="analysis-badge analysis-{{ t.analysisStatus.toLowerCase() }}">
-            @if (t.analysisStatus === 'IN_PROGRESS') {
-              <app-icon name="spinner" size="sm" class="spin-icon" />
-            }
-            {{ formatAnalysisStatus(t.analysisStatus) }}
-            @if (t.analysisStatus === 'COMPLETED' && t.lastAnalyzedAt) {
-              <span class="analysis-time">{{ t.lastAnalyzedAt | date:'short' }}</span>
-            }
-          </span>
-          @if (t.analysisStatus === 'FAILED') {
-            <app-bronco-button variant="destructive" size="sm" (click)="reanalyze()" [disabled]="reanalyzing()">
-              <app-icon name="refresh" size="sm" /> Retry Analysis
-            </app-bronco-button>
-          }
+          <div class="ticket-meta">
+            <div class="ticket-pills">
+              <app-priority-pill [priority]="$any(t.priority)" />
+              <app-status-badge [status]="$any(t.status.toLowerCase())" />
+              @if (t.category) {
+                <app-category-chip [category]="t.category" />
+              }
+            </div>
+            <div class="ticket-meta-actions">
+              <app-bronco-button
+                variant="icon"
+                size="sm"
+                ariaLabel="Edit ticket attributes"
+                (click)="openQuickActionsDialog()">
+                <app-icon name="edit" size="sm" />
+              </app-bronco-button>
+              <app-bronco-button
+                variant="icon"
+                size="sm"
+                ariaLabel="Refresh ticket"
+                (click)="refreshTicket()">
+                <app-icon name="refresh" size="sm" />
+              </app-bronco-button>
+              @if (t.analysisStatus === 'FAILED') {
+                <app-bronco-button variant="destructive" size="sm" (click)="reanalyze()" [disabled]="reanalyzing()">
+                  <app-icon name="refresh" size="sm" /> Retry Analysis
+                </app-bronco-button>
+              }
+            </div>
+          </div>
         </div>
 
         @if (t.analysisStatus === 'FAILED' && t.analysisError) {
@@ -159,11 +178,12 @@ interface ConvTreeNode {
               <app-ticket-detail-summary [emailBlurb]="emailBlurb()!" />
             </app-tab>
           }
-          @if (t.summary) {
-            <app-tab label="Resolution Summary">
-              <app-ticket-detail-resolution [summary]="t.summary" />
-            </app-tab>
-          }
+          <app-tab label="Resolution">
+            <app-ticket-detail-resolution
+              [summary]="t.summary"
+              [reanalyzing]="reanalyzing()"
+              (reanalyze)="reanalyze()" />
+          </app-tab>
           <app-tab label="Details">
             <app-ticket-detail-details
               [description]="t.description"
@@ -677,12 +697,6 @@ interface ConvTreeNode {
           </app-tab>
         </app-tab-group>
 
-        <div class="reanalyze-bar">
-          <app-bronco-button variant="secondary" (click)="reanalyze()" [disabled]="reanalyzing()">
-            <app-icon name="refresh" size="sm" /> Re-run Analysis
-          </app-bronco-button>
-        </div>
-
         <button class="ai-fab" type="button" aria-label="Ask AI for Help" (click)="openAiHelp()">
           <app-icon name="sparkles" size="md" />
         </button>
@@ -696,6 +710,19 @@ interface ConvTreeNode {
         <app-ai-help-dialog-content
           [submitFn]="aiHelpSubmitFn"
           (closed)="onAiHelpClosed()" />
+      </app-dialog>
+    }
+
+    @if (showQuickActionsDialog() && ticket(); as t) {
+      <app-dialog
+        [open]="true"
+        title="Edit ticket attributes"
+        maxWidth="420px"
+        (openChange)="closeQuickActionsDialog()">
+        <app-ticket-quick-actions-content
+          [ticket]="t"
+          (saved)="onQuickActionsSaved()"
+          (cancelled)="closeQuickActionsDialog()" />
       </app-dialog>
     }
   `,
@@ -715,6 +742,7 @@ export class TicketDetailComponent implements OnInit {
   showAiHelpDialog = signal(false);
   aiHelpTitle = signal('');
   aiHelpSubmitFn: (params: { question?: string; provider?: string; model?: string }) => Promise<AiHelpResponse> = () => Promise.reject(new Error('not initialized'));
+  showQuickActionsDialog = signal(false);
 
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly POLL_INTERVAL_MS = 4_000;
@@ -774,7 +802,7 @@ export class TicketDetailComponent implements OnInit {
     const labels: string[] = [];
     labels.push('AI Cost');
     if (this.emailBlurb()) labels.push('AI Summary');
-    if (t?.summary) labels.push('Resolution Summary');
+    labels.push('Resolution');
     labels.push('Details');
     labels.push('Attachments');
     if (t?.knowledgeDoc || this.editingKnowledgeDoc()) labels.push('Knowledge');
@@ -1450,6 +1478,38 @@ export class TicketDetailComponent implements OnInit {
     this.aiHelpTitle.set(`Ask AI — ${ticketSubject}`);
     this.aiHelpSubmitFn = (params) => firstValueFrom(this.ticketService.askAi(ticketId, params));
     this.showAiHelpDialog.set(true);
+  }
+
+  openQuickActionsDialog(): void {
+    this.showQuickActionsDialog.set(true);
+  }
+
+  closeQuickActionsDialog(): void {
+    this.showQuickActionsDialog.set(false);
+  }
+
+  onQuickActionsSaved(): void {
+    this.showQuickActionsDialog.set(false);
+    this.toast.success('Ticket updated');
+    this.load();
+  }
+
+  /**
+   * Manually refresh ticket data + cost summaries without scrolling to top.
+   * Captures window.scrollY before re-fetching and restores it on the next
+   * macrotask once the new data has rendered.
+   */
+  refreshTicket(): void {
+    const savedScrollY = typeof window !== 'undefined' ? window.scrollY : 0;
+    this.load();
+    this.loadTicketCost();
+    this.loadCostSummary();
+    this.loadUnifiedLogs();
+    if (typeof window !== 'undefined') {
+      // Restore after Angular flushes the resulting view updates. setTimeout(0)
+      // queues the restore behind the change detection pass triggered by load().
+      setTimeout(() => window.scrollTo(0, savedScrollY), 0);
+    }
   }
 
   onAiHelpClosed(): void {

--- a/services/control-panel/src/app/shared/components/status-badge.component.ts
+++ b/services/control-panel/src/app/shared/components/status-badge.component.ts
@@ -1,11 +1,20 @@
 import { Component, computed, input } from '@angular/core';
 
+export type StatusBadgeValue =
+  | 'new'
+  | 'open'
+  | 'in_progress'
+  | 'waiting'
+  | 'analyzing'
+  | 'resolved'
+  | 'closed';
+
 @Component({
   selector: 'app-status-badge',
   standalone: true,
   template: `
     <span class="status-badge">
-      <span [class]="'status-dot dot-' + status()"></span>
+      <span [class]="'status-dot dot-' + normalizedStatus()"></span>
       <span class="status-label">{{ displayLabel() }}</span>
     </span>
   `,
@@ -23,8 +32,10 @@ import { Component, computed, input } from '@angular/core';
       flex-shrink: 0;
     }
 
+    .dot-new { background: var(--color-info); }
     .dot-open { background: var(--color-info); }
     .dot-in_progress { background: var(--color-warning); }
+    .dot-waiting { background: var(--color-warning); }
     .dot-analyzing { background: var(--accent); }
     .dot-resolved { background: var(--color-success); }
     .dot-closed { background: var(--text-tertiary); }
@@ -38,16 +49,24 @@ import { Component, computed, input } from '@angular/core';
   `],
 })
 export class StatusBadgeComponent {
-  status = input.required<'open' | 'in_progress' | 'analyzing' | 'resolved' | 'closed'>();
+  // Accept any string so callers passing the raw API enum (e.g. 'WAITING')
+  // don't need to lowercase or cast at the call site.
+  status = input.required<StatusBadgeValue | string>();
+
+  /** Lowercased status for use in dot-* class lookup. */
+  normalizedStatus = computed(() => (this.status() ?? '').toLowerCase());
 
   displayLabel = computed(() => {
     const labels: Record<string, string> = {
+      new: 'New',
       open: 'Open',
       in_progress: 'In Progress',
+      waiting: 'Waiting',
       analyzing: 'Analyzing',
       resolved: 'Resolved',
       closed: 'Closed',
     };
-    return labels[this.status()] ?? this.status();
+    const key = this.normalizedStatus();
+    return labels[key] ?? this.status();
   });
 }

--- a/services/copilot-api/src/routes/scheduled-probes.ts
+++ b/services/copilot-api/src/routes/scheduled-probes.ts
@@ -410,11 +410,12 @@ export async function scheduledProbeRoutes(
       return fastify.httpErrors.badRequest(`Invalid category. Must be one of: ${[...VALID_CATEGORIES].join(', ')}`);
     }
 
-    // toolName and toolParams are immutable via PATCH to avoid persisting
-    // probes that reference invalid or disabled tools
-    if (updates.toolName !== undefined || updates.toolParams !== undefined) {
+    // toolName is immutable via PATCH — changing the tool changes the probe
+    // identity. Create a new probe instead. toolParams remains editable so
+    // operators can adjust tool inputs (e.g. lookback windows) on existing probes.
+    if (updates.toolName !== undefined) {
       return fastify.httpErrors.badRequest(
-        'Updating toolName or toolParams is not supported; create a new probe instead',
+        'Updating toolName is not supported; create a new probe instead',
       );
     }
 
@@ -443,6 +444,9 @@ export async function scheduledProbeRoutes(
     if (updates.scheduleDaysOfWeek !== undefined) data.scheduleDaysOfWeek = updates.scheduleDaysOfWeek;
     if (updates.retentionDays !== undefined) data.retentionDays = updates.retentionDays;
     if (updates.retentionMaxRuns !== undefined) data.retentionMaxRuns = updates.retentionMaxRuns;
+    if (updates.toolParams !== undefined) {
+      data.toolParams = updates.toolParams as Prisma.InputJsonValue;
+    }
 
     try {
       return await fastify.db.scheduledProbe.update({

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -668,7 +668,7 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     const scopeWhere = scopeToWhere(scope);
     const ticket = await fastify.db.ticket.findFirst({
       where: { id: request.params.id, ...scopeWhere },
-      select: { id: true, clientId: true, source: true, category: true },
+      select: { id: true, clientId: true, source: true, category: true, analysisStatus: true, analysisError: true },
     });
     if (!ticket) return fastify.httpErrors.notFound('Ticket not found');
     if (!opts?.ticketCreatedQueue) return fastify.httpErrors.serviceUnavailable('Ticket queue not available');
@@ -676,24 +676,46 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     const enqueuedAt = Date.now();
     const jobId = `ticket-created-reanalyze-${ticket.id}-${enqueuedAt}`;
 
+    // Capture pre-update analysis state so we can revert if the enqueue throws.
+    // Race fix (#380 thread 1): previously the status was flipped to PENDING
+    // BEFORE queue.add(); a transient Redis exception left the ticket stuck in
+    // PENDING with no job running. Now we still update first (so the UI sees
+    // immediate feedback) but wrap the enqueue in try/catch and revert on
+    // failure. A 409 dedupe (existing job returned) is treated as
+    // success-with-existing-job — the prior job is still running/completed, so
+    // the PENDING status is not a lie.
+    const priorAnalysisStatus = ticket.analysisStatus;
+    const priorAnalysisError = ticket.analysisError;
+
     await fastify.db.ticket.update({
       where: { id: ticket.id },
       data: { analysisStatus: AnalysisStatus.PENDING, analysisError: null },
     });
 
-    const enqueuedJob = await opts.ticketCreatedQueue.add('ticket-created', {
-      ticketId: ticket.id,
-      clientId: ticket.clientId,
-      source: (ticket.source ?? TicketSource.MANUAL) as TicketCreatedJob['source'],
-      category: ticket.category ?? null,
-      reanalysis: true,
-    }, {
-      jobId,
-      attempts: 4,
-      backoff: { type: 'exponential', delay: 30_000 },
-      removeOnComplete: { age: 3600, count: 1000 },
-      removeOnFail: { age: 24 * 3600, count: 1000 },
-    });
+    let enqueuedJob;
+    try {
+      enqueuedJob = await opts.ticketCreatedQueue.add('ticket-created', {
+        ticketId: ticket.id,
+        clientId: ticket.clientId,
+        source: (ticket.source ?? TicketSource.MANUAL) as TicketCreatedJob['source'],
+        category: ticket.category ?? null,
+        reanalysis: true,
+      }, {
+        jobId,
+        attempts: 4,
+        backoff: { type: 'exponential', delay: 30_000 },
+        removeOnComplete: { age: 3600, count: 1000 },
+        removeOnFail: { age: 24 * 3600, count: 1000 },
+      });
+    } catch (err) {
+      // Revert the optimistic PENDING update so the ticket isn't stuck.
+      await fastify.db.ticket.update({
+        where: { id: ticket.id },
+        data: { analysisStatus: priorAnalysisStatus, analysisError: priorAnalysisError },
+      }).catch(() => { /* best-effort revert */ });
+      request.log.error({ err, ticketId: ticket.id, jobId }, 'Failed to enqueue reanalyze job — reverted analysisStatus');
+      throw err;
+    }
 
     // Belt-and-braces dedupe check. With a timestamped jobId this should never
     // trigger, but catching it here means we never lie to the UI.

--- a/services/copilot-api/src/routes/tickets.ts
+++ b/services/copilot-api/src/routes/tickets.ts
@@ -681,9 +681,11 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
     // BEFORE queue.add(); a transient Redis exception left the ticket stuck in
     // PENDING with no job running. Now we still update first (so the UI sees
     // immediate feedback) but wrap the enqueue in try/catch and revert on
-    // failure. A 409 dedupe (existing job returned) is treated as
-    // success-with-existing-job — the prior job is still running/completed, so
-    // the PENDING status is not a lie.
+    // failure. With the timestamped jobId the dedupe branch below should never
+    // fire; if it does, we return HTTP 409 so the UI surfaces a real error
+    // ("another analysis is already running for this ticket") rather than
+    // optimistic success. Future followup: revisit whether 409 is the right
+    // operator UX vs surfacing the in-flight job's progress instead.
     const priorAnalysisStatus = ticket.analysisStatus;
     const priorAnalysisError = ticket.analysisError;
 
@@ -709,8 +711,12 @@ export async function ticketRoutes(fastify: FastifyInstance, opts?: TicketRouteO
       });
     } catch (err) {
       // Revert the optimistic PENDING update so the ticket isn't stuck.
-      await fastify.db.ticket.update({
-        where: { id: ticket.id },
+      // Conditional: only revert if analysisStatus is STILL PENDING. If a
+      // concurrent analysis run finished (COMPLETED/FAILED) while queue.add()
+      // was timing out, the WHERE acts as a guard so our enqueue rollback can
+      // never clobber legitimate state from a real analysis.
+      await fastify.db.ticket.updateMany({
+        where: { id: ticket.id, analysisStatus: AnalysisStatus.PENDING },
         data: { analysisStatus: priorAnalysisStatus, analysisError: priorAnalysisError },
       }).catch(() => { /* best-effort revert */ });
       request.log.error({ err, ticketId: ticket.id, jobId }, 'Failed to enqueue reanalyze job — reverted analysisStatus');

--- a/services/ticket-analyzer/src/ingestion-engine.integration.test.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.integration.test.ts
@@ -95,9 +95,9 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       ],
     };
 
-    // Stub db.ticketRoute.findFirst to return our route
-    const origFindFirst = db.ticketRoute.findFirst.bind(db.ticketRoute);
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValueOnce(route as never);
+    // Stub db.ticketRoute.findMany to return our route
+    const origFindMany = db.ticketRoute.findMany.bind(db.ticketRoute);
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValueOnce([route] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -137,7 +137,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
 
     // Restore
     vi.restoreAllMocks();
-    void origFindFirst;
+    void origFindMany;
   });
 
   it('assigns sequential ticketNumbers per client', async () => {
@@ -147,7 +147,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -163,7 +163,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -199,7 +199,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -215,7 +215,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -259,7 +259,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -275,7 +275,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -313,7 +313,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -329,7 +329,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -377,7 +377,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -393,7 +393,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -448,7 +448,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -464,7 +464,7 @@ describe.skipIf(!hasDb)('integration: CREATE_TICKET step', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -539,7 +539,7 @@ describe.skipIf(!hasDb)('integration: ADD_FOLLOWER step', () => {
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -556,7 +556,7 @@ describe.skipIf(!hasDb)('integration: ADD_FOLLOWER step', () => {
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's2', stepOrder: 2, name: 'Add Follower', stepType: RouteStepType.ADD_FOLLOWER, taskTypeOverride: null, promptKeyOverride: null, config: { email: 'bob@example.com', followerType: 'FOLLOWER' }, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -612,7 +612,7 @@ describe.skipIf(!hasDb)('integration: ADD_FOLLOWER step', () => {
     const ticketCreatedQueue = makeMockQueue();
 
     // Stub ticketRoute + ticket.create to reuse the existing ticket
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -629,13 +629,13 @@ describe.skipIf(!hasDb)('integration: ADD_FOLLOWER step', () => {
         // No CREATE_TICKET — inject ticketId directly via mock
         { id: 's1', stepOrder: 1, name: 'Add Follower', stepType: RouteStepType.ADD_FOLLOWER, taskTypeOverride: null, promptKeyOverride: null, config: { email: 'carol@example.com', followerType: 'FOLLOWER' }, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     // We need ctx.ticketId to be set for ADD_FOLLOWER to run.
     // Since there's no CREATE_TICKET step, ADD_FOLLOWER will be skipped (ctx.ticketId = null).
     // Use CREATE_TICKET step to set up the context, but with the existing ticket.
     // Instead, directly test by running a route that includes both steps:
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -652,7 +652,7 @@ describe.skipIf(!hasDb)('integration: ADD_FOLLOWER step', () => {
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's2', stepOrder: 2, name: 'Add Follower', stepType: RouteStepType.ADD_FOLLOWER, taskTypeOverride: null, promptKeyOverride: null, config: { email: 'carol@example.com', followerType: 'FOLLOWER' }, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const processor = createIngestionProcessor({
       db,
@@ -717,7 +717,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
       }),
     };
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -735,7 +735,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
         { id: 's2', stepOrder: 2, name: 'Triage', stepType: RouteStepType.TRIAGE_PRIORITY, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's3', stepOrder: 3, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const ticketCreatedQueue = makeMockQueue();
     const processor = createIngestionProcessor({
@@ -766,8 +766,8 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
   });
 
   it('uses default fallback route when no DB route matches', async () => {
-    // ticketRoute.findFirst returns null → engine should use built-in default
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue(null);
+    // ticketRoute.findMany returns [] → engine should use built-in default
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([]);
 
     let categorizeCalled = false;
     const ai = {
@@ -804,7 +804,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
   });
 
   it('writes ingestion_run tracking rows for the full pipeline', async () => {
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Tracked Pipeline',
       description: null,
@@ -821,7 +821,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
         { id: 's1', stepOrder: 1, name: 'Categorize', stepType: RouteStepType.CATEGORIZE, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's2', stepOrder: 2, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const ai = makeMockAI('BUG_FIX');
     const ticketCreatedQueue = makeMockQueue();
@@ -869,7 +869,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
 
   it('marks ingestion_run as error when pipeline throws', async () => {
     // Make ticket.create throw to cause a hard pipeline failure
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Failing Pipeline',
       description: null,
@@ -885,7 +885,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
       steps: [
         { id: 's1', stepOrder: 1, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     vi.spyOn(db.ticket, 'create').mockRejectedValue(new Error('DB insert failed'));
 
@@ -931,7 +931,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
       return originalFindFirst(args as Parameters<typeof originalFindFirst>[0]);
     }) as never);
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -948,7 +948,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
         { id: 's1', stepOrder: 1, name: 'Resolve Thread', stepType: RouteStepType.RESOLVE_THREAD, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's2', stepOrder: 2, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -991,7 +991,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
       },
     });
 
-    vi.spyOn(db.ticketRoute, 'findFirst').mockResolvedValue({
+    vi.spyOn(db.ticketRoute, 'findMany').mockResolvedValue([{
       id: null,
       name: 'Test',
       description: null,
@@ -1008,7 +1008,7 @@ describe.skipIf(!hasDb)('integration: pipeline orchestration', () => {
         { id: 's1', stepOrder: 1, name: 'Resolve Thread', stepType: RouteStepType.RESOLVE_THREAD, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 's2', stepOrder: 2, name: 'Create Ticket', stepType: RouteStepType.CREATE_TICKET, taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
       ],
-    } as never);
+    }] as never);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();

--- a/services/ticket-analyzer/src/ingestion-engine.test.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.test.ts
@@ -25,15 +25,25 @@ import type { PrismaClient } from '@bronco/db';
 // hoist them to the top of the transformed module.
 // ---------------------------------------------------------------------------
 
+// Shared logger spies — exposed so individual tests can assert on logger.warn
+// calls (e.g. the "not implemented in ingestion phase" branch). Use
+// `vi.hoisted` so the spies exist before `vi.mock` factories run.
+const { loggerWarnSpy, loggerInfoSpy, loggerErrorSpy, loggerDebugSpy } = vi.hoisted(() => ({
+  loggerWarnSpy: vi.fn(),
+  loggerInfoSpy: vi.fn(),
+  loggerErrorSpy: vi.fn(),
+  loggerDebugSpy: vi.fn(),
+}));
+
 vi.mock('@bronco/shared-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@bronco/shared-utils')>();
   return {
     ...actual,
     createLogger: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
+      info: loggerInfoSpy,
+      warn: loggerWarnSpy,
+      error: loggerErrorSpy,
+      debug: loggerDebugSpy,
     }),
   };
 });
@@ -935,6 +945,80 @@ describe('ingestion-engine: unknown step type', () => {
     ).resolves.toBeUndefined();
 
     // Pipeline continued to CREATE_TICKET
+    expect(db.ticket.create).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unhandled-but-known step types — analysis-phase steps that have no ingestion
+// implementation must skip with a WARN log + tracker entry whose reason flags
+// "not implemented in ingestion phase", NOT fall through to the unknown/default
+// case path. (PR #451 — Copilot review feedback for issue #430.)
+// ---------------------------------------------------------------------------
+
+describe('ingestion-engine: unhandled-but-known step types skip with WARN + tracker entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'LOAD_CLIENT_CONTEXT',
+    'LOAD_ENVIRONMENT_CONTEXT',
+    'DISPATCH_TO_ROUTE',
+    'NOTIFY_OPERATOR',
+  ])('%s: emits logger.warn + tracker.skipStep with "not implemented in ingestion phase" reason', async (stepType) => {
+    const db = makeMockDb();
+    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute([stepType, 'CREATE_TICKET']));
+
+    const ai = makeMockAI('GENERAL');
+    const ticketCreatedQueue = makeMockQueue();
+
+    const processor = createIngestionProcessor({
+      db,
+      ai: ai as never,
+      mailer: null,
+      ticketCreatedQueue: ticketCreatedQueue as never,
+      senderSignature: 'Test',
+      smtpFrom: 'test@example.com',
+    });
+
+    await processor(makeJob({
+      source: TicketSource.MANUAL,
+      clientId: 'client-1',
+      payload: { description: 'Something' },
+    }) as never);
+
+    // 1. tracker.skipStep was called with status=skipped + reason matching
+    //    "not implemented in ingestion phase" (skipStep updates the
+    //    ingestionRunStep row to status=skipped with output=reason).
+    const skipUpdateCalls = (db.ingestionRunStep.update as ReturnType<typeof vi.fn>).mock.calls
+      .filter((call) => (call[0] as { data?: { status?: string } }).data?.status === 'skipped');
+    expect(skipUpdateCalls.length).toBeGreaterThan(0);
+
+    const reasonMatch = skipUpdateCalls.some((call) => {
+      const data = (call[0] as { data?: { output?: string } }).data;
+      return typeof data?.output === 'string' && data.output.includes('not implemented in ingestion phase');
+    });
+    expect(reasonMatch).toBe(true);
+
+    // 2. logger.warn was invoked with the same "not implemented" message.
+    const warnMatch = loggerWarnSpy.mock.calls.some((call) => {
+      // Logger calls follow Pino shape: (obj, message)
+      const message = call[1];
+      return typeof message === 'string' && message.includes('not implemented in ingestion phase');
+    });
+    expect(warnMatch).toBe(true);
+
+    // 3. Did NOT fall through to the unknown/default case path. The default
+    //    case logs "Unknown ingestion step type: <type>" — assert that
+    //    message was never emitted for our known-but-unhandled step.
+    const fellThroughToUnknown = loggerWarnSpy.mock.calls.some((call) => {
+      const message = call[1];
+      return typeof message === 'string' && message.startsWith('Unknown ingestion step type:');
+    });
+    expect(fellThroughToUnknown).toBe(false);
+
+    // Pipeline still continued — CREATE_TICKET ran after the skip.
     expect(db.ticket.create).toHaveBeenCalled();
   });
 });

--- a/services/ticket-analyzer/src/ingestion-engine.test.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.test.ts
@@ -25,16 +25,20 @@ import type { PrismaClient } from '@bronco/db';
 // hoist them to the top of the transformed module.
 // ---------------------------------------------------------------------------
 
+// Shared logger mock — hoisted so the SUT and the test both reference the same
+// instance, allowing assertions on logger.warn/info calls.
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
 vi.mock('@bronco/shared-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@bronco/shared-utils')>();
   return {
     ...actual,
-    createLogger: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    }),
+    createLogger: () => mockLogger,
   };
 });
 
@@ -59,7 +63,10 @@ function makeMockDb(overrides: Record<string, unknown> = {}): PrismaClient {
       create: vi.fn().mockResolvedValue({}),
       findFirst: vi.fn().mockResolvedValue(null),
     },
-    ticketRoute: { findFirst: vi.fn().mockResolvedValue(null) },
+    ticketRoute: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     person: { findFirst: vi.fn().mockResolvedValue(null) },
     ticketFollower: { create: vi.fn().mockResolvedValue({}) },
     ingestionRun: {
@@ -141,7 +148,7 @@ describe('ingestion-engine: CATEGORIZE step', () => {
   it('sets ctx.category from a valid AI response', async () => {
     const db = makeMockDb();
     // The only route returned from DB is our mock route
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('DATABASE_PERF');
     const ticketCreatedQueue = makeMockQueue();
@@ -171,7 +178,7 @@ describe('ingestion-engine: CATEGORIZE step', () => {
 
   it('falls back to GENERAL for an unrecognised AI response', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('NOT_A_REAL_CATEGORY');
     const ticketCreatedQueue = makeMockQueue();
@@ -200,7 +207,7 @@ describe('ingestion-engine: CATEGORIZE step', () => {
 
   it('falls back to GENERAL when AI throws', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     const ai = {
       generate: vi.fn().mockRejectedValue(new Error('Ollama offline')),
@@ -231,7 +238,7 @@ describe('ingestion-engine: CATEGORIZE step', () => {
 
   it('skips CATEGORIZE and uses payload category when operator provides a valid category', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('BUG_FIX');
     const ticketCreatedQueue = makeMockQueue();
@@ -263,7 +270,7 @@ describe('ingestion-engine: CATEGORIZE step', () => {
 
   it('trims and uppercases the AI response before checking validity', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     // AI returns with leading/trailing whitespace and mixed case
     const ai = makeMockAI('  bug_fix  ');
@@ -308,7 +315,7 @@ describe('ingestion-engine: TRIAGE_PRIORITY step', () => {
     ['CRITICAL', 'CRITICAL'],
   ])('sets priority to %s from valid AI response %s', async (expected, aiResponse) => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI(aiResponse);
     const ticketCreatedQueue = makeMockQueue();
@@ -337,7 +344,7 @@ describe('ingestion-engine: TRIAGE_PRIORITY step', () => {
 
   it('falls back to MEDIUM for an unrecognised AI priority response', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('URGENT'); // not valid
     const ticketCreatedQueue = makeMockQueue();
@@ -366,7 +373,7 @@ describe('ingestion-engine: TRIAGE_PRIORITY step', () => {
 
   it('falls back to MEDIUM when AI throws', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET'])]);
 
     const ai = { generate: vi.fn().mockRejectedValue(new Error('AI error')) };
     const ticketCreatedQueue = makeMockQueue();
@@ -395,7 +402,7 @@ describe('ingestion-engine: TRIAGE_PRIORITY step', () => {
 
   it('skips TRIAGE_PRIORITY and preserves payload priority when operator provides HIGH', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['TRIAGE_PRIORITY', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('LOW');
     const ticketCreatedQueue = makeMockQueue();
@@ -435,7 +442,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('strips leading/trailing quotes from AI title', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('"Database performance issue"');
     const ticketCreatedQueue = makeMockQueue();
@@ -464,7 +471,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('strips "Here\'s a concise ticket title:" preamble', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI("Here's a concise ticket title: My Issue Title");
     const ticketCreatedQueue = makeMockQueue();
@@ -493,7 +500,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('strips "Title:" prefix', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('Title: My Issue Title');
     const ticketCreatedQueue = makeMockQueue();
@@ -522,7 +529,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('truncates title to 80 characters', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('A'.repeat(150));
     const ticketCreatedQueue = makeMockQueue();
@@ -548,7 +555,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('keeps original title when AI returns empty string', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('');
     const ticketCreatedQueue = makeMockQueue();
@@ -577,7 +584,7 @@ describe('ingestion-engine: GENERATE_TITLE step', () => {
 
   it('pipeline continues after GENERATE_TITLE failure — uses original title', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['GENERATE_TITLE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['GENERATE_TITLE', 'CREATE_TICKET'])]);
 
     const ai = { generate: vi.fn().mockRejectedValue(new Error('AI error')) };
     const ticketCreatedQueue = makeMockQueue();
@@ -617,7 +624,7 @@ describe('ingestion-engine: initial priority from numeric payload', () => {
     const db = makeMockDb();
     // No route found → uses default fallback pipeline
     // Payload has a valid priority so TRIAGE_PRIORITY will skip (operator-provided)
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CREATE_TICKET'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -654,7 +661,7 @@ describe('ingestion-engine: CREATE_TICKET skip when ticket already exists', () =
     const db = makeMockDb();
 
     // Simulate a route with RESOLVE_THREAD + CREATE_TICKET
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['RESOLVE_THREAD', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['RESOLVE_THREAD', 'CREATE_TICKET'])]);
 
     // Simulate RESOLVE_THREAD finding an existing ticket
     (db.ticketEvent.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -702,7 +709,7 @@ describe('ingestion-engine: CREATE_TICKET skip when ticket already exists', () =
 describe('ingestion-engine: step error accumulation', () => {
   it('continues to CREATE_TICKET after CATEGORIZE failure', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'CREATE_TICKET'])]);
 
     const ai = { generate: vi.fn().mockRejectedValue(new Error('Categorize failed')) };
     const ticketCreatedQueue = makeMockQueue();
@@ -728,7 +735,7 @@ describe('ingestion-engine: step error accumulation', () => {
 
   it('continues to CREATE_TICKET after both CATEGORIZE and TRIAGE_PRIORITY fail', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE', 'TRIAGE_PRIORITY', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE', 'TRIAGE_PRIORITY', 'CREATE_TICKET'])]);
 
     let callCount = 0;
     const ai = {
@@ -778,7 +785,7 @@ describe('ingestion-engine: safeTracker proxy', () => {
         update: vi.fn().mockResolvedValue({}),
       },
     });
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CREATE_TICKET'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -812,7 +819,7 @@ describe('ingestion-engine: safeTracker proxy', () => {
         update: vi.fn().mockResolvedValue({}),
       },
     });
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CREATE_TICKET'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -843,13 +850,17 @@ describe('ingestion-engine: safeTracker proxy', () => {
 // ---------------------------------------------------------------------------
 
 describe('ingestion-engine: zero-step route fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('falls back to built-in default pipeline when all DB routes have zero steps', async () => {
     // The route resolution logic skips routes with zero active steps and falls
     // through to null, causing the engine to use the built-in default pipeline.
     // This is the designed behavior: a zero-step route is not usable.
     const db = makeMockDb();
     // All 4 DB queries return a zero-step route → resolveIngestionRoute returns null
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute([]));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute([])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -878,7 +889,7 @@ describe('ingestion-engine: zero-step route fallback', () => {
   it('no DB route and no-route mock → uses built-in default', async () => {
     const db = makeMockDb();
     // All DB queries return null → route falls back to built-in default
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -903,6 +914,138 @@ describe('ingestion-engine: zero-step route fallback', () => {
     // Default pipeline includes CREATE_TICKET
     expect(db.ticket.create).toHaveBeenCalled();
   });
+
+  it('emits WARN with the route id when a route has zero active steps', async () => {
+    const db = makeMockDb();
+    const emptyRoute = { ...makeRoute([]), id: 'empty-route-xyz', name: 'Empty Route' };
+    // All four tier queries return the same empty route → cascade exhausts to null
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([emptyRoute]);
+
+    const ai = makeMockAI('GENERAL');
+    const ticketCreatedQueue = makeMockQueue();
+
+    const processor = createIngestionProcessor({
+      db,
+      ai: ai as never,
+      mailer: null,
+      ticketCreatedQueue: ticketCreatedQueue as never,
+      senderSignature: 'Test',
+      smtpFrom: 'test@example.com',
+    });
+
+    await processor(makeJob({
+      source: TicketSource.MANUAL,
+      clientId: 'client-1',
+      payload: { description: 'Something' },
+    }) as never);
+
+    // WARN should have been emitted for each tier the empty route appeared in.
+    // The mocked findMany returns the empty route on every tier query (4 total),
+    // so we expect at least one WARN call referencing the route id.
+    const warnCalls = (mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const matchingCalls = warnCalls.filter((call) => {
+      const ctx = call[0] as { routeId?: string } | undefined;
+      const msg = call[1] as string | undefined;
+      return ctx?.routeId === 'empty-route-xyz' && typeof msg === 'string' && msg.includes('no active steps');
+    });
+    expect(matchingCalls.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Within-tier preference: a non-empty route should win over an empty one with
+// a lower sortOrder in the same tier (no shadowing).
+// ---------------------------------------------------------------------------
+
+describe('ingestion-engine: within-tier non-empty route preference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects the non-empty route from a tier even when an empty route comes first', async () => {
+    const db = makeMockDb();
+    const emptyRoute = { ...makeRoute([]), id: 'empty-1', name: 'Empty', sortOrder: 1 };
+    const workingRoute = {
+      ...makeRoute(['CREATE_TICKET']),
+      id: 'working-1',
+      name: 'Working',
+      sortOrder: 2,
+    };
+
+    // First (client+source) tier returns both; the resolver should skip the
+    // empty one and pick the working one — no fallthrough to later tiers.
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([emptyRoute, workingRoute]);
+
+    const ai = makeMockAI('GENERAL');
+    const ticketCreatedQueue = makeMockQueue();
+
+    const processor = createIngestionProcessor({
+      db,
+      ai: ai as never,
+      mailer: null,
+      ticketCreatedQueue: ticketCreatedQueue as never,
+      senderSignature: 'Test',
+      smtpFrom: 'test@example.com',
+    });
+
+    await processor(makeJob({
+      source: TicketSource.MANUAL,
+      clientId: 'client-1',
+      payload: { description: 'Something' },
+    }) as never);
+
+    // Ticket created via the working route's CREATE_TICKET step
+    expect(db.ticket.create).toHaveBeenCalled();
+
+    // Only one tier was queried (we returned a non-empty match) so there's
+    // exactly one findMany call.
+    expect(db.ticketRoute.findMany as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+
+    // WARN should fire for the empty route that was skipped within the tier
+    const warnCalls = (mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const skipWarn = warnCalls.find((call) => {
+      const ctx = call[0] as { routeId?: string } | undefined;
+      return ctx?.routeId === 'empty-1';
+    });
+    expect(skipWarn).toBeDefined();
+  });
+
+  it('does not emit a WARN when the only route in a tier is non-empty', async () => {
+    const db = makeMockDb();
+    const workingRoute = makeRoute(['CREATE_TICKET']);
+
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([workingRoute]);
+
+    const ai = makeMockAI('GENERAL');
+    const ticketCreatedQueue = makeMockQueue();
+
+    const processor = createIngestionProcessor({
+      db,
+      ai: ai as never,
+      mailer: null,
+      ticketCreatedQueue: ticketCreatedQueue as never,
+      senderSignature: 'Test',
+      smtpFrom: 'test@example.com',
+    });
+
+    await processor(makeJob({
+      source: TicketSource.MANUAL,
+      clientId: 'client-1',
+      payload: { description: 'Something' },
+    }) as never);
+
+    expect(db.ticket.create).toHaveBeenCalled();
+
+    // No empty route → no WARN about empty active steps
+    const warnCalls = (mockLogger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const emptyWarn = warnCalls.find((call) => {
+      const msg = call[1] as string | undefined;
+      return typeof msg === 'string' && msg.includes('no active steps');
+    });
+    expect(emptyWarn).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -912,7 +1055,7 @@ describe('ingestion-engine: zero-step route fallback', () => {
 describe('ingestion-engine: unknown step type', () => {
   it('skips unknown step type without throwing', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['UNKNOWN_FUTURE_STEP_TYPE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['UNKNOWN_FUTURE_STEP_TYPE', 'CREATE_TICKET'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -980,7 +1123,7 @@ describe('ingestion-engine: ADD_FOLLOWER step', () => {
   it('skips ADD_FOLLOWER when no ticket has been created', async () => {
     const db = makeMockDb();
     // Route with ADD_FOLLOWER first (no CREATE_TICKET before it)
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['ADD_FOLLOWER']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['ADD_FOLLOWER'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -1005,22 +1148,8 @@ describe('ingestion-engine: ADD_FOLLOWER step', () => {
 
   it('adds follower by email after CREATE_TICKET', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
-      makeRoute(['CREATE_TICKET', 'ADD_FOLLOWER']),
-    );
-
-    // Patch step config for ADD_FOLLOWER
-    const route = (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mock.results[0]?.value;
-    if (route) {
-      const addFollowerStep = route.steps.find((s: { stepType: string }) => s.stepType === 'ADD_FOLLOWER');
-      if (addFollowerStep) {
-        addFollowerStep.config = { email: 'follower@example.com', followerType: 'FOLLOWER' };
-      }
-    }
-
-    // The route mock is evaluated lazily (mockResolvedValue stores the value, not a ref)
-    // Re-declare to include config:
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+    // Explicit route with config on the ADD_FOLLOWER step
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([{
       id: 'route-1',
       name: 'Test Route',
       description: null,
@@ -1037,7 +1166,7 @@ describe('ingestion-engine: ADD_FOLLOWER step', () => {
         { id: 'step-0', stepOrder: 1, name: 'CREATE_TICKET', stepType: 'CREATE_TICKET', taskTypeOverride: null, promptKeyOverride: null, config: null, isActive: true },
         { id: 'step-1', stepOrder: 2, name: 'ADD_FOLLOWER', stepType: 'ADD_FOLLOWER', taskTypeOverride: null, promptKeyOverride: null, config: { email: 'follower@example.com', followerType: 'FOLLOWER' }, isActive: true },
       ],
-    });
+    }]);
 
     (db.person.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'person-1' });
 
@@ -1077,7 +1206,7 @@ describe('ingestion-engine: ADD_FOLLOWER step', () => {
 describe('ingestion-engine: context accumulation', () => {
   it('uses summary from SUMMARIZE_EMAIL in CATEGORIZE prompt', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['SUMMARIZE_EMAIL', 'CATEGORIZE', 'CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['SUMMARIZE_EMAIL', 'CATEGORIZE', 'CREATE_TICKET'])]);
 
     let callOrder: string[] = [];
     const ai = {
@@ -1130,7 +1259,7 @@ describe('ingestion-engine: context accumulation', () => {
 describe('ingestion-engine: ticket-created queue enqueue', () => {
   it('adds to ticketCreatedQueue after successful ticket creation', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CREATE_TICKET']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CREATE_TICKET'])]);
 
     const ai = makeMockAI('GENERAL');
     const ticketCreatedQueue = makeMockQueue();
@@ -1159,7 +1288,7 @@ describe('ingestion-engine: ticket-created queue enqueue', () => {
 
   it('does NOT add to ticketCreatedQueue when no CREATE_TICKET step', async () => {
     const db = makeMockDb();
-    (db.ticketRoute.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeRoute(['CATEGORIZE']));
+    (db.ticketRoute.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeRoute(['CATEGORIZE'])]);
 
     const ai = makeMockAI('BUG_FIX');
     const ticketCreatedQueue = makeMockQueue();

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -160,6 +160,23 @@ async function resolveIngestionRoute(
     steps: { where: { isActive: true }, orderBy: { stepOrder: 'asc' as const } },
   };
 
+  // Helper: emit a WARN when a route row matched but has zero active steps so operators
+  // can distinguish "no route configured" (silent fallthrough) from "operator built an
+  // empty route" (likely a mass-deactivation accident). Behavior is unchanged — we still
+  // continue the resolution cascade and ultimately fall through to the default pipeline
+  // — but the empty route is now observable in the run trace.
+  const warnIfEmpty = (
+    route: { id: string; name: string; steps: unknown[] } | null,
+    tier: string,
+  ): void => {
+    if (route && route.steps.length === 0) {
+      logger.warn(
+        { routeId: route.id, routeName: route.name, tier, source, clientId },
+        `route ${route.id} (${route.name}) has no active steps — falling through to default ingestion pipeline`,
+      );
+    }
+  };
+
   // 1. Client-specific + source-specific
   const clientSourceRoute = await db.ticketRoute.findFirst({
     where: { routeType: 'INGESTION', clientId, source, isActive: true } as never,
@@ -167,6 +184,7 @@ async function resolveIngestionRoute(
     orderBy: { sortOrder: 'asc' },
   });
   if (clientSourceRoute && clientSourceRoute.steps.length > 0) return clientSourceRoute as ResolvedRoute;
+  warnIfEmpty(clientSourceRoute, 'client+source');
 
   // 2. Client-specific + any-source
   const clientAnyRoute = await db.ticketRoute.findFirst({
@@ -175,6 +193,7 @@ async function resolveIngestionRoute(
     orderBy: { sortOrder: 'asc' },
   });
   if (clientAnyRoute && clientAnyRoute.steps.length > 0) return clientAnyRoute as ResolvedRoute;
+  warnIfEmpty(clientAnyRoute, 'client+any');
 
   // 3. Global + source-specific
   const globalSourceRoute = await db.ticketRoute.findFirst({
@@ -183,6 +202,7 @@ async function resolveIngestionRoute(
     orderBy: { sortOrder: 'asc' },
   });
   if (globalSourceRoute && globalSourceRoute.steps.length > 0) return globalSourceRoute as ResolvedRoute;
+  warnIfEmpty(globalSourceRoute, 'global+source');
 
   // 4. Global + any-source
   const globalAnyRoute = await db.ticketRoute.findFirst({
@@ -191,6 +211,7 @@ async function resolveIngestionRoute(
     orderBy: { sortOrder: 'asc' },
   });
   if (globalAnyRoute && globalAnyRoute.steps.length > 0) return globalAnyRoute as ResolvedRoute;
+  warnIfEmpty(globalAnyRoute, 'global+any');
 
   return null;
 }

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -160,58 +160,65 @@ async function resolveIngestionRoute(
     steps: { where: { isActive: true }, orderBy: { stepOrder: 'asc' as const } },
   };
 
-  // Helper: emit a WARN when a route row matched but has zero active steps so operators
-  // can distinguish "no route configured" (silent fallthrough) from "operator built an
-  // empty route" (likely a mass-deactivation accident). Behavior is unchanged — we still
-  // continue the resolution cascade and ultimately fall through to the default pipeline
-  // — but the empty route is now observable in the run trace.
-  const warnIfEmpty = (
-    route: { id: string; name: string; steps: unknown[] } | null,
+  // Pick the first route within a tier whose active-step count is > 0. Empty routes
+  // (zero active steps) are skipped so they don't shadow a later non-empty match
+  // within the same tier (e.g. a sortOrder=1 empty route would otherwise hide a
+  // sortOrder=2 working route). Each empty route encountered emits a WARN so
+  // operators can distinguish "no route configured" (silent cascade) from
+  // "operator built an empty route" (likely a mass-deactivation accident).
+  // Behavior on the chosen-route path is unchanged — only the shadowing edge case
+  // and observability are improved.
+  const pickFromTier = async (
+    where: Record<string, unknown>,
     tier: string,
-  ): void => {
-    if (route && route.steps.length === 0) {
-      logger.warn(
-        { routeId: route.id, routeName: route.name, tier, source, clientId },
-        `route ${route.id} (${route.name}) has no active steps — falling through to default ingestion pipeline`,
-      );
+  ): Promise<ResolvedRoute | null> => {
+    const routes = await db.ticketRoute.findMany({
+      where: where as never,
+      include: includeSteps,
+      orderBy: { sortOrder: 'asc' },
+    });
+    let chosen: ResolvedRoute | null = null;
+    for (const route of routes) {
+      if (route.steps.length === 0) {
+        logger.warn(
+          { routeId: route.id, routeName: route.name, tier, source, clientId },
+          `route ${route.id} (${route.name}) has no active steps — skipping to next route in route resolution cascade`,
+        );
+        continue;
+      }
+      chosen = route as ResolvedRoute;
+      break;
     }
+    return chosen;
   };
 
   // 1. Client-specific + source-specific
-  const clientSourceRoute = await db.ticketRoute.findFirst({
-    where: { routeType: 'INGESTION', clientId, source, isActive: true } as never,
-    include: includeSteps,
-    orderBy: { sortOrder: 'asc' },
-  });
-  if (clientSourceRoute && clientSourceRoute.steps.length > 0) return clientSourceRoute as ResolvedRoute;
-  warnIfEmpty(clientSourceRoute, 'client+source');
+  const clientSourceRoute = await pickFromTier(
+    { routeType: 'INGESTION', clientId, source, isActive: true },
+    'client+source',
+  );
+  if (clientSourceRoute) return clientSourceRoute;
 
   // 2. Client-specific + any-source
-  const clientAnyRoute = await db.ticketRoute.findFirst({
-    where: { routeType: 'INGESTION', clientId, source: null, isActive: true } as never,
-    include: includeSteps,
-    orderBy: { sortOrder: 'asc' },
-  });
-  if (clientAnyRoute && clientAnyRoute.steps.length > 0) return clientAnyRoute as ResolvedRoute;
-  warnIfEmpty(clientAnyRoute, 'client+any');
+  const clientAnyRoute = await pickFromTier(
+    { routeType: 'INGESTION', clientId, source: null, isActive: true },
+    'client+any',
+  );
+  if (clientAnyRoute) return clientAnyRoute;
 
   // 3. Global + source-specific
-  const globalSourceRoute = await db.ticketRoute.findFirst({
-    where: { routeType: 'INGESTION', clientId: null, source, isActive: true } as never,
-    include: includeSteps,
-    orderBy: { sortOrder: 'asc' },
-  });
-  if (globalSourceRoute && globalSourceRoute.steps.length > 0) return globalSourceRoute as ResolvedRoute;
-  warnIfEmpty(globalSourceRoute, 'global+source');
+  const globalSourceRoute = await pickFromTier(
+    { routeType: 'INGESTION', clientId: null, source, isActive: true },
+    'global+source',
+  );
+  if (globalSourceRoute) return globalSourceRoute;
 
   // 4. Global + any-source
-  const globalAnyRoute = await db.ticketRoute.findFirst({
-    where: { routeType: 'INGESTION', clientId: null, source: null, isActive: true } as never,
-    include: includeSteps,
-    orderBy: { sortOrder: 'asc' },
-  });
-  if (globalAnyRoute && globalAnyRoute.steps.length > 0) return globalAnyRoute as ResolvedRoute;
-  warnIfEmpty(globalAnyRoute, 'global+any');
+  const globalAnyRoute = await pickFromTier(
+    { routeType: 'INGESTION', clientId: null, source: null, isActive: true },
+    'global+any',
+  );
+  if (globalAnyRoute) return globalAnyRoute;
 
   return null;
 }

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -1018,8 +1018,43 @@ async function executeIngestionPipeline(
         break;
       }
 
+      // Known route step types that are valid in the analysis phase but have
+      // no ingestion-phase implementation. Operators wire these into routes
+      // expecting them to do something here; surface the skip so it's visible
+      // in WARN logs and in ingestion_run_steps history rather than failing
+      // silently. Implementing the actual handlers is a separate scope (#430).
+      case RouteStepType.LOAD_CLIENT_CONTEXT:
+      case RouteStepType.LOAD_ENVIRONMENT_CONTEXT:
+      case RouteStepType.DISPATCH_TO_ROUTE:
+      case RouteStepType.NOTIFY_OPERATOR: {
+        logger.warn(
+          {
+            stepType: step.stepType,
+            stepName: step.name,
+            clientId,
+            ticketId: ctx.ticketId,
+            routeId: route!.id,
+            routeName: route!.name,
+          },
+          'Step skipped — not implemented in ingestion phase',
+        );
+        await safeTracker.skipStep(stepId, `Step skipped — ${step.stepType} not implemented in ingestion phase`);
+        stepsSkipped++;
+        break;
+      }
+
       default:
-        logger.warn({ stepType: step.stepType, clientId }, `Unknown ingestion step type: ${step.stepType} — skipping`);
+        logger.warn(
+          {
+            stepType: step.stepType,
+            stepName: step.name,
+            clientId,
+            ticketId: ctx.ticketId,
+            routeId: route!.id,
+            routeName: route!.name,
+          },
+          `Unknown ingestion step type: ${step.stepType} — skipping`,
+        );
         await safeTracker.skipStep(stepId, `Unknown step type: ${step.stepType}`);
         stepsSkipped++;
         break;

--- a/services/ticket-analyzer/src/route-dispatcher.ts
+++ b/services/ticket-analyzer/src/route-dispatcher.ts
@@ -67,16 +67,26 @@ export function createRouteDispatcher(deps: {
     // Job ID strategy (#375):
     //   - Initial ticket-created dispatch uses the deterministic `analysis-<ticketId>`
     //     ID so a burst of duplicate ticket-created events collapses to one job.
-    //   - Retries (operator-clicked Retry Analysis) use `reanalysis-<ticketId>-<ts>`
-    //     so every click produces a unique job and is not silently deduped against
-    //     the completed initial run. The timestamp also makes retries easy to count
-    //     in Redis telemetry.
+    //   - Retries (operator-clicked Retry Analysis) use `reanalysis-<ticketId>-<key>`
+    //     where <key> is derived from the OUTER ticket-created job. Every operator
+    //     click produces a fresh outer job (the reanalyze API endpoint timestamps
+    //     the outer jobId), so each click maps to a unique inner analysis job; but
+    //     if BullMQ retries or stalls and reprocesses the SAME outer job, the inner
+    //     jobId stays stable and dedupes correctly.
+    //
+    //   #380 thread 2: Was previously `Date.now()`. That was wrong — Date.now()
+    //   inside a BullMQ processor regenerates on every retry of the outer job,
+    //   spawning a new inner analysis job per retry attempt. job.id is stable
+    //   across retries; job.timestamp is the fallback for the unlikely case where
+    //   job.id is missing (BullMQ always assigns one, but the type is `string |
+    //   undefined`).
     //
     // `removeOnComplete` ages completed jobs out of Redis after 1 hour so the
     // initial-run ID can be reused if the pipeline genuinely needs to rerun later
     // (defence-in-depth against the same dedupe-on-completed failure class).
+    const reanalysisJobKey = String(job.id ?? job.timestamp);
     const analysisJobId = reanalysis === true
-      ? `reanalysis-${ticketId}-${Date.now()}`
+      ? `reanalysis-${ticketId}-${reanalysisJobKey}`
       : `analysis-${ticketId}`;
 
     const enqueuedJob = await deps.analysisQueue.add('analyze-ticket', {


### PR DESCRIPTION
## v0.2.9 release

6 PRs since v0.2.8. Theme: bug fixes + correctness improvements + ticket-detail UX overhaul + CI guardrail to prevent the v0.2.7 deploy-failure pattern from recurring.

## Highlights

### Ticket-detail UX overhaul (#454)

Mobile-first redesign of the ticket-detail page header:
- Three full-width Priority/Status/Category dropdowns → compact inline pills (priority + status badge + category chip)
- Pencil icon opens a small edit dialog with the dropdowns (reuses the existing `ticket-quick-actions` component, so save/validate logic is unchanged)
- New manual-refresh icon next to the pencil — re-fetches via `forkJoin` and restores `scrollY` inside `requestAnimationFrame` after all loads land (no scroll jump)
- Header block is `position: sticky; top: 0` with conditional bottom shadow (IntersectionObserver sentinel — only paints when actually scrolled)
- Re-run Analysis moved off the floating bottom-left position into the Resolution tab where it belongs
- Status badge extended to handle all 6 API statuses (NEW, OPEN, IN_PROGRESS, WAITING, RESOLVED, CLOSED) with normalized casing
- Conversation tab now refreshes on manual reload (was guarded by a one-time-load flag)
- Removed duplicate success toast on save (child component already toasts)

### Probe `toolParams` editing restored (#449)

Two-layer bug: backend explicitly rejected `toolParams` updates with HTTP 400; frontend never even sent them on update — silent drop with misleading success toast. Now: `toolParams` round-trips on PATCH; `toolName` remains immutable. Empty-string clearing on numeric params correctly deletes the key (was coercing to `0`).

User impact: operators can now change a probe's lookback window (e.g. `hours: 24` → `hours: 48`) via the UI.

### Ingestion route resolution clarity (#450 / #431, #451 / #430)

- `services/ticket-analyzer/src/ingestion-engine.ts`: a route with zero active steps no longer silently shadows non-empty routes within the same tier. Resolution now iterates `findMany` per tier ordered by `sortOrder` and prefers the first non-empty route. Empty matches log a WARN with route id + tier.
- Four registered step types (LOAD_CLIENT_CONTEXT, LOAD_ENVIRONMENT_CONTEXT, DISPATCH_TO_ROUTE, NOTIFY_OPERATOR) that previously hit the default case now have explicit cases that emit a WARN log + `tracker.skipStep` entry on `ingestion_run_steps`. Operators see "Step skipped — not implemented in ingestion phase" in the run trace instead of silent success.
- 7 new unit tests cover both behaviors.

### Retry-analysis correctness (#452 / #380 threads 1+2)

- `/api/tickets/:id/reanalyze` no longer leaves the ticket stuck in `PENDING` if `queue.add()` throws. Status revert is now `updateMany({ where: { id, analysisStatus: 'PENDING' } })` so a concurrent COMPLETED/FAILED write from a real analysis can't be clobbered.
- `route-dispatcher.ts` no longer uses `Date.now()` inside the BullMQ processor — replaced with `String(job.id ?? job.timestamp)` so outer-job retries don't generate fresh jobIds and break dedupe.
- Threads 3 & 4 (unbounded `getJobs` scan) deferred to a separate scope.

### Migration-edit CI guardrail (#453 / #447)

The v0.2.7 deploy crash (Prisma checksum mismatch from editing an already-applied migration) is now caught at PR time. New `.github/workflows/migration-guard.yml` runs on PRs targeting `staging`, diffs `origin/master...HEAD` for `packages/db/prisma/migrations/*/migration.sql`, and fails on any non-Added change with a clear error message pointing at the rule. Standalone workflow file so the existing `check` job stays push-only and isn't double-run.

CLAUDE.md gets a new "Migration Discipline (CRITICAL)" section codifying the rule.

## Migration

None this release. Schema and migrations are unchanged.

## Pre-deploy requirements

None. No new env vars; no schema changes; no docker-compose changes.

## Test plan (post-deploy)

- [ ] Hugo health: all 16 services healthy
- [ ] copilot-api `/api/health` reports `version: v0.2.9`
- [ ] Open any ticket → header shows pills + pencil + refresh; sticky on scroll; refresh preserves scroll position
- [ ] Edit a probe's `toolParams` (e.g. deadlock probe `hours: 24` → `48`) → save round-trips correctly; clearing a numeric param removes the key (no `0` persisted)
- [ ] Create a route with zero active steps → ingestion logs WARN with route id + tier (no silent default fallthrough within the tier)
- [ ] Trigger reanalyze on a ticket → status moves PENDING → analyzed correctly; if queue.add fails, status reverts cleanly
- [ ] Open a future PR that edits an existing migration file → CI fails on `migration-edit-guard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
