### PR TITLE
fix: add Client.searchIgnoreTerms blocklist for pre-gather

### DIFF
--- a/packages/db/prisma/migrations/20260426000001_add_client_search_ignore_terms/migration.sql
+++ b/packages/db/prisma/migrations/20260426000001_add_client_search_ignore_terms/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "clients" ADD COLUMN "search_ignore_terms" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Client {
   companyProfile       String?  @map("company_profile")
   systemsProfile       String?  @map("systems_profile")
   domainMappings       String[] @default([]) @map("domain_mappings") // e.g. ["altmanplants.com", "altman.com"]
+  searchIgnoreTerms    String[] @default([]) @map("search_ignore_terms")
   billingMarkupPercent Float    @default(1.0) @map("billing_markup_percent")
   billingPeriod        String   @default("disabled") @map("billing_period")
   billingAnchorDay     Int      @default(1) @map("billing_anchor_day")

--- a/packages/shared-types/src/client.ts
+++ b/packages/shared-types/src/client.ts
@@ -39,6 +39,7 @@ export interface Client {
   companyProfile: string | null;
   systemsProfile: string | null;
   domainMappings: string[];
+  searchIgnoreTerms: string[];
   billingMarkupPercent: number;
   billingPeriod: BillingPeriod;
   billingAnchorDay: number;

--- a/services/control-panel/src/app/core/services/client.service.ts
+++ b/services/control-panel/src/app/core/services/client.service.ts
@@ -16,6 +16,7 @@ export interface Client {
   companyProfile: string | null;
   systemsProfile: string | null;
   domainMappings: string[];
+  searchIgnoreTerms: string[];
   billingMarkupPercent: number;
   slackChannelId: string | null;
   createdAt: string;

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
@@ -88,6 +88,23 @@ import {
         </div>
 
         <div class="config-section">
+          <h3 class="section-title">Repo Search</h3>
+          <app-form-field label="Search Ignore Terms" hint="Terms to skip during repo pre-gather searches (e.g., client name, common but uninformative words)">
+            <app-text-input
+              [value]="searchIgnoreTermsValue()"
+              placeholder="acme, myapp, support"
+              (valueChange)="searchIgnoreTermsValue.set($event)" />
+          </app-form-field>
+          <app-bronco-button
+            variant="primary"
+            size="sm"
+            [disabled]="searchIgnoreTermsValue() === (c.searchIgnoreTerms ?? []).join(', ')"
+            (click)="saveSearchIgnoreTerms()">
+            Save
+          </app-bronco-button>
+        </div>
+
+        <div class="config-section">
           <h3 class="section-title">Notes</h3>
           <app-form-field label="Internal Notes">
             <app-textarea
@@ -139,6 +156,7 @@ export class ClientConfigTabComponent {
 
   slackValue = signal('');
   domainsValue = signal('');
+  searchIgnoreTermsValue = signal('');
   notesValue = signal('');
 
   ngOnChanges(): void {
@@ -146,6 +164,7 @@ export class ClientConfigTabComponent {
     if (c) {
       this.slackValue.set(c.slackChannelId ?? '');
       this.domainsValue.set((c.domainMappings).join(', '));
+      this.searchIgnoreTermsValue.set((c.searchIgnoreTerms ?? []).join(', '));
       this.notesValue.set(c.notes ?? '');
     }
   }
@@ -168,6 +187,14 @@ export class ClientConfigTabComponent {
       .map(d => d.trim())
       .filter(Boolean);
     this.patch({ domainMappings: domains } as Partial<Client>, 'Domains saved');
+  }
+
+  saveSearchIgnoreTerms(): void {
+    const terms = this.searchIgnoreTermsValue()
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+    this.patch({ searchIgnoreTerms: terms } as Partial<Client>, 'Search ignore terms saved');
   }
 
   saveNotes(): void {

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -149,22 +149,27 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     };
   });
 
-  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[] } }>(
+  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[]; searchIgnoreTerms?: string[] } }>(
     '/api/clients',
     async (request, reply) => {
       const domainMappings = validateDomainMappings(request.body.domainMappings);
+      const { searchIgnoreTerms, ...rest } = request.body;
       const client = await fastify.db.client.create({
-        data: { ...request.body, domainMappings },
+        data: {
+          ...rest,
+          domainMappings,
+          ...(searchIgnoreTerms !== undefined && { searchIgnoreTerms }),
+        },
       });
       reply.code(201);
       return client;
     },
   );
 
-  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
+  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; searchIgnoreTerms?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
     '/api/clients/:id',
     async (request, reply) => {
-      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, ...rest } = request.body;
+      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, searchIgnoreTerms, ...rest } = request.body;
       if (aiMode !== undefined && !VALID_AI_MODES.has(aiMode)) {
         return reply.code(400).send({ error: `Invalid aiMode "${aiMode}". Valid: ${[...VALID_AI_MODES].join(', ')}` });
       }
