### PR TITLE
fix(analyzer): trim sanitized search term to match pre-gather filter

### DIFF
--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -924,7 +924,7 @@ async function deepAnalysis(
 
       for (const rawTerm of searchTerms) {
         if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
-        const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+        const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
         try {
           const searchResult = await callMcpToolViaSdk(
             deps.mcpRepoUrl, '/mcp', 'search_code',
@@ -2053,7 +2053,7 @@ async function executeRoutePipeline(
             const relevantFiles = new Set<string>();
             for (const rawTerm of searchTerms) {
               if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
-              const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+              const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
               try {
                 const searchResult = await callMcpToolViaSdk(
                   mcpRepoUrl, '/mcp', 'search_code',
@@ -2631,7 +2631,7 @@ async function executeRoutePipeline(
                   // Search by terms (skip non-string entries from untyped JSON config)
                   for (const rawTerm of rs.searchTerms ?? []) {
                     if (typeof rawTerm !== 'string') continue;
-                    const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+                    const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
                     if (!sanitized) continue;
                     try {
                       const searchResult = await callMcpToolViaSdk(


### PR DESCRIPTION
## Summary

Closes the follow-up Copilot review on PR #463. The pre-gather filter introduced in #460 (and trim-normalized in #463) compares `t.trim().toLowerCase()` against `client.name`, `client.shortCode`, and the configured ignore terms — but the **search itself** still uses the raw term without trim. So a term arriving with leading/trailing whitespace **passes the filter** (after trim) and then **runs `search_code` with the whitespace baked in**, producing false-negative "no match" results.

This fix adds `.trim()` to the `sanitized` chain at all three analyzer call sites that hit `search_code`:

| File:line | Context |
|---|---|
| `services/ticket-analyzer/src/analyzer.ts:927` | Initial-gather (early in analysis) |
| `services/ticket-analyzer/src/analyzer.ts:2056` | Pre-gather (the site Copilot flagged) |
| `services/ticket-analyzer/src/analyzer.ts:2634` | CUSTOM_AI_QUERY route step |

The pre-existing empty-after-trim early-skip already used `.trim()` for the empty check; this change only ensures the value passed to `search_code` is also trimmed.

## Verification

- `pnpm build` — clean (full monorepo)
- 3-line change, single file
- Lockfile unchanged

## Test plan (post-deploy)

- [ ] Trigger analysis on a ticket whose EXTRACT_FACTS produces a term with whitespace (e.g. via line-wrapped text) and confirm `search_code` is called with the trimmed query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
