### PR TITLE
fix: address Copilot review on PR #460 — input hygiene for searchIgnoreTerms

### DIFF
--- a/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
@@ -98,7 +98,7 @@ import {
           <app-bronco-button
             variant="primary"
             size="sm"
-            [disabled]="searchIgnoreTermsValue() === (c.searchIgnoreTerms ?? []).join(', ')"
+            [disabled]="!isSearchIgnoreTermsDirty(c)"
             (click)="saveSearchIgnoreTerms()">
             Save
           </app-bronco-button>
@@ -169,6 +169,25 @@ export class ClientConfigTabComponent {
     }
   }
 
+  private normalizeTerms(input: string | string[]): string[] {
+    const raw = Array.isArray(input) ? input.join(',') : input;
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const t of raw.split(',')) {
+      const norm = t.trim().toLowerCase();
+      if (norm && !seen.has(norm)) {
+        seen.add(norm);
+        result.push(norm);
+      }
+    }
+    return result;
+  }
+
+  isSearchIgnoreTermsDirty(c: Client): boolean {
+    return JSON.stringify(this.normalizeTerms(this.searchIgnoreTermsValue())) !==
+      JSON.stringify(this.normalizeTerms(c.searchIgnoreTerms ?? []));
+  }
+
   toggle(field: 'isActive' | 'autoRouteTickets' | 'allowSelfRegistration', value: boolean): void {
     this.patch({ [field]: value });
   }
@@ -190,10 +209,7 @@ export class ClientConfigTabComponent {
   }
 
   saveSearchIgnoreTerms(): void {
-    const terms = this.searchIgnoreTermsValue()
-      .split(',')
-      .map(t => t.trim())
-      .filter(Boolean);
+    const terms = this.normalizeTerms(this.searchIgnoreTermsValue());
     this.patch({ searchIgnoreTerms: terms } as Partial<Client>, 'Search ignore terms saved');
   }
 

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -7,6 +7,19 @@ const VALID_AI_MODES = new Set<string>(Object.values(AiMode));
 // Basic domain format validation: alphanumeric labels separated by dots, no protocol prefix
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 
+function normalizeSearchIgnoreTerms(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    throw Object.assign(new Error('searchIgnoreTerms must be an array of strings'), { statusCode: 400 });
+  }
+  for (const item of raw) {
+    if (typeof item !== 'string') {
+      throw Object.assign(new Error('searchIgnoreTerms must be an array of strings'), { statusCode: 400 });
+    }
+  }
+  const trimmed = (raw as string[]).map(t => t.trim().toLowerCase()).filter(Boolean);
+  return [...new Set(trimmed)];
+}
+
 function validateDomainMappings(domains: string[] | undefined): string[] | undefined {
   if (!domains) return undefined;
   const cleaned = domains.map(d => d.trim().toLowerCase()).filter(Boolean);
@@ -149,16 +162,19 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     };
   });
 
-  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[]; searchIgnoreTerms?: string[] } }>(
+  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[]; searchIgnoreTerms?: unknown } }>(
     '/api/clients',
     async (request, reply) => {
       const domainMappings = validateDomainMappings(request.body.domainMappings);
-      const { searchIgnoreTerms, ...rest } = request.body;
+      const { searchIgnoreTerms: rawSearchIgnoreTerms, ...rest } = request.body;
+      const searchIgnoreTerms = rawSearchIgnoreTerms !== undefined
+        ? normalizeSearchIgnoreTerms(rawSearchIgnoreTerms)
+        : [];
       const client = await fastify.db.client.create({
         data: {
           ...rest,
           domainMappings,
-          ...(searchIgnoreTerms !== undefined && { searchIgnoreTerms }),
+          searchIgnoreTerms,
         },
       });
       reply.code(201);
@@ -166,10 +182,13 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     },
   );
 