@@ -195,6 +200,7 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
         data: {
           ...rest,
           ...(domainMappings !== undefined && { domainMappings }),
+          ...(searchIgnoreTerms !== undefined && { searchIgnoreTerms }),
           ...(aiMode !== undefined && { aiMode }),
           ...(billingPeriod !== undefined && { billingPeriod }),
           ...(billingAnchorDay !== undefined && { billingAnchorDay }),

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -2018,6 +2018,31 @@ async function executeRoutePipeline(
               searchTerms = [...searchTerms, ...subjectTokens].slice(0, 10);
             }
 
+            // Drop terms that are guaranteed noise for this client: the client's
+            // own name, short code, any operator-configured ignore terms, and
+            // anything shorter than 4 characters.
+            const clientNameLower = ticket.client.name.toLowerCase();
+            const clientShortCodeLower = ticket.client.shortCode.toLowerCase();
+            const ignoreSet = new Set<string>(
+              (ticket.client.searchIgnoreTerms ?? []).map((t) => t.toLowerCase()),
+            );
+            const preFilterCount = searchTerms.length;
+            searchTerms = searchTerms.filter((t) => {
+              const lower = t.toLowerCase();
+              if (lower.length < 4) return false;
+              if (lower === clientNameLower) return false;
+              if (lower === clientShortCodeLower) return false;
+              if (ignoreSet.has(lower)) return false;
+              return true;
+            });
+            if (searchTerms.length === 0) {
+              appLog.info(
+                `pre-gather: all ${preFilterCount} term(s) filtered out for ${repo.name}, skipping search`,
+                { ticketId, repo: repo.name },
+                ticketId, 'ticket',
+              );
+            }
+
             const exts = (repo.fileExtensions && repo.fileExtensions.length > 0)
               ? repo.fileExtensions
               : [...DEFAULT_REPO_FILE_EXTENSIONS];


### PR DESCRIPTION
## Summary

Stops the ticket-analyzer pre-gather from searching for terms guaranteed to be useless on a given client's repos. This is the **blocklist half** of the fix for the `GATHER_REPO_CONTEXT` 30-second MCP timeout class — paired with `fix/mcp-pregather-search-code` (the executor switch to ripgrep + per-file `--max-count`), which lands separately.

Ticket #48 (Evolution DB Deadlock) burned ~$5 of Opus tokens partly because pre-gather's first term — the client name "Evolution" — hits nearly every file in Altman's SQL-schema repo, walks the full tree under raw `grep -rn`, and times out at 30s. A blocklist eliminates that whole class of useless searches before they're even issued.

## What lands

| File | Change |
|---|---|
| `packages/db/prisma/migrations/20260426000001_add_client_search_ignore_terms/migration.sql` | Additive: `ALTER TABLE "clients" ADD COLUMN "search_ignore_terms" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];` |
| `packages/db/prisma/schema.prisma` | `searchIgnoreTerms String[] @default([]) @map("search_ignore_terms")` on `Client` |
| `packages/shared-types/src/client.ts` | `searchIgnoreTerms: string[]` on `Client` interface |
| `services/copilot-api/src/routes/clients.ts` | Accept on POST/PATCH (optional, default `[]`); return on GET |
| `services/ticket-analyzer/src/analyzer.ts` | Filter block before the `for (const rawTerm of searchTerms)` loop: drops `client.name`, `client.shortCode`, configured terms, and terms `< 4` chars (case-insensitive); single info log if all terms are filtered out |
| `services/control-panel/src/app/core/services/client.service.ts` | `searchIgnoreTerms: string[]` on Angular `Client` interface |
| `services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts` | "Repo Search" section with comma-input + Save |

## Filter rules

A term is dropped if any of the following match (all comparisons `toLowerCase()`):

1. Length `< 4` characters
2. Equals `client.name`
3. Equals `client.shortCode` (when set)
4. Appears in `client.searchIgnoreTerms`

If the entire term list is filtered to empty, pre-gather logs a single info line and skips the loop — it does not fail the analysis. Other repo context paths (later agentic searches via tool calls) are unaffected.

## Migration

Single column add, `NOT NULL DEFAULT ARRAY[]::TEXT[]`. Existing rows backfill to empty array automatically. No data loss.

## Verification

- `pnpm build` — clean
- `pnpm typecheck` — clean
- `pnpm --filter @bronco/ticket-analyzer test` — **223 passed**
- Lockfile unchanged

## Coordinated merge

Pairs with `fix/mcp-pregather-search-code` (executor swap to ripgrep). Both branches edit `analyzer.ts` in the pre-gather region — this branch's filter block sits **before** the loop, the other branch swaps the call **inside** the loop. Hunks are adjacent and will conflict on merge. **Merge this branch first, then rebase the executor branch on top** — the rebase is cleaner that way (the filter block is upstream of the call-site rewrite).

## Pre-deploy

None. Migration is additive, no env vars added, no docker-compose changes.

## Test plan (post-deploy)

- [ ] CI passes
- [ ] Open Altman client → Config tab → "Repo Search" section visible; field round-trips
- [ ] Re-run analysis on a ticket whose EXTRACT_FACTS terms include "Evolution" or "Altman" → analyzer logs filtered terms; no 30s timeout
- [ ] Confirm `Client.searchIgnoreTerms` round-trips on POST and PATCH via API
- [ ] Schema reflects `search_ignore_terms TEXT[] NOT NULL DEFAULT '{}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
