### PR TITLE
feat(analysis): artifact schema metadata + structured Attachments block in agentic prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,18 @@ All four tools run inside `withTicketLock` (Postgres advisory transaction lock o
 - `composeFinalAnalysis(knowledgeDoc, sectionMeta, agentExecutiveSummary)` merges the agent's executive summary with Problem Statement / Root Cause / Recommended Fix / Risks pulled from the doc — that composed text is what lands in the `AI_ANALYSIS` ticket event and email.
 - After each iteration (and at run end) the orchestrator writes a `KnowledgeDocSnapshot` row capturing the doc + sidecar, so future iteration-diff views have ground truth per iteration.
 
+## Artifact Attachments and Schema (v2 Agentic Prompt)
+
+The v2 agentic prompt (orchestrated-v2 + flat-v2) renders a structured `## Attachments` block that surfaces every `Artifact` row attached to the ticket — probe results, MCP tool results, email attachments, operator uploads. Each entry shows kind, displayName, size, `artifact_id`, optional description, and a one-line schema preview, plus tool hints for fetching content. The block sits right after ticket metadata + body so the strategist sees the catalog before any other context.
+
+Artifact content is NEVER inlined into the prompt body. Phase 4's Haiku description stays in `emailBody` (for probe-sourced tickets); the agent uses `platform__read_tool_result_artifact(artifactId, …)` to read full content or `platform__query_artifact(artifact_id, path)` to pull surgical slices via JSONPath / XPath / CSV column.
+
+Schema is sourced from two tiers, stored on `Artifact.schemaJson` (additive nullable column):
+1. **`mcp_provided`** — the producing MCP tool emits a top-level `_schema` field in its response envelope. Adopted as-is via `adoptMcpSchema()`.
+2. **`head_tail_infer`** — best-effort inference at save time from the artifact's leading 2 KB and trailing 0.5 KB via `inferSchemaFromHeadTail()` in `packages/shared-utils/src/artifact-schema.ts`. Detects JSON object/array, XML, CSV, or text. Always marked `partial: true` when source bytes were truncated.
+
+v1 paths (`flat-v1`, `orchestrated-v1`) do NOT render the attachments block — they remain at pre-#300 fidelity. EXTRACT_FACTS / SUMMARIZE / CATEGORIZE / TRIAGE prompts are also unchanged; only the agentic step gets the new context shape.
+
 ## Ticket Route Step Types
 
 Ticket routes define configurable analysis pipelines executed when tickets are processed. Each route consists of ordered steps, each performing a specific processing function.

--- a/mcp-servers/platform/package.json
+++ b/mcp-servers/platform/package.json
@@ -17,8 +17,11 @@
     "@bronco/db": "workspace:*",
     "@bronco/shared-types": "workspace:*",
     "@bronco/shared-utils": "workspace:*",
+    "@xmldom/xmldom": "^0.8.10",
     "bullmq": "^5.0.0",
     "express": "^4.21.0",
+    "jsonpath-plus": "^10.2.0",
+    "xpath": "^0.0.34",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/mcp-servers/platform/src/auth/caller-registry.ts
+++ b/mcp-servers/platform/src/auth/caller-registry.ts
@@ -41,6 +41,7 @@ export const CALLER_ALLOWLIST: Record<string, Set<string> | typeof ALLOW_ALL> = 
   'ticket-analyzer': new Set([
     // Artifact / tool result access
     'read_tool_result_artifact',
+    'query_artifact',
     // Knowledge-doc tools (agentic analysis writes to these)
     'kd_read_toc',
     'kd_read_section',

--- a/mcp-servers/platform/src/tools/index.ts
+++ b/mcp-servers/platform/src/tools/index.ts
@@ -17,6 +17,7 @@ import { registerSystemStatusTools } from './system-status.js';
 import { registerSlackConversationTools } from './slack-conversations.js';
 import { registerUserTools } from './users.js';
 import { registerArtifactTools } from './read-tool-result-artifact.js';
+import { registerQueryArtifactTool } from './query-artifact.js';
 import { registerRequestToolTool } from './request-tool.js';
 import { registerToolRequestTools } from './tool-requests.js';
 import { registerKnowledgeDocTools } from './knowledge-doc.js';
@@ -107,6 +108,7 @@ export function registerAllTools(server: McpServer, deps: ServerDeps): void {
   registerSystemStatusTools(guardedServer, deps);
   registerSlackConversationTools(guardedServer, deps);
   registerArtifactTools(guardedServer, deps);
+  registerQueryArtifactTool(guardedServer, deps);
   registerRequestToolTool(guardedServer, deps);
   registerToolRequestTools(guardedServer, deps);
   registerKnowledgeDocTools(guardedServer, deps);

--- a/mcp-servers/platform/src/tools/query-artifact.ts
+++ b/mcp-servers/platform/src/tools/query-artifact.ts
@@ -1,0 +1,201 @@
+import { readFile } from 'node:fs/promises';
+import { relative, resolve } from 'node:path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { JSONPath } from 'jsonpath-plus';
+import { DOMParser } from '@xmldom/xmldom';
+import xpath from 'xpath';
+import type { ServerDeps } from '../server.js';
+
+/** Cap response payload to bound prompt size. Same convention as read_tool_result_artifact. */
+const MAX_RESPONSE_BYTES = 50 * 1024;
+
+type Format = 'json' | 'xml' | 'csv';
+
+function detectFormat(mimeType: string | null, content: string): Format | null {
+  const mt = (mimeType ?? '').toLowerCase();
+  if (mt.includes('json')) return 'json';
+  if (mt.includes('xml')) return 'xml';
+  if (mt.includes('csv')) return 'csv';
+  // Fallback to content sniff.
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
+  if (trimmed.startsWith('<')) return 'xml';
+  if (trimmed.includes(',') && !trimmed.startsWith('<') && !trimmed.startsWith('{')) return 'csv';
+  return null;
+}
+
+function truncatePayload(text: string): { text: string; truncated: boolean } {
+  if (Buffer.byteLength(text, 'utf-8') <= MAX_RESPONSE_BYTES) {
+    return { text, truncated: false };
+  }
+  // Slice by char count then append marker. Char ≤ byte.
+  const slice = text.slice(0, MAX_RESPONSE_BYTES);
+  return { text: slice, truncated: true };
+}
+
+/** Parse CSV row, respecting double-quoted fields. */
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQ) {
+      if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; continue; }
+      if (ch === '"') { inQ = false; continue; }
+      cur += ch;
+      continue;
+    }
+    if (ch === '"') { inQ = true; continue; }
+    if (ch === ',') { out.push(cur); cur = ''; continue; }
+    cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+export function registerQueryArtifactTool(server: McpServer, { db, config }: ServerDeps): void {
+  server.tool(
+    'query_artifact',
+    'Run a path query against an artifact and return matching slices. Use to pull surgical pieces of structured data (JSON, XML, CSV) without reading the whole file. JSON: JSONPath ($.x.y or $.items[*].name). XML: XPath (/root/elem). CSV: column name to return that column, or @N for row index N.',
+    {
+      artifact_id: z.string().uuid().describe('The artifact ID to query'),
+      path: z.string().describe('JSONPath ($.x.y) for JSON, XPath (/root/elem) for XML, header column name (or @N for row N) for CSV'),
+      format: z.enum(['json', 'xml', 'csv']).optional().describe('Override format auto-detection (otherwise inferred from artifact mimeType + content)'),
+    },
+    async (params) => {
+      // Resolve artifact + scope.
+      const artifact = await db.artifact.findUnique({ where: { id: params.artifact_id } });
+      if (!artifact) {
+        return { content: [{ type: 'text', text: 'ERROR: artifact not found' }], isError: true };
+      }
+
+      // Defense-in-depth path validation (matches read_tool_result_artifact).
+      const resolvedStorage = resolve(config.ARTIFACT_STORAGE_PATH);
+      const absPath = resolve(resolvedStorage, artifact.storagePath);
+      const rel = relative(resolvedStorage, absPath);
+      if (rel.startsWith('..') || rel === '' || rel.startsWith('/')) {
+        return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
+      }
+
+      let content: string;
+      try {
+        const buf = await readFile(absPath);
+        content = buf.toString('utf-8');
+      } catch {
+        return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
+      }
+
+      const fmt: Format | null = params.format ?? detectFormat(artifact.mimeType, content);
+      if (!fmt) {
+        return {
+          content: [{ type: 'text', text: 'ERROR: could not determine artifact format. Pass `format` explicitly (json|xml|csv).' }],
+          isError: true,
+        };
+      }
+
+      try {
+        if (fmt === 'json') {
+          let json: unknown;
+          try {
+            json = JSON.parse(content);
+          } catch (err) {
+            return {
+              content: [{ type: 'text', text: `ERROR: artifact is not valid JSON: ${err instanceof Error ? err.message : String(err)}` }],
+              isError: true,
+            };
+          }
+          const matches = JSONPath({ path: params.path, json: json as object });
+          const rendered = JSON.stringify(matches, null, 2);
+          const { text, truncated } = truncatePayload(rendered);
+          const footer = `\n\n[matched ${Array.isArray(matches) ? matches.length : 0} value(s)${truncated ? `; payload truncated to ${MAX_RESPONSE_BYTES} bytes` : ''}]`;
+          return { content: [{ type: 'text', text: `${text}${footer}` }] };
+        }
+
+        if (fmt === 'xml') {
+          let doc: Document;
+          try {
+            doc = new DOMParser().parseFromString(content, 'application/xml') as unknown as Document;
+          } catch (err) {
+            return {
+              content: [{ type: 'text', text: `ERROR: artifact is not valid XML: ${err instanceof Error ? err.message : String(err)}` }],
+              isError: true,
+            };
+          }
+          // xpath.select returns either a node[] (default) or an Attr[] / string / number / boolean
+          // depending on the expression. Coerce to string output.
+          let result: unknown;
+          try {
+            result = xpath.select(params.path, doc as unknown as Node);
+          } catch (err) {
+            return {
+              content: [{ type: 'text', text: `ERROR: invalid XPath expression: ${err instanceof Error ? err.message : String(err)}` }],
+              isError: true,
+            };
+          }
+          let rendered: string;
+          let count = 0;
+          if (Array.isArray(result)) {
+            count = result.length;
+            rendered = result
+              .map((n) => {
+                if (n && typeof n === 'object' && 'toString' in n) return String(n);
+                return String(n);
+              })
+              .join('\n');
+          } else {
+            count = result === null || result === undefined ? 0 : 1;
+            rendered = String(result);
+          }
+          const { text, truncated } = truncatePayload(rendered);
+          const footer = `\n\n[matched ${count} node(s)${truncated ? `; payload truncated to ${MAX_RESPONSE_BYTES} bytes` : ''}]`;
+          return { content: [{ type: 'text', text: `${text}${footer}` }] };
+        }
+
+        // CSV
+        const lines = content.split(/\r?\n/).filter((l) => l.length > 0);
+        if (lines.length === 0) {
+          return { content: [{ type: 'text', text: 'ERROR: artifact has no rows' }], isError: true };
+        }
+        const header = parseCsvLine(lines[0]);
+        // Row-index path: `@N` returns row N (0-indexed, after header).
+        if (params.path.startsWith('@')) {
+          const idx = Number.parseInt(params.path.slice(1), 10);
+          if (!Number.isFinite(idx) || idx < 0 || idx >= lines.length - 1) {
+            return { content: [{ type: 'text', text: `ERROR: row index out of range. CSV has ${lines.length - 1} data rows.` }], isError: true };
+          }
+          const row = parseCsvLine(lines[idx + 1]);
+          const obj: Record<string, string> = {};
+          for (let i = 0; i < header.length; i++) obj[header[i]] = row[i] ?? '';
+          const rendered = JSON.stringify(obj, null, 2);
+          const { text, truncated } = truncatePayload(rendered);
+          const footer = `\n\n[returned row ${idx}${truncated ? `; payload truncated to ${MAX_RESPONSE_BYTES} bytes` : ''}]`;
+          return { content: [{ type: 'text', text: `${text}${footer}` }] };
+        }
+        // Column-name path: return all values for that column.
+        const colIdx = header.indexOf(params.path);
+        if (colIdx < 0) {
+          return {
+            content: [{ type: 'text', text: `ERROR: column "${params.path}" not found. Available: ${header.join(', ')}` }],
+            isError: true,
+          };
+        }
+        const values: string[] = [];
+        for (let i = 1; i < lines.length; i++) {
+          const row = parseCsvLine(lines[i]);
+          values.push(row[colIdx] ?? '');
+        }
+        const rendered = JSON.stringify(values, null, 2);
+        const { text, truncated } = truncatePayload(rendered);
+        const footer = `\n\n[returned ${values.length} value(s) from column "${params.path}"${truncated ? `; payload truncated to ${MAX_RESPONSE_BYTES} bytes` : ''}]`;
+        return { content: [{ type: 'text', text: `${text}${footer}` }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `ERROR: query_artifact failed: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/mcp-servers/platform/src/tools/query-artifact.ts
+++ b/mcp-servers/platform/src/tools/query-artifact.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { open, stat } from 'node:fs/promises';
 import { relative, resolve } from 'node:path';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -9,6 +9,15 @@ import type { ServerDeps } from '../server.js';
 
 /** Cap response payload to bound prompt size. Same convention as read_tool_result_artifact. */
 const MAX_RESPONSE_BYTES = 50 * 1024;
+
+/**
+ * Above this artifact file size, refuse to load into memory. query_artifact must
+ * parse the entire artifact (JSON.parse / DOMParser / CSV split), so unlike
+ * read_tool_result_artifact we cannot stream — we instead bail and tell the agent
+ * to page via read_tool_result_artifact. Mirrors STREAM_THRESHOLD_BYTES on the
+ * sibling tool so the boundary is consistent.
+ */
+const MAX_ARTIFACT_BYTES = 5 * 1024 * 1024;
 
 type Format = 'json' | 'xml' | 'csv';
 
@@ -25,12 +34,22 @@ function detectFormat(mimeType: string | null, content: string): Format | null {
   return null;
 }
 
+/**
+ * Truncate `text` to fit MAX_RESPONSE_BYTES *bytes* of UTF-8. The naive
+ * `text.slice(0, N)` slices by JS code units, but multi-byte UTF-8 chars
+ * can still exceed the byte budget — and slicing mid-character can also
+ * produce a U+FFFD replacement (3 bytes) that bumps the encoded length
+ * over the limit. Walk the trim boundary back until it fits.
+ */
 function truncatePayload(text: string): { text: string; truncated: boolean } {
-  if (Buffer.byteLength(text, 'utf-8') <= MAX_RESPONSE_BYTES) {
-    return { text, truncated: false };
+  const buffer = Buffer.from(text, 'utf-8');
+  if (buffer.length <= MAX_RESPONSE_BYTES) return { text, truncated: false };
+  let end = MAX_RESPONSE_BYTES;
+  let slice = buffer.subarray(0, end).toString('utf-8');
+  while (end > 0 && Buffer.byteLength(slice, 'utf-8') > MAX_RESPONSE_BYTES) {
+    end--;
+    slice = buffer.subarray(0, end).toString('utf-8');
   }
-  // Slice by char count then append marker. Char ≤ byte.
-  const slice = text.slice(0, MAX_RESPONSE_BYTES);
   return { text: slice, truncated: true };
 }
 
@@ -61,14 +80,20 @@ export function registerQueryArtifactTool(server: McpServer, { db, config }: Ser
     'Run a path query against an artifact and return matching slices. Use to pull surgical pieces of structured data (JSON, XML, CSV) without reading the whole file. JSON: JSONPath ($.x.y or $.items[*].name). XML: XPath (/root/elem). CSV: column name to return that column, or @N for row index N.',
     {
       artifact_id: z.string().uuid().describe('The artifact ID to query'),
+      ticketId: z.string().uuid().describe('The active ticket ID (server-injected for auth scope)'),
       path: z.string().describe('JSONPath ($.x.y) for JSON, XPath (/root/elem) for XML, header column name (or @N for row N) for CSV'),
       format: z.enum(['json', 'xml', 'csv']).optional().describe('Override format auto-detection (otherwise inferred from artifact mimeType + content)'),
     },
     async (params) => {
-      // Resolve artifact + scope.
-      const artifact = await db.artifact.findUnique({ where: { id: params.artifact_id } });
+      // Resolve artifact + scope. Use findFirst with ticketId in WHERE so the
+      // ticket scope acts as the auth guard — unscoped artifacts cannot be
+      // reached by a query that supplies any ticketId, and scoped artifacts
+      // for a different ticket return "not found" identically.
+      const artifact = await db.artifact.findFirst({
+        where: { id: params.artifact_id, ticketId: params.ticketId },
+      });
       if (!artifact) {
-        return { content: [{ type: 'text', text: 'ERROR: artifact not found' }], isError: true };
+        return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
       }
 
       // Defense-in-depth path validation (matches read_tool_result_artifact).
@@ -79,10 +104,42 @@ export function registerQueryArtifactTool(server: McpServer, { db, config }: Ser
         return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
       }
 
+      // Guard against pathological large artifacts. query_artifact must parse
+      // the whole file (JSON.parse / DOMParser / CSV split), so we cannot stream
+      // here the way read_tool_result_artifact can. Above the threshold, bail
+      // and direct the agent to page through it via the streaming sibling tool.
+      let fileSize: number;
+      try {
+        const stats = await stat(absPath);
+        fileSize = stats.size;
+      } catch {
+        return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
+      }
+      if (fileSize > MAX_ARTIFACT_BYTES) {
+        const sizeMb = (fileSize / 1024 / 1024).toFixed(1);
+        const limitMb = (MAX_ARTIFACT_BYTES / 1024 / 1024).toFixed(0);
+        return {
+          content: [{
+            type: 'text',
+            text: `ERROR: artifact too large for query_artifact (${sizeMb} MB > ${limitMb} MB threshold). Use platform__read_tool_result_artifact with offset+limit to page through it instead.`,
+          }],
+          isError: true,
+        };
+      }
+
       let content: string;
       try {
-        const buf = await readFile(absPath);
-        content = buf.toString('utf-8');
+        // Bounded positional read — file size is verified <= MAX_ARTIFACT_BYTES above.
+        const handle = await open(absPath, 'r');
+        try {
+          const buf = Buffer.alloc(fileSize);
+          if (fileSize > 0) {
+            await handle.read(buf, 0, fileSize, 0);
+          }
+          content = buf.toString('utf-8');
+        } finally {
+          await handle.close();
+        }
       } catch {
         return { content: [{ type: 'text', text: 'ERROR: artifact not found or not accessible' }], isError: true };
       }

--- a/packages/db/prisma/migrations/20260426000000_add_artifact_schema_json/migration.sql
+++ b/packages/db/prisma/migrations/20260426000000_add_artifact_schema_json/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "artifacts" ADD COLUMN "schema_json" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -469,6 +469,7 @@ model Artifact {
   addedBySystem        String?       @map("added_by_system")
   originatingEventId   String?       @map("originating_event_id")
   originatingEventType String?       @map("originating_event_type")
+  schemaJson           Json?         @map("schema_json")
 
   ticket        Ticket?  @relation(fields: [ticketId], references: [id])
   finding       Finding? @relation(fields: [findingId], references: [id])

--- a/packages/shared-types/src/artifact.ts
+++ b/packages/shared-types/src/artifact.ts
@@ -41,6 +41,9 @@ export interface Artifact {
   addedBySystem: string | null;
   originatingEventId: string | null;
   originatingEventType: string | null;
+  // Inferred or MCP-provided schema (JSONPath-style summary of contents).
+  // Used by the agentic prompt to surface attachment shape without inlining content.
+  schemaJson: Record<string, unknown> | null;
 }
 
 export interface Finding {

--- a/packages/shared-utils/src/artifact-schema.test.ts
+++ b/packages/shared-utils/src/artifact-schema.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for packages/shared-utils/src/artifact-schema.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  inferSchemaFromHeadTail,
+  adoptMcpSchema,
+  formatSchemaForPrompt,
+} from './artifact-schema.js';
+
+describe('inferSchemaFromHeadTail', () => {
+  it('infers a JSON object with top-level keys and types', () => {
+    const head = '{"id": 42, "name": "alpha", "active": true, "ratio": 1.5, "meta": null}';
+    const schema = inferSchemaFromHeadTail(head, '', 'application/json');
+    expect(schema.kind).toBe('json_object');
+    expect(schema.partial).toBe(false);
+    expect(schema.topLevelKeys).toEqual({
+      id: 'int',
+      name: 'string',
+      active: 'boolean',
+      ratio: 'float',
+      meta: 'null',
+    });
+    expect(schema.inferenceSource).toBe('head_tail_infer');
+  });
+
+  it('infers a JSON array with itemCount and item schema', () => {
+    const head = '[{"id":1,"deadlock_time":"2026-04-25T00:00:00Z"},{"id":2,"deadlock_time":"2026-04-25T01:00:00Z"}]';
+    const schema = inferSchemaFromHeadTail(head, '', 'application/json');
+    expect(schema.kind).toBe('json_array');
+    expect(schema.itemCount).toBe(2);
+    expect(schema.itemSchema).toEqual({ id: 'int', deadlock_time: 'string' });
+    expect(schema.partial).toBe(false);
+  });
+
+  it('infers XML with root element and first children', () => {
+    const head = '<?xml version="1.0"?><root><child1>a</child1><child2>b</child2><child3>c</child3></root>';
+    const schema = inferSchemaFromHeadTail(head, '', 'application/xml');
+    expect(schema.kind).toBe('xml');
+    expect(schema.rootElement).toBe('root');
+    expect(schema.firstChildren).toEqual(['child1', 'child2', 'child3']);
+    expect(schema.partial).toBe(true);
+  });
+
+  it('infers CSV with column names', () => {
+    const head = 'id,name,timestamp\n1,alpha,2026-04-25\n2,beta,2026-04-25\n';
+    const schema = inferSchemaFromHeadTail(head, '', 'text/csv');
+    expect(schema.kind).toBe('csv');
+    expect(schema.columns).toEqual(['id', 'name', 'timestamp']);
+    expect(schema.partial).toBe(true);
+  });
+
+  it('falls through to text for plain content', () => {
+    const head = 'just some plain text\nwith two lines\n';
+    const schema = inferSchemaFromHeadTail(head, '', 'text/plain');
+    expect(schema.kind).toBe('text');
+    expect(schema.lineCount).toBeGreaterThan(0);
+    expect(schema.byteCount).toBeGreaterThan(0);
+  });
+
+  it('marks JSON as partial when input is mid-record-truncated', () => {
+    // Truncated mid-object: missing closing `}`. Recovery cuts to last `}` (the inner one).
+    const head = '[{"id":1,"name":"alpha"},{"id":2,"name":"be';
+    const tail = '';
+    const schema = inferSchemaFromHeadTail(head, tail, 'application/json');
+    expect(schema.kind).toBe('json_array');
+    // Should still extract some signal even though parse failed on full input.
+    expect(schema.partial).toBe(true);
+    // itemSchema should at least include keys from the first object.
+    expect(schema.itemSchema).toBeDefined();
+    expect(schema.itemSchema).toHaveProperty('id');
+    expect(schema.itemSchema).toHaveProperty('name');
+  });
+});
+
+describe('adoptMcpSchema', () => {
+  it('adopts a producer-supplied schema and stamps inferenceSource', () => {
+    const schema = adoptMcpSchema({
+      kind: 'json_array',
+      itemCount: 6,
+      itemSchema: { Id: 'int', DeadlockTime: 'string' },
+    });
+    expect(schema.kind).toBe('json_array');
+    expect(schema.itemCount).toBe(6);
+    expect(schema.inferenceSource).toBe('mcp_provided');
+  });
+
+  it('handles non-object input gracefully', () => {
+    const schema = adoptMcpSchema(null);
+    expect(schema.kind).toBe('unknown');
+    expect(schema.inferenceSource).toBe('unknown');
+  });
+});
+
+describe('formatSchemaForPrompt', () => {
+  it('formats a JSON array with item count + item shape', () => {
+    const out = formatSchemaForPrompt({
+      kind: 'json_array',
+      itemCount: 6,
+      itemSchema: { Id: 'int', DeadlockTime: 'string' },
+      inferenceSource: 'mcp_provided',
+    });
+    expect(out).toContain('6 items');
+    expect(out).toContain('Id (int)');
+    expect(out).toContain('DeadlockTime (string)');
+  });
+
+  it('formats a partial JSON object', () => {
+    const out = formatSchemaForPrompt({
+      kind: 'json_object',
+      topLevelKeys: { id: 'int', name: 'string' },
+      partial: true,
+      inferenceSource: 'head_tail_infer',
+    });
+    expect(out).toContain('id (int)');
+    expect(out).toContain('partial');
+  });
+
+  it('formats XML with root + children', () => {
+    const out = formatSchemaForPrompt({
+      kind: 'xml',
+      rootElement: 'ShowPlanXML',
+      firstChildren: ['BatchSequence', 'Statements'],
+      inferenceSource: 'head_tail_infer',
+    });
+    expect(out).toContain('XML <ShowPlanXML>');
+    expect(out).toContain('BatchSequence');
+  });
+
+  it('formats CSV with columns', () => {
+    const out = formatSchemaForPrompt({
+      kind: 'csv',
+      columns: ['id', 'name'],
+      rowCount: 100,
+      inferenceSource: 'head_tail_infer',
+    });
+    expect(out).toContain('CSV');
+    expect(out).toContain('id, name');
+  });
+
+  it('formats text with line + byte counts', () => {
+    const out = formatSchemaForPrompt({
+      kind: 'text',
+      lineCount: 42,
+      byteCount: 1024,
+      inferenceSource: 'head_tail_infer',
+    });
+    expect(out).toContain('42 lines');
+    expect(out).toContain('1024 bytes');
+  });
+});

--- a/packages/shared-utils/src/artifact-schema.ts
+++ b/packages/shared-utils/src/artifact-schema.ts
@@ -1,0 +1,349 @@
+/**
+ * Artifact schema inference.
+ *
+ * Lightweight, best-effort schema/shape inference from an artifact's head + tail bytes.
+ * Used to render the structured `## Attachments` block in the agentic prompt without
+ * inlining content. The agent can then decide whether to call
+ * `platform__read_tool_result_artifact` (full body) or `platform__query_artifact`
+ * (surgical slice) to dig.
+ *
+ * Two tiers:
+ *   1. `mcp_provided` — the producing MCP tool emitted a top-level `_schema` field
+ *      in its envelope. This is the canonical contract; adopt as-is.
+ *   2. `head_tail_infer` — best-effort inference from the artifact's leading + trailing
+ *      bytes. Always partial; never fail (caller logs WARN and falls through).
+ *
+ * No external deps — all parsing is hand-rolled and bounded.
+ */
+
+export interface InferredSchema {
+  kind: 'json_object' | 'json_array' | 'xml' | 'csv' | 'text' | 'unknown';
+  // For json_array
+  itemCount?: number;
+  itemSchema?: Record<string, string>; // keys → coarse type names
+  // For json_object
+  topLevelKeys?: Record<string, string>;
+  // For xml
+  rootElement?: string;
+  firstChildren?: string[];
+  // For csv
+  columns?: string[];
+  rowCount?: number;
+  // For text
+  lineCount?: number;
+  byteCount?: number;
+  // Caveats
+  partial?: boolean; // schema may be incomplete (truncated input, polymorphic items)
+  inferenceSource: 'mcp_provided' | 'head_tail_infer' | 'unknown';
+}
+
+/** Coarse type name for a JS value. */
+function jsTypeName(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  const t = typeof v;
+  if (t === 'number') return Number.isInteger(v as number) ? 'int' : 'float';
+  return t;
+}
+
+/** Try to parse JSON; if it fails, attempt a "trim trailing junk" recovery. */
+function tryParseJson(text: string): { value: unknown; partial: boolean } | null {
+  try {
+    return { value: JSON.parse(text), partial: false };
+  } catch {
+    // Recovery 1: cut to last `}` (object) or `]` (array)
+    const lastBrace = text.lastIndexOf('}');
+    const lastBracket = text.lastIndexOf(']');
+    const cut = Math.max(lastBrace, lastBracket);
+    if (cut > 0) {
+      try {
+        return { value: JSON.parse(text.slice(0, cut + 1)), partial: true };
+      } catch {
+        // fall through
+      }
+    }
+    return null;
+  }
+}
+
+/** Extract top-level keys → type names from a parsed object. */
+function objectKeysToTypes(obj: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = jsTypeName(v);
+  }
+  return out;
+}
+
+/** Find the first `{...}` balanced object substring in text. */
+function extractFirstObject(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inStr = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inStr = true;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/** Count top-level commas in a text fragment of a JSON array (best-effort). */
+function countTopLevelArrayItems(text: string): number | undefined {
+  // Find first `[` and last `]`.
+  const start = text.indexOf('[');
+  const end = text.lastIndexOf(']');
+  if (start < 0 || end <= start) return undefined;
+  const body = text.slice(start + 1, end);
+  let depth = 0;
+  let inStr = false;
+  let escape = false;
+  let commas = 0;
+  let nonWs = false;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (inStr) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inStr = true;
+      nonWs = true;
+      continue;
+    }
+    if (ch === '[' || ch === '{') depth++;
+    else if (ch === ']' || ch === '}') depth--;
+    else if (ch === ',' && depth === 0) {
+      commas++;
+      continue;
+    }
+    if (!/\s/.test(ch)) nonWs = true;
+  }
+  if (!nonWs) return 0;
+  return commas + 1;
+}
+
+/** Adopt a top-level `_schema` field from an MCP tool envelope (tier 1). */
+export function adoptMcpSchema(mcpSchema: unknown): InferredSchema {
+  if (!mcpSchema || typeof mcpSchema !== 'object') {
+    return { kind: 'unknown', inferenceSource: 'unknown' };
+  }
+  const s = mcpSchema as Record<string, unknown>;
+  // Trust the producer; coerce shape if recognizable, else passthrough as object.
+  const kind = typeof s.kind === 'string' ? (s.kind as InferredSchema['kind']) : 'unknown';
+  return {
+    ...(s as Partial<InferredSchema>),
+    kind,
+    inferenceSource: 'mcp_provided',
+  };
+}
+
+/**
+ * Infer a lightweight schema from the head + tail of an artifact.
+ * Never throws — returns `{ kind: 'unknown', inferenceSource: 'unknown' }`
+ * if nothing matches.
+ */
+export function inferSchemaFromHeadTail(
+  head: string,
+  tail: string,
+  mimeType: string | null
+): InferredSchema {
+  const trimmedHead = head.trimStart();
+  const combined = head + tail;
+  const mt = (mimeType ?? '').toLowerCase();
+
+  // ---- JSON detection ----
+  if (trimmedHead.startsWith('{') || mt.includes('json') && trimmedHead.startsWith('{')) {
+    // Object
+    const parsed = tryParseJson(combined) ?? tryParseJson(trimmedHead);
+    if (parsed && parsed.value && typeof parsed.value === 'object' && !Array.isArray(parsed.value)) {
+      return {
+        kind: 'json_object',
+        topLevelKeys: objectKeysToTypes(parsed.value as Record<string, unknown>),
+        partial: parsed.partial,
+        inferenceSource: 'head_tail_infer',
+      };
+    }
+    // Got `{` but couldn't parse — return partial with no keys.
+    return { kind: 'json_object', partial: true, inferenceSource: 'head_tail_infer' };
+  }
+
+  if (trimmedHead.startsWith('[')) {
+    // Array
+    const parsed = tryParseJson(combined);
+    if (parsed && Array.isArray(parsed.value)) {
+      const arr = parsed.value as unknown[];
+      const first = arr.find((x) => x && typeof x === 'object' && !Array.isArray(x)) as
+        | Record<string, unknown>
+        | undefined;
+      const itemSchema = first ? objectKeysToTypes(first) : undefined;
+      return {
+        kind: 'json_array',
+        itemCount: arr.length,
+        itemSchema,
+        partial: parsed.partial,
+        inferenceSource: 'head_tail_infer',
+      };
+    }
+    // Couldn't parse the whole thing — try first object from head, count items via tail.
+    const firstObj = extractFirstObject(trimmedHead);
+    let itemSchema: Record<string, string> | undefined;
+    if (firstObj) {
+      try {
+        const obj = JSON.parse(firstObj) as Record<string, unknown>;
+        itemSchema = objectKeysToTypes(obj);
+      } catch {
+        // ignore
+      }
+    }
+    const itemCount = countTopLevelArrayItems(combined);
+    return {
+      kind: 'json_array',
+      itemSchema,
+      itemCount,
+      partial: true,
+      inferenceSource: 'head_tail_infer',
+    };
+  }
+
+  // ---- XML detection ----
+  if (trimmedHead.startsWith('<?xml') || trimmedHead.startsWith('<') && /^<[a-zA-Z]/.test(trimmedHead)) {
+    // Skip XML preamble if any.
+    let body = trimmedHead;
+    const preambleEnd = body.indexOf('?>');
+    if (body.startsWith('<?xml') && preambleEnd > 0) {
+      body = body.slice(preambleEnd + 2).trimStart();
+    }
+    // First element name.
+    const rootMatch = /^<([a-zA-Z_][\w:-]*)/.exec(body);
+    if (rootMatch) {
+      const rootElement = rootMatch[1];
+      // Find first 3-5 distinct child element names by scanning for `<name` after rootMatch.
+      const childRegex = /<([a-zA-Z_][\w:-]*)/g;
+      childRegex.lastIndex = rootMatch[0].length;
+      const seen = new Set<string>();
+      const firstChildren: string[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = childRegex.exec(body)) !== null && firstChildren.length < 5) {
+        const name = m[1];
+        if (name === rootElement) continue;
+        if (seen.has(name)) continue;
+        seen.add(name);
+        firstChildren.push(name);
+      }
+      return {
+        kind: 'xml',
+        rootElement,
+        firstChildren: firstChildren.length > 0 ? firstChildren : undefined,
+        partial: true,
+        inferenceSource: 'head_tail_infer',
+      };
+    }
+  }
+
+  // ---- CSV detection ----
+  // Heuristic: first line has commas, no leading `<` or `{`, and most lines look comma-separated.
+  const firstNewline = head.indexOf('\n');
+  if (firstNewline > 0) {
+    const firstLine = head.slice(0, firstNewline).trim();
+    if (firstLine.length > 0 && firstLine.includes(',') && !firstLine.startsWith('<') && !firstLine.startsWith('{')) {
+      // Simple split — doesn't handle quoted commas, but good enough for a preview.
+      const columns = firstLine.split(',').map((c) => c.trim().replace(/^"|"$/g, ''));
+      // rowCount: count newlines across head + tail; mark partial.
+      const headLines = head.split('\n').length - 1;
+      const tailLines = tail.split('\n').length - 1;
+      return {
+        kind: 'csv',
+        columns,
+        rowCount: headLines + tailLines, // approximate
+        partial: true,
+        inferenceSource: 'head_tail_infer',
+      };
+    }
+  }
+
+  // ---- Text fallback ----
+  const lineCount = head.split('\n').length + tail.split('\n').length;
+  const byteCount = head.length + tail.length;
+  return {
+    kind: 'text',
+    lineCount,
+    byteCount,
+    partial: true,
+    inferenceSource: 'head_tail_infer',
+  };
+}
+
+/**
+ * Render an InferredSchema as a short human-readable string for the agentic prompt.
+ * Targets ~1 line; agent reads this to decide whether to fetch full content.
+ */
+export function formatSchemaForPrompt(schema: InferredSchema): string {
+  if (!schema) return '';
+  const partialMark = schema.partial ? ' (partial)' : '';
+  switch (schema.kind) {
+    case 'json_object': {
+      if (!schema.topLevelKeys || Object.keys(schema.topLevelKeys).length === 0) {
+        return `JSON object${partialMark}`;
+      }
+      const keys = Object.entries(schema.topLevelKeys)
+        .map(([k, t]) => `${k} (${t})`)
+        .join(', ');
+      return `JSON object: ${keys}${partialMark}`;
+    }
+    case 'json_array': {
+      const count = schema.itemCount != null ? `${schema.itemCount} items` : '? items';
+      if (!schema.itemSchema || Object.keys(schema.itemSchema).length === 0) {
+        return `JSON array [${count}]${partialMark}`;
+      }
+      const itemKeys = Object.entries(schema.itemSchema)
+        .map(([k, t]) => `${k} (${t})`)
+        .join(', ');
+      return `JSON array [${count}]; each: ${itemKeys}${partialMark}`;
+    }
+    case 'xml': {
+      const root = schema.rootElement ?? '?';
+      const children = schema.firstChildren && schema.firstChildren.length > 0
+        ? `; children: ${schema.firstChildren.join(', ')}`
+        : '';
+      return `XML <${root}>${children}${partialMark}`;
+    }
+    case 'csv': {
+      const cols = schema.columns ? schema.columns.join(', ') : '?';
+      const rows = schema.rowCount != null ? `${schema.rowCount} rows` : '? rows';
+      return `CSV (${rows}): ${cols}${partialMark}`;
+    }
+    case 'text': {
+      const lc = schema.lineCount != null ? `${schema.lineCount} lines` : '?';
+      const bc = schema.byteCount != null ? `${schema.byteCount} bytes` : '?';
+      return `Text (~${lc}, ~${bc})`;
+    }
+    default:
+      return 'unknown';
+  }
+}

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -62,3 +62,9 @@ export {
   REQUIRED_SECTION_KEYS,
 } from './knowledge-doc.js';
 export type { KdSection, KdReadSectionResult } from './knowledge-doc.js';
+export {
+  inferSchemaFromHeadTail,
+  adoptMcpSchema,
+  formatSchemaForPrompt,
+} from './artifact-schema.js';
+export type { InferredSchema } from './artifact-schema.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,12 +78,21 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.26.0(zod@3.25.76)
+      '@xmldom/xmldom':
+        specifier: ^0.8.10
+        version: 0.8.13
       bullmq:
         specifier: ^5.0.0
         version: 5.69.3
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      jsonpath-plus:
+        specifier: ^10.2.0
+        version: 10.4.0
+      xpath:
+        specifier: ^0.0.34
+        version: 0.0.34
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1779,6 +1788,18 @@ packages:
   '@js-joda/core@5.7.0':
     resolution: {integrity: sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -2508,6 +2529,10 @@ packages:
 
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -3735,6 +3760,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3773,6 +3802,11 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -5181,6 +5215,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6296,6 +6334,14 @@ snapshots:
 
   '@js-joda/core@5.7.0': {}
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -7067,6 +7113,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.0
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xmldom/xmldom@0.8.13': {}
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -8450,6 +8498,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsep@1.4.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -8473,6 +8523,12 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   jsonparse@1.3.1: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -10072,6 +10128,8 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xpath@0.0.34: {}
 
   y18n@5.0.8: {}
 

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -1,8 +1,10 @@
 import type { FastifyInstance } from 'fastify';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import { Prisma } from '@bronco/db';
+import { inferSchemaFromHeadTail } from '@bronco/shared-utils';
 import type { Config } from '../config.js';
 import { resolveClientScope, scopeToWhere } from '../plugins/client-scope.js';
 
@@ -25,6 +27,7 @@ const ARTIFACT_SELECT = {
   addedBySystem: true,
   originatingEventId: true,
   originatingEventType: true,
+  schemaJson: true,
   // Person join: project only safe fields (id, name, email — no passwordHash etc.)
   addedByPerson: {
     select: {
@@ -205,6 +208,23 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
       // Resolve the operator's Person ID from the JWT (present for authenticated callers).
       const callerPersonId = request.user?.personId ?? null;
 
+      // Best-effort schema inference for text/json/xml/csv operator uploads. Binaries leave schemaJson null.
+      const mt = (file.mimetype || '').toLowerCase();
+      const isText = mt.startsWith('text/') || mt.includes('json') || mt.includes('xml') || mt.includes('csv');
+      let schemaJson: Prisma.InputJsonValue | undefined;
+      if (isText) {
+        try {
+          const buf = await readFile(fullPath);
+          const text = buf.toString('utf-8');
+          const head = text.slice(0, 2048);
+          const tail = text.length > 2048 ? text.slice(-512) : '';
+          const inferred = inferSchemaFromHeadTail(head, tail, file.mimetype || null);
+          schemaJson = inferred as unknown as Prisma.InputJsonValue;
+        } catch (err) {
+          fastify.log.warn({ err, filename: sanitizedFilename }, 'Operator-upload schema inference failed — continuing without schema');
+        }
+      }
+
       const artifact = await fastify.db.artifact.create({
         data: {
           ticketId: ticketId ?? null,
@@ -219,6 +239,7 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
           source: 'upload',
           addedByPersonId: callerPersonId,
           addedBySystem: 'copilot-api:upload',
+          ...(schemaJson !== undefined ? { schemaJson } : {}),
         },
         select: ARTIFACT_SELECT,
       });

--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { mkdir, readFile } from 'node:fs/promises';
+import { mkdir, open } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Prisma } from '@bronco/db';
@@ -209,17 +209,29 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
       const callerPersonId = request.user?.personId ?? null;
 
       // Best-effort schema inference for text/json/xml/csv operator uploads. Binaries leave schemaJson null.
+      // Use bounded positional reads (head + tail) so a multi-GB upload can't OOM the API.
       const mt = (file.mimetype || '').toLowerCase();
       const isText = mt.startsWith('text/') || mt.includes('json') || mt.includes('xml') || mt.includes('csv');
       let schemaJson: Prisma.InputJsonValue | undefined;
       if (isText) {
         try {
-          const buf = await readFile(fullPath);
-          const text = buf.toString('utf-8');
-          const head = text.slice(0, 2048);
-          const tail = text.length > 2048 ? text.slice(-512) : '';
-          const inferred = inferSchemaFromHeadTail(head, tail, file.mimetype || null);
-          schemaJson = inferred as unknown as Prisma.InputJsonValue;
+          const fh = await open(fullPath, 'r');
+          try {
+            const stat = await fh.stat();
+            const headBuf = Buffer.alloc(2048);
+            const headRead = await fh.read(headBuf, 0, 2048, 0);
+            const head = headBuf.subarray(0, headRead.bytesRead).toString('utf-8');
+            let tail = '';
+            if (stat.size > 2048 + 512) {
+              const tailBuf = Buffer.alloc(512);
+              const tailRead = await fh.read(tailBuf, 0, 512, Math.max(0, stat.size - 512));
+              tail = tailBuf.subarray(0, tailRead.bytesRead).toString('utf-8');
+            }
+            const inferred = inferSchemaFromHeadTail(head, tail, file.mimetype || null);
+            schemaJson = inferred as unknown as Prisma.InputJsonValue;
+          } finally {
+            await fh.close();
+          }
         } catch (err) {
           fastify.log.warn({ err, filename: sanitizedFilename }, 'Operator-upload schema inference failed — continuing without schema');
         }

--- a/services/ticket-analyzer/src/analysis/flat-v2.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.ts
@@ -31,6 +31,7 @@ import {
 } from './v2-knowledge-doc.js';
 import {
   AD_HOC_QUERY_PAIRING_SNIPPET,
+  buildAttachmentsBlock,
   KD_SYSTEM_PROMPT_SNIPPET,
   PREFER_EXISTING_TOOLS_SNIPPET,
   REQUEST_NEW_TOOL_SNIPPET,
@@ -54,7 +55,7 @@ export async function runFlatV2(
   opts: { maxIterations: number; reanalysisCtx?: ReanalysisContext },
 ): Promise<AnalysisResult> {
   const { db, ai, appLog, artifactStoragePath } = deps;
-  const { ticketId, clientId, category, priority, emailSubject, emailBody, clientContext, environmentContext, codeContext, dbContext, facts, summary } = ctx;
+  const { ticketId, clientId, category, priority, emailSubject, emailBody, clientContext, environmentContext, codeContext, dbContext, facts, summary, attachments } = ctx;
   const { maxIterations, reanalysisCtx } = opts;
   const { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: clientRepos } = tools;
 
@@ -79,6 +80,10 @@ export async function runFlatV2(
       `Subject: ${emailSubject}`,
       `Category: ${category}`,
       `Priority: ${priority}`,
+    );
+    const reanalAttBlock = buildAttachmentsBlock(attachments);
+    if (reanalAttBlock) systemParts.push(reanalAttBlock);
+    systemParts.push(
       '',
       '## Conversation History',
       '',
@@ -104,6 +109,8 @@ export async function runFlatV2(
       `Priority: ${priority}`,
       '', emailBody,
     );
+    const initAttBlock = buildAttachmentsBlock(attachments);
+    if (initAttBlock) systemParts.push(initAttBlock);
   }
 
   if (summary) systemParts.push('', `## Summary`, summary);

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -47,6 +47,7 @@ import {
 } from './v2-knowledge-doc.js';
 import {
   AD_HOC_QUERY_PAIRING_SNIPPET,
+  buildAttachmentsBlock,
   KD_SYSTEM_PROMPT_SNIPPET,
   NO_STALL_SYSTEM_PROMPT_SNIPPET,
   PREFER_EXISTING_TOOLS_SNIPPET,
@@ -846,7 +847,7 @@ export async function runOrchestratedV2(
   opts: { maxIterations: number; existingKnowledgeDoc: string; reanalysisCtx?: ReanalysisContext },
 ): Promise<AnalysisResult> {
   const { db, ai, appLog } = deps;
-  const { ticketId, clientId, category, priority, emailSubject, emailBody, clientContext, environmentContext, codeContext, dbContext, facts, summary } = ctx;
+  const { ticketId, clientId, category, priority, emailSubject, emailBody, clientContext, environmentContext, codeContext, dbContext, facts, summary, attachments } = ctx;
   const { maxIterations: orchMaxIterations, existingKnowledgeDoc, reanalysisCtx } = opts;
   const reanalysisMode = reanalysisCtx?.mode ?? ReanalysisMode.CONTINUE;
   const isReanalysis = !!reanalysisCtx && reanalysisMode !== ReanalysisMode.FRESH_START;
@@ -896,6 +897,10 @@ export async function runOrchestratedV2(
     '', emailBody,
   ].join('\n');
   const contextParts: string[] = [ticketContext];
+  // Attachments block sits right after metadata + body so the strategist sees
+  // the artifact catalog before any subsequent context (client memory, summary, etc).
+  const attachmentsBlock = buildAttachmentsBlock(attachments);
+  if (attachmentsBlock) contextParts.push(attachmentsBlock);
   if (summary) contextParts.push(`\n## Summary\n${summary}`);
   if (clientContext) contextParts.push(`\n${clientContext}`);
   if (environmentContext) contextParts.push(`\n${environmentContext}`);

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -448,6 +448,20 @@ export async function buildAgenticTools(
   });
 
   tools.push({
+    name: 'platform__query_artifact',
+    description: 'Run a path query against an artifact and return matching slices. Use to pull surgical pieces of structured data (JSON, XML, CSV) without reading the whole file. JSON: JSONPath ($.x.y or $.items[*].name). XML: XPath (/root/elem). CSV: column name to return that column, or @N for row index N.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        artifact_id: { type: 'string', description: 'The artifact ID to query' },
+        path: { type: 'string', description: 'JSONPath ($.x.y) for JSON, XPath (/root/elem) for XML, header column name (or @N for row N) for CSV' },
+        format: { type: 'string', enum: ['json', 'xml', 'csv'], description: 'Override format auto-detection (otherwise inferred from artifact mimeType + content)' },
+      },
+      required: ['artifact_id', 'path'],
+    },
+  });
+
+  tools.push({
     name: 'platform__request_tool',
     description: [
       'Flag a capability gap discovered during analysis.',
@@ -708,6 +722,10 @@ export async function executeAgenticToolCall(
     } else if (actualToolName === 'list_repos' && clientId) {
       toolInput = { ...input, clientId };
     } else if (actualToolName === 'read_tool_result_artifact' && ticketId) {
+      toolInput = { ...input, ticketId };
+    } else if (actualToolName === 'query_artifact' && ticketId) {
+      // Inject ticketId so the platform server can scope the artifact lookup
+      // to this ticket (defense-in-depth — the agent never sets it directly).
       toolInput = { ...input, ticketId };
     } else if (actualToolName === 'request_tool' && ticketId) {
       // Inject ticketId so the MCP server can derive clientId from the ticket

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import type { PrismaClient } from '@bronco/db';
+import { Prisma } from '@bronco/db';
 import { AIRouter } from '@bronco/ai-provider';
 import {
   TaskType,
@@ -15,6 +16,8 @@ import {
   decrypt,
   looksEncrypted,
   callMcpToolViaSdk,
+  inferSchemaFromHeadTail,
+  adoptMcpSchema,
 } from '@bronco/shared-utils';
 import { enqueueArtifactNameGeneration } from '../artifact-name-queue.js';
 
@@ -1050,6 +1053,33 @@ export async function saveMcpToolArtifact(
     await mkdir(ticketDir, { recursive: true });
     await writeFile(fullPath, rawResult, 'utf-8');
     const relativePath = `tickets/${ticketId}/${filename}`;
+    // Best-effort schema capture: prefer a top-level `_schema` field in the MCP tool envelope
+    // (tier 1 — `mcp_provided`); else infer from head + tail (tier 2 — `head_tail_infer`).
+    let schemaJson: Prisma.InputJsonValue | undefined;
+    try {
+      let producerSchema: unknown = undefined;
+      if (isJson) {
+        try {
+          const parsed = JSON.parse(rawResult) as unknown;
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            const env = parsed as Record<string, unknown>;
+            if (env._schema !== undefined) {
+              producerSchema = env._schema;
+            }
+          }
+        } catch { /* ignore parse */ }
+      }
+      const inferred = producerSchema !== undefined
+        ? adoptMcpSchema(producerSchema)
+        : inferSchemaFromHeadTail(
+            rawResult.slice(0, 2048),
+            rawResult.length > 2048 ? rawResult.slice(-512) : '',
+            mimeType,
+          );
+      schemaJson = inferred as unknown as Prisma.InputJsonValue;
+    } catch (err) {
+      logger.warn({ err, ticketId, toolName }, 'MCP tool artifact schema inference failed — continuing without schema');
+    }
     const created = await db.artifact.create({
       data: {
         ...(artifactId ? { id: artifactId } : {}),
@@ -1064,6 +1094,7 @@ export async function saveMcpToolArtifact(
         source: `mcp_tool:${toolName}`,
         addedBySystem: 'ticket-analyzer:agentic',
         addedByPersonId: null,
+        ...(schemaJson !== undefined ? { schemaJson } : {}),
       },
       select: { id: true },
     });
@@ -1201,6 +1232,22 @@ export interface AnalysisDeps {
   loadDefaultMaxTokens?: () => Promise<number | undefined>;
 }
 
+/**
+ * One row in the structured `## Attachments` block surfaced to the v2 agentic
+ * prompt. Mirrors AttachmentSummary in analyzer.ts; defined here as well so
+ * v2 strategy modules can consume it without depending on analyzer.ts.
+ */
+export interface PipelineAttachment {
+  artifactId: string;
+  kind: string | null;
+  displayName: string | null;
+  filename: string;
+  mimeType: string | null;
+  sizeBytes: number;
+  description: string | null;
+  schemaJson: unknown;
+}
+
 export interface AnalysisPipelineContext {
   ticketId: string;
   clientId: string;
@@ -1221,6 +1268,12 @@ export interface AnalysisPipelineContext {
   };
   summary: string;
   sufficiencyEval?: SufficiencyEvaluation;
+  /**
+   * v2 only: structured artifact catalog rendered as `## Attachments` block in
+   * the agentic prompt. Optional — missing/empty array means no block is rendered.
+   * v1 strategy modules ignore this field.
+   */
+  attachments?: PipelineAttachment[];
 }
 
 export interface AnalysisResult {

--- a/services/ticket-analyzer/src/analysis/v2-prompts.ts
+++ b/services/ticket-analyzer/src/analysis/v2-prompts.ts
@@ -216,3 +216,51 @@ export const NO_STALL_SYSTEM_PROMPT_SNIPPET = [
   'step. Repeated empty `tasks` arrays across consecutive turns will trip the stall',
   'detector and the orchestrator will terminate early.',
 ].join('\n');
+
+// ---------------------------------------------------------------------------
+// Attachments block (v2 agentic prompt)
+// ---------------------------------------------------------------------------
+
+import { formatSchemaForPrompt, type InferredSchema } from '@bronco/shared-utils';
+import type { PipelineAttachment } from './shared.js';
+
+/** Format a byte count as a short human-readable string. */
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/**
+ * Render the structured `## Attachments` block for the v2 agentic prompt.
+ * Surfaces every artifact attached to the ticket — probe results, MCP tool
+ * results, email attachments, operator uploads — with kind, displayName, size,
+ * artifact_id, and a one-line schema preview when known. Does NOT inline
+ * artifact content; the agent uses `platform__read_tool_result_artifact` for
+ * the full body or `platform__query_artifact` to pull surgical slices.
+ *
+ * Returns an empty string when there are no attachments so callers can
+ * unconditionally `.push(buildAttachmentsBlock(...))`.
+ */
+export function buildAttachmentsBlock(attachments: PipelineAttachment[] | undefined | null): string {
+  if (!attachments || attachments.length === 0) return '';
+  const lines: string[] = ['', '## Attachments', ''];
+  for (const a of attachments) {
+    const name = a.displayName ?? a.filename;
+    const kindStr = a.kind ?? 'attachment';
+    const size = humanSize(a.sizeBytes);
+    lines.push(`- 📎 ${name} (${kindStr}, ${size})`);
+    lines.push(`  artifact_id: ${a.artifactId}`);
+    if (a.description) lines.push(`  description: ${a.description}`);
+    const schema = a.schemaJson as InferredSchema | null | undefined;
+    if (schema && typeof schema === 'object') {
+      const formatted = formatSchemaForPrompt(schema);
+      if (formatted) lines.push(`  schema: ${formatted}`);
+    }
+    lines.push(`  Read full: platform__read_tool_result_artifact(artifactId="${a.artifactId}")`);
+    if (schema && typeof schema === 'object') {
+      lines.push(`  Query path: platform__query_artifact(artifact_id="${a.artifactId}", path=...)`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, open, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
-import { join, relative, resolve } from 'node:path';
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import type { Job } from 'bullmq';
 import { Prisma } from '@bronco/db';
@@ -14,7 +14,6 @@ import { executeRecommendations } from './recommendation-executor.js';
 import type { ParsedAction } from './recommendation-executor.js';
 import {
   buildAgenticTools,
-  buildTruncatedPreview,
   DEFAULT_REPO_FILE_EXTENSIONS,
   parseSufficiencyEvaluation,
   resolveAnalysisStrategy,
@@ -214,6 +213,23 @@ async function sendReplyWithRetry(
 // Re-export AnalysisJob from shared-types for backward compatibility with existing imports.
 export type { AnalysisJob } from '@bronco/shared-types';
 
+/**
+ * One row in the structured `## Attachments` block surfaced to the v2 agentic
+ * prompt. Sourced from the `artifacts` table (probe results, MCP tool results,
+ * email attachments, operator uploads).
+ */
+export interface AttachmentSummary {
+  artifactId: string;
+  kind: string | null;
+  displayName: string | null;
+  filename: string;
+  mimeType: string | null;
+  sizeBytes: number;
+  description: string | null;
+  /** InferredSchema (parsed JSON), null when not yet inferred. */
+  schemaJson: unknown;
+}
+
 /** Internal resolved context — loaded from DB at the start of the analysis pipeline. */
 interface AnalysisContext {
   ticketId: string;
@@ -226,6 +242,12 @@ interface AnalysisContext {
   ticketSource: TicketSource;
   /** Populated by AGENTIC_ANALYSIS or UPDATE_ANALYSIS — consumed by DRAFT_FINDINGS_EMAIL. */
   sufficiencyEval?: SufficiencyEvaluation;
+  /**
+   * All artifacts currently attached to this ticket (probe + email attachments
+   * + MCP tool results + operator uploads). Surfaced to the v2 agentic prompt
+   * as a structured `## Attachments` block. v1 paths ignore this field.
+   */
+  attachments?: AttachmentSummary[];
 }
 
 export interface AnalyzerDeps {
@@ -259,16 +281,49 @@ export interface AnalyzerDeps {
 // ---------------------------------------------------------------------------
 
 /**
- * Inline threshold: probe artifacts ≤ this many bytes are included verbatim in
- * the initial emailBody; larger ones are included as a 2000-char preview plus
- * an artifact-ref footer so Claude knows to call platform__read_tool_result_artifact.
+ * Load all artifacts for a ticket and project the fields the v2 agentic prompt
+ * surfaces in the structured `## Attachments` block. Best-effort — returns []
+ * on DB error (logged) so analysis never fails on attachment metadata.
  */
-const PROBE_ARTIFACT_INLINE_BYTES = 8 * 1024; // 8 KB
+async function loadTicketAttachments(
+  db: PrismaClient,
+  ticketId: string,
+): Promise<AttachmentSummary[]> {
+  try {
+    const rows = await db.artifact.findMany({
+      where: { ticketId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        kind: true,
+        displayName: true,
+        filename: true,
+        mimeType: true,
+        sizeBytes: true,
+        description: true,
+        schemaJson: true,
+      },
+    });
+    return rows.map((r) => ({
+      artifactId: r.id,
+      kind: r.kind,
+      displayName: r.displayName,
+      filename: r.filename,
+      mimeType: r.mimeType,
+      sizeBytes: r.sizeBytes,
+      description: r.description,
+      schemaJson: r.schemaJson,
+    }));
+  } catch (err) {
+    logger.warn({ err, ticketId }, 'Failed to load ticket attachments — continuing without attachment block');
+    return [];
+  }
+}
 
 async function loadAnalysisContext(
   db: PrismaClient,
   job: AnalysisJob,
-  artifactStoragePath?: string,
+  _artifactStoragePath?: string,
 ): Promise<AnalysisContext> {
   const { ticketId, reanalysis, triggerEventId } = job;
 
@@ -280,6 +335,10 @@ async function loadAnalysisContext(
   if (!ticket) {
     throw new Error(`Ticket ${ticketId} not found — cannot load analysis context`);
   }
+
+  // Always load all artifacts for the ticket — surfaced to v2 agentic prompts
+  // as a structured `## Attachments` block. v1 ignores this field.
+  const attachments = await loadTicketAttachments(db, ticketId);
 
   // For re-analysis, prefer the trigger event for sender/messageId/body context.
   // This ensures replies are sent to the actual replier (not always the original sender)
@@ -301,6 +360,7 @@ async function loadAnalysisContext(
           emailBody: triggerEvent.content ?? '',
           emailMessageId: triggerEvent.emailMessageId ?? undefined,
           ticketSource: ticket.source,
+          attachments,
         };
       }
     }
@@ -314,79 +374,21 @@ async function loadAnalysisContext(
   });
 
   if (!inboundEvent) {
-    // Non-email ticket (probe, manual, AI-detected) — fall back to requester email for notifications
-    logger.info({ ticketId, source: ticket.source }, 'No EMAIL_INBOUND event found — loading non-email context');
-
-    // If a probe artifact was saved at ingestion time, use its full content (or a
-    // preview-with-artifact-ref) instead of the 2000-char truncated description.
-    let emailBody = ticket.description ?? '';
-    const ticketMeta = ticket.metadata as Record<string, unknown> | null;
-    const probeArtifactId = typeof ticketMeta?.['probeArtifactId'] === 'string' ? ticketMeta['probeArtifactId'] : null;
-
-    if (probeArtifactId && artifactStoragePath) {
-      try {
-        const artifact = await db.artifact.findFirst({
-          where: { id: probeArtifactId, ticketId },
-          select: { storagePath: true, sizeBytes: true },
-        });
-        if (artifact) {
-          const resolvedStorage = resolve(artifactStoragePath);
-          const absPath = resolve(resolvedStorage, artifact.storagePath);
-          const rel = relative(resolvedStorage, absPath);
-          if (!rel.startsWith('..') && rel !== '' && !rel.startsWith('/')) {
-            if (artifact.sizeBytes <= PROBE_ARTIFACT_INLINE_BYTES) {
-              // Small enough to inline — read the full file; Claude sees the full probe result immediately
-              const rawContent = await readFile(absPath, 'utf-8');
-              emailBody = rawContent;
-              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact inlined in analysis context');
-            } else {
-              // Too large to inline — read only head and tail bytes to avoid loading the
-              // entire file into memory, then build a canonical truncated preview so
-              // Claude can page the rest via platform__read_tool_result_artifact.
-              const HEAD_BYTES = 1500;
-              const TAIL_BYTES = 500;
-              const fh = await open(absPath, 'r');
-              try {
-                const headBuf = Buffer.alloc(HEAD_BYTES);
-                const { bytesRead: headRead } = await fh.read(headBuf, 0, HEAD_BYTES, 0);
-                const tailOffset = Math.max(HEAD_BYTES, artifact.sizeBytes - TAIL_BYTES);
-                const tailBuf = Buffer.alloc(TAIL_BYTES);
-                const { bytesRead: tailRead } = await fh.read(tailBuf, 0, TAIL_BYTES, tailOffset);
-                const head = headBuf.subarray(0, headRead).toString('utf-8');
-                const tail = tailBuf.subarray(0, tailRead).toString('utf-8');
-                const approxChars = artifact.sizeBytes; // byte count ≈ char count for UTF-8 text
-                emailBody = buildTruncatedPreview(head + '\n...\n' + tail, probeArtifactId)
-                  .replace(/^size: \d+ chars$/m, `size: ~${approxChars} bytes`);
-              } finally {
-                await fh.close();
-              }
-              logger.info({ ticketId, probeArtifactId, sizeBytes: artifact.sizeBytes }, 'Probe artifact preview-with-ref added to analysis context');
-            }
-          } else {
-            logger.warn({ ticketId, probeArtifactId }, 'Probe artifact path escaped storage root — falling back to description');
-          }
-        }
-      } catch (artifactErr) {
-        logger.warn({ artifactErr, ticketId, probeArtifactId }, 'Failed to load probe artifact for analysis context — falling back to description');
-      }
-    } else if (probeArtifactId && !artifactStoragePath) {
-      // Artifact exists but no storage path — append a reference so Claude knows to fetch it
-      emailBody = [
-        ticket.description ?? '',
-        '',
-        `[Full probe result available at artifact ${probeArtifactId}. Use platform__read_tool_result_artifact to retrieve.]`,
-      ].join('\n').trim();
-      logger.info({ ticketId, probeArtifactId }, 'Probe artifact ID appended to analysis context (no storage path available)');
-    }
+    // Non-email ticket (probe, manual, AI-detected). Body = ticket.description verbatim
+    // (which is the Haiku narrative for probe-sourced tickets — Phase 4 generates this).
+    // Artifacts are surfaced to the v2 agentic prompt via the `attachments` field, NOT
+    // by overwriting emailBody. v1 paths render emailBody as-is.
+    logger.info({ ticketId, source: ticket.source, attachmentCount: attachments.length }, 'No EMAIL_INBOUND event found — loading non-email context');
 
     return {
       ticketId,
       clientId: ticket.clientId,
       emailFrom: ticket.followers[0]?.person?.email ?? undefined,
       emailSubject: ticket.subject ?? '(No subject)',
-      emailBody,
+      emailBody: ticket.description ?? '',
       emailMessageId: undefined,
       ticketSource: ticket.source,
+      attachments,
     };
   }
 
@@ -403,6 +405,7 @@ async function loadAnalysisContext(
       emailBody: inboundEvent.content ?? '',
       emailMessageId: undefined,
       ticketSource: ticket.source,
+      attachments,
     };
   }
 
@@ -414,6 +417,7 @@ async function loadAnalysisContext(
     emailBody: inboundEvent.content ?? '',
     emailMessageId: inboundEvent.emailMessageId ?? undefined,
     ticketSource: ticket.source,
+    attachments,
   };
 }
 
@@ -2294,6 +2298,7 @@ async function executeRoutePipeline(
         const analysisCtx: AnalysisPipelineContext = {
           ticketId, clientId, category, priority, emailSubject, emailBody,
           clientContext, environmentContext, codeContext, dbContext, facts, summary,
+          attachments: ctx.attachments,
         };
         const toolCtx = { tools: agenticTools, mcpIntegrations, repoIdByPrefix, repos: agenticRepos };
 

--- a/services/ticket-analyzer/src/ingestion-engine.ts
+++ b/services/ticket-analyzer/src/ingestion-engine.ts
@@ -18,7 +18,7 @@ import type {
   AnalysisJob,
   Priority,
 } from '@bronco/shared-types';
-import { createLogger } from '@bronco/shared-utils';
+import { createLogger, inferSchemaFromHeadTail } from '@bronco/shared-utils';
 import type { AppLogger, Mailer, ReplyOptions } from '@bronco/shared-utils';
 import { createIngestionRunTracker } from './ingestion-tracker.js';
 import type { IngestionRunTracker } from './ingestion-tracker.js';
@@ -1322,6 +1322,16 @@ async function saveProbeArtifact(
     await mkdir(ticketDir, { recursive: true });
     await writeFile(fullPath, rawResult, 'utf-8');
     const relativePath = `tickets/${ticketId}/${filename}`;
+    // Best-effort schema inference from head + tail of the raw result. Never blocks creation.
+    let schemaJson: Prisma.InputJsonValue | undefined;
+    try {
+      const head = rawResult.slice(0, 2048);
+      const tail = rawResult.length > 2048 ? rawResult.slice(-512) : '';
+      const inferred = inferSchemaFromHeadTail(head, tail, mimeType);
+      schemaJson = inferred as unknown as Prisma.InputJsonValue;
+    } catch (err) {
+      logger.warn({ err, ticketId }, 'Probe artifact schema inference failed — continuing without schema');
+    }
     const artifact = await db.artifact.create({
       data: {
         ticketId,
@@ -1335,6 +1345,7 @@ async function saveProbeArtifact(
         source: `probe:${toolName}`,
         addedBySystem: 'probe-worker',
         addedByPersonId: null,
+        ...(schemaJson !== undefined ? { schemaJson } : {}),
       },
       select: { id: true },
     });
@@ -1377,6 +1388,21 @@ async function saveEmailAttachmentArtifact(
     await writeFile(fullPath, contentBuffer);
     const relativePath = `tickets/${ticketId}/${filename}`;
     const sourceTag = `email:${emailSubject.slice(0, 80)}`;
+    // Best-effort schema inference for text/json attachments only. Binaries leave schemaJson null.
+    const mt = (att.contentType || '').toLowerCase();
+    const isText = mt.startsWith('text/') || mt.includes('json') || mt.includes('xml') || mt.includes('csv');
+    let schemaJson: Prisma.InputJsonValue | undefined;
+    if (isText) {
+      try {
+        const text = contentBuffer.toString('utf-8');
+        const head = text.slice(0, 2048);
+        const tail = text.length > 2048 ? text.slice(-512) : '';
+        const inferred = inferSchemaFromHeadTail(head, tail, att.contentType || null);
+        schemaJson = inferred as unknown as Prisma.InputJsonValue;
+      } catch (err) {
+        logger.warn({ err, ticketId, filename: att.filename }, 'Email attachment schema inference failed — continuing without schema');
+      }
+    }
     await db.artifact.create({
       data: {
         ticketId,
@@ -1392,6 +1418,7 @@ async function saveEmailAttachmentArtifact(
         addedBySystem: 'imap-worker',
         originatingEventId: originatingEventId,
         originatingEventType: originatingEventId ? 'ticket_event' : null,
+        ...(schemaJson !== undefined ? { schemaJson } : {}),
       },
     });
     logger.info({ ticketId, filename: att.filename }, 'Email attachment artifact saved');


### PR DESCRIPTION
## Summary

Closes the gap discovered while analyzing ticket #48 (Evolution DB deadlock): Phase 4's Haiku-composed `Ticket.description` was being overwritten in `loadAnalysisContext()` by the inlined probe artifact contents, dropping operator-narrative context on the floor before the agentic strategist saw it. The strategist then rediscovered the deadlock pattern from raw JSON every time, across 17 Opus calls and ~$5 of token spend.

This PR rewires the agentic prompt's structure: **body = Haiku narrative**, **artifacts = structured `## Attachments` block** with kind, displayName, size, schema preview, and read-tool hints. The agent sees framing context up front and decides whether to crack each artifact open via either the existing `platform__read_tool_result_artifact` (full read) or the new `platform__query_artifact` (path-scoped slice).

Refs the analysis-strategy review tracker (see today's session memo).

## Architecture — three-tier schema sourcing

1. **MCP `_schema` envelope** (highest confidence) — when an MCP tool response includes a top-level `_schema` field, it's adopted directly. The MCP servers don't emit this yet; the field is the contract for a follow-up rollout (1b).
2. **Head/tail inference at save time** (90% accurate, cheap) — for any artifact without `_schema`, infer from first ~2 KB + last ~500 bytes. Handles JSON object, JSON array, XML, CSV, text. Flags `partial: true` on truncation/polymorphism. Same positional-read pattern Phase 2 already uses for Haiku naming.
3. **Unknown** — genuinely opaque (binary, prose, weird formats) → schema = null. Agent falls back to the existing read tool.

## Migration

`packages/db/prisma/migrations/20260426000000_add_artifact_schema_json/migration.sql` — single column add:

```sql
ALTER TABLE "artifacts" ADD COLUMN "schema_json" JSONB;
```

Additive, nullable, no backfill. Existing rows have `null` and the analyzer falls back gracefully.

## What lands

| File | Change |
|---|---|
| `packages/db/prisma/schema.prisma` | `Artifact.schemaJson Json?` |
| `packages/db/prisma/migrations/20260426000000_*` | Single-column additive migration |
| `packages/shared-types/src/artifact.ts` | `schemaJson` field on `Artifact` interface |
| `packages/shared-utils/src/artifact-schema.ts` | New: `inferSchemaFromHeadTail`, `adoptMcpSchema`, `formatSchemaForPrompt`, types |
| `packages/shared-utils/src/artifact-schema.test.ts` | Unit tests covering JSON object / array / XML / CSV / text / partial |
| `mcp-servers/platform/src/tools/query-artifact.ts` | New `query_artifact` MCP tool — JSONPath via `jsonpath-plus`, XPath via `xpath` + `@xmldom/xmldom`, CSV-column |
| `mcp-servers/platform/src/auth/caller-registry.ts` | Adds `query_artifact` to `ticket-analyzer` allowlist |
| `services/ticket-analyzer/src/ingestion-engine.ts` | Schema capture in `saveProbeArtifact` + email-attachment save |
| `services/ticket-analyzer/src/analysis/shared.ts` | `saveMcpToolArtifact` checks tool envelope `_schema` first, falls back to inference |
| `services/copilot-api/src/routes/artifacts.ts` | Schema capture on `POST /upload` (operator upload) |
| `services/ticket-analyzer/src/analyzer.ts` | `loadAnalysisContext` no longer overwrites `emailBody`; loads all artifacts as `AttachmentSummary[]` |
| `services/ticket-analyzer/src/analysis/v2-prompts.ts` | New `buildAttachmentsBlock` helper |
| `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` | Injects attachments block in initial + re-analysis prompts |
| `services/ticket-analyzer/src/analysis/flat-v2.ts` | Same |
| `CLAUDE.md` | New "Artifact Attachments and Schema" section |

## Behavior change

Before, agentic prompt:
```
## Ticket
Subject: …
Category: DATABASE_PERF
Priority: HIGH

[ raw probe JSON dump — Haiku description silently lost ]
```

After:
```
## Ticket
Subject: …
Category: DATABASE_PERF
Priority: HIGH

[ Haiku description — operator narrative + probe context summary ]

## Attachments

- 📎 Probe result — Deadlock events Apr 24 (PROBE_RESULT, 5.2 KB)
  artifact_id: e8a10afa-…
  description: Probe captured 6 deadlock events on Evolution DB centered on…
  schema: array[6 items], each: Id (int), DeadlockTime (ISO string), …
  Read full: platform__read_tool_result_artifact(id=e8a10afa-…)
  Query path: platform__query_artifact(id=e8a10afa-…, path=…)
```

EXTRACT_FACTS / SUMMARIZE / CATEGORIZE / TRIAGE prompts are **unchanged** — those still use the raw probe payload as today (per scope).

v1 paths are **unchanged** — historical-fidelity rule from CLAUDE.md.

## Verification

- `pnpm build` — clean across 19 workspace packages
- `pnpm typecheck` — clean
- `pnpm --filter @bronco/shared-utils test` — **107 passed** (includes new schema-inference tests)
- `pnpm --filter @bronco/ticket-analyzer test` — **223 passed** (existing tests updated for new prompt shape)

## Side effects worth noting

This change should reduce Opus token spend per ticket meaningfully — the strategist no longer needs to re-discover artifact structure on every sub-task. Schemas are visible in the initial prompt; sub-tasks get the same context. Less re-fetching, fewer redundant deadlock_graph calls (which we saw 9 of in ticket #48).

## Pre-deploy

None. Migration is additive, no env vars added, no docker-compose changes. New `query_artifact` tool is a passive addition — agents call it only if they choose to.

## Test plan (post-deploy)

- [ ] CI passes
- [ ] Trigger a probe-sourced ticket → analyzer's first agentic prompt contains the Haiku description as the body AND a `## Attachments` block listing the probe artifact with schema preview
- [ ] Run an analysis with a large MCP tool result → attachment block lists it; schema reflects the response shape; agent calls `query_artifact` with a path instead of pulling the full artifact
- [ ] Email with attachment → attachment block lists it
- [ ] Operator upload → attachment block lists it with kind `OPERATOR_UPLOAD`
- [ ] Spot-check `ai_usage_logs` for the next probe-sourced ticket — verify Opus call count and token spend drop relative to ticket #48 baseline
- [ ] Re-analysis flow still includes the attachments block in the strategist prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