-  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; searchIgnoreTerms?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
+  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; searchIgnoreTerms?: unknown; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
     '/api/clients/:id',
     async (request, reply) => {
-      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, searchIgnoreTerms, ...rest } = request.body;
+      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, searchIgnoreTerms: rawSearchIgnoreTerms, ...rest } = request.body;
+      const searchIgnoreTerms = rawSearchIgnoreTerms !== undefined
+        ? normalizeSearchIgnoreTerms(rawSearchIgnoreTerms)
+        : undefined;
       if (aiMode !== undefined && !VALID_AI_MODES.has(aiMode)) {
         return reply.code(400).send({ error: `Invalid aiMode "${aiMode}". Valid: ${[...VALID_AI_MODES].join(', ')}` });
       }

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -2024,18 +2024,18 @@ async function executeRoutePipeline(
             // Drop terms that are guaranteed noise for this client: the client's
             // own name, short code, any operator-configured ignore terms, and
             // anything shorter than 4 characters.
-            const clientNameLower = ticket.client.name.toLowerCase();
-            const clientShortCodeLower = ticket.client.shortCode.toLowerCase();
+            const clientNameLower = ticket.client.name.trim().toLowerCase();
+            const clientShortCodeLower = ticket.client.shortCode.trim().toLowerCase();
             const ignoreSet = new Set<string>(
-              (ticket.client.searchIgnoreTerms ?? []).map((t) => t.toLowerCase()),
+              (ticket.client.searchIgnoreTerms ?? []).map((t) => t.trim().toLowerCase()),
             );
             const preFilterCount = searchTerms.length;
             searchTerms = searchTerms.filter((t) => {
-              const lower = t.toLowerCase();
-              if (lower.length < 4) return false;
-              if (lower === clientNameLower) return false;
-              if (lower === clientShortCodeLower) return false;
-              if (ignoreSet.has(lower)) return false;
+              const normalized = t.trim().toLowerCase();
+              if (normalized.length < 4) return false;
+              if (normalized === clientNameLower) return false;
+              if (normalized === clientShortCodeLower) return false;
+              if (ignoreSet.has(normalized)) return false;
               return true;
             });
             if (searchTerms.length === 0) {


### PR DESCRIPTION
## Summary

Addresses the four Copilot review comments on PR #460 (`Client.searchIgnoreTerms` blocklist). All four were valid input-hygiene gaps: missing Zod validation on the API, whitespace-sensitive dirty-check on the form, and non-trim-aware comparisons in the analyzer's pre-gather filter.

## Changes

| Comment | File | Fix |
|---|---|---|
| Copilot #1 (POST `clients.ts:162`) | `services/copilot-api/src/routes/clients.ts` | New `normalizeSearchIgnoreTerms()` helper validates as `string[]`, throws 400 on bad input, then trims + lowercases + dedups. POST always persists a normalized array (defaults to `[]`). |
| Copilot #2 (PATCH `clients.ts:203`) | (same file) | PATCH runs the same normalizer when the field is present; absent → leave unchanged (preserves "absent = don't change" semantics). |
| Copilot #3 (`config-tab.component.ts:102`) | `services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts` | Added `normalizeTerms()` and `isSearchIgnoreTermsDirty()` — dirty-check now compares normalized arrays (`JSON.stringify`), so `a,b` vs `a, b` no longer toggle the Save button. `saveSearchIgnoreTerms()` also sends the normalized output. |
| Copilot #4 (`analyzer.ts:2035`) | `services/ticket-analyzer/src/analyzer.ts` | Pre-gather filter applies `trim().toLowerCase()` to all three sides — `client.name`, `client.shortCode`, configured `ignoreSet` entries, and `searchTerms` entries. The `< 4` length check now runs **after** trimming. `shortCode` is non-nullable per schema, so no null guard needed. |

## Verification

- `pnpm build` — clean
- `pnpm typecheck` — clean
- No new tests (existing tests unaffected by the normalization changes)
- Lockfile unchanged

## Related

Follow-up to PR #460 (merged 2026-04-26). Each Copilot review thread will be replied to and resolved after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
