### PR TITLE
fix: restore admin access on artifact endpoints (regression from #411)

### DIFF
--- a/services/copilot-api/src/routes/artifacts.ts
+++ b/services/copilot-api/src/routes/artifacts.ts
@@ -60,41 +60,40 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
 
   fastify.get<{ Params: { id: string } }>('/api/artifacts/:id', async (request) => {
     const scope = await resolveClientScope(request);
-    // Load the artifact with its ticket's clientId so we can enforce scope.
     const artifact = await fastify.db.artifact.findFirst({
-      where: {
-        id: request.params.id,
-        OR: [
-          // Artifact is ticket-linked — enforce ticket scope.
-          { ticket: { ...scopeToWhere(scope) } },
-          // Artifact has no ticket (finding-only or unlinked) — allow all authenticated callers.
-          { ticketId: null },
-        ],
-      },
+      where: { id: request.params.id },
       select: ARTIFACT_SELECT,
     });
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
+    if (artifact.ticketId) {
+      const ticketInScope = await fastify.db.ticket.findFirst({
+        where: { id: artifact.ticketId, ...scopeToWhere(scope) },
+        select: { id: true },
+      });
+      if (!ticketInScope) return fastify.httpErrors.notFound('Artifact not found');
+    }
     return artifact;
   });
 
   fastify.get<{ Params: { id: string } }>('/api/artifacts/:id/download', async (request, reply) => {
     const scope = await resolveClientScope(request);
-    // Load the artifact with its ticket's clientId so we can enforce scope.
     const artifact = await fastify.db.artifact.findFirst({
-      where: {
-        id: request.params.id,
-        OR: [
-          { ticket: { ...scopeToWhere(scope) } },
-          { ticketId: null },
-        ],
-      },
+      where: { id: request.params.id },
       select: {
+        ticketId: true,
         storagePath: true,
         filename: true,
         mimeType: true,
       },
     });
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
+    if (artifact.ticketId) {
+      const ticketInScope = await fastify.db.ticket.findFirst({
+        where: { id: artifact.ticketId, ...scopeToWhere(scope) },
+        select: { id: true },
+      });
+      if (!ticketInScope) return fastify.httpErrors.notFound('Artifact not found');
+    }
 
     const filePath = join(storagePath, artifact.storagePath);
     const filename = artifact.filename;
@@ -117,23 +116,23 @@ export async function artifactRoutes(fastify: FastifyInstance, opts: { config: C
 
   fastify.get<{ Params: { id: string } }>('/api/artifacts/:id/content', async (request, reply) => {
     const scope = await resolveClientScope(request);
-    // Same scope check as /download — but serve with Content-Disposition: inline so
-    // browsers preview viewable content (text / json / images / pdf) instead of saving.
     const artifact = await fastify.db.artifact.findFirst({
-      where: {
-        id: request.params.id,
-        OR: [
-          { ticket: { ...scopeToWhere(scope) } },
-          { ticketId: null },
-        ],
-      },
+      where: { id: request.params.id },
       select: {
+        ticketId: true,
         storagePath: true,
         filename: true,
         mimeType: true,
       },
     });
     if (!artifact) return fastify.httpErrors.notFound('Artifact not found');
+    if (artifact.ticketId) {
+      const ticketInScope = await fastify.db.ticket.findFirst({
+        where: { id: artifact.ticketId, ...scopeToWhere(scope) },
+        select: { id: true },
+      });
+      if (!ticketInScope) return fastify.httpErrors.notFound('Artifact not found');
+    }
 
     const filePath = join(storagePath, artifact.storagePath);
     const filename = artifact.filename;


### PR DESCRIPTION
## Summary

Fixes a regression introduced by **PR #411** (2026-04-24, "fix(artifacts): scope artifact endpoints to caller tenant"). After that PR landed, admin operators viewing the **Attachments tab** on any ticket would see the artifact list correctly populate, but clicking **View** or **Download** on any ticket-linked artifact fired a "Not Found" toast. All ticket-linked artifacts were unreadable for admins; only artifacts with `ticketId: null` (rare — finding-only or unlinked) worked.

## Root cause

PR #411 added scope guards to three endpoints (`GET /api/artifacts/:id`, `/:id/download`, `/:id/content`) using a Prisma OR-clause:

```ts
where: {
  id: request.params.id,
  OR: [
    { ticket: { ...scopeToWhere(scope) } },
    { ticketId: null },
  ],
},
```

For admin callers, `scopeToWhere(scope)` returns `{}` (match-all), so the relation filter resolves to `{ ticket: {} }`. Prisma's empty-object relation-filter behavior on an optional one-to-one relation is a known sharp edge — it does **not** reliably mean "any non-null relation," and in our case it filtered out all ticket-linked artifacts. The first OR-arm matched nothing; the second arm only matches null-ticket rows; result: `findFirst` returned `null` for every ticket-linked artifact, the route returned 404, and the toast surfaced Fastify's standard `error: "Not Found"` envelope.

PR #411's test plan claimed "ADMIN can still download any artifact (no regression)" but did not exercise that path with a ticket-linked artifact in production-like data. The bug was discovered when the Attachments tab UI (PR #436, Apr 25) made the breakage visible.

## Fix

Mirror the LIST endpoint's working pattern (`GET /api/tickets/:ticketId/artifacts` at line 44): two-step query.

1. Load the artifact by id with no scope filter
2. If ticket-linked, verify the ticket is in scope via a separate `Ticket.findFirst` with `scopeToWhere(scope)` — exactly what LIST already does

Same security guarantees as #411:
- Out-of-scope ticket-linked artifact → 404 (verified via the second query)
- Null-ticket artifact → passes (skip the scope check)
- Admin sees everything

## What lands

| File | Change |
|---|---|
| `services/copilot-api/src/routes/artifacts.ts` | Three endpoints (`GET /:id`, `/:id/download`, `/:id/content`) refactored from the broken OR-clause to the two-step pattern. `/download` and `/content` selects gain `ticketId` so the scope check has it. No other behavior change. |

No schema changes, no migration, no env vars, no docker-compose, no front-end changes.

## Verification

- `pnpm build` — clean
- `pnpm typecheck` — clean
- No sibling test file exists for `artifacts.ts` — nothing to update

## Test plan (post-deploy)

- [ ] CI passes
- [ ] As admin operator, open any ticket → Attachments tab → click View on an MCP_TOOL_RESULT artifact → opens the JSON inline (no toast)
- [ ] Click Download on any artifact → file downloads (no toast)
- [ ] As a client-scoped operator (when one exists), confirm out-of-scope artifacts still 404 — security guarantee from #411 preserved

## Related

- Regresses fix from #411 — restores admin access while keeping the tenant-scope guarantee that #411 added
- Discovered while reviewing the Attachments tab on ticket #48 (Evolution DB Deadlock review, 2026-04-26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
