### PR TITLE
merge: staging → master (v0.2.11)

### DIFF
--- a/mcp-servers/database/package.json
+++ b/mcp-servers/database/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --passWithNoTests --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",
@@ -23,10 +25,12 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@bronco/test-utils": "workspace:*",
     "@types/express": "^5.0.0",
     "@types/mssql": "^9.0.0",
     "@types/node": "^25.3.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/mcp-servers/database/src/connections/pool-manager.test.ts
+++ b/mcp-servers/database/src/connections/pool-manager.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Unit tests for connections/pool-manager.ts
+ *
+ * The mssql driver is mocked so no real SQL Server connection is attempted.
+ * Coverage:
+ *  - buildMssqlConfig for MSSQL and AZURE_SQL_MI (host+port and connection string paths)
+ *  - Unsupported dbEngine throws
+ *  - Pool reuse on cache hit (connected pool)
+ *  - Pool recreation on disconnected pool
+ *  - getSystemConfig returns correct shape
+ *  - listSystems returns all configs
+ *  - reloadSystems closes pools for removed/changed systems
+ *  - onMissLoader is called when system is unknown
+ *  - closeAll clears pools and stops cleanup interval
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SystemConfigEntry } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Mock mssql
+// ---------------------------------------------------------------------------
+
+const mockPoolConnect = vi.fn().mockResolvedValue(undefined);
+const mockPoolClose = vi.fn().mockResolvedValue(undefined);
+const mockPoolOn = vi.fn();
+const mockParseConnectionString = vi.fn((cs: string) => {
+  // Simple stub: return parsed object from a fake ADO.NET-style string
+  return { server: 'parsed-server', port: 1433, database: 'parsedDb', user: 'sa', password: 'pw' };
+});
+
+// Mutable state read by the `connected` getter on every constructed pool.
+// Tests toggle this to simulate disconnected pools — the getter must be
+// re-invoked per access (NOT captured at construction time), so we attach
+// it via Object.defineProperty on each new instance.
+let poolConnectedState = true;
+
+function applyMockPoolShape(target: Record<string, unknown>): void {
+  target.connect = mockPoolConnect;
+  target.close = mockPoolClose;
+  target.on = mockPoolOn;
+  Object.defineProperty(target, 'connected', {
+    get: () => poolConnectedState,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+vi.mock('mssql', () => {
+  // Vitest 4 requires `function` keyword for `new`-able mocks; arrow-body
+  // mockImplementations are flagged as non-constructors and throw on `new`.
+  const ConnectionPool = vi.fn(function ConnectionPoolMock(this: Record<string, unknown>) {
+    applyMockPoolShape(this);
+  }) as unknown as { parseConnectionString: typeof mockParseConnectionString };
+  ConnectionPool.parseConnectionString = mockParseConnectionString;
+  return { default: { ConnectionPool } };
+});
+
+// Mock @bronco/shared-utils logger
+vi.mock('@bronco/shared-utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+// Import after mocks
+const { PoolManager } = await import('./pool-manager.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<SystemConfigEntry> = {}): SystemConfigEntry {
+  return {
+    id: 'test-id-1',
+    clientId: 'client-1',
+    clientName: 'Test Client',
+    clientCode: 'TC',
+    name: 'Test System',
+    dbEngine: 'MSSQL',
+    host: 'sql.test.local',
+    port: 1433,
+    connectionString: null,
+    instanceName: null,
+    defaultDatabase: 'TestDb',
+    authMethod: 'SQL_AUTH',
+    username: 'sa',
+    password: 'secret',
+    useTls: false,
+    trustServerCert: true,
+    connectionTimeout: 15000,
+    requestTimeout: 30000,
+    maxPoolSize: 10,
+    environment: 'PRODUCTION',
+    ...overrides,
+  };
+}
+
+function makeAzureMiConfig(overrides: Partial<SystemConfigEntry> = {}): SystemConfigEntry {
+  return makeConfig({
+    id: 'azure-id-1',
+    dbEngine: 'AZURE_SQL_MI',
+    host: 'instance.abc123.database.windows.net',
+    port: 3342,
+    connectionString: null,
+    useTls: true,
+    trustServerCert: false,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PoolManager', () => {
+  beforeEach(() => {
+    poolConnectedState = true;
+    vi.clearAllMocks();
+    mockPoolConnect.mockResolvedValue(undefined);
+    mockPoolClose.mockResolvedValue(undefined);
+    mockParseConnectionString.mockReturnValue({
+      server: 'parsed-server',
+      port: 1433,
+      database: 'parsedDb',
+      user: 'sa',
+      password: 'pw',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Constructor / listSystems
+  // -------------------------------------------------------------------------
+
+  it('listSystems returns all loaded systems', () => {
+    const systems = [makeConfig({ id: 'a' }), makeConfig({ id: 'b', name: 'Second' })];
+    const manager = new PoolManager(systems);
+    const list = manager.listSystems();
+    expect(list).toHaveLength(2);
+    expect(list.map((s) => s.id)).toContain('a');
+    expect(list.map((s) => s.id)).toContain('b');
+    manager.closeAll();
+  });
+
+  it('listSystems returns correct shape fields', () => {
+    const cfg = makeConfig({ id: 'shape-test', clientCode: 'XYZ', environment: 'STAGING' });
+    const manager = new PoolManager([cfg]);
+    const [item] = manager.listSystems();
+    expect(item).toMatchObject({
+      id: 'shape-test',
+      name: cfg.name,
+      clientId: cfg.clientId,
+      clientName: cfg.clientName,
+      clientCode: 'XYZ',
+      dbEngine: 'MSSQL',
+      environment: 'STAGING',
+      host: cfg.host,
+      usesConnectionString: false,
+    });
+    manager.closeAll();
+  });
+
+  it('usesConnectionString is true when connectionString is set', () => {
+    const cfg = makeAzureMiConfig({ connectionString: 'Server=x;Database=y;' });
+    const manager = new PoolManager([cfg]);
+    const [item] = manager.listSystems();
+    expect(item.usesConnectionString).toBe(true);
+    manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // getSystemConfig
+  // -------------------------------------------------------------------------
+
+  it('getSystemConfig returns config for known systemId', () => {
+    const cfg = makeConfig({ id: 'cfg-test' });
+    const manager = new PoolManager([cfg]);
+    const result = manager.getSystemConfig('cfg-test');
+    expect(result.id).toBe('cfg-test');
+    expect(result.host).toBe(cfg.host);
+    expect(result.password).toBe(cfg.password);
+    manager.closeAll();
+  });
+
+  it('getSystemConfig throws for unknown systemId', () => {
+    const manager = new PoolManager([]);
+    expect(() => manager.getSystemConfig('does-not-exist')).toThrow('System not found');
+    manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // buildMssqlConfig — MSSQL (on-prem)
+  // -------------------------------------------------------------------------
+
+  it('getPool creates pool with MSSQL host+port config', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeConfig({ id: 'mssql-test' });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('mssql-test');
+
+    expect(mssql.ConnectionPool).toHaveBeenCalledOnce();
+    const constructorArg = (mssql.ConnectionPool as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect(constructorArg['server']).toBe(cfg.host);
+    expect(constructorArg['port']).toBe(cfg.port);
+    expect(constructorArg['database']).toBe(cfg.defaultDatabase);
+    expect(constructorArg['user']).toBe(cfg.username);
+    expect(constructorArg['password']).toBe(cfg.password);
+    expect((constructorArg['options'] as Record<string, unknown>)['encrypt']).toBe(cfg.useTls);
+    expect((constructorArg['options'] as Record<string, unknown>)['trustServerCertificate']).toBe(cfg.trustServerCert);
+    expect((constructorArg['pool'] as Record<string, unknown>)['max']).toBe(cfg.maxPoolSize);
+
+    await manager.closeAll();
+  });
+
+  it('MSSQL config uses instanceName when provided', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeConfig({ id: 'named-instance', instanceName: 'SQLEXPRESS' });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('named-instance');
+
+    const constructorArg = (mssql.ConnectionPool as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect((constructorArg['options'] as Record<string, unknown>)['instanceName']).toBe('SQLEXPRESS');
+
+    await manager.closeAll();
+  });
+
+  it('MSSQL config defaults database to "master" when defaultDatabase is null', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeConfig({ id: 'no-db', defaultDatabase: null });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('no-db');
+
+    const constructorArg = (mssql.ConnectionPool as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect(constructorArg['database']).toBe('master');
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // buildMssqlConfig — AZURE_SQL_MI (host+port path)
+  // -------------------------------------------------------------------------
+
+  it('getPool creates pool with AZURE_SQL_MI host+port config', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeAzureMiConfig({ id: 'azure-mi-hp' });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('azure-mi-hp');
+
+    const constructorArg = (mssql.ConnectionPool as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect(constructorArg['server']).toBe(cfg.host);
+    expect(constructorArg['port']).toBe(cfg.port);
+    // Azure MI always forces encrypt: true regardless of config
+    expect((constructorArg['options'] as Record<string, unknown>)['encrypt']).toBe(true);
+    // Azure MI always sets trustServerCertificate: false for real cert validation
+    expect((constructorArg['options'] as Record<string, unknown>)['trustServerCertificate']).toBe(false);
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // buildMssqlConfig — AZURE_SQL_MI (connection string path)
+  // -------------------------------------------------------------------------
+
+  it('getPool uses parseConnectionString when connectionString is set', async () => {
+    const mssql = (await import('mssql')).default;
+    const connString = 'Server=tcp:my.mi.db.windows.net,3342;Database=mydb;User Id=sa;Password=pw;Encrypt=True;';
+    const cfg = makeAzureMiConfig({ id: 'azure-mi-cs', connectionString: connString });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('azure-mi-cs');
+
+    expect(mssql.ConnectionPool.parseConnectionString).toHaveBeenCalledWith(connString);
+    // Pool should still be created
+    expect(mssql.ConnectionPool).toHaveBeenCalledOnce();
+
+    await manager.closeAll();
+  });
+
+  it('connection string path merges pool settings from config', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeAzureMiConfig({
+      id: 'azure-mi-cs-pool',
+      connectionString: 'Server=x;Database=y;',
+      maxPoolSize: 25,
+    });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('azure-mi-cs-pool');
+
+    const constructorArg = (mssql.ConnectionPool as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect((constructorArg['pool'] as Record<string, unknown>)['max']).toBe(25);
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // Unsupported dbEngine
+  // -------------------------------------------------------------------------
+
+  it('getPool throws for unsupported dbEngine (POSTGRESQL)', async () => {
+    const cfg = makeConfig({ id: 'pg-test', dbEngine: 'POSTGRESQL' as 'MSSQL' });
+    const manager = new PoolManager([cfg]);
+
+    await expect(manager.getPool('pg-test')).rejects.toThrow(/Unsupported dbEngine/);
+
+    await manager.closeAll();
+  });
+
+  it('getPool throws for unsupported dbEngine (MYSQL)', async () => {
+    const cfg = makeConfig({ id: 'mysql-test', dbEngine: 'MYSQL' as 'MSSQL' });
+    const manager = new PoolManager([cfg]);
+
+    await expect(manager.getPool('mysql-test')).rejects.toThrow(/Unsupported dbEngine/);
+
+    await manager.closeAll();
+  });
+
+  it('unsupported dbEngine error message includes the engine name', async () => {
+    const cfg = makeConfig({ id: 'pg-msg', dbEngine: 'POSTGRESQL' as 'MSSQL' });
+    const manager = new PoolManager([cfg]);
+
+    await expect(manager.getPool('pg-msg')).rejects.toThrow(/POSTGRESQL/);
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pool reuse on cache hit
+  // -------------------------------------------------------------------------
+
+  it('returns the same pool object on a second getPool call (cache hit)', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeConfig({ id: 'reuse-test' });
+    const manager = new PoolManager([cfg]);
+
+    const pool1 = await manager.getPool('reuse-test');
+    const pool2 = await manager.getPool('reuse-test');
+
+    expect(pool1).toBe(pool2);
+    // ConnectionPool constructor only called once
+    expect(mssql.ConnectionPool).toHaveBeenCalledOnce();
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // Pool recreation on disconnected pool
+  // -------------------------------------------------------------------------
+
+  it('recreates pool when cached pool is disconnected', async () => {
+    const mssql = (await import('mssql')).default;
+    const cfg = makeConfig({ id: 'reconnect-test' });
+    const manager = new PoolManager([cfg]);
+
+    // First call — pool connected
+    await manager.getPool('reconnect-test');
+    expect(mssql.ConnectionPool).toHaveBeenCalledTimes(1);
+
+    // Simulate disconnected state
+    poolConnectedState = false;
+
+    // Second call — should create a new pool
+    await manager.getPool('reconnect-test');
+    expect(mssql.ConnectionPool).toHaveBeenCalledTimes(2);
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // onMissLoader — called when system is unknown
+  // -------------------------------------------------------------------------
+
+  it('calls onMissLoader when systemId is not in cache', async () => {
+    const cfg = makeConfig({ id: 'dynamic-system' });
+    const manager = new PoolManager([]); // start empty
+
+    const loader = vi.fn().mockResolvedValue([cfg]);
+    manager.setOnMissLoader(loader);
+
+    await manager.getPool('dynamic-system');
+
+    expect(loader).toHaveBeenCalledOnce();
+
+    await manager.closeAll();
+  });
+
+  it('does not call onMissLoader when system is already in cache', async () => {
+    const cfg = makeConfig({ id: 'cached-system' });
+    const manager = new PoolManager([cfg]);
+
+    const loader = vi.fn().mockResolvedValue([cfg]);
+    manager.setOnMissLoader(loader);
+
+    await manager.getPool('cached-system');
+
+    expect(loader).not.toHaveBeenCalled();
+
+    await manager.closeAll();
+  });
+
+  it('throws System not found when onMissLoader returns no matching system', async () => {
+    const manager = new PoolManager([]);
+    const loader = vi.fn().mockResolvedValue([]); // returns empty — system still not found
+    manager.setOnMissLoader(loader);
+
+    await expect(manager.getPool('ghost-system')).rejects.toThrow('System not found');
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // reloadSystems
+  // -------------------------------------------------------------------------
+
+  it('reloadSystems replaces configs', async () => {
+    const oldCfg = makeConfig({ id: 'sys-old', name: 'Old' });
+    const manager = new PoolManager([oldCfg]);
+
+    const newCfg = makeConfig({ id: 'sys-new', name: 'New' });
+    await manager.reloadSystems([newCfg]);
+
+    const list = manager.listSystems();
+    expect(list.map((s) => s.id)).toContain('sys-new');
+    expect(list.map((s) => s.id)).not.toContain('sys-old');
+
+    await manager.closeAll();
+  });
+
+  it('reloadSystems closes pools for removed systems', async () => {
+    const cfg = makeConfig({ id: 'to-remove' });
+    const manager = new PoolManager([cfg]);
+
+    // Create pool
+    await manager.getPool('to-remove');
+
+    // Reload without the system
+    await manager.reloadSystems([]);
+
+    // Pool should have been closed
+    expect(mockPoolClose).toHaveBeenCalled();
+
+    await manager.closeAll();
+  });
+
+  it('reloadSystems closes pools for changed systems', async () => {
+    const cfg = makeConfig({ id: 'to-change', host: 'old-host' });
+    const manager = new PoolManager([cfg]);
+
+    // Create pool
+    await manager.getPool('to-change');
+
+    // Reload with changed host
+    const updated = { ...cfg, host: 'new-host' };
+    await manager.reloadSystems([updated]);
+
+    // Pool for old config should have been closed
+    expect(mockPoolClose).toHaveBeenCalled();
+
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // closePool
+  // -------------------------------------------------------------------------
+
+  it('closePool closes and removes a specific pool', async () => {
+    const cfg = makeConfig({ id: 'close-test' });
+    const manager = new PoolManager([cfg]);
+
+    await manager.getPool('close-test');
+    await manager.closePool('close-test');
+
+    expect(mockPoolClose).toHaveBeenCalled();
+
+    await manager.closeAll();
+  });
+
+  it('closePool is a no-op when pool does not exist', async () => {
+    const manager = new PoolManager([]);
+    // Should not throw
+    await expect(manager.closePool('nonexistent')).resolves.toBeUndefined();
+    await manager.closeAll();
+  });
+
+  // -------------------------------------------------------------------------
+  // closeAll
+  // -------------------------------------------------------------------------
+
+  it('closeAll closes all pools', async () => {
+    const cfgs = [makeConfig({ id: 'ca-1' }), makeConfig({ id: 'ca-2', name: 'Second' })];
+    const manager = new PoolManager(cfgs);
+
+    await manager.getPool('ca-1');
+    await manager.getPool('ca-2');
+
+    await manager.closeAll();
+
+    expect(mockPoolClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mcp-servers/database/src/security/audit-logger.test.ts
+++ b/mcp-servers/database/src/security/audit-logger.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for security/audit-logger.ts
+ *
+ * AuditLogger wraps Pino's createLogger. We capture what it emits to verify:
+ *  - The query itself is NOT logged (only its SHA-256 hash) — redaction
+ *  - Required fields (systemId, queryHash, toolName, caller) are present
+ *  - Optional fields (durationMs, rowCount, error) are included when provided, absent when not
+ *  - The log message is "query audit"
+ *  - queryHash is a valid 64-char hex string (sha256)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+
+// We spy on createLogger to intercept what AuditLogger calls on the logger instance.
+// Because AuditLogger calls createLogger at module evaluation time, we need to mock
+// before importing the module under test.
+
+// Capture logged objects
+let loggedObjects: Array<Record<string, unknown>> = [];
+let loggedMessages: string[] = [];
+
+// Create a fake pino logger whose .info() captures calls
+const fakeLogger = {
+  info: vi.fn((obj: Record<string, unknown>, msg: string) => {
+    loggedObjects.push(obj);
+    loggedMessages.push(msg);
+  }),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  fatal: vi.fn(),
+  child: vi.fn(() => fakeLogger),
+};
+
+// Mock @bronco/shared-utils before importing AuditLogger
+vi.mock('@bronco/shared-utils', () => ({
+  createLogger: vi.fn(() => fakeLogger),
+}));
+
+// Import after mock is registered
+const { AuditLogger } = await import('./audit-logger.js');
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+describe('AuditLogger', () => {
+  let auditLogger: InstanceType<typeof AuditLogger>;
+
+  beforeEach(() => {
+    loggedObjects = [];
+    loggedMessages = [];
+    vi.clearAllMocks();
+    // Re-wire the mock (clearAllMocks resets call counts but not implementations)
+    fakeLogger.info.mockImplementation((obj: Record<string, unknown>, msg: string) => {
+      loggedObjects.push(obj);
+      loggedMessages.push(msg);
+    });
+    auditLogger = new AuditLogger();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic structure
+  // -------------------------------------------------------------------------
+
+  it('calls logger.info once per log() call', async () => {
+    await auditLogger.log({
+      systemId: 'sys-1',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'mcp:claude-code',
+    });
+
+    expect(fakeLogger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets message to "query audit"', async () => {
+    await auditLogger.log({
+      systemId: 'sys-1',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'mcp:claude-code',
+    });
+
+    expect(loggedMessages[0]).toBe('query audit');
+  });
+
+  // -------------------------------------------------------------------------
+  // Query redaction — the raw query must NOT appear in the log object
+  // -------------------------------------------------------------------------
+
+  it('does NOT log the raw query text', async () => {
+    const query = 'SELECT secret_column FROM secret_table';
+    await auditLogger.log({
+      systemId: 'sys-1',
+      query,
+      toolName: 'run_query',
+      caller: 'mcp:claude-code',
+    });
+
+    const logged = loggedObjects[0]!;
+    // The raw query string should not appear as any value in the logged object
+    for (const value of Object.values(logged)) {
+      expect(String(value)).not.toBe(query);
+      expect(String(value)).not.toContain('secret_column');
+    }
+  });
+
+  it('logs the SHA-256 hash of the query instead', async () => {
+    const query = 'SELECT 1 FROM sys.tables';
+    await auditLogger.log({
+      systemId: 'sys-1',
+      query,
+      toolName: 'run_query',
+      caller: 'mcp:claude-code',
+    });
+
+    const logged = loggedObjects[0]!;
+    const expectedHash = sha256Hex(query);
+    expect(logged['queryHash']).toBe(expectedHash);
+  });
+
+  it('queryHash is a 64-character lowercase hex string', async () => {
+    await auditLogger.log({
+      systemId: 'sys-1',
+      query: 'SELECT name FROM sys.databases',
+      toolName: 'inspect_schema',
+      caller: 'test-caller',
+    });
+
+    const logged = loggedObjects[0]!;
+    const hash = logged['queryHash'];
+    expect(typeof hash).toBe('string');
+    expect((hash as string).length).toBe(64);
+    expect((hash as string)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Required fields
+  // -------------------------------------------------------------------------
+
+  it('includes systemId', async () => {
+    await auditLogger.log({
+      systemId: 'test-system-uuid',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'mcp:claude',
+    });
+    expect(loggedObjects[0]!['systemId']).toBe('test-system-uuid');
+  });
+
+  it('includes toolName', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'inspect_schema',
+      caller: 'mcp:claude',
+    });
+    expect(loggedObjects[0]!['toolName']).toBe('inspect_schema');
+  });
+
+  it('includes caller', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'unit-test-caller',
+    });
+    expect(loggedObjects[0]!['caller']).toBe('unit-test-caller');
+  });
+
+  // -------------------------------------------------------------------------
+  // Optional fields — present when provided
+  // -------------------------------------------------------------------------
+
+  it('includes durationMs when provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+      durationMs: 42,
+    });
+    expect(loggedObjects[0]!['durationMs']).toBe(42);
+  });
+
+  it('includes rowCount when provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+      rowCount: 100,
+    });
+    expect(loggedObjects[0]!['rowCount']).toBe(100);
+  });
+
+  it('includes error when provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+      error: 'Connection timeout',
+    });
+    expect(loggedObjects[0]!['error']).toBe('Connection timeout');
+  });
+
+  // -------------------------------------------------------------------------
+  // Optional fields — absent when not provided
+  // -------------------------------------------------------------------------
+
+  it('does not include durationMs when not provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+    });
+    // durationMs should be undefined (not set)
+    expect(loggedObjects[0]!['durationMs']).toBeUndefined();
+  });
+
+  it('does not include rowCount when not provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+    });
+    expect(loggedObjects[0]!['rowCount']).toBeUndefined();
+  });
+
+  it('does not include error when not provided', async () => {
+    await auditLogger.log({
+      systemId: 'sys',
+      query: 'SELECT 1',
+      toolName: 'run_query',
+      caller: 'test',
+    });
+    expect(loggedObjects[0]!['error']).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Hash determinism
+  // -------------------------------------------------------------------------
+
+  it('produces the same hash for the same query on repeated calls', async () => {
+    const query = 'SELECT name FROM sys.tables ORDER BY name';
+    await auditLogger.log({ systemId: 'a', query, toolName: 'run_query', caller: 'test' });
+    await auditLogger.log({ systemId: 'b', query, toolName: 'run_query', caller: 'test' });
+
+    expect(loggedObjects[0]!['queryHash']).toBe(loggedObjects[1]!['queryHash']);
+  });
+
+  it('produces different hashes for different queries', async () => {
+    await auditLogger.log({ systemId: 'sys', query: 'SELECT 1', toolName: 'run_query', caller: 'test' });
+    await auditLogger.log({ systemId: 'sys', query: 'SELECT 2', toolName: 'run_query', caller: 'test' });
+
+    expect(loggedObjects[0]!['queryHash']).not.toBe(loggedObjects[1]!['queryHash']);
+  });
+
+  // -------------------------------------------------------------------------
+  // log() returns a resolved promise (does not throw)
+  // -------------------------------------------------------------------------
+
+  it('returns a promise that resolves', async () => {
+    await expect(
+      auditLogger.log({
+        systemId: 'sys',
+        query: 'SELECT 1',
+        toolName: 'run_query',
+        caller: 'test',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/mcp-servers/database/src/security/query-validator.test.ts
+++ b/mcp-servers/database/src/security/query-validator.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Unit tests for security/query-validator.ts
+ *
+ * Coverage goals:
+ *  - Every blocked keyword fires on a normal input
+ *  - Bypass attempts: comment injection, case variants, Unicode lookalikes,
+ *    multi-statement, whitespace tricks, semicolons, hex/char escapes
+ *  - Valid queries that contain blocked keywords as substrings (not full words) pass
+ *  - wrapReadOnly output shape
+ *  - Empty / whitespace-only inputs
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateQuery, wrapReadOnly } from './query-validator.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function expectBlocked(query: string, label?: string): void {
+  const result = validateQuery(query);
+  expect(result.valid, `Expected BLOCKED but got VALID for: ${label ?? query}`).toBe(false);
+  expect(result.reason).toBeTruthy();
+}
+
+function expectAllowed(query: string, label?: string): void {
+  const result = validateQuery(query);
+  expect(result.valid, `Expected VALID but got BLOCKED for: ${label ?? query} — reason: ${result.reason}`).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Empty / blank inputs
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — empty / blank inputs', () => {
+  it('rejects empty string', () => {
+    const r = validateQuery('');
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/empty/i);
+  });
+
+  it('rejects whitespace-only string', () => {
+    const r = validateQuery('   \t\n  ');
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/empty/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Valid queries that should pass
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — valid SELECT queries', () => {
+  const validCases: Array<[string, string]> = [
+    ['SELECT 1', 'trivial select'],
+    ['SELECT * FROM sys.tables', 'select star'],
+    ['SELECT name, object_id FROM sys.objects WHERE type = \'U\'', 'select with WHERE'],
+    ['WITH cte AS (SELECT 1 AS n) SELECT n FROM cte', 'CTE'],
+    ['SELECT TOP 10 * FROM sys.dm_exec_requests', 'TOP select DMV'],
+    ['SELECT\n  name\nFROM\n  sys.databases', 'multiline select'],
+    ['select name from sys.tables', 'lowercase select'],
+    [
+      'SELECT d.name, mf.physical_name FROM sys.databases d JOIN sys.master_files mf ON d.database_id = mf.database_id',
+      'join select',
+    ],
+    // Keyword as a column alias / string literal — none of these contain a *blocked* keyword
+    ['SELECT 1 AS inserting_count', 'keyword as part of alias — inserting_count does NOT contain INSERT as whole word'],
+  ];
+
+  for (const [query, label] of validCases) {
+    it(`passes: ${label}`, () => {
+      expectAllowed(query, label);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Every blocked keyword fires (exact keyword, uppercase)
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — blocked keywords (exact, uppercase)', () => {
+  const cases: Array<[string, string]> = [
+    ['INSERT INTO t VALUES (1)', 'INSERT'],
+    ['UPDATE t SET col = 1', 'UPDATE'],
+    ['DELETE FROM t', 'DELETE'],
+    ['DROP TABLE t', 'DROP'],
+    ['ALTER TABLE t ADD col INT', 'ALTER'],
+    ['CREATE TABLE t (id INT)', 'CREATE'],
+    ['EXEC sp_who2', 'EXEC'],
+    ['EXECUTE sp_who2', 'EXECUTE'],
+    ['GRANT SELECT ON t TO user1', 'GRANT'],
+    ['REVOKE SELECT ON t FROM user1', 'REVOKE'],
+    ['DENY SELECT ON t TO user1', 'DENY'],
+    ['TRUNCATE TABLE t', 'TRUNCATE'],
+    ['BULK INSERT t FROM \'file.csv\'', 'BULK'],
+    ['SELECT * FROM OPENROWSET(\'SQLNCLI\', \'server\', \'SELECT 1\')', 'OPENROWSET'],
+    ['SELECT * FROM OPENQUERY(srv, \'SELECT 1\')', 'OPENQUERY'],
+    ['RECONFIGURE WITH OVERRIDE', 'RECONFIGURE'],
+    ['SHUTDOWN WITH NOWAIT', 'SHUTDOWN'],
+    ['BACKUP DATABASE db TO DISK = \'backup.bak\'', 'BACKUP'],
+    ['RESTORE DATABASE db FROM DISK = \'backup.bak\'', 'RESTORE'],
+    ['EXEC sp_configure \'show advanced options\', 1', 'sp_configure'],
+    ['EXEC xp_cmdshell \'dir\'', 'xp_cmdshell'],
+    ['EXEC xp_regwrite \'HKEY_LOCAL_MACHINE\', \'test\', \'val\'', 'xp_ prefix'],
+  ];
+
+  for (const [query, label] of cases) {
+    it(`blocks ${label}`, () => {
+      expectBlocked(query, label);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Case variant bypass attempts
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — case variant bypass attempts', () => {
+  const cases: Array<[string, string]> = [
+    ['insert into t values (1)', 'insert (lowercase)'],
+    ['Insert Into t Values (1)', 'Insert (mixed)'],
+    ['InSeRt INTO t VALUES (1)', 'InSeRt (mixed crazy)'],
+    ['update t set col = 1', 'update (lowercase)'],
+    ['delete from t', 'delete (lowercase)'],
+    ['drop table t', 'drop (lowercase)'],
+    ['alter table t add col int', 'alter (lowercase)'],
+    ['create table t (id int)', 'create (lowercase)'],
+    ['exec sp_who2', 'exec (lowercase)'],
+    ['execute sp_who2', 'execute (lowercase)'],
+    ['grant select on t to u', 'grant (lowercase)'],
+    ['revoke select on t from u', 'revoke (lowercase)'],
+    ['deny select on t to u', 'deny (lowercase)'],
+    ['truncate table t', 'truncate (lowercase)'],
+    ['bulk insert t from \'f\'', 'bulk (lowercase)'],
+    ['reconfigure', 'reconfigure (lowercase)'],
+    ['shutdown', 'shutdown (lowercase)'],
+    ['backup database db to disk = \'f\'', 'backup (lowercase)'],
+    ['restore database db from disk = \'f\'', 'restore (lowercase)'],
+  ];
+
+  for (const [query, label] of cases) {
+    it(`blocks ${label}`, () => {
+      expectBlocked(query, label);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Multi-statement bypass attempts (semicolon-separated)
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — multi-statement bypass attempts', () => {
+  it('blocks SELECT; DROP TABLE t', () => {
+    expectBlocked('SELECT * FROM sys.tables; DROP TABLE t', 'select then drop');
+  });
+
+  it('blocks SELECT; DELETE FROM t', () => {
+    expectBlocked('SELECT 1; DELETE FROM t WHERE 1=1', 'select then delete');
+  });
+
+  it('blocks SELECT; TRUNCATE TABLE t', () => {
+    expectBlocked('SELECT 1; TRUNCATE TABLE t', 'select then truncate');
+  });
+
+  it('blocks SELECT; EXEC xp_cmdshell', () => {
+    expectBlocked("SELECT 1; EXEC xp_cmdshell 'dir'", 'select then xp_cmdshell');
+  });
+
+  it('blocks SELECT; INSERT INTO', () => {
+    expectBlocked('SELECT 1; INSERT INTO t(c) VALUES(1)', 'select then insert');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Comment injection bypass attempts
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — comment injection bypass attempts', () => {
+  // Inline comments (--) don't change the word itself so the regex still matches
+  it('blocks DROP--comment TABLE t', () => {
+    expectBlocked('DROP--this is fine\nTABLE t', 'drop with inline comment after keyword');
+  });
+
+  it('blocks SELECT 1; /*harmless*/ DELETE FROM t', () => {
+    expectBlocked('SELECT 1; /*harmless*/ DELETE FROM t', 'delete with block comment');
+  });
+
+  it('blocks INSERT inside block comment bypass attempt', () => {
+    // Attacker tries to hide keyword in comment but keyword still appears unprotected before it
+    expectBlocked("/* legit */ INSERT INTO t VALUES(1)", 'insert after block comment');
+  });
+
+  it('blocks EXEC with inline comment between keyword chars (not splittable by regex)', () => {
+    // EXEC is a single token; SQL comment injection can't split a keyword at the lexer level
+    // but the regex will match the whole word before the comment
+    expectBlocked("EXEC /* comment */ xp_cmdshell 'dir'", 'exec with comment inside call');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace / newline normalization
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — whitespace / newline variants', () => {
+  it('blocks DROP\\nTABLE with newline', () => {
+    // The keyword DROP appears as a whole word on its own line
+    expectBlocked('DROP\nTABLE users', 'drop on own line');
+  });
+
+  it('blocks INSERT with leading whitespace', () => {
+    expectBlocked('   INSERT INTO t VALUES (1)', 'insert with leading spaces');
+  });
+
+  it('blocks UPDATE with tab indent', () => {
+    expectBlocked('\tUPDATE t SET col = 1', 'update with tab');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Substring non-collision (should NOT be blocked)
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — keyword as substring of identifier (should pass)', () => {
+  // These identifiers contain a keyword as a substring but NOT as a whole word
+  // \b word boundary means "DROPZONE" should not match DROP, etc.
+  const cases: Array<[string, string]> = [
+    ['SELECT * FROM dropzone_audit', 'dropzone contains drop substring'],
+    ['SELECT * FROM created_records', 'created_records contains create substring'],
+    ['SELECT * FROM alter_log', 'alter_log contains alter substring'],
+    ['SELECT deleted_at FROM audit_records', 'deleted_at contains delete substring'],
+    ['SELECT inserted_at FROM log_records', 'inserted_at contains insert substring'],
+    ['SELECT executor_id FROM tasks', 'executor_id contains exec substring'],
+    ['SELECT * FROM truncation_log', 'truncation_log contains truncat substring'],
+    ['SELECT backup_type FROM backup_schedules', 'backup as a column name (whole word)'],
+  ];
+
+  for (const [query, label] of cases) {
+    it(`passes: ${label}`, () => {
+      // backup_type and backup_schedules: note "BACKUP" as a whole word IS blocked
+      // but "backup_type" and "backup_schedules" — "backup" appears as a whole word here?
+      // Let's check: \bbackup\b in "backup_type" — underscore is \w so \b is NOT between backup and _
+      // Therefore backup_type does NOT match \bBACKUP\b. Good.
+      expectAllowed(query, label);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unicode / homoglyph bypass attempts
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — unicode / homoglyph bypass attempts', () => {
+  // These use unicode lookalikes that look like latin letters but are different code points.
+  // The regex uses \b which operates on ASCII word boundaries; non-ASCII chars outside
+  // the ASCII range do not form \w so the boundary behavior can differ.
+  // We document expected behaviour here — if these pass, it's a known limitation.
+
+  it('passes SELECT with Cyrillic C (not a real SQL keyword)', () => {
+    // Ϲ (U+03F9 Greek Capital Letter Lunate Sigma) instead of C in SELECT
+    // This is NOT the ASCII keyword SELECT so SQL Server would reject it anyway.
+    // The query validator should not block it (it's not a recognized keyword).
+    const query = 'ЅЕLECT * FROM sys.tables'; // Cyrillic Dze + Cyrillic letters
+    // This might or might not be blocked depending on unicode behavior of \b
+    // We just confirm the validator doesn't throw.
+    expect(() => validateQuery(query)).not.toThrow();
+  });
+
+  it('does not throw on null bytes in query', () => {
+    const query = 'SELECT\x001';
+    expect(() => validateQuery(query)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// xp_ prefix matching
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — xp_ prefix matching', () => {
+  it('blocks xp_cmdshell (lowercase)', () => {
+    expectBlocked("exec xp_cmdshell 'whoami'", 'xp_cmdshell lowercase');
+  });
+
+  it('blocks xp_regwrite', () => {
+    expectBlocked("EXEC xp_regwrite 'HKLM', 'Software', 'val'", 'xp_regwrite');
+  });
+
+  it('blocks xp_fixeddrives', () => {
+    expectBlocked('EXEC xp_fixeddrives', 'xp_fixeddrives');
+  });
+
+  it('blocks xp_fileexist', () => {
+    expectBlocked("EXEC xp_fileexist 'C:\\file.txt'", 'xp_fileexist');
+  });
+
+  it('blocks XP_CMDSHELL uppercase', () => {
+    expectBlocked("EXEC XP_CMDSHELL 'dir'", 'XP_CMDSHELL uppercase');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sp_configure matching
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — sp_configure', () => {
+  it('blocks sp_configure with show advanced options', () => {
+    expectBlocked("EXEC sp_configure 'show advanced options', 1", 'sp_configure show advanced');
+  });
+
+  it('blocks sp_configure (lowercase)', () => {
+    expectBlocked("exec sp_configure 'xp_cmdshell', 1", 'sp_configure lowercase');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error message content
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — error message content', () => {
+  it('includes the blocked keyword in the reason', () => {
+    const r = validateQuery('DROP TABLE users');
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/DROP/i);
+  });
+
+  it('reason mentions read-only guidance', () => {
+    const r = validateQuery('DELETE FROM users');
+    expect(r.valid).toBe(false);
+    expect(r.reason).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapReadOnly
+// ---------------------------------------------------------------------------
+
+describe('wrapReadOnly', () => {
+  it('prepends SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED', () => {
+    const wrapped = wrapReadOnly('SELECT 1');
+    expect(wrapped).toContain('SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED');
+  });
+
+  it('prepends SET NOCOUNT ON', () => {
+    const wrapped = wrapReadOnly('SELECT 1');
+    expect(wrapped).toContain('SET NOCOUNT ON');
+  });
+
+  it('includes the original query unchanged', () => {
+    const query = 'SELECT TOP 10 * FROM sys.tables';
+    const wrapped = wrapReadOnly(query);
+    expect(wrapped).toContain(query);
+  });
+
+  it('produces a multiline string with SET directives before the query', () => {
+    const wrapped = wrapReadOnly('SELECT 1');
+    const lines = wrapped.split('\n');
+    expect(lines[0]).toMatch(/SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED/);
+    expect(lines[1]).toMatch(/SET NOCOUNT ON/);
+    expect(lines[2]).toBe('SELECT 1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Completeness audit
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — keyword completeness audit', () => {
+  // Ensure the documented set of blocked keywords all fire.
+  // If this list diverges from the actual BLOCKED_KEYWORDS array, tests will fail.
+  const documentedKeywords = [
+    'INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'CREATE',
+    'EXEC', 'EXECUTE', 'GRANT', 'REVOKE', 'DENY',
+    'TRUNCATE', 'BULK', 'OPENROWSET', 'OPENQUERY',
+    'RECONFIGURE', 'SHUTDOWN', 'BACKUP', 'RESTORE',
+    'sp_configure', 'xp_cmdshell', 'xp_',
+  ] as const;
+
+  for (const kw of documentedKeywords) {
+    it(`documented keyword "${kw}" is enforced`, () => {
+      // Build a minimal query that uses the keyword as a standalone word
+      const query = `${kw} something`;
+      const r = validateQuery(query);
+      expect(r.valid, `Keyword "${kw}" should be blocked but passed`).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// STACKED QUERIES — SELECT followed by dangerous statement on same line
+// ---------------------------------------------------------------------------
+
+describe('validateQuery — stacked query patterns', () => {
+  it('blocks SELECT 1 UNION ALL SELECT 1; DROP TABLE users', () => {
+    expectBlocked('SELECT 1 UNION ALL SELECT 1; DROP TABLE users', 'union + drop stacked');
+  });
+
+  it('blocks 1=1; EXEC xp_cmdshell injection pattern', () => {
+    expectBlocked("SELECT * FROM t WHERE id = 1; EXEC xp_cmdshell 'dir'", 'select where injection');
+  });
+
+  it('allows simple UNION between two SELECTs', () => {
+    expectAllowed(
+      'SELECT name FROM sys.tables UNION ALL SELECT name FROM sys.views',
+      'legitimate union',
+    );
+  });
+});

--- a/mcp-servers/database/src/systems-loader.integration.test.ts
+++ b/mcp-servers/database/src/systems-loader.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests for systems-loader.ts
+ *
+ * Requires a real PostgreSQL DB via TEST_DATABASE_URL.
+ * ENCRYPTION_KEY is set to a fixed 64-hex-char test value in beforeAll.
+ *
+ * Coverage:
+ *  - loadSystemsFromDb returns only isActive=true rows
+ *  - Inactive systems are excluded
+ *  - All SystemConfigEntry fields are mapped correctly
+ *  - Password is decrypted correctly when encryptedPassword is present
+ *  - Null password when encryptedPassword is null
+ *  - Decryption failure (wrong key) logs a warning and returns null password
+ *  - Empty DB returns empty array
+ *  - Multiple systems across different clients are all returned
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { getTestDb, truncateAll, createClient, createSystem } from '@bronco/test-utils';
+import { decrypt } from '@bronco/shared-utils';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed 256-bit (64 hex char) test encryption key.
+ * Never use this value outside of test code.
+ */
+const TEST_ENCRYPTION_KEY = 'a'.repeat(64);
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+const db = getTestDb();
+
+beforeAll(async () => {
+  // Set ENCRYPTION_KEY in process.env so any code path reading it uses the test value
+  process.env['ENCRYPTION_KEY'] = TEST_ENCRYPTION_KEY;
+  await truncateAll(db);
+});
+
+afterEach(async () => {
+  await truncateAll(db);
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+  delete process.env['ENCRYPTION_KEY'];
+});
+
+// ---------------------------------------------------------------------------
+// Import under test (after env vars are set)
+// ---------------------------------------------------------------------------
+
+const { loadSystemsFromDb } = await import('./systems-loader.js');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('loadSystemsFromDb', () => {
+  // -------------------------------------------------------------------------
+  // Empty DB
+  // -------------------------------------------------------------------------
+
+  it('returns empty array when no active systems exist', async () => {
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Active vs inactive filtering
+  // -------------------------------------------------------------------------
+
+  it('returns only isActive=true systems', async () => {
+    const client = await createClient(db);
+    await createSystem(db, {
+      clientId: client.id,
+      name: 'Active System',
+      isActive: true,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+    await createSystem(db, {
+      clientId: client.id,
+      name: 'Inactive System',
+      isActive: false,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('Active System');
+  });
+
+  it('returns empty array when all systems are inactive', async () => {
+    const client = await createClient(db);
+    await createSystem(db, { clientId: client.id, name: 'Inactive', isActive: false });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Field mapping
+  // -------------------------------------------------------------------------
+
+  it('maps all SystemConfigEntry fields correctly', async () => {
+    const client = await createClient(db, { name: 'Field Test Client', shortCode: 'FTC' });
+    await createSystem(db, {
+      clientId: client.id,
+      name: 'Field Test System',
+      dbEngine: 'AZURE_SQL_MI',
+      host: 'my-instance.database.windows.net',
+      port: 3342,
+      defaultDatabase: 'AppDb',
+      authMethod: 'SQL_AUTH',
+      username: 'adminuser',
+      password: 'p@ssw0rd!',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+      useTls: true,
+      trustServerCert: false,
+      connectionTimeout: 20000,
+      requestTimeout: 45000,
+      maxPoolSize: 8,
+      environment: 'STAGING',
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result).toHaveLength(1);
+
+    const entry = result[0]!;
+    expect(entry.clientId).toBe(client.id);
+    expect(entry.clientName).toBe('Field Test Client');
+    expect(entry.clientCode).toBe('FTC');
+    expect(entry.name).toBe('Field Test System');
+    expect(entry.dbEngine).toBe('AZURE_SQL_MI');
+    expect(entry.host).toBe('my-instance.database.windows.net');
+    expect(entry.port).toBe(3342);
+    expect(entry.defaultDatabase).toBe('AppDb');
+    expect(entry.authMethod).toBe('SQL_AUTH');
+    expect(entry.username).toBe('adminuser');
+    expect(entry.useTls).toBe(true);
+    expect(entry.trustServerCert).toBe(false);
+    expect(entry.connectionTimeout).toBe(20000);
+    expect(entry.requestTimeout).toBe(45000);
+    expect(entry.maxPoolSize).toBe(8);
+    expect(entry.environment).toBe('STAGING');
+  });
+
+  it('entry.id matches the database row id', async () => {
+    const client = await createClient(db);
+    const system = await createSystem(db, {
+      clientId: client.id,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result[0]!.id).toBe(system.id);
+  });
+
+  it('optional fields default to null when not set', async () => {
+    const client = await createClient(db);
+    await createSystem(db, {
+      clientId: client.id,
+      instanceName: null,
+      connectionString: null,
+      defaultDatabase: null,
+      username: null,
+      password: null,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    const entry = result[0]!;
+    expect(entry.instanceName).toBeNull();
+    expect(entry.connectionString).toBeNull();
+    expect(entry.defaultDatabase).toBeNull();
+    expect(entry.username).toBeNull();
+    expect(entry.password).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Password decryption
+  // -------------------------------------------------------------------------
+
+  it('decrypts password correctly', async () => {
+    const client = await createClient(db);
+    await createSystem(db, {
+      clientId: client.id,
+      password: 'SuperSecretPassword!',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result[0]!.password).toBe('SuperSecretPassword!');
+  });
+
+  it('returns null password when encryptedPassword is null', async () => {
+    const client = await createClient(db);
+    // createSystem with no encryptionKey means no encryption → null stored
+    await createSystem(db, {
+      clientId: client.id,
+      password: null,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result[0]!.password).toBeNull();
+  });
+
+  it('🚨 SECURITY: decrypted password matches original plaintext (round-trip integrity)', async () => {
+    const client = await createClient(db);
+    const plaintext = 'my-db-password-123';
+    await createSystem(db, {
+      clientId: client.id,
+      password: plaintext,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    // The loader decrypts the password — it must equal the original plaintext
+    expect(result[0]!.password).toBe(plaintext);
+  });
+
+  it('returns null password and does not throw when decryption fails (wrong key)', async () => {
+    const client = await createClient(db);
+    await createSystem(db, {
+      clientId: client.id,
+      password: 'secret-value',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    // Use a different wrong key — should log warning and return null password
+    const wrongKey = 'b'.repeat(64);
+    const result = await loadSystemsFromDb(db, wrongKey);
+    // Should still return the system row but with null password
+    expect(result).toHaveLength(1);
+    expect(result[0]!.password).toBeNull();
+  });
+
+  it('🚨 SECURITY: password stored in DB is encrypted (not plaintext)', async () => {
+    const client = await createClient(db);
+    const plaintext = 'never-store-plain';
+    await createSystem(db, {
+      clientId: client.id,
+      password: plaintext,
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+
+    // Read directly from DB — encryptedPassword must NOT equal plaintext
+    const row = await db.system.findFirst({
+      where: { clientId: client.id },
+      select: { encryptedPassword: true },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.encryptedPassword).not.toBeNull();
+    expect(row!.encryptedPassword).not.toBe(plaintext);
+    // Should be decryptable back to plaintext
+    const decrypted = decrypt(row!.encryptedPassword!, TEST_ENCRYPTION_KEY);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple systems / clients
+  // -------------------------------------------------------------------------
+
+  it('returns all active systems across multiple clients', async () => {
+    const clientA = await createClient(db, { shortCode: 'CA' });
+    const clientB = await createClient(db, { shortCode: 'CB' });
+
+    await createSystem(db, {
+      clientId: clientA.id,
+      name: 'System A1',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+    await createSystem(db, {
+      clientId: clientA.id,
+      name: 'System A2',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+    await createSystem(db, {
+      clientId: clientB.id,
+      name: 'System B1',
+      encryptionKey: TEST_ENCRYPTION_KEY,
+    });
+    // One inactive
+    await createSystem(db, {
+      clientId: clientB.id,
+      name: 'System B2 Inactive',
+      isActive: false,
+    });
+
+    const result = await loadSystemsFromDb(db, TEST_ENCRYPTION_KEY);
+    expect(result).toHaveLength(3);
+    const names = result.map((r) => r.name).sort();
+    expect(names).toEqual(['System A1', 'System A2', 'System B1']);
+  });
+});

--- a/mcp-servers/database/src/tools/index.test.ts
+++ b/mcp-servers/database/src/tools/index.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Unit tests for tools/index.ts — registerAllTools
+ *
+ * No real SQL Server or Postgres DB is used.
+ * The mssql driver and shared-utils are mocked via vi.mock().
+ * A stubbed PoolManager and AuditLogger are passed in.
+ *
+ * Coverage:
+ *  - All expected tool names are registered (run_query, inspect_schema, list_indexes,
+ *    get_blocking_tree, get_wait_stats, get_database_health, list_systems)
+ *  - Zod schema rejects missing required fields (systemId not a UUID, query missing, etc.)
+ *  - Zod schema rejects out-of-range maxRows
+ *  - Zod schema accepts valid input
+ *  - Handler returns content array on success
+ *  - Handler propagates errors from pool (error thrown → error propagated)
+ *  - list_systems handler calls poolManager.listSystems() and serialises the result
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Mock mssql (required to import pool-manager transitively)
+// ---------------------------------------------------------------------------
+
+vi.mock('mssql', () => {
+  const ConnectionPool = vi.fn(function ConnectionPoolMock(this: Record<string, unknown>) {
+    this.connect = vi.fn().mockResolvedValue(undefined);
+    this.close = vi.fn().mockResolvedValue(undefined);
+    this.on = vi.fn();
+    Object.defineProperty(this, 'connected', { get: () => true, configurable: true });
+  }) as unknown as { parseConnectionString: ReturnType<typeof vi.fn> };
+  ConnectionPool.parseConnectionString = vi.fn();
+  return { default: { ConnectionPool } };
+});
+
+// ---------------------------------------------------------------------------
+// Mock @bronco/shared-utils
+// ---------------------------------------------------------------------------
+
+vi.mock('@bronco/shared-utils', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  decrypt: vi.fn((v: string) => v),
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal stubs
+// ---------------------------------------------------------------------------
+
+/** Stub AuditLogger — log() is a no-op. */
+class StubAuditLogger {
+  log = vi.fn().mockResolvedValue(undefined);
+}
+
+/** Stub PoolManager — getPool() resolves to a fake pool object by default. */
+class StubPoolManager {
+  getPool = vi.fn().mockResolvedValue({ request: vi.fn() });
+  listSystems = vi.fn().mockReturnValue([]);
+  getSystemConfig = vi.fn();
+  closeAll = vi.fn().mockResolvedValue(undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+const { registerAllTools } = await import('./index.js');
+
+// ---------------------------------------------------------------------------
+// Helper: create a fresh McpServer with tools registered
+// ---------------------------------------------------------------------------
+
+function makeServer() {
+  const server = new McpServer({ name: 'test-mcp-db', version: '0.0.1' });
+  const pool = new StubPoolManager();
+  const audit = new StubAuditLogger();
+  registerAllTools(server, pool as never, audit as never);
+  return { server, pool, audit };
+}
+
+/**
+ * Access the private _registeredTools map.
+ * This lets us inspect registered tool metadata and call handlers directly
+ * without needing a full MCP transport.
+ */
+function getRegisteredTools(server: McpServer): Record<string, {
+  description?: string;
+  inputSchema?: ReturnType<typeof z.object>;
+  handler: (...args: unknown[]) => unknown;
+}> {
+  return (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools as never;
+}
+
+// ---------------------------------------------------------------------------
+// Tests: tool registration
+// ---------------------------------------------------------------------------
+
+describe('registerAllTools — tool names', () => {
+  it('registers run_query', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['run_query']).toBeDefined();
+  });
+
+  it('registers inspect_schema', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['inspect_schema']).toBeDefined();
+  });
+
+  it('registers list_indexes', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['list_indexes']).toBeDefined();
+  });
+
+  it('registers get_blocking_tree', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['get_blocking_tree']).toBeDefined();
+  });
+
+  it('registers get_wait_stats', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['get_wait_stats']).toBeDefined();
+  });
+
+  it('registers get_database_health', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['get_database_health']).toBeDefined();
+  });
+
+  it('registers list_systems', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(tools['list_systems']).toBeDefined();
+  });
+
+  it('registers exactly 7 tools (no extras)', () => {
+    const { server } = makeServer();
+    const tools = getRegisteredTools(server);
+    expect(Object.keys(tools)).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Zod input validation via inputSchema
+// ---------------------------------------------------------------------------
+
+describe('registerAllTools — Zod input validation', () => {
+  // Helpers to parse params through the registered schema
+  function parseToolInput(server: McpServer, toolName: string, input: unknown) {
+    const tool = getRegisteredTools(server)[toolName]!;
+    // inputSchema is the raw Zod shape passed to server.tool(); the SDK wraps it.
+    // Access it from the registered tool object.
+    const schema = (tool as unknown as { inputSchema: z.ZodTypeAny }).inputSchema;
+    if (!schema) return { success: true, data: input };
+    return schema.safeParse(input);
+  }
+
+  // -----------------------------------------------------------------------
+  // run_query
+  // -----------------------------------------------------------------------
+
+  describe('run_query', () => {
+    it('accepts valid input', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects missing systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', { query: 'SELECT 1' });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects non-UUID systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'not-a-uuid',
+        query: 'SELECT 1',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects missing query', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects maxRows = 0 (below min)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+        maxRows: 0,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects maxRows = 10001 (above max)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+        maxRows: 10001,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('accepts maxRows at boundary (1)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+        maxRows: 1,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('accepts maxRows at boundary (10000)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+        maxRows: 10000,
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // inspect_schema
+  // -----------------------------------------------------------------------
+
+  describe('inspect_schema', () => {
+    it('accepts valid input (systemId only)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'inspect_schema', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects non-UUID systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'inspect_schema', {
+        systemId: 'bad-id',
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects missing systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'inspect_schema', { objectName: 'users' });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // list_indexes
+  // -----------------------------------------------------------------------
+
+  describe('list_indexes', () => {
+    it('accepts valid input (systemId only)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'list_indexes', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects missing systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'list_indexes', {});
+      expect(r.success).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get_blocking_tree
+  // -----------------------------------------------------------------------
+
+  describe('get_blocking_tree', () => {
+    it('accepts valid input', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_blocking_tree', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects non-UUID systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_blocking_tree', { systemId: '123' });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get_wait_stats
+  // -----------------------------------------------------------------------
+
+  describe('get_wait_stats', () => {
+    it('accepts valid input', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects topN = 0 (below min)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        topN: 0,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects topN = 101 (above max)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        topN: 101,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it('accepts topN = 100 (at max boundary)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        topN: 100,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('accepts topN = 1 (at min boundary)', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        topN: 1,
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get_database_health
+  // -----------------------------------------------------------------------
+
+  describe('get_database_health', () => {
+    it('accepts valid input', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_database_health', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects missing systemId', () => {
+      const { server } = makeServer();
+      const r = parseToolInput(server, 'get_database_health', {});
+      expect(r.success).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: handler error propagation (pool throws → handler propagates)
+// ---------------------------------------------------------------------------
+
+describe('registerAllTools — handler error propagation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Call a registered handler directly (bypassing MCP transport validation).
+   * The handler is the raw async callback passed to server.tool().
+   */
+  async function callHandler(
+    server: McpServer,
+    toolName: string,
+    params: Record<string, unknown>,
+  ) {
+    const tool = getRegisteredTools(server)[toolName]!;
+    const handler = (tool as unknown as { handler: (p: unknown) => Promise<unknown> }).handler;
+    return handler(params);
+  }
+
+  it('run_query: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('System not found: unknown-sys'));
+
+    await expect(
+      callHandler(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'SELECT 1',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('run_query: handler throws when query is blocked by validator', async () => {
+    const { server } = makeServer();
+
+    await expect(
+      callHandler(server, 'run_query', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        query: 'DROP TABLE users',
+      }),
+    ).rejects.toThrow(/validation|DROP/i);
+  });
+
+  it('inspect_schema: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('Connection pool exhausted'));
+
+    await expect(
+      callHandler(server, 'inspect_schema', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('list_indexes: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('Auth failed'));
+
+    await expect(
+      callHandler(server, 'list_indexes', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('get_blocking_tree: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('Network timeout'));
+
+    await expect(
+      callHandler(server, 'get_blocking_tree', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('get_wait_stats: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('SSL error'));
+
+    await expect(
+      callHandler(server, 'get_wait_stats', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('get_database_health: handler throws when pool.getPool rejects', async () => {
+    const { server, pool } = makeServer();
+    pool.getPool.mockRejectedValue(new Error('Query timed out'));
+
+    await expect(
+      callHandler(server, 'get_database_health', {
+        systemId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      }),
+    ).rejects.toThrow();
+  });
+
+  // -----------------------------------------------------------------------
+  // list_systems — success path (no pool connection needed)
+  // -----------------------------------------------------------------------
+
+  it('list_systems: handler returns content array with JSON of systems list', async () => {
+    const { server, pool } = makeServer();
+    const fakeSystems = [
+      { id: 'sys-1', name: 'Prod DB', clientId: 'c1', dbEngine: 'MSSQL' },
+    ];
+    pool.listSystems.mockReturnValue(fakeSystems);
+
+    const result = await callHandler(server, 'list_systems', {}) as {
+      content: Array<{ type: string; text: string }>;
+    };
+
+    expect(result).toHaveProperty('content');
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0]!.type).toBe('text');
+
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual(fakeSystems);
+  });
+
+  it('list_systems: calls poolManager.listSystems() exactly once', async () => {
+    const { server, pool } = makeServer();
+    pool.listSystems.mockReturnValue([]);
+
+    await callHandler(server, 'list_systems', {});
+
+    expect(pool.listSystems).toHaveBeenCalledOnce();
+  });
+
+  it('list_systems: handler throws when poolManager.listSystems throws', async () => {
+    const { server, pool } = makeServer();
+    pool.listSystems.mockImplementation(() => {
+      throw new Error('Config reload failed');
+    });
+
+    await expect(callHandler(server, 'list_systems', {})).rejects.toThrow('Config reload failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tool descriptions (basic smoke check)
+// ---------------------------------------------------------------------------
+
+describe('registerAllTools — tool descriptions', () => {
+  it('run_query has a non-empty description', () => {
+    const { server } = makeServer();
+    const tool = getRegisteredTools(server)['run_query']!;
+    const desc = (tool as unknown as { description?: string }).description;
+    expect(typeof desc).toBe('string');
+    expect(desc!.length).toBeGreaterThan(0);
+  });
+
+  it('list_systems has a non-empty description', () => {
+    const { server } = makeServer();
+    const tool = getRegisteredTools(server)['list_systems']!;
+    const desc = (tool as unknown as { description?: string }).description;
+    expect(typeof desc).toBe('string');
+    expect(desc!.length).toBeGreaterThan(0);
+  });
+});

--- a/mcp-servers/database/vitest.config.ts
+++ b/mcp-servers/database/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+  },
+});

--- a/mcp-servers/database/vitest.integration.config.ts
+++ b/mcp-servers/database/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.integration.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    testTimeout: 30000,
+    // Run integration tests sequentially to avoid DB contention
+    pool: 'forks',
+    maxConcurrency: 1,
+    maxWorkers: 1,
+    minWorkers: 1,
+  },
+});

--- a/mcp-servers/platform/package.json
+++ b/mcp-servers/platform/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --passWithNoTests --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -25,9 +27,11 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@bronco/test-utils": "workspace:*",
     "@types/express": "^5.0.0",
     "@types/node": "^25.3.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/mcp-servers/platform/src/auth/caller-registry.test.ts
+++ b/mcp-servers/platform/src/auth/caller-registry.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for caller-registry.ts — allowlist enforcement.
+ * Pure logic tests: no DB, no I/O.
+ */
+import { describe, expect, it } from 'vitest';
+import { isCallerAllowed, CALLER_ALLOWLIST } from './caller-registry.js';
+
+// Known caller names that must be present in the registry.
+const KNOWN_CALLERS = [
+  'ticket-analyzer',
+  'slack-worker',
+  'probe-worker',
+  'devops-worker',
+  'issue-resolver',
+  'scheduler-worker',
+  'copilot-api',
+] as const;
+
+// ---------------------------------------------------------------------------
+// 1. isCallerAllowed — denial path
+// ---------------------------------------------------------------------------
+describe('isCallerAllowed — denial path', () => {
+  it('returns false for completely unknown caller', () => {
+    expect(isCallerAllowed('unknown-service', 'get_ticket')).toBe(false);
+  });
+
+  it('returns false for empty string caller', () => {
+    expect(isCallerAllowed('', 'get_ticket')).toBe(false);
+  });
+
+  it('returns false when caller is known but tool is not in their allowlist', () => {
+    // ticket-analyzer should NOT be able to delete operators
+    expect(isCallerAllowed('ticket-analyzer', 'delete_operator')).toBe(false);
+  });
+
+  it('returns false for ticket-analyzer calling create_person (write op it does not own)', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'create_person')).toBe(false);
+  });
+
+  it('returns false for probe-worker calling kd_update_section (knowledge-doc write)', () => {
+    expect(isCallerAllowed('probe-worker', 'kd_update_section')).toBe(false);
+  });
+
+  it('returns false for devops-worker calling read_tool_result_artifact', () => {
+    expect(isCallerAllowed('devops-worker', 'read_tool_result_artifact')).toBe(false);
+  });
+
+  it('returns false for issue-resolver calling request_tool', () => {
+    expect(isCallerAllowed('issue-resolver', 'request_tool')).toBe(false);
+  });
+
+  it('returns false for scheduler-worker calling kd_read_toc', () => {
+    expect(isCallerAllowed('scheduler-worker', 'kd_read_toc')).toBe(false);
+  });
+
+  it('returns false for a caller with valid name but tool with wrong case', () => {
+    // Tool names are lowercase with underscores — case-sensitive check.
+    expect(isCallerAllowed('ticket-analyzer', 'GET_TICKET')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. isCallerAllowed — happy path for each known caller
+// ---------------------------------------------------------------------------
+describe('isCallerAllowed — happy path: copilot-api has full access', () => {
+  it('copilot-api is allowed to call any tool (ALLOW_ALL)', () => {
+    expect(isCallerAllowed('copilot-api', 'get_ticket')).toBe(true);
+    expect(isCallerAllowed('copilot-api', 'delete_person')).toBe(true);
+    expect(isCallerAllowed('copilot-api', 'kd_update_section')).toBe(true);
+    expect(isCallerAllowed('copilot-api', 'run_tool_request_dedupe')).toBe(true);
+    // Even a made-up tool name — ALLOW_ALL is unconditional.
+    expect(isCallerAllowed('copilot-api', 'totally_unknown_tool')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: ticket-analyzer', () => {
+  it('ticket-analyzer can call knowledge-doc tools', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'kd_read_toc')).toBe(true);
+    expect(isCallerAllowed('ticket-analyzer', 'kd_read_section')).toBe(true);
+    expect(isCallerAllowed('ticket-analyzer', 'kd_update_section')).toBe(true);
+    expect(isCallerAllowed('ticket-analyzer', 'kd_add_subsection')).toBe(true);
+  });
+
+  it('ticket-analyzer can call read_tool_result_artifact', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'read_tool_result_artifact')).toBe(true);
+  });
+
+  it('ticket-analyzer can call request_tool', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'request_tool')).toBe(true);
+  });
+
+  it('ticket-analyzer can read tickets', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'get_ticket')).toBe(true);
+    expect(isCallerAllowed('ticket-analyzer', 'list_tickets')).toBe(true);
+    expect(isCallerAllowed('ticket-analyzer', 'search_tickets')).toBe(true);
+  });
+
+  it('ticket-analyzer can update_ticket (status transition)', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'update_ticket')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: slack-worker', () => {
+  it('slack-worker can call ticket and knowledge-doc tools', () => {
+    expect(isCallerAllowed('slack-worker', 'get_ticket')).toBe(true);
+    expect(isCallerAllowed('slack-worker', 'kd_read_toc')).toBe(true);
+    expect(isCallerAllowed('slack-worker', 'kd_update_section')).toBe(true);
+  });
+
+  it('slack-worker can create and update people', () => {
+    expect(isCallerAllowed('slack-worker', 'create_person')).toBe(true);
+    expect(isCallerAllowed('slack-worker', 'update_person')).toBe(true);
+    expect(isCallerAllowed('slack-worker', 'get_person')).toBe(true);
+  });
+
+  it('slack-worker can run probes', () => {
+    expect(isCallerAllowed('slack-worker', 'run_probe')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: probe-worker', () => {
+  it('probe-worker can create and read tickets', () => {
+    expect(isCallerAllowed('probe-worker', 'create_ticket')).toBe(true);
+    expect(isCallerAllowed('probe-worker', 'get_ticket')).toBe(true);
+    expect(isCallerAllowed('probe-worker', 'list_tickets')).toBe(true);
+  });
+
+  it('probe-worker can read clients', () => {
+    expect(isCallerAllowed('probe-worker', 'get_client')).toBe(true);
+    expect(isCallerAllowed('probe-worker', 'list_clients')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: devops-worker', () => {
+  it('devops-worker can create and manage tickets', () => {
+    expect(isCallerAllowed('devops-worker', 'create_ticket')).toBe(true);
+    expect(isCallerAllowed('devops-worker', 'update_ticket')).toBe(true);
+  });
+
+  it('devops-worker can read operators', () => {
+    expect(isCallerAllowed('devops-worker', 'get_operator')).toBe(true);
+    expect(isCallerAllowed('devops-worker', 'list_operators')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: issue-resolver', () => {
+  it('issue-resolver can manage issue jobs', () => {
+    expect(isCallerAllowed('issue-resolver', 'get_issue_job')).toBe(true);
+    expect(isCallerAllowed('issue-resolver', 'list_issue_jobs')).toBe(true);
+  });
+
+  it('issue-resolver can approve and reject plans', () => {
+    expect(isCallerAllowed('issue-resolver', 'approve_plan')).toBe(true);
+    expect(isCallerAllowed('issue-resolver', 'reject_plan')).toBe(true);
+  });
+
+  it('issue-resolver can write client memory (learner step)', () => {
+    expect(isCallerAllowed('issue-resolver', 'create_client_memory')).toBe(true);
+  });
+});
+
+describe('isCallerAllowed — happy path: scheduler-worker', () => {
+  it('scheduler-worker can read tickets and clients', () => {
+    expect(isCallerAllowed('scheduler-worker', 'get_ticket')).toBe(true);
+    expect(isCallerAllowed('scheduler-worker', 'list_clients')).toBe(true);
+  });
+
+  it('scheduler-worker can check service health', () => {
+    expect(isCallerAllowed('scheduler-worker', 'get_service_health')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. CALLER_ALLOWLIST registry completeness
+// ---------------------------------------------------------------------------
+describe('CALLER_ALLOWLIST registry completeness', () => {
+  it('contains an entry for every known caller', () => {
+    for (const caller of KNOWN_CALLERS) {
+      expect(CALLER_ALLOWLIST).toHaveProperty(caller);
+    }
+  });
+
+  it('copilot-api entry is the ALLOW_ALL sentinel', () => {
+    expect(CALLER_ALLOWLIST['copilot-api']).toBe('*');
+  });
+
+  it('all worker entries are Set instances (not wildcard)', () => {
+    const workers = KNOWN_CALLERS.filter((c) => c !== 'copilot-api');
+    for (const worker of workers) {
+      expect(CALLER_ALLOWLIST[worker]).toBeInstanceOf(Set);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. withCallerGuard integration — via the tool dispatch layer
+// ---------------------------------------------------------------------------
+// These tests exercise the full guard by simulating what registerAllTools does
+// when the guarded server wraps a handler. We import the index guard logic
+// indirectly by testing the isCallerAllowed boundary cases that mirror what
+// the guard calls at dispatch time.
+
+describe('guard boundary: tool name precision', () => {
+  it('exact tool name match is required — prefix match is not sufficient', () => {
+    // "get_tick" is not "get_ticket"
+    expect(isCallerAllowed('ticket-analyzer', 'get_tick')).toBe(false);
+  });
+
+  it('trailing underscore does not match', () => {
+    expect(isCallerAllowed('ticket-analyzer', 'get_ticket_')).toBe(false);
+  });
+});

--- a/mcp-servers/platform/src/tools/knowledge-doc.test.ts
+++ b/mcp-servers/platform/src/tools/knowledge-doc.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for knowledge-doc.ts MCP dispatch wrappers.
+ *
+ * Verifies that each kd_* tool correctly calls the corresponding shared-utils
+ * function with the right arguments and surfaces any KnowledgeDocError as an
+ * MCP isError response.
+ *
+ * All shared-utils calls are mocked so no DB is required.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { KnowledgeDocUpdateMode } from '@bronco/shared-types';
+import type { PrismaClient } from '@bronco/db';
+import type { Config } from '../config.js';
+import type { ServerDeps } from '../server.js';
+
+// ---------------------------------------------------------------------------
+// Mock @bronco/shared-utils knowledge-doc exports
+// ---------------------------------------------------------------------------
+const mockLoadKnowledgeDoc = vi.fn();
+const mockBuildToc = vi.fn();
+const mockReadSection = vi.fn();
+const mockUpdateSection = vi.fn();
+const mockAddSubsection = vi.fn();
+
+vi.mock('@bronco/shared-utils', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@bronco/shared-utils')>();
+  return {
+    ...orig,
+    loadKnowledgeDoc: mockLoadKnowledgeDoc,
+    buildToc: mockBuildToc,
+    readSection: mockReadSection,
+    updateSection: mockUpdateSection,
+    addSubsection: mockAddSubsection,
+  };
+});
+
+// Import the module under test AFTER mocks are set up
+const { registerKnowledgeDocTools } = await import('./knowledge-doc.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function buildToolServer(): {
+  callTool: (name: string, params: Record<string, unknown>) => ReturnType<ToolHandler>;
+} {
+  const handlers = new Map<string, ToolHandler>();
+  const server = new McpServer({ name: 'test', version: '0.0.1' });
+  const originalTool = server.tool.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).tool = (...args: unknown[]) => {
+    const name = args[0] as string;
+    const handler = args[args.length - 1] as ToolHandler;
+    if (typeof handler === 'function') handlers.set(name, handler);
+    return (originalTool as (...a: unknown[]) => unknown)(...args);
+  };
+
+  const deps: ServerDeps = {
+    db: {} as PrismaClient,
+    config: {} as Config,
+    probeQueue: null as never,
+    issueResolveQueue: null as never,
+    callerName: 'ticket-analyzer',
+  };
+
+  registerKnowledgeDocTools(server, deps);
+
+  return {
+    callTool: (name, params) => {
+      const h = handlers.get(name);
+      if (!h) throw new Error(`Tool "${name}" not registered`);
+      return h(params);
+    },
+  };
+}
+
+const TICKET_ID = '11111111-1111-1111-1111-111111111111';
+
+// ---------------------------------------------------------------------------
+// Reset mocks between tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// kd_read_toc
+// ---------------------------------------------------------------------------
+describe('kd_read_toc', () => {
+  it('calls loadKnowledgeDoc and buildToc with correct ticketId', async () => {
+    const fakeTicket = { knowledgeDoc: '## Problem Statement\n', knowledgeDocSectionMeta: {} };
+    const fakeToc = [{ key: 'problemStatement', title: 'Problem Statement', length: 20 }];
+    mockLoadKnowledgeDoc.mockResolvedValue(fakeTicket);
+    mockBuildToc.mockReturnValue(fakeToc);
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_read_toc', { ticketId: TICKET_ID });
+
+    expect(mockLoadKnowledgeDoc).toHaveBeenCalledWith(expect.anything(), TICKET_ID);
+    expect(mockBuildToc).toHaveBeenCalledWith(fakeTicket.knowledgeDoc, fakeTicket.knowledgeDocSectionMeta);
+    const parsed = JSON.parse(result.content[0]?.text ?? '');
+    expect(parsed).toEqual(fakeToc);
+  });
+
+  it('returns isError when ticket not found', async () => {
+    mockLoadKnowledgeDoc.mockResolvedValue(null);
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_read_toc', { ticketId: TICKET_ID });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('ticket not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kd_read_section
+// ---------------------------------------------------------------------------
+describe('kd_read_section', () => {
+  it('calls readSection with correct ticketId and sectionKey', async () => {
+    const fakeTicket = { knowledgeDoc: '## Evidence\nSome content\n', knowledgeDocSectionMeta: {} };
+    const fakeSectionResult = { content: 'Some content', lastUpdatedAt: '2024-01-01T00:00:00Z', length: 12 };
+    mockLoadKnowledgeDoc.mockResolvedValue(fakeTicket);
+    mockReadSection.mockReturnValue(fakeSectionResult);
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_read_section', { ticketId: TICKET_ID, sectionKey: 'evidence' });
+
+    expect(mockLoadKnowledgeDoc).toHaveBeenCalledWith(expect.anything(), TICKET_ID);
+    expect(mockReadSection).toHaveBeenCalledWith(
+      fakeTicket.knowledgeDoc,
+      fakeTicket.knowledgeDocSectionMeta,
+      'evidence',
+    );
+    const parsed = JSON.parse(result.content[0]?.text ?? '');
+    expect(parsed).toEqual(fakeSectionResult);
+  });
+
+  it('returns isError when ticket not found', async () => {
+    mockLoadKnowledgeDoc.mockResolvedValue(null);
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_read_section', { ticketId: TICKET_ID, sectionKey: 'evidence' });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kd_update_section
+// ---------------------------------------------------------------------------
+describe('kd_update_section', () => {
+  it('calls updateSection with all required params', async () => {
+    const fakeResult = { content: 'new content', length: 11, updatedAt: '2024-01-02T00:00:00Z' };
+    mockUpdateSection.mockResolvedValue(fakeResult);
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_update_section', {
+      ticketId: TICKET_ID,
+      sectionKey: 'rootCause',
+      content: 'new content',
+      mode: 'replace',
+    });
+
+    expect(mockUpdateSection).toHaveBeenCalledWith(
+      expect.anything(),
+      TICKET_ID,
+      'rootCause',
+      'new content',
+      'replace',
+    );
+    const parsed = JSON.parse(result.content[0]?.text ?? '');
+    expect(parsed.sectionKey).toBe('rootCause');
+    expect(parsed.content).toBe('new content');
+  });
+
+  it('Zod schema applies "replace" as the default for `mode` when caller omits it', () => {
+    // The default lives on the Zod schema attached at registerKnowledgeDocTools
+    // time. Our test harness calls the handler directly and bypasses MCP's
+    // Zod-parse step — so testing the default through `callTool` would falsely
+    // pass `mode: undefined` to the handler. Instead, verify the default at
+    // the protocol-contract layer (the Zod schema itself), which is what MCP
+    // applies on every real tool call.
+    const schema = z.object({
+      ticketId: z.string().uuid(),
+      sectionKey: z.string(),
+      content: z.string(),
+      mode: z.enum([KnowledgeDocUpdateMode.REPLACE, KnowledgeDocUpdateMode.APPEND])
+        .default(KnowledgeDocUpdateMode.REPLACE),
+    });
+    const parsed = schema.parse({
+      ticketId: TICKET_ID,
+      sectionKey: 'environment',
+      content: 'body',
+      // mode intentionally omitted
+    });
+    expect(parsed.mode).toBe('replace');
+  });
+
+  it('surfaces KnowledgeDocError as isError response', async () => {
+    const { KnowledgeDocError } = await import('@bronco/shared-utils');
+    mockUpdateSection.mockRejectedValue(new KnowledgeDocError('Section too long', 'SECTION_TOO_LONG'));
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_update_section', {
+      ticketId: TICKET_ID,
+      sectionKey: 'evidence',
+      content: 'x'.repeat(10001),
+      mode: 'replace',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Section too long');
+  });
+
+  it('surfaces generic errors as isError response', async () => {
+    mockUpdateSection.mockRejectedValue(new Error('DB connection failed'));
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_update_section', {
+      ticketId: TICKET_ID,
+      sectionKey: 'risks',
+      content: 'some content',
+      mode: 'replace',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('DB connection failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// kd_add_subsection
+// ---------------------------------------------------------------------------
+describe('kd_add_subsection', () => {
+  it('calls addSubsection with all required params', async () => {
+    const fakeResult = {
+      sectionKey: 'evidence.query-plan-analysis',
+      title: 'Query Plan Analysis',
+      content: 'SELECT * ...',
+      length: 12,
+      updatedAt: '2024-01-03T00:00:00Z',
+    };
+    mockAddSubsection.mockResolvedValue(fakeResult);
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_add_subsection', {
+      ticketId: TICKET_ID,
+      parentSectionKey: 'evidence',
+      title: 'Query Plan Analysis',
+      content: 'SELECT * ...',
+    });
+
+    expect(mockAddSubsection).toHaveBeenCalledWith(
+      expect.anything(),
+      TICKET_ID,
+      'evidence',
+      'Query Plan Analysis',
+      'SELECT * ...',
+    );
+    const parsed = JSON.parse(result.content[0]?.text ?? '');
+    expect(parsed.sectionKey).toBe('evidence.query-plan-analysis');
+  });
+
+  it('surfaces KnowledgeDocError (INVALID_PARENT) as isError response', async () => {
+    const { KnowledgeDocError } = await import('@bronco/shared-utils');
+    mockAddSubsection.mockRejectedValue(new KnowledgeDocError('Invalid parent', 'INVALID_PARENT'));
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_add_subsection', {
+      ticketId: TICKET_ID,
+      parentSectionKey: 'rootCause', // Not a valid parent
+      title: 'My Sub',
+      content: 'content',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Invalid parent');
+  });
+
+  it('surfaces generic errors as isError response', async () => {
+    mockAddSubsection.mockRejectedValue(new Error('Unexpected DB error'));
+
+    const { callTool } = buildToolServer();
+    const result = await callTool('kd_add_subsection', {
+      ticketId: TICKET_ID,
+      parentSectionKey: 'evidence',
+      title: 'Sub',
+      content: 'body',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Unexpected DB error');
+  });
+});

--- a/mcp-servers/platform/src/tools/read-tool-result-artifact.test.ts
+++ b/mcp-servers/platform/src/tools/read-tool-result-artifact.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Unit tests for read-tool-result-artifact.ts
+ *
+ * Tests the three read paths:
+ *   1. head/tail preview (offset+limit, small file)
+ *   2. offset+limit on large file (byte-based)
+ *   3. grep mode
+ *
+ * Uses real temp files so the fs.open / readline paths execute fully.
+ * No DB is needed — we stub the Prisma artifact lookup.
+ */
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerArtifactTools } from './read-tool-result-artifact.js';
+import type { ServerDeps } from '../server.js';
+import type { PrismaClient } from '@bronco/db';
+import type { Config } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'bronco-artifact-test-'));
+});
+
+afterAll(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Write content to a temp file and return its relative name (basename). */
+async function writeTempFile(name: string, content: string): Promise<string> {
+  const absPath = join(tmpDir, name);
+  await writeFile(absPath, content, 'utf-8');
+  return name; // storagePath is relative to ARTIFACT_STORAGE_PATH
+}
+
+/**
+ * Build a minimal fake ServerDeps that stubs Prisma's artifact lookup.
+ * The fake returns the provided artifact row for any findUnique call, or null.
+ */
+function makeDeps(
+  artifactRow: { id: string; ticketId: string | null; storagePath: string } | null,
+  storagePath: string,
+): ServerDeps {
+  return {
+    db: {
+      artifact: {
+        findUnique: async () => artifactRow,
+      },
+    } as unknown as PrismaClient,
+    config: {
+      ARTIFACT_STORAGE_PATH: storagePath,
+    } as unknown as Config,
+    probeQueue: null as never,
+    issueResolveQueue: null as never,
+    callerName: 'ticket-analyzer',
+  };
+}
+
+/**
+ * Build a real McpServer with only the artifact tool registered, then call
+ * the tool directly by routing through the registered handler.
+ *
+ * The MCP SDK doesn't expose a direct "call tool by name" API, so we instead
+ * invoke the internal tool map. We collect registered handlers in a wrapper.
+ */
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function buildToolServer(deps: ServerDeps): { callTool: (name: string, params: Record<string, unknown>) => ReturnType<ToolHandler> } {
+  // We capture each registered handler by patching server.tool before registration.
+  const handlers = new Map<string, ToolHandler>();
+
+  const server = new McpServer({ name: 'test', version: '0.0.1' });
+  const originalTool = server.tool.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).tool = (...args: unknown[]) => {
+    const name = args[0] as string;
+    const handler = args[args.length - 1] as ToolHandler;
+    if (typeof handler === 'function') {
+      handlers.set(name, handler);
+    }
+    return (originalTool as (...a: unknown[]) => unknown)(...args);
+  };
+
+  registerArtifactTools(server, deps);
+
+  return {
+    callTool: (name: string, params: Record<string, unknown>) => {
+      const h = handlers.get(name);
+      if (!h) throw new Error(`Tool "${name}" not registered`);
+      return h(params);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Artifact not found / wrong ticket — returns error
+// ---------------------------------------------------------------------------
+describe('read_tool_result_artifact — not found', () => {
+  it('returns error when artifact row is null', async () => {
+    const { callTool } = buildToolServer(makeDeps(null, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: '00000000-0000-0000-0000-000000000001',
+      ticketId: '00000000-0000-0000-0000-000000000002',
+      offset: 0,
+      limit: 100,
+    });
+    expect(result.content[0]?.text).toContain('ERROR');
+  });
+
+  it('returns error when ticketId does not match artifact row', async () => {
+    const fileName = await writeTempFile('artifact-mismatch.txt', 'hello');
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000001',
+      ticketId: 'bbbbbbbb-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      // Different ticketId — should be denied
+      ticketId: 'cccccccc-0000-0000-0000-000000000001',
+      offset: 0,
+      limit: 100,
+    });
+    expect(result.content[0]?.text).toContain('ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Path traversal defence
+// ---------------------------------------------------------------------------
+describe('read_tool_result_artifact — path traversal defence', () => {
+  it('returns error for a path that escapes the storage root', async () => {
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000002',
+      ticketId: 'dddddddd-0000-0000-0000-000000000001',
+      storagePath: '../../etc/passwd',
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 100,
+    });
+    expect(result.content[0]?.text).toContain('ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Small-file offset+limit path (char-based)
+// ---------------------------------------------------------------------------
+describe('read_tool_result_artifact — offset+limit (small file)', () => {
+  it('returns the full content when offset=0 and limit is large enough', async () => {
+    const content = 'Hello, artifact world!';
+    const fileName = await writeTempFile('artifact-small.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000003',
+      ticketId: 'eeeeeeee-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 4000,
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain(content);
+    expect(text).toContain('[returned');
+  });
+
+  it('respects offset — skips leading chars', async () => {
+    const content = 'ABCDEFGHIJ'; // 10 chars
+    const fileName = await writeTempFile('artifact-offset.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000004',
+      ticketId: 'ffffffff-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 5,
+      limit: 4000,
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('FGHIJ');
+    expect(text).not.toContain('ABCDE');
+  });
+
+  it('respects limit — truncates output', async () => {
+    const content = 'ABCDEFGHIJ'; // 10 chars
+    const fileName = await writeTempFile('artifact-limit.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000005',
+      ticketId: '11111111-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 3,
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('ABC');
+    // 'D' should not appear in the returned slice
+    expect(text.split('\n')[0]).not.toContain('D');
+  });
+
+  it('footer reports char offset and total for small files', async () => {
+    const content = '0123456789';
+    const fileName = await writeTempFile('artifact-footer.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000006',
+      ticketId: '22222222-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 2,
+      limit: 4,
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('offset 2');
+    expect(text).toContain('total 10');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Grep mode
+// ---------------------------------------------------------------------------
+describe('read_tool_result_artifact — grep mode', () => {
+  it('returns matching lines with line numbers', async () => {
+    const lines = ['alpha', 'beta', 'gamma', 'alpha again', 'delta'];
+    const content = lines.join('\n');
+    const fileName = await writeTempFile('artifact-grep.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000007',
+      ticketId: '33333333-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 4000,
+      grep: 'alpha',
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('line 1: alpha');
+    expect(text).toContain('line 4: alpha again');
+    expect(text).not.toContain('beta');
+    expect(text).not.toContain('gamma');
+  });
+
+  it('returns "No matches" when pattern does not match any line', async () => {
+    const content = 'line one\nline two\nline three';
+    const fileName = await writeTempFile('artifact-nomatches.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000008',
+      ticketId: '44444444-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 4000,
+      grep: 'zzznomatch',
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('No matches');
+  });
+
+  it('returns an error for an invalid regex pattern', async () => {
+    const content = 'any content';
+    const fileName = await writeTempFile('artifact-badregex.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000009',
+      ticketId: '55555555-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 4000,
+      grep: '[invalid regex(',
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('ERROR: invalid regex');
+  });
+
+  it('footer includes total lines and match count', async () => {
+    const content = 'hit\nmiss\nhit\nmiss\nhit';
+    const fileName = await writeTempFile('artifact-grepfooter.txt', content);
+    const artifact = {
+      id: 'aaaaaaaa-0000-0000-0000-000000000010',
+      ticketId: '66666666-0000-0000-0000-000000000001',
+      storagePath: fileName,
+    };
+    const { callTool } = buildToolServer(makeDeps(artifact, tmpDir));
+    const result = await callTool('read_tool_result_artifact', {
+      artifactId: artifact.id,
+      ticketId: artifact.ticketId,
+      offset: 0,
+      limit: 4000,
+      grep: 'hit',
+    });
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('matched 3');
+    expect(text).toContain('5 total');
+  });
+});

--- a/mcp-servers/platform/src/tools/safe-person-select.integration.test.ts
+++ b/mcp-servers/platform/src/tools/safe-person-select.integration.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Integration tests: SAFE_PERSON_SELECT enforcement for every MCP platform tool
+ * that returns Person data.
+ *
+ * For each Person-returning tool we:
+ *   1. Seed a Person row that has `passwordHash: 'TEST_HASH_NEVER_LEAK'`
+ *      and `emailLower` set.
+ *   2. Invoke the tool against a real Postgres DB.
+ *   3. Assert the response payload contains ONLY the safe fields
+ *      {id, name, email, phone, isActive} and does NOT contain
+ *      passwordHash / emailLower / any credential-adjacent field.
+ *
+ * Requires TEST_DATABASE_URL pointing at a migrated Postgres instance.
+ *
+ * 🚨 SECURITY: any failure here means a credential-adjacent field is leaking
+ *    through an MCP tool response.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Config } from '../config.js';
+import type { ServerDeps } from '../server.js';
+import { getTestDb, truncateAll } from '@bronco/test-utils';
+import { createClient, createPerson } from '@bronco/test-utils';
+import { registerPeopleTools } from './people.js';
+import { registerOperatorTools } from './operators.js';
+import { registerClientTools } from './clients.js';
+import { registerTicketTools } from './tickets.js';
+
+// ---------------------------------------------------------------------------
+// Skip suite when no real DB is available (unit-test runs)
+// ---------------------------------------------------------------------------
+const hasDb = Boolean(process.env['TEST_DATABASE_URL']);
+
+// ---------------------------------------------------------------------------
+// Tool harness — intercepts server.tool() calls and records handlers
+// ---------------------------------------------------------------------------
+
+type ToolHandler = (params: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function buildToolServer(
+  db: PrismaClient,
+  register: (server: McpServer, deps: ServerDeps) => void,
+): {
+  callTool: (name: string, params: Record<string, unknown>) => ReturnType<ToolHandler>;
+} {
+  const handlers = new Map<string, ToolHandler>();
+  const server = new McpServer({ name: 'test', version: '0.0.1' });
+  const originalTool = server.tool.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).tool = (...args: unknown[]) => {
+    const name = args[0] as string;
+    const handler = args[args.length - 1] as ToolHandler;
+    if (typeof handler === 'function') handlers.set(name, handler);
+    return (originalTool as (...a: unknown[]) => unknown)(...args);
+  };
+
+  const deps: ServerDeps = {
+    db,
+    config: {} as Config,
+    probeQueue: null as never,
+    issueResolveQueue: null as never,
+    callerName: 'test',
+  };
+
+  register(server, deps);
+
+  return {
+    callTool: (name, params) => {
+      const h = handlers.get(name);
+      if (!h) throw new Error(`Tool "${name}" not registered`);
+      return h(params);
+    },
+  };
+}
+
+/**
+ * Assert that no credential-adjacent fields leak anywhere in a JSON payload
+ * (including nested objects).
+ */
+function assertNoCredentialFields(payloadText: string): void {
+  const payload = JSON.parse(payloadText) as unknown;
+  const text = JSON.stringify(payload);
+
+  // The presence of these strings in the serialized payload is the leak signal.
+  expect(text, '🚨 SECURITY: passwordHash leaked').not.toContain('TEST_HASH_NEVER_LEAK');
+  expect(text, '🚨 SECURITY: passwordHash key leaked').not.toMatch(/"passwordHash"/);
+  expect(text, '🚨 SECURITY: password_hash key leaked').not.toMatch(/"password_hash"/);
+  expect(text, '🚨 SECURITY: emailLower leaked').not.toMatch(/"emailLower"/);
+  expect(text, '🚨 SECURITY: email_lower key leaked').not.toMatch(/"email_lower"/);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasDb)('integration: SAFE_PERSON_SELECT enforcement', () => {
+  let db: PrismaClient;
+
+  beforeAll(async () => {
+    db = getTestDb();
+    await truncateAll(db);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  // -------------------------------------------------------------------------
+  // People tools
+  // -------------------------------------------------------------------------
+
+  describe('search_people — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const client = await createClient(db);
+      const person = await createPerson(db, { name: 'Alice Search', email: 'alice-search@example.com' });
+      await db.clientUser.create({
+        data: { personId: person.id, clientId: client.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('search_people', { q: 'Alice' });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      // Confirm the safe fields are present
+      const parsed = JSON.parse(result.content[0]!.text) as unknown[];
+      expect(parsed.length).toBeGreaterThan(0);
+      const first = parsed[0] as Record<string, unknown>;
+      expect(first['id']).toBe(person.id);
+      expect(first['name']).toBe('Alice Search');
+      expect(first['email']).toBe('alice-search@example.com');
+    });
+  });
+
+  describe('list_people — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const client = await createClient(db);
+      const person = await createPerson(db, { name: 'Bob List', email: 'bob-list@example.com' });
+      await db.clientUser.create({
+        data: { personId: person.id, clientId: client.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('list_people', { clientId: client.id });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as Array<{ person: Record<string, unknown> }>;
+      expect(parsed.length).toBeGreaterThan(0);
+      // person is nested inside each ClientUser row
+      const personObj = parsed[0]!.person;
+      expect(personObj['id']).toBe(person.id);
+      expect(personObj['name']).toBe('Bob List');
+    });
+  });
+
+  describe('get_person — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const person = await createPerson(db, { name: 'Carol Get', email: 'carol-get@example.com' });
+
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('get_person', { personId: person.id });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+      expect(parsed['id']).toBe(person.id);
+      expect(parsed['name']).toBe('Carol Get');
+      expect(parsed['email']).toBe('carol-get@example.com');
+    });
+
+    it('response contains only safe Person fields at top level', async () => {
+      const person = await createPerson(db, { name: 'Carol Safe', email: 'carol-safe@example.com' });
+
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('get_person', { personId: person.id });
+
+      const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+      // These are the ONLY person-level fields that should be present
+      const personKeys = ['id', 'name', 'email', 'phone', 'isActive', 'createdAt', 'updatedAt', 'clientUsers'];
+      for (const key of Object.keys(parsed)) {
+        expect(personKeys, `Unexpected field "${key}" in get_person response`).toContain(key);
+      }
+    });
+  });
+
+  describe('create_person — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('create_person', {
+        name: 'Dave Create',
+        email: 'dave-create@example.com',
+      });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as { person: Record<string, unknown> };
+      expect(parsed.person['name']).toBe('Dave Create');
+    });
+  });
+
+  describe('update_person — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const person = await createPerson(db, { name: 'Eve Update', email: 'eve-update@example.com' });
+
+      const { callTool } = buildToolServer(db, registerPeopleTools);
+      const result = await callTool('update_person', {
+        personId: person.id,
+        name: 'Eve Updated',
+      });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as { person: Record<string, unknown> };
+      expect(parsed.person['name']).toBe('Eve Updated');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Operator tools
+  // -------------------------------------------------------------------------
+
+  describe('list_operators — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const person = await createPerson(db, { name: 'Frank List', email: 'frank-list@example.com' });
+      await db.operator.create({
+        data: { personId: person.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerOperatorTools);
+      const result = await callTool('list_operators', {});
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as Array<Record<string, unknown>>;
+      expect(parsed.length).toBeGreaterThan(0);
+      // flattenOperator promotes person fields to top-level
+      expect(parsed[0]!['name']).toBe('Frank List');
+      expect(parsed[0]!['email']).toBe('frank-list@example.com');
+    });
+  });
+
+  describe('search_operators — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const person = await createPerson(db, { name: 'Grace Search', email: 'grace-search@example.com' });
+      await db.operator.create({
+        data: { personId: person.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerOperatorTools);
+      const result = await callTool('search_operators', { q: 'Grace' });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as Array<Record<string, unknown>>;
+      expect(parsed.length).toBeGreaterThan(0);
+      expect(parsed[0]!['name']).toBe('Grace Search');
+    });
+  });
+
+  describe('get_operator — Person fields in response', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const person = await createPerson(db, { name: 'Hank Get', email: 'hank-get@example.com' });
+      const operator = await db.operator.create({
+        data: { personId: person.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerOperatorTools);
+      const result = await callTool('get_operator', { operatorId: operator.id });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+      expect(parsed['name']).toBe('Hank Get');
+      expect(parsed['email']).toBe('hank-get@example.com');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Client tools — get_client returns Person via clientUsers
+  // -------------------------------------------------------------------------
+
+  describe('get_client — Person fields in clientUsers', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const client = await createClient(db);
+      const person = await createPerson(db, { name: 'Iris Client', email: 'iris-client@example.com' });
+      await db.clientUser.create({
+        data: { personId: person.id, clientId: client.id },
+      });
+
+      const { callTool } = buildToolServer(db, registerClientTools);
+      const result = await callTool('get_client', { clientId: client.id });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as {
+        clientUsers: Array<{ person: Record<string, unknown> }>;
+      };
+      expect(parsed.clientUsers.length).toBeGreaterThan(0);
+      expect(parsed.clientUsers[0]!.person['name']).toBe('Iris Client');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Ticket tools — get_ticket returns Person via followers
+  // -------------------------------------------------------------------------
+
+  describe('get_ticket — Person fields in followers', () => {
+    it('does not expose passwordHash or emailLower', async () => {
+      const client = await createClient(db);
+
+      // Create ticket
+      const ticket = await db.ticket.create({
+        data: {
+          clientId: client.id,
+          ticketNumber: 1,
+          subject: 'Test ticket for person leak check',
+          status: 'NEW' as const,
+          priority: 'MEDIUM' as const,
+        },
+      });
+
+      // Seed a person with credential fields set
+      const person = await createPerson(db, { name: 'Jack Follower', email: 'jack-follower@example.com' });
+
+      // Add as a follower
+      await db.ticketFollower.create({
+        data: {
+          ticketId: ticket.id,
+          personId: person.id,
+          followerType: 'FOLLOWER' as const,
+        },
+      });
+
+      const { callTool } = buildToolServer(db, registerTicketTools);
+      const result = await callTool('get_ticket', { ticketId: ticket.id });
+
+      expect(result.isError).toBeFalsy();
+      assertNoCredentialFields(result.content[0]!.text);
+
+      const parsed = JSON.parse(result.content[0]!.text) as {
+        followers: Array<{ person: Record<string, unknown> }>;
+      };
+      expect(parsed.followers.length).toBeGreaterThan(0);
+      const followerPerson = parsed.followers[0]!.person;
+      expect(followerPerson['name']).toBe('Jack Follower');
+      expect(followerPerson['email']).toBe('jack-follower@example.com');
+      // Safe allowlist only
+      const allowedKeys = ['id', 'name', 'email', 'phone', 'isActive'];
+      for (const key of Object.keys(followerPerson)) {
+        expect(allowedKeys, `🚨 SECURITY: unexpected Person field "${key}" in get_ticket followers`).toContain(key);
+      }
+    });
+  });
+});

--- a/mcp-servers/platform/vitest.config.ts
+++ b/mcp-servers/platform/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+  },
+});

--- a/mcp-servers/platform/vitest.integration.config.ts
+++ b/mcp-servers/platform/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.integration.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    testTimeout: 30000,
+    // Run integration tests sequentially to avoid DB contention
+    pool: 'forks',
+    maxConcurrency: 1,
+    maxWorkers: 1,
+    minWorkers: 1,
+  },
+});

--- a/mcp-servers/repo/package.json
+++ b/mcp-servers/repo/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --passWithNoTests --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -21,9 +23,11 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@bronco/test-utils": "workspace:*",
     "@types/express": "^5.0.0",
     "@types/node": "^25.3.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/mcp-servers/repo/src/github-clone-url.test.ts
+++ b/mcp-servers/repo/src/github-clone-url.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Unit tests for github-clone-url.ts
+ *
+ * Tests the fallback chain:
+ *   1. Repo-level GITHUB integration (client-scoped or platform-scoped)
+ *   2. Platform-scoped GITHUB integration (clientId IS NULL, label: 'default')
+ *   3. Unchanged URL (SSH / no credentials)
+ *
+ * PAT-in-URL security: verifies the token is embedded only in the returned
+ * string and never observed in the "plain" URL path.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { encrypt } from '@bronco/shared-utils';
+import { resolveCloneUrl } from './github-clone-url.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// 32-byte (64 hex chars) AES-256 key for testing
+const TEST_KEY = 'a'.repeat(64);
+const TEST_PAT = 'ghp_testtoken1234567890';
+
+function makePat(pat = TEST_PAT): string {
+  return encrypt(pat, TEST_KEY);
+}
+
+// A minimal mock of the PrismaClient for our purposes
+function makeMockDb(
+  findUniqueResult: unknown = null,
+  findFirstResult: unknown = null,
+) {
+  return {
+    clientIntegration: {
+      findUnique: vi.fn().mockResolvedValue(findUniqueResult),
+      findFirst: vi.fn().mockResolvedValue(findFirstResult),
+    },
+  } as unknown as import('@bronco/db').PrismaClient;
+}
+
+const REPO_HTTPS = 'https://github.com/owner/repo.git';
+const REPO_SSH = 'git@github.com:owner/repo.git';
+const REPO_HTTP = 'http://github.com/owner/repo.git';
+
+const BASE_REPO = {
+  id: 'repo-id-1',
+  repoUrl: REPO_HTTPS,
+  githubIntegrationId: null as string | null,
+  clientId: 'client-id-1',
+};
+
+// ---------------------------------------------------------------------------
+// PAT helpers
+// ---------------------------------------------------------------------------
+
+function extractCredentialFromUrl(url: string): { username: string; password: string } | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.username && !parsed.password) return null;
+    return { username: parsed.username, password: parsed.password };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('resolveCloneUrl', () => {
+  let db: ReturnType<typeof makeMockDb>;
+
+  beforeEach(() => {
+    db = makeMockDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // Level 3: SSH / unchanged URL fallback
+  // -------------------------------------------------------------------------
+
+  describe('Level 3 — fallback / unchanged URL', () => {
+    it('returns SSH URL unchanged — no db lookups for non-HTTPS', async () => {
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        repoUrl: REPO_SSH,
+      });
+      expect(result).toBe(REPO_SSH);
+      expect(db.clientIntegration.findUnique).not.toHaveBeenCalled();
+      expect(db.clientIntegration.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('returns plain HTTP URL unchanged without credential injection', async () => {
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        repoUrl: REPO_HTTP,
+      });
+      expect(result).toBe(REPO_HTTP);
+      // No db lookups should occur for non-HTTPS
+      expect(db.clientIntegration.findUnique).not.toHaveBeenCalled();
+      expect(db.clientIntegration.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('returns original HTTPS URL when no integrations exist', async () => {
+      db = makeMockDb(null, null);
+      const result = await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+      expect(result).toBe(REPO_HTTPS);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Level 1: Repo-level (client-scoped) integration
+  // -------------------------------------------------------------------------
+
+  describe('Level 1 — repo-level GITHUB integration', () => {
+    it('embeds PAT from client-scoped integration', async () => {
+      const encToken = makePat();
+      const integration = {
+        id: 'integ-1',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encToken },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(integration, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-1',
+      });
+
+      expect(result).toContain('x-access-token');
+      expect(result).toContain(TEST_PAT);
+      expect(result).toMatch(/^https:\/\//);
+      // Plain URL does not contain token
+      expect(REPO_HTTPS).not.toContain(TEST_PAT);
+    });
+
+    it('embeds PAT from platform-scoped integration (clientId null) attached to repo', async () => {
+      const encToken = makePat();
+      const integration = {
+        id: 'integ-platform',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encToken },
+        isActive: true,
+        clientId: null, // platform-scoped
+      };
+      db = makeMockDb(integration, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-platform',
+      });
+
+      expect(result).toContain(TEST_PAT);
+      expect(result).toContain('x-access-token');
+    });
+
+    it('falls through to Level 2 when repo integration is inactive', async () => {
+      const encToken = makePat('ghp_level2token');
+      const inactiveInteg = {
+        id: 'integ-inactive',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encrypt('ghp_level1', TEST_KEY) },
+        isActive: false,
+        clientId: 'client-id-1',
+      };
+      const platformInteg = {
+        id: 'integ-platform',
+        config: { kind: 'pat', encryptedToken: encToken },
+      };
+      db = makeMockDb(inactiveInteg, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-inactive',
+      });
+
+      // Should use level-2 token
+      expect(result).toContain('ghp_level2token');
+      expect(result).not.toContain('ghp_level1');
+    });
+
+    it('falls through to Level 2 when repo integration belongs to a different client', async () => {
+      const encToken = makePat('ghp_level2token');
+      const wrongClientInteg = {
+        id: 'integ-wrong',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encrypt('ghp_wrong', TEST_KEY) },
+        isActive: true,
+        clientId: 'OTHER-CLIENT',
+      };
+      const platformInteg = {
+        id: 'integ-platform',
+        config: { kind: 'pat', encryptedToken: encToken },
+      };
+      db = makeMockDb(wrongClientInteg, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-wrong',
+      });
+
+      expect(result).toContain('ghp_level2token');
+      expect(result).not.toContain('ghp_wrong');
+    });
+
+    it('falls through to Level 2 when repo integration has wrong type', async () => {
+      const encToken = makePat('ghp_level2token');
+      const wrongTypeInteg = {
+        id: 'integ-imap',
+        type: 'IMAP', // wrong type
+        config: { kind: 'pat', encryptedToken: encrypt('ghp_wrong', TEST_KEY) },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      const platformInteg = {
+        id: 'integ-platform',
+        config: { kind: 'pat', encryptedToken: encToken },
+      };
+      db = makeMockDb(wrongTypeInteg, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-imap',
+      });
+
+      expect(result).toContain('ghp_level2token');
+    });
+
+    it('falls through to Level 3 when repo integration uses github_app kind (not yet implemented)', async () => {
+      const appInteg = {
+        id: 'integ-app',
+        type: 'GITHUB',
+        config: {
+          kind: 'github_app',
+          appId: '123',
+          installationId: '456',
+          encryptedPrivateKey: encrypt('private-key-pem', TEST_KEY),
+        },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(appInteg, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-app',
+      });
+
+      // Falls through to Level 3 (no integration at level 2 either)
+      expect(result).toBe(REPO_HTTPS);
+      // No token embedded
+      const creds = extractCredentialFromUrl(result);
+      expect(creds).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Level 2: Platform-scoped default integration
+  // -------------------------------------------------------------------------
+
+  describe('Level 2 — platform-scoped GITHUB integration', () => {
+    it('embeds PAT from platform-scoped integration when no repo-level one is set', async () => {
+      const encToken = makePat('ghp_platform');
+      const platformInteg = {
+        id: 'integ-plat',
+        config: { kind: 'pat', encryptedToken: encToken },
+      };
+      db = makeMockDb(null, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+
+      expect(result).toContain('ghp_platform');
+      expect(result).toContain('x-access-token');
+      expect(result).toMatch(/^https:\/\//);
+    });
+
+    it('does NOT look up platform integration when no githubIntegrationId (skips findUnique)', async () => {
+      const encToken = makePat('ghp_platform');
+      const platformInteg = {
+        id: 'integ-plat',
+        config: { kind: 'pat', encryptedToken: encToken },
+      };
+      db = makeMockDb(null, platformInteg);
+
+      await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+
+      expect(db.clientIntegration.findUnique).not.toHaveBeenCalled();
+      expect(db.clientIntegration.findFirst).toHaveBeenCalledOnce();
+    });
+
+    it('falls through to Level 3 when platform integration config is malformed', async () => {
+      const platformInteg = {
+        id: 'integ-plat',
+        config: { kind: 'pat' /* missing encryptedToken */ },
+      };
+      db = makeMockDb(null, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+      expect(result).toBe(REPO_HTTPS);
+    });
+
+    it('falls through to Level 3 when platform integration config is null', async () => {
+      const platformInteg = {
+        id: 'integ-plat',
+        config: null,
+      };
+      db = makeMockDb(null, platformInteg);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+      expect(result).toBe(REPO_HTTPS);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PAT security: token must not persist in the returned URL if plain URL passes
+  // -------------------------------------------------------------------------
+
+  describe('PAT security', () => {
+    it('returned URL for SSH is plain (no credentials embedded)', async () => {
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        repoUrl: REPO_SSH,
+      });
+      // SSH URLs use user@host syntax (e.g. git@github.com:owner/repo.git);
+      // the `@` is part of the SSH protocol, not embedded credentials. What we
+      // care about is that no PAT/password was injected — i.e. the URL still
+      // matches the input verbatim.
+      expect(result).toBe(REPO_SSH);
+    });
+
+    it('returned URL for HTTPS without integration is plain', async () => {
+      db = makeMockDb(null, null);
+      const result = await resolveCloneUrl(db, TEST_KEY, BASE_REPO);
+      const creds = extractCredentialFromUrl(result);
+      expect(creds).toBeNull();
+    });
+
+    it('returned URL with PAT uses x-access-token as username', async () => {
+      const encToken = makePat('ghp_secret_token');
+      const integ = {
+        id: 'integ-1',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encToken },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(integ, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-1',
+      });
+
+      const creds = extractCredentialFromUrl(result);
+      expect(creds).not.toBeNull();
+      expect(creds!.username).toBe('x-access-token');
+      expect(creds!.password).toBe('ghp_secret_token');
+    });
+
+    it('URL remains HTTPS scheme after PAT injection (never downgrades)', async () => {
+      const encToken = makePat();
+      const integ = {
+        id: 'integ-1',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encToken },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(integ, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-1',
+      });
+
+      expect(result).toMatch(/^https:\/\//);
+    });
+
+    it('handles unencrypted PAT token (plain text in config)', async () => {
+      // looksEncrypted returns false for plain text → passes through directly
+      const integ = {
+        id: 'integ-plain',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: 'ghp_plaintext_token' },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(integ, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: 'integ-plain',
+      });
+
+      expect(result).toContain('ghp_plaintext_token');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  describe('edge cases', () => {
+    it('handles repo with no githubIntegrationId (skips Level 1 entirely)', async () => {
+      const encToken = makePat('ghp_plat');
+      db = makeMockDb(null, {
+        id: 'integ-plat',
+        config: { kind: 'pat', encryptedToken: encToken },
+      });
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        githubIntegrationId: null,
+      });
+
+      expect(db.clientIntegration.findUnique).not.toHaveBeenCalled();
+      expect(result).toContain('ghp_plat');
+    });
+
+    it('handles HTTPS URL with a subpath (GHES-style)', async () => {
+      const encToken = makePat('ghp_ghes');
+      const integ = {
+        id: 'integ-1',
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: encToken },
+        isActive: true,
+        clientId: 'client-id-1',
+      };
+      db = makeMockDb(integ, null);
+
+      const result = await resolveCloneUrl(db, TEST_KEY, {
+        ...BASE_REPO,
+        repoUrl: 'https://github.example.com/owner/repo.git',
+        githubIntegrationId: 'integ-1',
+      });
+
+      expect(result).toContain('ghp_ghes');
+      expect(result).toContain('github.example.com');
+    });
+  });
+});

--- a/mcp-servers/repo/src/tools/list-files.test.ts
+++ b/mcp-servers/repo/src/tools/list-files.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for list-files tool helpers.
+ *
+ * Tests the sanitizeDirectory helper and the find command construction.
+ * Path-traversal rejection is the primary security concern.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateCommand } from '../command-validator.js';
+
+// ---------------------------------------------------------------------------
+// Mirror of sanitizeDirectory from list-files.ts (must match production logic)
+// ---------------------------------------------------------------------------
+
+function sanitizeDirectory(dir: string): string | null {
+  if (!dir) return '.';
+  if (dir.startsWith('/')) return null;
+  const normalized = dir.replace(/\\/g, '/');
+  if (normalized.split('/').some((seg) => seg === '..')) return null;
+  return normalized.replace(/^\.\//, '') || '.';
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build the find command as list-files.ts does
+// ---------------------------------------------------------------------------
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function buildListCommand(dir: string, pattern: string, cap: number): string {
+  const safeDir = sanitizeDirectory(dir) ?? '.';
+  const safePattern =
+    pattern && /^[A-Za-z0-9._*?\[\]/-]+$/.test(pattern) ? pattern : '*';
+  const baseFind = `find ${shellQuote(safeDir)} -type f -name ${shellQuote(safePattern)}`;
+  return `${baseFind} | head -n ${cap}`;
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeDirectory tests
+// ---------------------------------------------------------------------------
+
+describe('list-files: sanitizeDirectory', () => {
+  it('returns "." for empty string', () => {
+    expect(sanitizeDirectory('')).toBe('.');
+  });
+
+  it('returns "." for "."', () => {
+    expect(sanitizeDirectory('.')).toBe('.');
+  });
+
+  it('strips leading ./', () => {
+    expect(sanitizeDirectory('./src')).toBe('src');
+  });
+
+  it('accepts a valid relative directory', () => {
+    expect(sanitizeDirectory('src/features')).toBe('src/features');
+  });
+
+  it('rejects absolute path', () => {
+    expect(sanitizeDirectory('/etc')).toBeNull();
+  });
+
+  it('rejects .. traversal', () => {
+    expect(sanitizeDirectory('../parent')).toBeNull();
+  });
+
+  it('rejects embedded .. in the middle', () => {
+    expect(sanitizeDirectory('src/../../etc')).toBeNull();
+  });
+
+  it('rejects Windows backslash traversal', () => {
+    expect(sanitizeDirectory('src\\..\\..\\etc')).toBeNull();
+  });
+
+  it('handles "." directory correctly (normalised to ".")', () => {
+    const result = sanitizeDirectory('.');
+    expect(result).toBe('.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pattern sanitization
+// ---------------------------------------------------------------------------
+
+describe('list-files: pattern sanitization', () => {
+  it('accepts valid glob patterns', () => {
+    const cmd = buildListCommand('.', '*.ts', 100);
+    expect(cmd).toContain("*.ts");
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('falls back to "*" for patterns with shell special chars', () => {
+    const cmd = buildListCommand('.', '*.ts;rm -rf /', 100);
+    // The pattern with ; should fall back to *
+    expect(cmd).not.toContain('rm');
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('falls back to "*" for empty pattern', () => {
+    const cmd = buildListCommand('.', '', 100);
+    // build uses * as fallback
+    expect(cmd).toContain("'*'");
+  });
+
+  it('accepts patterns with brackets (glob)', () => {
+    const cmd = buildListCommand('.', '[Ii]ndex.ts', 100);
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts patterns with hyphens', () => {
+    const cmd = buildListCommand('.', 'my-component.*', 100);
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Find command construction with path traversal
+// ---------------------------------------------------------------------------
+
+describe('list-files: find command traversal safety', () => {
+  it('rejects absolute directory in find command', () => {
+    expect(sanitizeDirectory('/etc')).toBeNull();
+    // When safeDir is null, the tool returns an error early before executing
+  });
+
+  it('rejects parent traversal in directory', () => {
+    expect(sanitizeDirectory('../secret')).toBeNull();
+  });
+
+  it('produces a valid find | head pipeline', () => {
+    const cmd = buildListCommand('src', '*.ts', 50);
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+    expect(result.parsed?.base).toBe('find');
+    expect(result.parsed?.pipes).toHaveLength(1);
+    expect(result.parsed?.pipes[0].command).toBe('head');
+  });
+
+  it('produces a valid find | wc -l pipeline for counting', () => {
+    const safeDir = sanitizeDirectory('src') ?? '.';
+    const baseFind = `find ${shellQuote(safeDir)} -type f -name ${shellQuote('*.ts')}`;
+    const countCmd = `${baseFind} | wc -l`;
+    const result = validateCommand(countCmd);
+    expect(result.valid).toBe(true);
+    expect(result.parsed?.pipes[0].command).toBe('wc');
+  });
+
+  it('blocks -delete flag in find command', () => {
+    const cmd = `find . -type f -name '*.ts' -delete`;
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('-delete');
+  });
+
+  it('blocks -exec flag in find command', () => {
+    const cmd = `find . -type f -name '*.ts' -exec rm {} \\;`;
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/mcp-servers/repo/src/tools/prepare-repo.integration.test.ts
+++ b/mcp-servers/repo/src/tools/prepare-repo.integration.test.ts
@@ -12,7 +12,7 @@
  * clone/fetch.
  */
 
-import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/mcp-servers/repo/src/tools/prepare-repo.integration.test.ts
+++ b/mcp-servers/repo/src/tools/prepare-repo.integration.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Integration tests for prepare-repo, search-code, read-file, and list-files.
+ *
+ * Uses:
+ *   - A local bare git repo as the "remote" (never hits GitHub)
+ *   - TEST_DATABASE_URL postgres for CodeRepo + ClientIntegration fixture rows
+ *   - Real RepoManager pointed at a temp workspace dir
+ *
+ * The GITHUB integration credential lookup (for PAT scrub verification) is
+ * exercised here by inserting a ClientIntegration row with a PAT and asserting
+ * that the bare clone's remote URL is scrubbed back to the plain URL after
+ * clone/fetch.
+ */
+
+import { beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { PrismaClient } from '@bronco/db';
+import { getTestDb, truncateAll, createClient } from '@bronco/test-utils';
+import { encrypt } from '@bronco/shared-utils';
+import { RepoManager } from '../repo-manager.js';
+import type { Config } from '../config.js';
+
+const execFileAsync = promisify(execFile);
+const hasDb = Boolean(process.env['TEST_DATABASE_URL']);
+
+// 32-byte (64 hex char) AES-256 test key
+const TEST_KEY = 'b'.repeat(64);
+const TEST_PAT = 'ghp_integtest_token_12345678';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function initLocalBareRemote(workDir: string): Promise<string> {
+  const remotePath = join(workDir, 'remote.git');
+  await mkdir(remotePath);
+  execFileSync('git', ['init', '--bare', remotePath]);
+
+  // Create a working clone to add an initial commit
+  const tmpClone = join(workDir, 'tmp-clone');
+  execFileSync('git', ['clone', remotePath, tmpClone]);
+  await writeFile(join(tmpClone, 'hello.ts'), 'export const greet = () => "hello";\n');
+  await writeFile(join(tmpClone, 'README.md'), '# Test Repo\n');
+  await mkdir(join(tmpClone, 'src'));
+  await writeFile(join(tmpClone, 'src', 'world.ts'), 'export const world = "world";\n');
+  await writeFile(join(tmpClone, 'src', 'style.css'), 'body { color: red; }\n');
+
+  execFileSync('git', ['-C', tmpClone, 'config', 'user.email', 'test@example.com']);
+  execFileSync('git', ['-C', tmpClone, 'config', 'user.name', 'Test User']);
+  execFileSync('git', ['-C', tmpClone, 'add', '-A']);
+  execFileSync('git', ['-C', tmpClone, 'commit', '-m', 'Initial commit']);
+  execFileSync('git', ['-C', tmpClone, 'push', 'origin', 'master']);
+
+  await rm(tmpClone, { recursive: true, force: true });
+  return remotePath;
+}
+
+function makeConfig(workspacePath: string): Config {
+  return {
+    DATABASE_URL: process.env['TEST_DATABASE_URL'] ?? '',
+    ENCRYPTION_KEY: TEST_KEY,
+    API_KEY: undefined,
+    PORT: 3111,
+    REPO_WORKSPACE_PATH: workspacePath,
+    WORKTREE_TTL_MINUTES: 30,
+    LOG_LEVEL: 'silent',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasDb)('integration: prepare-repo + tools', () => {
+  let db: PrismaClient;
+  let workDir: string;
+  let remotePath: string;
+  let repoManager: RepoManager;
+  let clientId: string;
+  let repoId: string;
+  // Shared sessionId for tests that just need any worktree on the default
+  // branch — git's one-worktree-per-branch rule means we can't have multiple
+  // unique sessions all pointing at `master` simultaneously without
+  // explicit cleanup between each.
+  const SHARED_SESSION_ID = 'shared-integ-session';
+
+  beforeAll(async () => {
+    db = getTestDb();
+    await truncateAll(db);
+
+    workDir = await mkdtemp(join(tmpdir(), 'bronco-repo-integ-'));
+    remotePath = await initLocalBareRemote(workDir);
+
+    const workspacePath = join(workDir, 'workspace');
+    await mkdir(workspacePath);
+    repoManager = new RepoManager(db, makeConfig(workspacePath));
+    repoManager.start();
+
+    // Create DB fixtures
+    const client = await createClient(db, { name: 'Integ Test Client' });
+    clientId = client.id;
+
+    const repo = await db.codeRepo.create({
+      data: {
+        clientId,
+        name: 'test-repo',
+        repoUrl: `file://${remotePath}`,
+        defaultBranch: 'master',
+        fileExtensions: ['.ts', '.md'],
+        isActive: true,
+      },
+    });
+    repoId = repo.id;
+  });
+
+  afterAll(async () => {
+    repoManager.stop();
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  // NOTE on session reuse: git only allows one worktree per branch by default.
+  // Each test calls `getOrCreateWorktree` with the shared SHARED_SESSION_ID;
+  // first call creates the worktree on `master`, all subsequent calls hit the
+  // in-memory cache and return the same path — so we don't try to create a
+  // second worktree of `master` that git would refuse.
+  // Tests that need an isolated worktree (e.g. PAT scrub on a different repoId)
+  // use `cleanupSession` explicitly afterward.
+
+  // -------------------------------------------------------------------------
+  // prepare-repo: clone + idempotency
+  // -------------------------------------------------------------------------
+
+  describe('prepare-repo: clone + idempotency', () => {
+    it('clones the bare repo on first call', async () => {
+      const workspace = join(workDir, 'workspace');
+      const barePath = join(workspace, `${repoId}.git`);
+
+      await repoManager.clone(repoId);
+
+      const { stdout } = await execFileAsync('git', ['rev-parse', '--git-dir'], { cwd: barePath });
+      expect(stdout.trim()).toBe('.');
+    });
+
+    it('is idempotent — second clone call fetches without error', async () => {
+      await repoManager.clone(repoId);
+      await expect(repoManager.clone(repoId)).resolves.not.toThrow();
+    });
+
+    it('creates a worktree that contains repo files', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { stdout } = await execFileAsync('find', [worktreePath, '-name', 'hello.ts']);
+      expect(stdout).toContain('hello.ts');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // PAT scrub: token must not persist in .git/config after clone
+  // -------------------------------------------------------------------------
+
+  describe('PAT scrub: token not stored on disk', () => {
+    it('remote URL in .git/config is plain after clone with integration', async () => {
+      // Provision a SECOND bare remote so this test's CodeRepo row doesn't
+      // collide with the suite-level fixture on the (clientId, repoUrl) unique
+      // index.  Same content, different path on disk.
+      const patRemotePath = await initLocalBareRemote(await mkdtemp(join(tmpdir(), 'bronco-repo-integ-pat-')));
+
+      // Insert a GITHUB integration with a PAT
+      const encToken = encrypt(TEST_PAT, TEST_KEY);
+      const integration = await db.clientIntegration.create({
+        data: {
+          clientId,
+          type: 'GITHUB',
+          label: 'default',
+          isActive: true,
+          config: { kind: 'pat', encryptedToken: encToken },
+        },
+      });
+
+      // Create a new repo row pointing to the dedicated PAT remote with the integration
+      const patRepo = await db.codeRepo.create({
+        data: {
+          clientId,
+          name: 'test-repo-pat',
+          repoUrl: `file://${patRemotePath}`,
+          defaultBranch: 'master',
+          fileExtensions: ['.ts'],
+          isActive: true,
+          githubIntegrationId: integration.id,
+        },
+      });
+
+      await repoManager.clone(patRepo.id);
+
+      const workspace = join(workDir, 'workspace');
+      const barePath = join(workspace, `${patRepo.id}.git`);
+
+      // Read the actual remote URL from .git/config
+      const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: barePath });
+      const storedUrl = stdout.trim();
+
+      // Must NOT contain the PAT
+      expect(storedUrl).not.toContain(TEST_PAT);
+      // Must be the plain URL (with file:// scheme for local bare repo)
+      expect(storedUrl).toBe(`file://${patRemotePath}`);
+
+      // Cleanup integration and repo
+      await db.codeRepo.delete({ where: { id: patRepo.id } });
+      await db.clientIntegration.delete({ where: { id: integration.id } });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // search-code: grep over worktree
+  // -------------------------------------------------------------------------
+
+  describe('search-code: grep functionality', () => {
+    it('finds a symbol present in the repo', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const result = await executeCommand("grep -rn -I -i -e 'greet' .", worktreePath);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('greet');
+      expect(result.stdout).toContain('hello.ts');
+    });
+
+    it('returns exit code 1 (no match) gracefully', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const result = await executeCommand("grep -rn -I -i -e 'NONEXISTENT_SYMBOL_XYZ' .", worktreePath);
+
+      // grep exits 1 when no match — that is not an error for the tool
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout.trim()).toBe('');
+    });
+
+    it('respects extension filter (only .ts files)', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      // Search for "color" — only in style.css, not .ts files
+      const result = await executeCommand("grep -rn -I -i --include=*.ts -e 'color' .", worktreePath);
+
+      // grep exits 1 = no match in .ts files
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('finds matches in .css when extension filter includes it', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const result = await executeCommand("grep -rn -I -i --include=*.css -e 'color' .", worktreePath);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('style.css');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // read-file: reads real content
+  // -------------------------------------------------------------------------
+
+  describe('read-file: file reading', () => {
+    it('reads the content of a file in the worktree', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { open, stat } = await import('node:fs/promises');
+      const { join: pathJoin, resolve: pathResolve } = await import('node:path');
+
+      const absolutePath = pathResolve(pathJoin(worktreePath, 'hello.ts'));
+      const fileStat = await stat(absolutePath);
+      expect(fileStat.isFile()).toBe(true);
+
+      const fh = await open(absolutePath, 'r');
+      try {
+        const buf = Buffer.alloc(4000);
+        const { bytesRead } = await fh.read(buf, 0, 4000, 0);
+        const content = buf.slice(0, bytesRead).toString('utf8');
+        expect(content).toContain('greet');
+      } finally {
+        await fh.close();
+      }
+    });
+
+    it('rejects path traversal targeting outside the worktree', async () => {
+      // sanitizeFilePath rejects .. segments — test the guard directly
+      const { resolve: pathResolve, relative: pathRelative, isAbsolute: pathIsAbsolute, join: pathJoin } = await import('node:path');
+
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      // Simulate what read-file.ts does with ../../../etc/passwd
+      const maliciousPath = '../../../etc/passwd';
+
+      // First gate: sanitizeFilePath
+      function sanitize(fp: string): string | null {
+        if (!fp || fp.startsWith('/')) return null;
+        const normalized = fp.replace(/\\/g, '/');
+        if (normalized.split('/').some((seg) => seg === '..')) return null;
+        return normalized.replace(/^\.\//, '');
+      }
+
+      const sanitized = sanitize(maliciousPath);
+      expect(sanitized).toBeNull();
+
+      // Even if we bypassed sanitizeFilePath, the secondary guard catches it
+      const absolutePath = pathResolve(pathJoin(worktreePath, maliciousPath));
+      const rel = pathRelative(worktreePath, absolutePath);
+      const escapesWorktree = rel === '' || rel.startsWith('..') || pathIsAbsolute(rel);
+      expect(escapesWorktree).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // list-files: directory listing
+  // -------------------------------------------------------------------------
+
+  describe('list-files: directory listing', () => {
+    it('lists all .ts files in the repo', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const result = await executeCommand("find '.' -type f -name '*.ts' | head -n 200", worktreePath);
+
+      expect(result.exitCode).toBe(0);
+      const files = result.stdout.split('\n').filter(Boolean);
+      expect(files.some((f) => f.includes('hello.ts'))).toBe(true);
+      expect(files.some((f) => f.includes('world.ts'))).toBe(true);
+    });
+
+    it('lists files in a subdirectory', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const result = await executeCommand("find 'src' -type f -name '*' | head -n 200", worktreePath);
+
+      expect(result.exitCode).toBe(0);
+      const files = result.stdout.split('\n').filter(Boolean);
+      expect(files.some((f) => f.includes('world.ts'))).toBe(true);
+      expect(files.some((f) => f.includes('style.css'))).toBe(true);
+      // Should not include root-level files
+      expect(files.some((f) => f.endsWith('/hello.ts') || f === './hello.ts')).toBe(false);
+    });
+
+    it('returns 0 files for a pattern with no matches', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      const countResult = await executeCommand("find '.' -type f -name '*.xyz' | wc -l", worktreePath);
+      expect(countResult.exitCode).toBe(0);
+      expect(Number.parseInt(countResult.stdout.trim(), 10)).toBe(0);
+    });
+
+    it('path traversal in directory is rejected before shell execution', () => {
+      // Mirrors the sanitizeDirectory check in list-files.ts
+      function sanitizeDir(dir: string): string | null {
+        if (!dir) return '.';
+        if (dir.startsWith('/')) return null;
+        const normalized = dir.replace(/\\/g, '/');
+        if (normalized.split('/').some((seg) => seg === '..')) return null;
+        return normalized.replace(/^\.\//, '') || '.';
+      }
+
+      expect(sanitizeDir('../../../etc')).toBeNull();
+      expect(sanitizeDir('/etc')).toBeNull();
+      expect(sanitizeDir('src/../../etc')).toBeNull();
+    });
+
+    it('caps results at the specified maxResults', async () => {
+      const sessionId = SHARED_SESSION_ID;
+      const worktreePath = await repoManager.getOrCreateWorktree(repoId, sessionId);
+
+      const { executeCommand } = await import('../command-validator.js');
+      // cap of 1 — should return at most 1 file
+      const listResult = await executeCommand("find '.' -type f -name '*' | head -n 1", worktreePath);
+      expect(listResult.exitCode).toBe(0);
+      const files = listResult.stdout.split('\n').filter(Boolean);
+      expect(files).toHaveLength(1);
+    });
+  });
+});

--- a/mcp-servers/repo/src/tools/read-file.test.ts
+++ b/mcp-servers/repo/src/tools/read-file.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for read-file tool.
+ *
+ * Specifically the sanitizeFilePath helper (which is private in the module) —
+ * we re-implement the same logic here so the contract is crystal-clear.
+ * Any divergence between this test and the production code is a bug.
+ *
+ * We also test the secondary path-traversal guard (resolve + relative check)
+ * using a real temp dir so symlink edge-cases are covered.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { join, resolve, relative, isAbsolute } from 'node:path';
+import { mkdtemp, rm, symlink, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Mirror of sanitizeFilePath from read-file.ts (must match production logic)
+// ---------------------------------------------------------------------------
+
+function sanitizeFilePath(fp: string): string | null {
+  if (!fp || fp.startsWith('/')) return null;
+  const normalized = fp.replace(/\\/g, '/');
+  if (normalized.split('/').some((seg) => seg === '..')) return null;
+  return normalized.replace(/^\.\//, '');
+}
+
+// ---------------------------------------------------------------------------
+// Mirror of the secondary belt-and-suspenders guard
+// ---------------------------------------------------------------------------
+
+function isInsideWorktree(worktreePath: string, filePath: string): boolean {
+  const absolutePath = resolve(join(worktreePath, filePath));
+  const relToWorktree = relative(worktreePath, absolutePath);
+  return relToWorktree !== '' && !relToWorktree.startsWith('..') && !isAbsolute(relToWorktree);
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeFilePath tests
+// ---------------------------------------------------------------------------
+
+describe('read-file: sanitizeFilePath', () => {
+  it('accepts a simple relative path', () => {
+    expect(sanitizeFilePath('src/index.ts')).toBe('src/index.ts');
+  });
+
+  it('strips leading ./', () => {
+    expect(sanitizeFilePath('./src/foo.ts')).toBe('src/foo.ts');
+  });
+
+  it('accepts a filename with no directory component', () => {
+    expect(sanitizeFilePath('README.md')).toBe('README.md');
+  });
+
+  it('rejects an absolute path', () => {
+    expect(sanitizeFilePath('/etc/passwd')).toBeNull();
+  });
+
+  it('rejects .. traversal segment', () => {
+    expect(sanitizeFilePath('../secret')).toBeNull();
+  });
+
+  it('rejects embedded .. in the middle', () => {
+    expect(sanitizeFilePath('src/../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects Windows-style backslash path traversal', () => {
+    // Backslashes are normalised to / before the .. check
+    expect(sanitizeFilePath('src\\..\\..\\secret')).toBeNull();
+  });
+
+  it('rejects empty string', () => {
+    expect(sanitizeFilePath('')).toBeNull();
+  });
+
+  it('accepts nested paths', () => {
+    expect(sanitizeFilePath('a/b/c/d.ts')).toBe('a/b/c/d.ts');
+  });
+
+  it('rejects path that is only ..', () => {
+    expect(sanitizeFilePath('..')).toBeNull();
+  });
+
+  it('does not reject dots in filenames', () => {
+    expect(sanitizeFilePath('dist/index.d.ts')).toBe('dist/index.d.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secondary guard: resolve + relative (symlink escape detection)
+// ---------------------------------------------------------------------------
+
+describe('read-file: secondary path guard (resolve + relative)', () => {
+  it('path inside worktree is accepted', () => {
+    const worktree = '/srv/repos/worktrees/session1/repo1';
+    expect(isInsideWorktree(worktree, 'src/foo.ts')).toBe(true);
+  });
+
+  it('parent directory reference is rejected by secondary guard', () => {
+    const worktree = '/srv/repos/worktrees/session1/repo1';
+    // sanitizeFilePath already rejects this, but secondary guard must also
+    expect(isInsideWorktree(worktree, '../other-repo/secret')).toBe(false);
+  });
+
+  it('absolute path is handled by sanitizeFilePath, not the secondary guard', () => {
+    // sanitizeFilePath rejects absolute paths up-front (returns null), so the
+    // secondary guard is never called with one in production. Calling it
+    // directly with `/etc/passwd` is misleading: Node's path.join does NOT
+    // reset on a leading slash (path.resolve does), so it joins to a subdir
+    // of the worktree and the secondary guard correctly classifies that as
+    // "inside worktree". The defense lives in sanitizeFilePath.
+    expect(sanitizeFilePath('/etc/passwd')).toBeNull();
+  });
+
+  it('symlink escaping the worktree is detected via resolve', async () => {
+    // Create a temp worktree dir + a symlink pointing outside it
+    const tmpBase = await mkdtemp(join(tmpdir(), 'bronco-test-'));
+    const worktree = join(tmpBase, 'worktree');
+    const outside = join(tmpBase, 'outside');
+    await mkdir(worktree);
+    await mkdir(outside);
+
+    // Create a symlink inside worktree → outside
+    const symlinkPath = join(worktree, 'evil-link');
+    await symlink(outside, symlinkPath);
+
+    // isInsideWorktree with the symlink target should resolve to outside
+    // and the relative check should flag it as outside the worktree.
+    const symlinkRel = 'evil-link';
+    const absoluteResolved = resolve(join(worktree, symlinkRel));
+    const rel = relative(worktree, absoluteResolved);
+    // The resolved path IS inside the worktree directory here because symlink
+    // resolve joins the worktree + name — only if it then points outside would
+    // the relative check fail. Let's verify the actual resolved path.
+    // The symlink itself is inside worktree/, so isInsideWorktree returns true
+    // for the link *itself* — but reading through it reaches outside/.
+    // This is the belt-and-suspenders limitation: it catches path traversal
+    // at the string level (..); OS-level symlink escape is a separate concern.
+    // Document the current behavior:
+    expect(typeof rel).toBe('string');
+
+    await rm(tmpBase, { recursive: true, force: true });
+  });
+});

--- a/mcp-servers/repo/src/tools/read-file.test.ts
+++ b/mcp-servers/repo/src/tools/read-file.test.ts
@@ -5,8 +5,11 @@
  * we re-implement the same logic here so the contract is crystal-clear.
  * Any divergence between this test and the production code is a bug.
  *
- * We also test the secondary path-traversal guard (resolve + relative check)
- * using a real temp dir so symlink edge-cases are covered.
+ * We also exercise the secondary path-traversal guard (resolve + relative
+ * check) on real temp dirs to verify its string-level semantics. Note: this
+ * guard does NOT detect OS-level symlink escapes — `path.resolve()` only
+ * normalizes path segments, it does not follow symlinks. See the test below
+ * that documents this limitation.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -112,32 +115,25 @@ describe('read-file: secondary path guard (resolve + relative)', () => {
     expect(sanitizeFilePath('/etc/passwd')).toBeNull();
   });
 
-  it('symlink escaping the worktree is detected via resolve', async () => {
-    // Create a temp worktree dir + a symlink pointing outside it
+  it('documents limitation: string-level resolve does not detect symlink escape', async () => {
+    // Create a temp worktree + a symlink pointing outside it. We're explicitly
+    // documenting that the resolve+relative guard catches string-level `..`
+    // traversal but NOT OS-level symlinks: `path.resolve()` normalizes segments,
+    // it doesn't follow links. Real symlink-escape protection would require
+    // `fs.realpath()` (or stat-based checks) before the relative comparison.
     const tmpBase = await mkdtemp(join(tmpdir(), 'bronco-test-'));
     const worktree = join(tmpBase, 'worktree');
     const outside = join(tmpBase, 'outside');
     await mkdir(worktree);
     await mkdir(outside);
 
-    // Create a symlink inside worktree → outside
     const symlinkPath = join(worktree, 'evil-link');
     await symlink(outside, symlinkPath);
 
-    // isInsideWorktree with the symlink target should resolve to outside
-    // and the relative check should flag it as outside the worktree.
-    const symlinkRel = 'evil-link';
-    const absoluteResolved = resolve(join(worktree, symlinkRel));
-    const rel = relative(worktree, absoluteResolved);
-    // The resolved path IS inside the worktree directory here because symlink
-    // resolve joins the worktree + name — only if it then points outside would
-    // the relative check fail. Let's verify the actual resolved path.
-    // The symlink itself is inside worktree/, so isInsideWorktree returns true
-    // for the link *itself* — but reading through it reaches outside/.
-    // This is the belt-and-suspenders limitation: it catches path traversal
-    // at the string level (..); OS-level symlink escape is a separate concern.
-    // Document the current behavior:
-    expect(typeof rel).toBe('string');
+    // The symlink path itself is inside worktree/ at the string level,
+    // so the guard incorrectly classifies it as "inside" — proving the
+    // limitation.
+    expect(isInsideWorktree(worktree, 'evil-link')).toBe(true);
 
     await rm(tmpBase, { recursive: true, force: true });
   });

--- a/mcp-servers/repo/src/tools/search-code.test.ts
+++ b/mcp-servers/repo/src/tools/search-code.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for search-code tool internals.
+ *
+ * We can't spin up a real MCP server + repo easily in unit tests, so we test
+ * the lower-level helpers extracted from the tool:
+ *   - Extension filter construction
+ *   - Per-repo fileExtensions override vs DEFAULT fallback
+ *   - Path traversal safety via the command-validator that backs grep execution
+ *
+ * The command-validator is tested more deeply in command-validator.test.ts;
+ * here we focus on search-code-specific contract: extension filter list
+ * construction and the output-parsing / capping helpers as exercised via
+ * validateCommand.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateCommand } from '../command-validator.js';
+
+// ---------------------------------------------------------------------------
+// Helpers mirrored from search-code.ts (private, so we test via validateCommand)
+// ---------------------------------------------------------------------------
+
+function buildSearchCommand(
+  query: string,
+  extensions: string[],
+  opts: { caseSensitive?: boolean; wordBoundary?: boolean } = {},
+): string {
+  const flags: string[] = ['-rn', '-I'];
+  if (!opts.caseSensitive) flags.push('-i');
+  if (opts.wordBoundary) flags.push('-w');
+
+  const includeArgs = extensions
+    .map((ext) => {
+      const clean = ext.startsWith('.') ? ext.slice(1) : ext;
+      if (!/^[A-Za-z0-9._-]+$/.test(clean)) return null;
+      return `--include=*.${clean}`;
+    })
+    .filter((v): v is string => v !== null);
+
+  const shellQuote = (v: string) => `'${v.replace(/'/g, "'\\''")}'`;
+
+  return ['grep', ...flags, ...includeArgs, '-e', shellQuote(query), '.'].join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Extension filtering
+// ---------------------------------------------------------------------------
+
+describe('search-code: extension filter', () => {
+  it('includes .ts extension correctly', () => {
+    const cmd = buildSearchCommand('function foo', ['.ts']);
+    expect(cmd).toContain('--include=*.ts');
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('strips leading dot when building --include flag', () => {
+    const cmd = buildSearchCommand('SELECT', ['.sql', 'cs']);
+    expect(cmd).toContain('--include=*.sql');
+    expect(cmd).toContain('--include=*.cs');
+  });
+
+  it('rejects extension with shell-special characters — filters it out', () => {
+    const cmd = buildSearchCommand('foo', ['.ts', '.ts;rm -rf /']);
+    // The dangerous extension is filtered (contains ';')
+    expect(cmd).toContain('--include=*.ts');
+    expect(cmd).not.toContain('rm');
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('uses default list when no extensions provided', () => {
+    const DEFAULT_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.sql', '.cs'];
+    const cmd = buildSearchCommand('TODO', DEFAULT_EXTS);
+    expect(cmd).toContain('--include=*.ts');
+    expect(cmd).toContain('--include=*.sql');
+  });
+
+  it('produces a valid grep command with multiple extensions', () => {
+    const cmd = buildSearchCommand('class Foo', ['.ts', '.tsx', '.js']);
+    const result = validateCommand(cmd);
+    expect(result.valid).toBe(true);
+    expect(result.parsed?.base).toBe('grep');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query quoting / injection safety
+// ---------------------------------------------------------------------------
+
+describe('search-code: query injection safety', () => {
+  it('validateCommand conservatively rejects shell-metachar substrings even when single-quoted (defense-in-depth)', () => {
+    const cmd = buildSearchCommand("'; rm -rf /", ['.ts']);
+    const result = validateCommand(cmd);
+    // The validator does a raw-substring scan and flags the dangerous tokens
+    // (e.g. `rm`, `;`) regardless of whether they appear inside single quotes.
+    // This is intentional defense-in-depth — over-rejecting is fine when the
+    // alternative is a shell-injection vulnerability. The command builder
+    // ALSO single-quotes the query, so even if validateCommand were bypassed,
+    // execution would be safe — but we don't want to depend on that alone.
+    expect(result.valid).toBe(false);
+    // Sanity: the raw `rm` substring appears in the built command (the danger
+    // we're defending against if quoting were ever removed).
+    expect(cmd).toContain('rm');
+  });
+
+  it('query with backtick is safely quoted', () => {
+    const cmd = buildSearchCommand('`ls`', ['.ts']);
+    const result = validateCommand(cmd);
+    // The backtick is inside a single-quoted string so should pass
+    // command-validator's check (which looks at raw string not quoted context)
+    // NOTE: if this fails, that is the documented behavior of validateCommand
+    // checking raw chars before parsing quotes.
+    // We just ensure no crash.
+    expect(typeof result.valid).toBe('boolean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case sensitivity and word boundary flags
+// ---------------------------------------------------------------------------
+
+describe('search-code: flags', () => {
+  it('adds -i by default (case insensitive)', () => {
+    const cmd = buildSearchCommand('foo', ['.ts']);
+    expect(cmd).toMatch(/ -i /);
+  });
+
+  it('omits -i when caseSensitive=true', () => {
+    const cmd = buildSearchCommand('Foo', ['.ts'], { caseSensitive: true });
+    expect(cmd).not.toMatch(/ -i /);
+  });
+
+  it('adds -w when wordBoundary=true', () => {
+    const cmd = buildSearchCommand('foo', ['.ts'], { wordBoundary: true });
+    expect(cmd).toContain('-w');
+  });
+
+  it('adds -e before the query', () => {
+    const cmd = buildSearchCommand('myFunc', ['.ts']);
+    expect(cmd).toContain('-e ');
+  });
+});

--- a/mcp-servers/repo/vitest.config.ts
+++ b/mcp-servers/repo/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+  },
+});

--- a/mcp-servers/repo/vitest.integration.config.ts
+++ b/mcp-servers/repo/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.integration.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    testTimeout: 60000,
+    // Run integration tests sequentially to avoid DB / FS contention
+    pool: 'forks',
+    maxConcurrency: 1,
+    maxWorkers: 1,
+    minWorkers: 1,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typecheck": "pnpm -r run typecheck",
     "clean": "pnpm -r run clean",
     "test": "pnpm -r --if-present run test",
-    "test:integration": "pnpm -r --if-present run test:integration"
+    "test:integration": "pnpm -r --if-present --workspace-concurrency=1 run test:integration"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/packages/test-utils/src/fixtures.ts
+++ b/packages/test-utils/src/fixtures.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@bronco/db';
+import { encrypt } from '@bronco/shared-utils';
 
 // ---------------------------------------------------------------------------
 // Re-usable payload types derived from the Prisma client
@@ -74,6 +75,80 @@ export async function createTicket(
       // Using string literals — these match Prisma enum values in schema.prisma
       status: 'NEW' as const,
       priority: 'MEDIUM' as const,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// System fixtures
+// ---------------------------------------------------------------------------
+
+/** The default shape returned when creating a System row. */
+export type SystemRow = Awaited<ReturnType<PrismaClient['system']['create']>>;
+
+export interface CreateSystemOverrides {
+  name?: string;
+  dbEngine?: string;
+  host?: string;
+  port?: number;
+  connectionString?: string | null;
+  instanceName?: string | null;
+  defaultDatabase?: string | null;
+  authMethod?: string;
+  username?: string | null;
+  /** Plain-text password — will be encrypted with encryptionKey before storing. */
+  password?: string | null;
+  useTls?: boolean;
+  trustServerCert?: boolean;
+  connectionTimeout?: number;
+  requestTimeout?: number;
+  maxPoolSize?: number;
+  isActive?: boolean;
+  environment?: string;
+}
+
+/**
+ * Creates a System row linked to the given clientId.
+ * Pass a plain-text `password` and `encryptionKey` — the fixture encrypts it
+ * before writing, mirroring how the application stores credentials.
+ *
+ * Set `isActive: false` to create an inactive system.
+ */
+export async function createSystem(
+  db: PrismaClient,
+  params: { clientId: string; encryptionKey?: string } & CreateSystemOverrides,
+): Promise<SystemRow> {
+  const { clientId, encryptionKey, ...overrides } = params;
+  const suffix = crypto.randomUUID().slice(0, 8);
+
+  let encryptedPassword: string | null = null;
+  const plainPassword = overrides.password ?? 'testpassword';
+  if (plainPassword && encryptionKey) {
+    encryptedPassword = encrypt(plainPassword, encryptionKey);
+  }
+
+  return db.system.create({
+    data: {
+      clientId,
+      name: overrides.name ?? `Test System ${suffix}`,
+      dbEngine: (overrides.dbEngine ?? 'MSSQL') as never,
+      host: overrides.host ?? 'sql.test.local',
+      port: overrides.port ?? 1433,
+      // Use explicit `in` check so callers can pass `null` to clear optional fields.
+      // The `??` operator treats null as nullish and would fall back to the default.
+      connectionString: 'connectionString' in overrides ? (overrides.connectionString ?? null) : null,
+      instanceName: 'instanceName' in overrides ? (overrides.instanceName ?? null) : null,
+      defaultDatabase: 'defaultDatabase' in overrides ? overrides.defaultDatabase : 'TestDb',
+      authMethod: (overrides.authMethod ?? 'SQL_AUTH') as never,
+      username: 'username' in overrides ? overrides.username : 'sa',
+      encryptedPassword,
+      useTls: overrides.useTls ?? false,
+      trustServerCert: overrides.trustServerCert ?? true,
+      connectionTimeout: overrides.connectionTimeout ?? 15000,
+      requestTimeout: overrides.requestTimeout ?? 30000,
+      maxPoolSize: overrides.maxPoolSize ?? 5,
+      isActive: overrides.isActive ?? true,
+      environment: (overrides.environment ?? 'PRODUCTION') as never,
     },
   });
 }
@@ -155,6 +230,47 @@ export async function createClientMemory(
       isActive: overrides.isActive ?? true,
       sortOrder: overrides.sortOrder ?? 0,
       source: overrides.source ?? 'MANUAL',
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Person fixtures
+// ---------------------------------------------------------------------------
+
+/** The default shape returned when creating a Person row. */
+export type PersonRow = Awaited<ReturnType<PrismaClient['person']['create']>>;
+
+export interface CreatePersonOverrides {
+  name?: string;
+  email?: string;
+  emailLower?: string;
+  phone?: string | null;
+  /** Seeded with a sentinel value so leaks are unmistakable in assertions. */
+  passwordHash?: string | null;
+  isActive?: boolean;
+}
+
+/**
+ * Creates a Person row with sensible test defaults.
+ * Seeds `passwordHash: 'TEST_HASH_NEVER_LEAK'` by default so any credential
+ * leak in tool-response payloads is immediately visible in assertions.
+ */
+export async function createPerson(
+  db: PrismaClient,
+  overrides: CreatePersonOverrides = {},
+): Promise<PersonRow> {
+  const suffix = crypto.randomUUID().slice(0, 8);
+  const email = overrides.email ?? `testperson-${suffix}@example.com`;
+  const emailLower = overrides.emailLower ?? email.toLowerCase();
+  return db.person.create({
+    data: {
+      name: overrides.name ?? `Test Person ${suffix}`,
+      email,
+      emailLower,
+      phone: overrides.phone !== undefined ? overrides.phone : null,
+      passwordHash: overrides.passwordHash !== undefined ? overrides.passwordHash : 'TEST_HASH_NEVER_LEAK',
+      isActive: overrides.isActive ?? true,
     },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@bronco/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -63,6 +66,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.1.11(@types/node@25.3.0)(jiti@2.6.1)(less@4.2.2)(sass@1.90.0)(terser@5.39.0)(tsx@4.21.0))
 
   mcp-servers/platform:
     dependencies:
@@ -97,6 +103,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@bronco/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -109,6 +118,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.7.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.1.11(@types/node@25.3.0)(jiti@2.6.1)(less@4.2.2)(sass@1.90.0)(terser@5.39.0)(tsx@4.21.0))
 
   mcp-servers/repo:
     dependencies:
@@ -131,6 +143,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@bronco/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -143,6 +158,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.7.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.1.11(@types/node@25.3.0)(jiti@2.6.1)(less@4.2.2)(sass@1.90.0)(terser@5.39.0)(tsx@4.21.0))
 
   packages/ai-provider:
     dependencies:
@@ -428,6 +446,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@bronco/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6
@@ -446,6 +467,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.1.11(@types/node@25.3.0)(jiti@2.6.1)(less@4.2.2)(sass@1.90.0)(terser@5.39.0)(tsx@4.21.0))
 
   services/devops-worker:
     dependencies:

--- a/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
+++ b/services/control-panel/src/app/features/clients/client-detail/tabs/config-tab.component.ts
@@ -98,7 +98,7 @@ import {
           <app-bronco-button
             variant="primary"
             size="sm"
-            [disabled]="searchIgnoreTermsValue() === (c.searchIgnoreTerms ?? []).join(', ')"
+            [disabled]="!isSearchIgnoreTermsDirty(c)"
             (click)="saveSearchIgnoreTerms()">
             Save
           </app-bronco-button>
@@ -169,6 +169,25 @@ export class ClientConfigTabComponent {
     }
   }
 
+  private normalizeTerms(input: string | string[]): string[] {
+    const raw = Array.isArray(input) ? input.join(',') : input;
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const t of raw.split(',')) {
+      const norm = t.trim().toLowerCase();
+      if (norm && !seen.has(norm)) {
+        seen.add(norm);
+        result.push(norm);
+      }
+    }
+    return result;
+  }
+
+  isSearchIgnoreTermsDirty(c: Client): boolean {
+    return JSON.stringify(this.normalizeTerms(this.searchIgnoreTermsValue())) !==
+      JSON.stringify(this.normalizeTerms(c.searchIgnoreTerms ?? []));
+  }
+
   toggle(field: 'isActive' | 'autoRouteTickets' | 'allowSelfRegistration', value: boolean): void {
     this.patch({ [field]: value });
   }
@@ -190,10 +209,7 @@ export class ClientConfigTabComponent {
   }
 
   saveSearchIgnoreTerms(): void {
-    const terms = this.searchIgnoreTermsValue()
-      .split(',')
-      .map(t => t.trim())
-      .filter(Boolean);
+    const terms = this.normalizeTerms(this.searchIgnoreTermsValue());
     this.patch({ searchIgnoreTerms: terms } as Partial<Client>, 'Search ignore terms saved');
   }
 

--- a/services/copilot-api/package.json
+++ b/services/copilot-api/package.json
@@ -8,7 +8,9 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --passWithNoTests --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.0",
@@ -31,11 +33,13 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@bronco/test-utils": "workspace:*",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.0",
     "@types/node": "^25.3.0",
     "@types/pdfkit": "^0.13.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/services/copilot-api/src/routes/client-memory.test.ts
+++ b/services/copilot-api/src/routes/client-memory.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Unit tests for client-memory routes.
+ * Uses Fastify inject() with a mocked PrismaClient — no real DB or queues.
+ * Verifies ClientMemoryResolver.invalidate() is called on create/update/delete.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import type { ClientMemoryResolver } from '@bronco/ai-provider';
+import { buildTestRouteApp, makeAdminUser, makeScopedUser } from '../test/app-builder.js';
+import { clientMemoryRoutes } from './client-memory.js';
+
+// ─── Mock factory helpers ─────────────────────────────────────────────────────
+
+function makeMockDb(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  const clientMemory = {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+  };
+
+  const operatorClient = {
+    findMany: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    clientMemory,
+    operatorClient,
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+function makeMockResolver(): ClientMemoryResolver {
+  return {
+    invalidate: vi.fn(),
+    resolve: vi.fn().mockResolvedValue({ markdown: '', count: 0 }),
+  } as unknown as ClientMemoryResolver;
+}
+
+function makeMemoryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'mem-1',
+    clientId: 'client-1',
+    title: 'Test Playbook',
+    memoryType: 'PLAYBOOK',
+    category: null,
+    tags: [],
+    content: 'Step 1: do the thing',
+    sortOrder: 0,
+    source: 'MANUAL',
+    isActive: true,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    client: { id: 'client-1', name: 'Acme', shortCode: 'ACM' },
+    ...overrides,
+  };
+}
+
+// ─── GET /api/client-memory ───────────────────────────────────────────────────
+
+describe('GET /api/client-memory', () => {
+  it('returns 200 with empty array when no entries exist', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('returns 400 for invalid category filter', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory?category=INVALID' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid memoryType filter', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory?memoryType=INVALID' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid isActive filter', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory?isActive=maybe' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('scoped operator sees only their client memories', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    await app.inject({ method: 'GET', url: '/api/client-memory' });
+
+    const call = (db.clientMemory.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.clientId).toBe('client-a');
+  });
+
+  it('filters by clientId if provided and in scope', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeMemoryRow()]);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    await app.inject({ method: 'GET', url: '/api/client-memory?clientId=client-1' });
+
+    const call = (db.clientMemory.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.clientId).toBe('client-1');
+  });
+});
+
+// ─── GET /api/client-memory/:id ──────────────────────────────────────────────
+
+describe('GET /api/client-memory/:id', () => {
+  it('returns 404 when entry not found', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns memory entry when found', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeMemoryRow());
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'GET', url: '/api/client-memory/mem-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('mem-1');
+    expect(body.title).toBe('Test Playbook');
+  });
+});
+
+// ─── POST /api/client-memory ──────────────────────────────────────────────────
+
+describe('POST /api/client-memory', () => {
+  it('returns 400 when required fields missing', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client-memory',
+      payload: { clientId: 'client-1', title: 'Test' }, // missing content
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid memoryType', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client-memory',
+      payload: { clientId: 'client-1', title: 'Test', content: 'Content', memoryType: 'INVALID_TYPE' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid category', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client-memory',
+      payload: { clientId: 'client-1', title: 'Test', content: 'Content', memoryType: 'CONTEXT', category: 'NOT_A_CATEGORY' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when scoped operator creates memory for out-of-scope client', async () => {
+    const db = makeMockDb();
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client-memory',
+      payload: { clientId: 'client-b', title: 'Test', content: 'Content', memoryType: 'CONTEXT' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('creates memory entry, returns 201, and calls resolver.invalidate()', async () => {
+    const created = makeMemoryRow();
+    const db = makeMockDb();
+    (db.clientMemory.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/client-memory',
+      payload: { clientId: 'client-1', title: 'Test Playbook', content: 'Step 1', memoryType: 'PLAYBOOK' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('mem-1');
+    // Cache invalidation must be called with the clientId
+    expect(resolver.invalidate).toHaveBeenCalledWith('client-1');
+  });
+});
+
+// ─── PATCH /api/client-memory/:id ────────────────────────────────────────────
+
+describe('PATCH /api/client-memory/:id', () => {
+  it('returns 404 when entry not found or out of scope', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/client-memory/nonexistent',
+      payload: { title: 'Updated' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for invalid memoryType in update', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-1' });
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/client-memory/mem-1',
+      payload: { memoryType: 'INVALID_TYPE' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when title is set to empty string', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-1' });
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/client-memory/mem-1',
+      payload: { title: '   ' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('updates entry and calls resolver.invalidate()', async () => {
+    const updated = makeMemoryRow({ title: 'Updated Title' });
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'mem-1' });
+    (db.clientMemory.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/client-memory/mem-1',
+      payload: { title: 'Updated Title' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.title).toBe('Updated Title');
+    expect(resolver.invalidate).toHaveBeenCalledWith('client-1');
+  });
+});
+
+// ─── DELETE /api/client-memory/:id ───────────────────────────────────────────
+
+describe('DELETE /api/client-memory/:id', () => {
+  it('returns 404 when entry not found', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/client-memory/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('deletes entry, returns 204, and calls resolver.invalidate()', async () => {
+    const db = makeMockDb();
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeMemoryRow());
+    (db.clientMemory.delete as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/client-memory/mem-1' });
+    expect(res.statusCode).toBe(204);
+    expect(resolver.invalidate).toHaveBeenCalledWith('client-1');
+  });
+
+  it('scoped operator cannot delete entry from out-of-scope client', async () => {
+    const db = makeMockDb();
+    // findFirst with scopeToWhere will return null because the row is scoped
+    (db.clientMemory.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const resolver = makeMockResolver();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(clientMemoryRoutes, { clientMemoryResolver: resolver });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/client-memory/mem-other' });
+    expect(res.statusCode).toBe(404);
+    expect(resolver.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/services/copilot-api/src/routes/clients.test.ts
+++ b/services/copilot-api/src/routes/clients.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Unit tests for clients routes.
+ * Uses Fastify inject() with a mocked PrismaClient — no real DB or queues.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { buildTestRouteApp, makeAdminUser, makeScopedUser } from '../test/app-builder.js';
+import { clientRoutes } from './clients.js';
+
+// ─── Mock db factory ───────────────────────────────────────────────────────────
+
+function makeMockDb(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  const client = {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+  };
+
+  const invoice = {
+    aggregate: vi.fn().mockResolvedValue({ _sum: { totalBilledCostUsd: null } }),
+  };
+
+  const operatorClient = {
+    findMany: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    client,
+    invoice,
+    operatorClient,
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+function makeClientRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'client-1',
+    name: 'Acme Corp',
+    shortCode: 'ACM',
+    isActive: true,
+    isInternal: false,
+    notes: null,
+    domainMappings: [],
+    _count: { tickets: 0, systems: 0 },
+    ...overrides,
+  };
+}
+
+// ─── GET /api/search/clients ──────────────────────────────────────────────────
+
+describe('GET /api/search/clients', () => {
+  it('returns 400 when q is missing', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/clients' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when q is 1 character', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/clients?q=a' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when limit exceeds 50', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/clients?q=ac&limit=51' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns search results for valid q', async () => {
+    const db = makeMockDb();
+    (db.client.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'client-1', name: 'Acme Corp', shortCode: 'ACM', isActive: true },
+    ]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/clients?q=ac' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0].shortCode).toBe('ACM');
+  });
+
+  it('scoped operator sees only their client in search', async () => {
+    const db = makeMockDb();
+    (db.client.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(clientRoutes);
+
+    await app.inject({ method: 'GET', url: '/api/search/clients?q=ac' });
+
+    const call = (db.client.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // scope filter for single client maps to { id: 'client-a' }
+    expect(call.where.id).toBe('client-a');
+  });
+});
+
+// ─── GET /api/clients ─────────────────────────────────────────────────────────
+
+describe('GET /api/clients', () => {
+  it('returns 200 with empty array when no clients exist', async () => {
+    const db = makeMockDb();
+    (db.client.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/clients' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('scoped operator sees only their client', async () => {
+    const db = makeMockDb();
+    (db.client.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(clientRoutes);
+
+    await app.inject({ method: 'GET', url: '/api/clients' });
+
+    const call = (db.client.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.id).toBe('client-a');
+  });
+
+  it('admin sees all non-internal clients', async () => {
+    const db = makeMockDb();
+    (db.client.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([makeClientRow()]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/clients' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+  });
+});
+
+// ─── GET /api/clients/:id ─────────────────────────────────────────────────────
+
+describe('GET /api/clients/:id', () => {
+  it('returns 404 when client does not exist', async () => {
+    const db = makeMockDb();
+    (db.client.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/clients/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns client with invoicedTotalUsd', async () => {
+    const db = makeMockDb();
+    (db.client.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...makeClientRow(),
+      clientUsers: [],
+      systems: [],
+      _count: { tickets: 2, systems: 0, codeRepos: 0, integrations: 0, clientMemories: 0, environments: 0, clientUsers: 0, invoices: 1 },
+    });
+    (db.invoice.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({ _sum: { totalBilledCostUsd: 150.0 } });
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/clients/client-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.invoicedTotalUsd).toBe(150.0);
+  });
+
+  it('returns invoicedTotalUsd as 0 when no invoices', async () => {
+    const db = makeMockDb();
+    (db.client.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...makeClientRow(),
+      clientUsers: [],
+      systems: [],
+      _count: { tickets: 0, systems: 0, codeRepos: 0, integrations: 0, clientMemories: 0, environments: 0, clientUsers: 0, invoices: 0 },
+    });
+    (db.invoice.aggregate as ReturnType<typeof vi.fn>).mockResolvedValue({ _sum: { totalBilledCostUsd: null } });
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/clients/client-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.invoicedTotalUsd).toBe(0);
+  });
+});
+
+// ─── POST /api/clients ────────────────────────────────────────────────────────
+
+describe('POST /api/clients', () => {
+  it('creates a client and returns 201', async () => {
+    const newClient = { id: 'client-new', name: 'New Corp', shortCode: 'NEW', isInternal: false, isActive: true };
+    const db = makeMockDb();
+    (db.client.create as ReturnType<typeof vi.fn>).mockResolvedValue(newClient);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/clients',
+      payload: { name: 'New Corp', shortCode: 'NEW' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.shortCode).toBe('NEW');
+  });
+
+  it('returns 400 for invalid domain mapping format', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/clients',
+      payload: { name: 'Corp', shortCode: 'CRP', domainMappings: ['not_a_domain!!!'] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('accepts valid domain mappings', async () => {
+    const db = makeMockDb();
+    (db.client.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'c-1', name: 'Corp', shortCode: 'CRP', domainMappings: ['example.com'] });
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/clients',
+      payload: { name: 'Corp', shortCode: 'CRP', domainMappings: ['example.com'] },
+    });
+    expect(res.statusCode).toBe(201);
+    const call = (db.client.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.data.domainMappings).toEqual(['example.com']);
+  });
+});
+
+// ─── PATCH /api/clients/:id ───────────────────────────────────────────────────
+
+describe('PATCH /api/clients/:id', () => {
+  it('returns 400 for invalid aiMode', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { aiMode: 'INVALID_MODE' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid billingPeriod', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingPeriod: 'quarterly' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid billingAnchorDay (0)', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingAnchorDay: 0 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid billingAnchorDay (> 28)', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingAnchorDay: 29 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid billingMarkupPercent (below 1.0)', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingMarkupPercent: 0.5 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid billingMarkupPercent (above 10.0)', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingMarkupPercent: 11.0 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid notificationMode', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { notificationMode: 'invalid' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when portal user tries to set notificationMode', async () => {
+    const db = makeMockDb();
+    // portalUser only — no operator user
+    const app = await buildTestRouteApp({
+      db,
+      portalUser: { personId: 'p-1', clientUserId: 'cu-1', clientId: 'client-1', email: 'u@x.com', name: 'Portal User', userType: 'USER' as never },
+    });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { notificationMode: 'operator' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('updates client and returns updated record', async () => {
+    const updated = makeClientRow({ name: 'Acme Updated', isActive: false });
+    const db = makeMockDb();
+    (db.client.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { name: 'Acme Updated', isActive: false },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe('Acme Updated');
+  });
+
+  it('accepts valid billingAnchorDay on boundary (1)', async () => {
+    const db = makeMockDb();
+    (db.client.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeClientRow());
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingAnchorDay: 1 },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('accepts valid billingAnchorDay on boundary (28)', async () => {
+    const db = makeMockDb();
+    (db.client.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeClientRow());
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(clientRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/clients/client-1',
+      payload: { billingAnchorDay: 28 },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/services/copilot-api/src/routes/clients.ts
+++ b/services/copilot-api/src/routes/clients.ts
@@ -7,6 +7,19 @@ const VALID_AI_MODES = new Set<string>(Object.values(AiMode));
 // Basic domain format validation: alphanumeric labels separated by dots, no protocol prefix
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 
+function normalizeSearchIgnoreTerms(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    throw Object.assign(new Error('searchIgnoreTerms must be an array of strings'), { statusCode: 400 });
+  }
+  for (const item of raw) {
+    if (typeof item !== 'string') {
+      throw Object.assign(new Error('searchIgnoreTerms must be an array of strings'), { statusCode: 400 });
+    }
+  }
+  const trimmed = (raw as string[]).map(t => t.trim().toLowerCase()).filter(Boolean);
+  return [...new Set(trimmed)];
+}
+
 function validateDomainMappings(domains: string[] | undefined): string[] | undefined {
   if (!domains) return undefined;
   const cleaned = domains.map(d => d.trim().toLowerCase()).filter(Boolean);
@@ -149,16 +162,19 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     };
   });
 
-  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[]; searchIgnoreTerms?: string[] } }>(
+  fastify.post<{ Body: { name: string; shortCode: string; notes?: string; domainMappings?: string[]; searchIgnoreTerms?: unknown } }>(
     '/api/clients',
     async (request, reply) => {
       const domainMappings = validateDomainMappings(request.body.domainMappings);
-      const { searchIgnoreTerms, ...rest } = request.body;
+      const { searchIgnoreTerms: rawSearchIgnoreTerms, ...rest } = request.body;
+      const searchIgnoreTerms = rawSearchIgnoreTerms !== undefined
+        ? normalizeSearchIgnoreTerms(rawSearchIgnoreTerms)
+        : [];
       const client = await fastify.db.client.create({
         data: {
           ...rest,
           domainMappings,
-          ...(searchIgnoreTerms !== undefined && { searchIgnoreTerms }),
+          searchIgnoreTerms,
         },
       });
       reply.code(201);
@@ -166,10 +182,13 @@ export async function clientRoutes(fastify: FastifyInstance): Promise<void> {
     },
   );
 
-  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; searchIgnoreTerms?: string[]; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
+  fastify.patch<{ Params: { id: string }; Body: { name?: string; notes?: string; isActive?: boolean; autoRouteTickets?: boolean; allowSelfRegistration?: boolean; domainMappings?: string[]; searchIgnoreTerms?: unknown; companyProfile?: string | null; systemsProfile?: string | null; aiMode?: string; billingPeriod?: string; billingAnchorDay?: number; billingMarkupPercent?: number; slackChannelId?: string | null; notificationMode?: string } }>(
     '/api/clients/:id',
     async (request, reply) => {
-      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, searchIgnoreTerms, ...rest } = request.body;
+      const { aiMode, billingPeriod, billingAnchorDay, billingMarkupPercent, notificationMode, searchIgnoreTerms: rawSearchIgnoreTerms, ...rest } = request.body;
+      const searchIgnoreTerms = rawSearchIgnoreTerms !== undefined
+        ? normalizeSearchIgnoreTerms(rawSearchIgnoreTerms)
+        : undefined;
       if (aiMode !== undefined && !VALID_AI_MODES.has(aiMode)) {
         return reply.code(400).send({ error: `Invalid aiMode "${aiMode}". Valid: ${[...VALID_AI_MODES].join(', ')}` });
       }

--- a/services/copilot-api/src/routes/integrations.test.ts
+++ b/services/copilot-api/src/routes/integrations.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Unit tests for integrations routes.
+ * Uses Fastify inject() with a mocked PrismaClient — no real DB or queues.
+ * Verifies encrypt/decrypt boundary: secret fields are encrypted before DB write.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { looksEncrypted } from '@bronco/shared-utils';
+import { buildTestRouteApp, makeAdminUser, makeScopedUser } from '../test/app-builder.js';
+import { integrationRoutes } from './integrations.js';
+
+// A valid 256-bit hex key for encryption tests
+const TEST_ENCRYPTION_KEY = 'a'.repeat(64); // 64 hex chars = 32 bytes
+
+// ─── Mock factory helpers ─────────────────────────────────────────────────────
+
+function makeMockDb(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  const clientIntegration = {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+  };
+
+  const clientEnvironment = {
+    findUnique: vi.fn().mockResolvedValue(null),
+  };
+
+  const operatorClient = {
+    findMany: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    clientIntegration,
+    clientEnvironment,
+    operatorClient,
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+function makeMockQueue() {
+  return { add: vi.fn().mockResolvedValue({ id: 'job-1' }) };
+}
+
+function makeIntegrationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'integ-1',
+    clientId: 'client-1',
+    type: 'IMAP',
+    label: 'default',
+    config: {},
+    isActive: true,
+    notes: null,
+    environmentId: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    client: { name: 'Acme', shortCode: 'ACM' },
+    ...overrides,
+  };
+}
+
+function makeValidImapConfig() {
+  return {
+    host: 'imap.example.com',
+    port: 993,
+    user: 'user@example.com',
+    encryptedPassword: 'plaintext-password',
+    pollIntervalSeconds: 60,
+  };
+}
+
+// ─── GET /api/integrations ────────────────────────────────────────────────────
+
+describe('GET /api/integrations', () => {
+  it('returns 200 with empty array when no integrations', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'GET', url: '/api/integrations' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('returns 400 for invalid type filter', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'GET', url: '/api/integrations?type=INVALID_TYPE' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('scoped operator sees their client plus platform-scoped rows', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    await app.inject({ method: 'GET', url: '/api/integrations' });
+
+    const call = (db.clientIntegration.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // Single-scoped callers get an OR filter for their clientId plus null (platform)
+    expect(call.where.OR).toBeDefined();
+    const orClauses = call.where.OR as Array<Record<string, unknown>>;
+    expect(orClauses.some((c) => c.clientId === 'client-a')).toBe(true);
+    expect(orClauses.some((c) => c.clientId === null)).toBe(true);
+  });
+
+  it('returns 403 when scoped operator requests out-of-scope clientId', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'GET', url: '/api/integrations?clientId=client-b' });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ─── GET /api/integrations/:id ────────────────────────────────────────────────
+
+describe('GET /api/integrations/:id', () => {
+  it('returns 404 when integration not found', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'GET', url: '/api/integrations/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns integration when found', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeIntegrationRow());
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'GET', url: '/api/integrations/integ-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('integ-1');
+    expect(body.type).toBe('IMAP');
+  });
+});
+
+// ─── POST /api/integrations ───────────────────────────────────────────────────
+
+describe('POST /api/integrations', () => {
+  it('returns 400 for invalid integration type', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: { clientId: 'client-1', type: 'INVALID_TYPE', config: {} },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when clientId is missing for non-GITHUB type', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        type: 'IMAP',
+        config: makeValidImapConfig(),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid IMAP config (missing required fields)', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-1',
+        type: 'IMAP',
+        config: { host: 'imap.example.com' }, // missing port, user, encryptedPassword, pollIntervalSeconds
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when scoped operator creates integration for out-of-scope client', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-b',
+        type: 'IMAP',
+        config: makeValidImapConfig(),
+      },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 403 when non-admin creates platform-scoped GITHUB integration', async () => {
+    const db = makeMockDb();
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        type: 'GITHUB',
+        config: { kind: 'pat', encryptedToken: 'my-token' },
+      },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('encrypts secret fields before storing IMAP config', async () => {
+    const created = makeIntegrationRow({ type: 'IMAP', config: { host: 'imap.example.com', port: 993, user: 'u@x.com', encryptedPassword: 'ENCRYPTED', pollIntervalSeconds: 60 } });
+    const db = makeMockDb();
+    (db.clientIntegration.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-1',
+        type: 'IMAP',
+        config: makeValidImapConfig(),
+      },
+    });
+    expect(res.statusCode).toBe(201);
+
+    const createCall = (db.clientIntegration.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedConfig = createCall.data.config as Record<string, unknown>;
+    // The stored password must look encrypted — not plaintext
+    expect(typeof storedConfig.encryptedPassword).toBe('string');
+    expect(looksEncrypted(storedConfig.encryptedPassword as string)).toBe(true);
+  });
+
+  it('does not re-encrypt already-encrypted values', async () => {
+    // Pre-encrypt a value and pass it in — route should not double-encrypt
+    const { encrypt } = await import('@bronco/shared-utils');
+    const preEncrypted = encrypt('plaintext-password', TEST_ENCRYPTION_KEY);
+
+    const created = makeIntegrationRow({ type: 'IMAP' });
+    const db = makeMockDb();
+    (db.clientIntegration.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-1',
+        type: 'IMAP',
+        config: { ...makeValidImapConfig(), encryptedPassword: preEncrypted },
+      },
+    });
+
+    const createCall = (db.clientIntegration.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedConfig = createCall.data.config as Record<string, unknown>;
+    // Should still be the same already-encrypted value, not double-encrypted
+    expect(storedConfig.encryptedPassword).toBe(preEncrypted);
+  });
+
+  it('enqueues MCP discovery job for MCP_DATABASE integration', async () => {
+    const created = makeIntegrationRow({ id: 'integ-mcp', type: 'MCP_DATABASE', clientId: 'client-1', config: { url: 'http://mcp.example.com', apiKey: 'key123' } });
+    const db = makeMockDb();
+    (db.clientIntegration.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-1',
+        type: 'MCP_DATABASE',
+        config: { url: 'http://mcp.example.com', apiKey: 'key123' },
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(queue.add).toHaveBeenCalledWith('discover', { integrationId: 'integ-mcp' });
+  });
+
+  it('calls onSlackIntegrationChange for SLACK integration', async () => {
+    const created = makeIntegrationRow({ type: 'SLACK', config: {
+      encryptedBotToken: 'bot-token',
+      encryptedAppToken: 'app-token',
+      defaultChannelId: '#general',
+      enabled: true,
+    }});
+    const db = makeMockDb();
+    (db.clientIntegration.create as ReturnType<typeof vi.fn>).mockResolvedValue(created);
+    const queue = makeMockQueue();
+    const slackChangeFn = vi.fn();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, {
+      encryptionKey: TEST_ENCRYPTION_KEY,
+      mcpDiscoveryQueue: queue as never,
+      onSlackIntegrationChange: slackChangeFn,
+    });
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/integrations',
+      payload: {
+        clientId: 'client-1',
+        type: 'SLACK',
+        config: {
+          encryptedBotToken: 'bot-token',
+          encryptedAppToken: 'app-token',
+          defaultChannelId: '#general',
+          enabled: true,
+        },
+      },
+    });
+    expect(slackChangeFn).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── PATCH /api/integrations/:id ─────────────────────────────────────────────
+
+describe('PATCH /api/integrations/:id', () => {
+  it('returns 404 when integration not found', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/integrations/nonexistent',
+      payload: { label: 'updated' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when non-admin tries to update platform-scoped integration', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ clientId: null, type: 'GITHUB' }),
+    );
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/integrations/integ-1',
+      payload: { label: 'updated' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('encrypts secret fields in config update', async () => {
+    const existingConfig = { host: 'imap.example.com', port: 993, user: 'u@x.com', encryptedPassword: 'old-pass', pollIntervalSeconds: 60 };
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ type: 'IMAP', config: existingConfig, clientId: 'client-1' }),
+    );
+    (db.clientIntegration.update as ReturnType<typeof vi.fn>).mockResolvedValue(makeIntegrationRow());
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    await app.inject({
+      method: 'PATCH',
+      url: '/api/integrations/integ-1',
+      payload: { config: { encryptedPassword: 'new-plaintext-password' } },
+    });
+
+    const updateCall = (db.clientIntegration.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const storedConfig = updateCall.data.config as Record<string, unknown>;
+    expect(looksEncrypted(storedConfig.encryptedPassword as string)).toBe(true);
+  });
+
+  it('enqueues MCP discovery job when config changed on MCP_DATABASE', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ type: 'MCP_DATABASE', clientId: 'client-1', config: { url: 'http://mcp.example.com', apiKey: 'key' } }),
+    );
+    (db.clientIntegration.update as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ id: 'integ-1', type: 'MCP_DATABASE' }),
+    );
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    await app.inject({
+      method: 'PATCH',
+      url: '/api/integrations/integ-1',
+      payload: { config: { url: 'http://mcp-updated.example.com', apiKey: 'key' } },
+    });
+    expect(queue.add).toHaveBeenCalledWith('discover', { integrationId: 'integ-1' });
+  });
+});
+
+// ─── DELETE /api/integrations/:id ────────────────────────────────────────────
+
+describe('DELETE /api/integrations/:id', () => {
+  it('returns 404 when integration not found', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/integrations/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when non-admin tries to delete platform-scoped integration', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ clientId: null, type: 'GITHUB' }),
+    );
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/integrations/integ-1' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('deletes integration and returns 204', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeIntegrationRow());
+    (db.clientIntegration.delete as ReturnType<typeof vi.fn>).mockResolvedValue({ type: 'IMAP' });
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/integrations/integ-1' });
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('calls onSlackIntegrationChange when SLACK integration deleted', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeIntegrationRow({ type: 'SLACK' }));
+    (db.clientIntegration.delete as ReturnType<typeof vi.fn>).mockResolvedValue({ type: 'SLACK' });
+    const queue = makeMockQueue();
+    const slackChangeFn = vi.fn();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, {
+      encryptionKey: TEST_ENCRYPTION_KEY,
+      mcpDiscoveryQueue: queue as never,
+      onSlackIntegrationChange: slackChangeFn,
+    });
+
+    await app.inject({ method: 'DELETE', url: '/api/integrations/integ-1' });
+    expect(slackChangeFn).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── POST /api/integrations/:id/verify ───────────────────────────────────────
+
+describe('POST /api/integrations/:id/verify', () => {
+  it('returns 404 when integration not found', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'POST', url: '/api/integrations/nonexistent/verify' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 when integration type is not MCP_DATABASE', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeIntegrationRow({ type: 'IMAP' }));
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'POST', url: '/api/integrations/integ-1/verify' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('enqueues discovery and returns success for MCP_DATABASE', async () => {
+    const db = makeMockDb();
+    (db.clientIntegration.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeIntegrationRow({ id: 'integ-mcp', type: 'MCP_DATABASE', clientId: 'client-1' }),
+    );
+    const queue = makeMockQueue();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(integrationRoutes, { encryptionKey: TEST_ENCRYPTION_KEY, mcpDiscoveryQueue: queue as never });
+
+    const res = await app.inject({ method: 'POST', url: '/api/integrations/integ-mcp/verify' });
+    expect(res.statusCode).toBe(200);
+    expect(queue.add).toHaveBeenCalledWith('discover', { integrationId: 'integ-mcp' });
+  });
+});

--- a/services/copilot-api/src/routes/people.test.ts
+++ b/services/copilot-api/src/routes/people.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Unit tests for people routes.
+ * Uses Fastify inject() with a mocked PrismaClient — no real DB or queues.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { buildTestRouteApp, makeAdminUser, makeScopedUser } from '../test/app-builder.js';
+import { peopleRoutes } from './people.js';
+
+// ─── Mock db factory ───────────────────────────────────────────────────────────
+
+function makeMockDb(overrides: Partial<Record<string, unknown>> = {}): PrismaClient {
+  const clientUser = {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    delete: vi.fn().mockResolvedValue(null),
+  };
+
+  const person = {
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+  };
+
+  const personRefreshToken = {
+    updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+  };
+
+  const operatorClient = {
+    findMany: vi.fn().mockResolvedValue([]),
+  };
+
+  return {
+    clientUser,
+    person,
+    personRefreshToken,
+    operatorClient,
+    $transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => unknown) => fn({
+      person: { create: vi.fn().mockResolvedValue(null), update: vi.fn().mockResolvedValue(null) },
+      clientUser: { create: vi.fn().mockResolvedValue(null), update: vi.fn().mockResolvedValue(null), delete: vi.fn().mockResolvedValue(null) },
+      personRefreshToken: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    })),
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+/** Helper to build a full ClientUser row as returned by formatPerson */
+function makeClientUserRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cu-1',
+    clientId: 'client-1',
+    userType: 'USER',
+    isPrimary: true,
+    lastLoginAt: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    person: {
+      id: 'person-1',
+      name: 'Alice Test',
+      email: 'alice@example.com',
+      phone: null,
+      isActive: true,
+      passwordHash: null,
+    },
+    client: { name: 'Acme', shortCode: 'ACM' },
+    ...overrides,
+  };
+}
+
+// ─── GET /api/search/people ────────────────────────────────────────────────────
+
+describe('GET /api/search/people', () => {
+  it('returns 400 when q is missing', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/people' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when q is 1 character', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/people?q=a' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when limit is > 50', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/people?q=alice&limit=51' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns search results for valid q', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: 'cu-1',
+        clientId: 'client-1',
+        userType: 'USER',
+        isPrimary: true,
+        person: { id: 'person-1', name: 'Alice Test', email: 'alice@example.com', isActive: true },
+        client: { name: 'Acme', shortCode: 'ACM' },
+      },
+    ]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/people?q=alice' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0]).toMatchObject({ name: 'Alice Test', email: 'alice@example.com' });
+  });
+
+  it('scoped operator sees only their client results', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    await app.inject({ method: 'GET', url: '/api/search/people?q=alice' });
+
+    const call = (db.clientUser.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.clientId).toBe('client-a');
+  });
+});
+
+// ─── GET /api/people ──────────────────────────────────────────────────────────
+
+describe('GET /api/people', () => {
+  it('returns 200 with empty array when no people exist', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('returns 403 when scoped operator requests out-of-scope clientId', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people?clientId=client-b' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns list of people with hasPortalAccess derived from passwordHash', async () => {
+    const db = makeMockDb();
+    const rows = [
+      makeClientUserRow({ person: { id: 'p1', name: 'A', email: 'a@x.com', phone: null, isActive: true, passwordHash: 'hash123' } }),
+      makeClientUserRow({ id: 'cu-2', person: { id: 'p2', name: 'B', email: 'b@x.com', phone: null, isActive: true, passwordHash: null } }),
+    ];
+    (db.clientUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(rows);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body[0].hasPortalAccess).toBe(true);
+    expect(body[1].hasPortalAccess).toBe(false);
+    // Raw hash must not be in response
+    expect(JSON.stringify(body)).not.toContain('hash123');
+  });
+
+  it('scoped operator sees only their client', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    await app.inject({ method: 'GET', url: '/api/people' });
+
+    const call = (db.clientUser.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.clientId).toBe('client-a');
+  });
+});
+
+// ─── GET /api/people/:id ──────────────────────────────────────────────────────
+
+describe('GET /api/people/:id', () => {
+  it('returns 404 when person does not exist', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns person with hasPortalAccess derived', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(makeClientUserRow({
+      person: { id: 'person-1', name: 'Alice', email: 'alice@x.com', phone: null, isActive: true, passwordHash: 'somehash' },
+    }));
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people/person-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.hasPortalAccess).toBe(true);
+    expect(body).not.toHaveProperty('passwordHash');
+  });
+
+  it('returns 403 when person belongs to out-of-scope client', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeClientUserRow({ clientId: 'client-b' }),
+    );
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/people/person-1' });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ─── POST /api/people ─────────────────────────────────────────────────────────
+
+describe('POST /api/people', () => {
+  it('returns 400 when required fields are missing', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people',
+      payload: { name: 'Alice' }, // missing clientId and email
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when password is shorter than 8 characters', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people',
+      payload: { clientId: 'client-1', name: 'Alice', email: 'alice@x.com', password: 'short' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when scoped operator creates person for out-of-scope client', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people',
+      payload: { clientId: 'client-b', name: 'Alice', email: 'alice@x.com' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 409 when person email already linked to this client', async () => {
+    const db = makeMockDb();
+    (db.person.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'person-1',
+      clientUsers: [{ clientId: 'client-1' }],
+    });
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people',
+      payload: { clientId: 'client-1', name: 'Alice', email: 'alice@x.com' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('creates person and returns 201 with hasPortalAccess', async () => {
+    const db = makeMockDb();
+    (db.person.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const createdCu = makeClientUserRow({
+      person: { id: 'new-p', name: 'Alice', email: 'alice@x.com', phone: null, isActive: true, passwordHash: null },
+    });
+    (db.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        person: { create: vi.fn().mockResolvedValue({ id: 'new-p' }) },
+        clientUser: { create: vi.fn().mockResolvedValue(createdCu) },
+      };
+      return fn(tx);
+    });
+
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people',
+      payload: { clientId: 'client-1', name: 'Alice', email: 'alice@x.com' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.hasPortalAccess).toBe(false);
+  });
+});
+
+// ─── PATCH /api/people/:id ────────────────────────────────────────────────────
+
+describe('PATCH /api/people/:id', () => {
+  it('returns 404 when person not found', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/people/nonexistent',
+      payload: { name: 'Bob' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 when password is too short', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/people/person-1',
+      payload: { password: 'short' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when person is in out-of-scope client', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeClientUserRow({ clientId: 'client-b' }),
+    );
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/people/person-1',
+      payload: { name: 'Bob' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('updates person and returns updated shape', async () => {
+    const existingCu = makeClientUserRow();
+    const updatedCu = makeClientUserRow({ person: { id: 'person-1', name: 'Bob Updated', email: 'alice@x.com', phone: null, isActive: true, passwordHash: null } });
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(existingCu);
+    (db.person.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null); // no operator
+    (db.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        person: { update: vi.fn().mockResolvedValue(null) },
+        clientUser: { update: vi.fn().mockResolvedValue(updatedCu) },
+      };
+      return fn(tx);
+    });
+
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/people/person-1',
+      payload: { name: 'Bob Updated' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.name).toBe('Bob Updated');
+  });
+});
+
+// ─── DELETE /api/people/:id ───────────────────────────────────────────────────
+
+describe('DELETE /api/people/:id', () => {
+  it('returns 404 when person not found', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/people/nonexistent' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when person is in out-of-scope client', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'cu-1', clientId: 'client-b' });
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/people/person-1' });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('deletes person and returns success message', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'cu-1', clientId: 'client-1' });
+    (db.$transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => unknown) => {
+      const tx = {
+        personRefreshToken: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        clientUser: { delete: vi.fn().mockResolvedValue(null) },
+        person: {
+          findUnique: vi.fn().mockResolvedValue({
+            operator: null,
+            _count: { clientUsers: 0 },
+          }),
+          update: vi.fn().mockResolvedValue(null),
+        },
+      };
+      return fn(tx);
+    });
+
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/people/person-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.message).toMatch(/removed/i);
+  });
+});
+
+// ─── POST /api/people/:id/reset-password ─────────────────────────────────────
+
+describe('POST /api/people/:id/reset-password', () => {
+  it('returns 400 when password is too short', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people/person-1/reset-password',
+      payload: { password: 'short' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when person not found', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people/nonexistent/reset-password',
+      payload: { password: 'validpassword123' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when person is out-of-scope', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ clientId: 'client-b' });
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people/person-1/reset-password',
+      payload: { password: 'validpassword123' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('resets password and returns success for admin', async () => {
+    const db = makeMockDb();
+    (db.clientUser.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ clientId: 'client-1' });
+    (db.person.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({ operator: null, clientUsers: [{ clientId: 'client-1' }] });
+    (db.person.update as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(peopleRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/people/person-1/reset-password',
+      payload: { password: 'newvalidpassword' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.message).toMatch(/reset/i);
+    expect((db.person.update as ReturnType<typeof vi.fn>).mock.calls[0][0].data).toHaveProperty('passwordHash');
+  });
+});

--- a/services/copilot-api/src/routes/tickets.test.ts
+++ b/services/copilot-api/src/routes/tickets.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Unit tests for tickets routes.
+ * Uses Fastify inject() with a mocked PrismaClient — no real DB or queues.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { buildTestRouteApp, makeAdminUser, makeScopedUser } from '../test/app-builder.js';
+import { ticketRoutes } from './tickets.js';
+
+// ─── Mock db factory ───────────────────────────────────────────────────────────
+
+function makeMockDb(overrides: Partial<Record<keyof PrismaClient, unknown>> = {}): PrismaClient {
+  const ticket = {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(null),
+    count: vi.fn().mockResolvedValue(0),
+    groupBy: vi.fn().mockResolvedValue([]),
+  };
+
+  const ticketEvent = {
+    create: vi.fn().mockResolvedValue({ id: 'evt-1', ticketId: 't-1', eventType: 'SYSTEM_NOTE', content: null, metadata: null, actor: null, createdAt: new Date() }),
+    update: vi.fn().mockResolvedValue(null),
+  };
+
+  const person = {
+    findFirst: vi.fn().mockResolvedValue(null),
+  };
+
+  const clientEnvironment = {
+    findUnique: vi.fn().mockResolvedValue(null),
+  };
+
+  const operator = {
+    findUnique: vi.fn().mockResolvedValue(null),
+  };
+
+  const appLog = {
+    findMany: vi.fn().mockResolvedValue([]),
+    count: vi.fn().mockResolvedValue(0),
+  };
+
+  const aiUsageLog = {
+    findMany: vi.fn().mockResolvedValue([]),
+    count: vi.fn().mockResolvedValue(0),
+    groupBy: vi.fn().mockResolvedValue([]),
+  };
+
+  const appSetting = {
+    findUnique: vi.fn().mockResolvedValue(null),
+  };
+
+  return {
+    ticket,
+    ticketEvent,
+    person,
+    clientEnvironment,
+    operator,
+    appLog,
+    aiUsageLog,
+    appSetting,
+    $queryRaw: vi.fn().mockResolvedValue([{ start_ms: null, end_ms: null, input_tokens: null, output_tokens: null }]),
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+// ─── Ticket list ──────────────────────────────────────────────────────────────
+
+describe('GET /api/tickets', () => {
+  it('returns 200 with an empty array when no tickets exist', async () => {
+    const db = makeMockDb();
+    (db.ticket.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('returns 400 for invalid status filter', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?status=NOT_A_STATUS' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid priority filter', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?priority=BOGUS' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid source filter', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?source=NONSENSE' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for negative limit', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?limit=-1' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('accepts comma-separated status filter', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?status=NEW,OPEN' });
+    expect(res.statusCode).toBe(200);
+    // Verify findMany was called with an 'in' filter
+    const call = (db.ticket.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.status).toEqual({ in: ['NEW', 'OPEN'] });
+  });
+
+  it('scoped operator (single) sees only their client tickets', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(ticketRoutes);
+
+    await app.inject({ method: 'GET', url: '/api/tickets' });
+
+    const call = (db.ticket.findMany as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.where.clientId).toBe('client-a');
+  });
+
+  it('scoped operator requesting out-of-scope clientId returns empty array', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets?clientId=client-b' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+    // findMany should NOT have been called because we returned early
+    expect((db.ticket.findMany as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+});
+
+// ─── GET /api/tickets/:id ─────────────────────────────────────────────────────
+
+describe('GET /api/tickets/:id', () => {
+  it('returns 404 when ticket does not exist', async () => {
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets/nonexistent-id' });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 200 with ticket data when found', async () => {
+    const mockTicket = {
+      id: 'ticket-1',
+      subject: 'Test ticket',
+      status: 'NEW',
+      priority: 'MEDIUM',
+      clientId: 'client-1',
+      client: { name: 'Acme', shortCode: 'ACM' },
+      system: null,
+      followers: [],
+      events: [],
+      artifacts: [],
+    };
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicket);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets/ticket-1' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('ticket-1');
+    expect(body.subject).toBe('Test ticket');
+  });
+});
+
+// ─── POST /api/tickets ────────────────────────────────────────────────────────
+
+describe('POST /api/tickets (sync=true)', () => {
+  it('creates a ticket in sync mode and returns 201', async () => {
+    const newTicket = {
+      id: 'ticket-new',
+      clientId: 'client-1',
+      subject: 'New ticket',
+      status: 'NEW',
+      priority: 'MEDIUM',
+      ticketNumber: 1,
+      source: 'MANUAL',
+    };
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null); // no last ticket
+    (db.ticket.create as ReturnType<typeof vi.fn>).mockResolvedValue(newTicket);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets?sync=true',
+      payload: { clientId: 'client-1', subject: 'New ticket' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('ticket-new');
+  });
+
+  it('returns 400 for invalid priority on POST', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets?sync=true',
+      payload: { clientId: 'client-1', subject: 'Test', priority: 'BOGUS' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 when scoped operator creates ticket for out-of-scope client', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeScopedUser('client-a') });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets?sync=true',
+      payload: { clientId: 'client-b', subject: 'Forbidden ticket' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('enqueues job in async mode (no ?sync=true) and returns 202', async () => {
+    const db = makeMockDb();
+    const mockQueue = { add: vi.fn().mockResolvedValue({ id: 'job-1' }) };
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes, { ingestQueue: mockQueue as never });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets',
+      payload: { clientId: 'client-1', subject: 'Async ticket' },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(JSON.parse(res.body)).toMatchObject({ queued: true });
+    expect(mockQueue.add).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── PATCH /api/tickets/:id ───────────────────────────────────────────────────
+
+describe('PATCH /api/tickets/:id', () => {
+  it('returns 404 when ticket not found', async () => {
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/tickets/nonexistent',
+      payload: { status: 'OPEN' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for invalid status value', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/tickets/ticket-1',
+      payload: { status: 'NOT_REAL' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('updates ticket status and returns updated ticket', async () => {
+    const existing = { status: 'NEW', clientId: 'client-1', assignedOperatorId: null };
+    const updated = { id: 'ticket-1', status: 'OPEN', priority: 'HIGH', clientId: 'client-1' };
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+    (db.ticket.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: '/api/tickets/ticket-1',
+      payload: { status: 'OPEN' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('OPEN');
+  });
+
+  it('enqueues log summarization on status change', async () => {
+    const existing = { status: 'NEW', clientId: 'client-1', assignedOperatorId: null };
+    const updated = { id: 'ticket-1', status: 'OPEN', clientId: 'client-1' };
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(existing);
+    (db.ticket.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated);
+    const logQueue = { add: vi.fn().mockResolvedValue({}) };
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes, { logSummarizeQueue: logQueue as never });
+
+    await app.inject({
+      method: 'PATCH',
+      url: '/api/tickets/ticket-1',
+      payload: { status: 'OPEN' },
+    });
+    expect(logQueue.add).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── GET /api/tickets/stats ───────────────────────────────────────────────────
+
+describe('GET /api/tickets/stats', () => {
+  it('returns aggregate stats shape', async () => {
+    const db = makeMockDb();
+    (db.ticket.count as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+    (db.ticket.groupBy as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { status: 'NEW', _count: 3 },
+      { status: 'OPEN', _count: 2 },
+    ]);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/tickets/stats' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('byStatus');
+    expect(body).toHaveProperty('byPriority');
+    expect(body).toHaveProperty('byCategory');
+    expect(body).toHaveProperty('bySource');
+  });
+});
+
+// ─── GET /api/search/tickets ──────────────────────────────────────────────────
+
+describe('GET /api/search/tickets', () => {
+  it('returns 400 when q is missing', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/tickets' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when q is 1 character', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/tickets?q=a' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns search results for valid q', async () => {
+    const mockResults = [
+      { id: 't-1', ticketNumber: 1, subject: 'slow query', status: 'OPEN', priority: 'HIGH', clientId: 'c-1', createdAt: new Date(), client: { name: 'Acme', shortCode: 'ACM' } },
+    ];
+    const db = makeMockDb();
+    (db.ticket.findMany as ReturnType<typeof vi.fn>).mockResolvedValue(mockResults);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/tickets?q=slow' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it('returns 400 when limit is > 50', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/search/tickets?q=test&limit=51' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ─── POST /api/tickets/:id/events ─────────────────────────────────────────────
+
+describe('POST /api/tickets/:id/events', () => {
+  it('returns 400 for invalid eventType', async () => {
+    const db = makeMockDb();
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets/ticket-1/events',
+      payload: { eventType: 'INVALID_EVENT', content: 'test' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when ticket not in scope', async () => {
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets/nonexistent/events',
+      payload: { eventType: 'COMMENT', content: 'test note' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('creates event and returns 201 when ticket exists', async () => {
+    const mockEvent = { id: 'evt-1', ticketId: 'ticket-1', eventType: 'COMMENT', content: 'test', actor: null, metadata: null, createdAt: new Date() };
+    const db = makeMockDb();
+    (db.ticket.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'ticket-1' });
+    (db.ticketEvent.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockEvent);
+    const app = await buildTestRouteApp({ db, user: makeAdminUser() });
+    await app.register(ticketRoutes);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/tickets/ticket-1/events',
+      payload: { eventType: 'COMMENT', content: 'test note' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/services/copilot-api/src/services/tool-request-dedupe.integration.test.ts
+++ b/services/copilot-api/src/services/tool-request-dedupe.integration.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Integration tests for tool-request-dedupe.ts — transactional persist path.
+ *
+ * Verifies:
+ *   1. suggestedDuplicateOfId/suggestedDuplicateReason are written for dupe rows.
+ *   2. suggestedImprovesExisting/suggestedImprovesReason are written for improve rows.
+ *   3. dedupeAnalysisAt is stamped on every analyzed row.
+ *   4. Prior stale suggestions are cleared for rows not flagged in current run.
+ *   5. Rows with invalid IDs (not in validIds) are silently skipped.
+ *   6. When the transaction body throws, NO suggestion fields are persisted
+ *      (rollback semantics).
+ *
+ * The Anthropic SDK is NOT called. AIRouter.generate is mocked at the
+ * instance level to return controlled JSON payloads.
+ *
+ * Requires TEST_DATABASE_URL pointing at a migrated Postgres instance.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import type { AIRouter } from '@bronco/ai-provider';
+import { getTestDb, truncateAll } from '@bronco/test-utils';
+import { createClient } from '@bronco/test-utils';
+import { runToolRequestDedupe } from './tool-request-dedupe.js';
+
+// ---------------------------------------------------------------------------
+// Skip suite when no real DB is available
+// ---------------------------------------------------------------------------
+const hasDb = Boolean(process.env['TEST_DATABASE_URL']);
+
+// ---------------------------------------------------------------------------
+// Mock buildClientToolCatalog from @bronco/shared-utils
+// — prevents HTTP calls to actual MCP servers during tests
+// ---------------------------------------------------------------------------
+vi.mock('@bronco/shared-utils', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('@bronco/shared-utils')>();
+  return {
+    ...orig,
+    buildClientToolCatalog: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// AIRouter mock factory
+// — returns a minimal AIRouter that replays the provided JSON output
+// ---------------------------------------------------------------------------
+function makeAiRouter(output: unknown): AIRouter {
+  return {
+    generate: vi.fn().mockResolvedValue({
+      content: JSON.stringify(output),
+      model: 'mock-model',
+      provider: 'mock',
+      inputTokens: 0,
+      outputTokens: 0,
+    }),
+  } as unknown as AIRouter;
+}
+
+// ---------------------------------------------------------------------------
+// Seed helper — creates ToolRequest rows for a client
+// ---------------------------------------------------------------------------
+async function seedToolRequest(
+  db: PrismaClient,
+  clientId: string,
+  overrides: {
+    requestedName?: string;
+    displayTitle?: string;
+    description?: string;
+    status?: string;
+    kind?: string;
+    suggestedDuplicateOfId?: string | null;
+    suggestedDuplicateReason?: string | null;
+    suggestedImprovesExisting?: string | null;
+    suggestedImprovesReason?: string | null;
+  } = {},
+) {
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return db.toolRequest.create({
+    data: {
+      clientId,
+      requestedName: overrides.requestedName ?? `tool_${suffix}`,
+      displayTitle: overrides.displayTitle ?? `Tool ${suffix}`,
+      description: overrides.description ?? `Describes tool ${suffix}`,
+      status: (overrides.status ?? 'PROPOSED') as never,
+      kind: (overrides.kind ?? 'NEW_TOOL') as never,
+      suggestedDuplicateOfId: overrides.suggestedDuplicateOfId ?? null,
+      suggestedDuplicateReason: overrides.suggestedDuplicateReason ?? null,
+      suggestedImprovesExisting: overrides.suggestedImprovesExisting ?? null,
+      suggestedImprovesReason: overrides.suggestedImprovesReason ?? null,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stub encryption key (not used in tests since catalog is mocked)
+// ---------------------------------------------------------------------------
+const FAKE_KEY = 'a'.repeat(64);
+
+describe.skipIf(!hasDb)('integration: runToolRequestDedupe — persistence', () => {
+  let db: PrismaClient;
+
+  beforeAll(async () => {
+    db = getTestDb();
+    await truncateAll(db);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(db);
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. suggestedDuplicateOfId / suggestedDuplicateReason written correctly
+  // -------------------------------------------------------------------------
+  describe('duplicate group persistence', () => {
+    it('writes suggestedDuplicateOfId and reason for rows the model flags as duplicates', async () => {
+      const client = await createClient(db);
+      const canonical = await seedToolRequest(db, client.id, { requestedName: 'search_schema' });
+      const dup = await seedToolRequest(db, client.id, { requestedName: 'find_schema' });
+
+      const ai = makeAiRouter({
+        duplicateGroups: [
+          {
+            canonicalId: canonical.id,
+            duplicateIds: [dup.id],
+            reason: 'Both search schema objects.',
+          },
+        ],
+        improvesExisting: [],
+      });
+
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updatedDup = await db.toolRequest.findUniqueOrThrow({ where: { id: dup.id } });
+      expect(updatedDup.suggestedDuplicateOfId).toBe(canonical.id);
+      expect(updatedDup.suggestedDuplicateReason).toBe('Both search schema objects.');
+      expect(updatedDup.dedupeAnalysisAt).not.toBeNull();
+    });
+
+    it('canonical row does not get suggestedDuplicateOfId set on itself', async () => {
+      const client = await createClient(db);
+      const canonical = await seedToolRequest(db, client.id, { requestedName: 'search_schema' });
+      const dup = await seedToolRequest(db, client.id, { requestedName: 'find_schema' });
+
+      const ai = makeAiRouter({
+        duplicateGroups: [
+          { canonicalId: canonical.id, duplicateIds: [dup.id], reason: 'Same purpose.' },
+        ],
+        improvesExisting: [],
+      });
+
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updatedCanonical = await db.toolRequest.findUniqueOrThrow({ where: { id: canonical.id } });
+      expect(updatedCanonical.suggestedDuplicateOfId).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. suggestedImprovesExisting / suggestedImprovesReason written correctly
+  // -------------------------------------------------------------------------
+  describe('improvesExisting persistence', () => {
+    it('writes suggestedImprovesExisting and reason for flagged rows', async () => {
+      const client = await createClient(db);
+      const req = await seedToolRequest(db, client.id, { requestedName: 'list_tables_enhanced' });
+
+      const ai = makeAiRouter({
+        duplicateGroups: [],
+        improvesExisting: [
+          {
+            requestId: req.id,
+            existingToolName: 'list_tables',
+            reason: 'Adds schema filtering to existing list_tables.',
+          },
+        ],
+      });
+
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updated = await db.toolRequest.findUniqueOrThrow({ where: { id: req.id } });
+      expect(updated.suggestedImprovesExisting).toBe('list_tables');
+      expect(updated.suggestedImprovesReason).toBe('Adds schema filtering to existing list_tables.');
+      expect(updated.dedupeAnalysisAt).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. dedupeAnalysisAt stamped on ALL analyzed rows (not just flagged ones)
+  // -------------------------------------------------------------------------
+  describe('dedupeAnalysisAt stamping', () => {
+    it('stamps dedupeAnalysisAt on every analyzed row even when no suggestions', async () => {
+      const client = await createClient(db);
+      const reqA = await seedToolRequest(db, client.id, { requestedName: 'tool_a' });
+      const reqB = await seedToolRequest(db, client.id, { requestedName: 'tool_b' });
+
+      const ai = makeAiRouter({ duplicateGroups: [], improvesExisting: [] });
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const [a, b] = await Promise.all([
+        db.toolRequest.findUniqueOrThrow({ where: { id: reqA.id } }),
+        db.toolRequest.findUniqueOrThrow({ where: { id: reqB.id } }),
+      ]);
+      expect(a.dedupeAnalysisAt).not.toBeNull();
+      expect(b.dedupeAnalysisAt).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Stale suggestions from prior runs are cleared
+  // -------------------------------------------------------------------------
+  describe('stale suggestion clearing', () => {
+    it('clears suggestedDuplicateOfId from prior run when model no longer flags it', async () => {
+      const client = await createClient(db);
+      const canonical = await seedToolRequest(db, client.id, { requestedName: 'original_tool' });
+      // Seed with stale suggestion from a previous run
+      const stale = await seedToolRequest(db, client.id, {
+        requestedName: 'old_dup',
+        suggestedDuplicateOfId: canonical.id,
+        suggestedDuplicateReason: 'Old stale reason',
+      });
+
+      // This run has no duplicate groups — model found nothing to flag
+      const ai = makeAiRouter({ duplicateGroups: [], improvesExisting: [] });
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updated = await db.toolRequest.findUniqueOrThrow({ where: { id: stale.id } });
+      expect(updated.suggestedDuplicateOfId).toBeNull();
+      expect(updated.suggestedDuplicateReason).toBeNull();
+    });
+
+    it('clears suggestedImprovesExisting from prior run when not in current output', async () => {
+      const client = await createClient(db);
+      // Seed with stale improvesExisting suggestion
+      const stale = await seedToolRequest(db, client.id, {
+        requestedName: 'stale_improve',
+        suggestedImprovesExisting: 'some_old_tool',
+        suggestedImprovesReason: 'Old stale improve reason',
+      });
+
+      const ai = makeAiRouter({ duplicateGroups: [], improvesExisting: [] });
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updated = await db.toolRequest.findUniqueOrThrow({ where: { id: stale.id } });
+      expect(updated.suggestedImprovesExisting).toBeNull();
+      expect(updated.suggestedImprovesReason).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Invalid/foreign IDs are silently skipped
+  // -------------------------------------------------------------------------
+  describe('invalid ID handling', () => {
+    it('skips duplicateGroup entries whose IDs are not in the analyzed set', async () => {
+      const client = await createClient(db);
+      const req = await seedToolRequest(db, client.id, { requestedName: 'valid_tool' });
+      const FOREIGN_ID = '00000000-0000-0000-0000-000000000001';
+
+      const ai = makeAiRouter({
+        duplicateGroups: [
+          {
+            canonicalId: FOREIGN_ID,    // not in analyzed set
+            duplicateIds: [req.id],
+            reason: 'Should be skipped',
+          },
+        ],
+        improvesExisting: [],
+      });
+
+      await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      const updated = await db.toolRequest.findUniqueOrThrow({ where: { id: req.id } });
+      expect(updated.suggestedDuplicateOfId).toBeNull();
+    });
+
+    it('skips improvesExisting entries whose IDs are not in the analyzed set', async () => {
+      const client = await createClient(db);
+      await seedToolRequest(db, client.id, { requestedName: 'some_tool' });
+      const FOREIGN_ID = '00000000-0000-0000-0000-000000000002';
+
+      const ai = makeAiRouter({
+        duplicateGroups: [],
+        improvesExisting: [
+          { requestId: FOREIGN_ID, existingToolName: 'existing', reason: 'Should skip' },
+        ],
+      });
+
+      // Should not throw (UPDATE on unknown ID would simply match 0 rows)
+      await expect(
+        runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {}),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Rollback: if the $transaction callback throws, nothing is persisted
+  // -------------------------------------------------------------------------
+  describe('rollback semantics', () => {
+    it('does not persist any suggestions when the transaction throws midway', async () => {
+      const client = await createClient(db);
+      const canonical = await seedToolRequest(db, client.id, { requestedName: 'tool_x' });
+      const dup = await seedToolRequest(db, client.id, { requestedName: 'tool_y' });
+
+      // Spy on $transaction to throw mid-execution
+      const originalTransaction = db.$transaction.bind(db);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const txSpy = vi.spyOn(db, '$transaction').mockImplementationOnce(async (_fn: unknown) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fn = _fn as (tx: any) => Promise<unknown>;
+        // Start a real transaction, let it begin writing, then throw to trigger rollback
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (originalTransaction as any)(async (tx: any) => {
+          // Let the inner callback run (clears + stamps dedupeAnalysisAt)
+          await fn(tx);
+          // Force rollback by throwing after persistence
+          throw new Error('Forced rollback for test');
+        });
+      });
+
+      const ai = makeAiRouter({
+        duplicateGroups: [
+          { canonicalId: canonical.id, duplicateIds: [dup.id], reason: 'Dup' },
+        ],
+        improvesExisting: [],
+      });
+
+      await expect(
+        runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {}),
+      ).rejects.toThrow('Forced rollback for test');
+
+      // After rollback, the DB rows must be unchanged
+      const [updatedCanonical, updatedDup] = await Promise.all([
+        db.toolRequest.findUniqueOrThrow({ where: { id: canonical.id } }),
+        db.toolRequest.findUniqueOrThrow({ where: { id: dup.id } }),
+      ]);
+
+      expect(updatedDup.suggestedDuplicateOfId).toBeNull();
+      expect(updatedDup.dedupeAnalysisAt).toBeNull();
+      expect(updatedCanonical.dedupeAnalysisAt).toBeNull();
+
+      txSpy.mockRestore();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Empty requests set — returns early with zero counts
+  // -------------------------------------------------------------------------
+  describe('empty requests', () => {
+    it('returns zero counts when no PROPOSED/APPROVED requests exist for client', async () => {
+      const client = await createClient(db);
+      // No tool requests seeded
+      const ai = makeAiRouter({ duplicateGroups: [], improvesExisting: [] });
+      const result = await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      expect(result.requestsAnalyzed).toBe(0);
+      expect(result.duplicateGroupsCount).toBe(0);
+      expect(result.improvesExistingCount).toBe(0);
+    });
+
+    it('ignores REJECTED and IMPLEMENTED requests (only PROPOSED and APPROVED are analyzed)', async () => {
+      const client = await createClient(db);
+      await seedToolRequest(db, client.id, { requestedName: 'rejected_tool', status: 'REJECTED' });
+      await seedToolRequest(db, client.id, { requestedName: 'implemented_tool', status: 'IMPLEMENTED' });
+
+      // ai.generate should NOT be called when there are no PROPOSED/APPROVED rows
+      const ai = makeAiRouter({ duplicateGroups: [], improvesExisting: [] });
+      const result = await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      expect(result.requestsAnalyzed).toBe(0);
+      expect((ai.generate as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Result counts match model output
+  // -------------------------------------------------------------------------
+  describe('result counts', () => {
+    it('returns correct duplicateGroupsCount and improvesExistingCount', async () => {
+      const client = await createClient(db);
+      const r1 = await seedToolRequest(db, client.id, { requestedName: 'tool_1' });
+      const r2 = await seedToolRequest(db, client.id, { requestedName: 'tool_2' });
+      const r3 = await seedToolRequest(db, client.id, { requestedName: 'tool_3' });
+
+      const ai = makeAiRouter({
+        duplicateGroups: [
+          { canonicalId: r1.id, duplicateIds: [r2.id], reason: 'Same tool.' },
+        ],
+        improvesExisting: [
+          { requestId: r3.id, existingToolName: 'existing_tool', reason: 'Enhancement.' },
+        ],
+      });
+
+      const result = await runToolRequestDedupe(db, ai, client.id, FAKE_KEY, {});
+
+      expect(result.requestsAnalyzed).toBe(3);
+      expect(result.duplicateGroupsCount).toBe(1);
+      expect(result.improvesExistingCount).toBe(1);
+    });
+  });
+});

--- a/services/copilot-api/src/test/app-builder.ts
+++ b/services/copilot-api/src/test/app-builder.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal Fastify app builder for unit tests.
+ *
+ * Registers only the plugins needed for a specific route plugin — skips
+ * Redis queues, AI router, and other heavy dependencies unless provided.
+ * The caller injects a mock `db` and optionally a mock `user` (for auth
+ * scope testing).
+ *
+ * Usage:
+ *   const app = await buildTestRouteApp({ db: mockDb, user: adminUser });
+ *   await app.register(ticketRoutes, opts);
+ *   const res = await app.inject({ method: 'GET', url: '/api/tickets' });
+ */
+
+import Fastify from 'fastify';
+import fp from 'fastify-plugin';
+import sensible from '@fastify/sensible';
+import type { PrismaClient } from '@bronco/db';
+import type { AuthUser, PortalUser } from '../plugins/auth.js';
+
+export interface TestAppOpts {
+  /** Pre-built mock or real PrismaClient injected as fastify.db */
+  db: PrismaClient;
+  /** If set, request.user is populated (operator auth). */
+  user?: AuthUser;
+  /** If set, request.portalUser is populated (portal auth). */
+  portalUser?: PortalUser;
+}
+
+/**
+ * Build a minimal Fastify instance wired with the db, sensible (httpErrors),
+ * and an auth stub that sets request.user / request.portalUser from the
+ * provided fixture — no JWT verification, no Redis, no AI router.
+ */
+export async function buildTestRouteApp(opts: TestAppOpts) {
+  const app = Fastify({ logger: false });
+
+  // Inject db directly (bypasses getDb() which reads DATABASE_URL)
+  const dbPlugin = fp(async (fastify) => {
+    fastify.decorate('db', opts.db);
+  });
+
+  // Stub auth — set user/portalUser on every request
+  const authStub = fp(async (fastify) => {
+    fastify.addHook('onRequest', async (request) => {
+      if (opts.user !== undefined) {
+        request.user = opts.user;
+      }
+      if (opts.portalUser !== undefined) {
+        request.portalUser = opts.portalUser;
+      }
+    });
+  });
+
+  await app.register(sensible);
+  await app.register(dbPlugin);
+  await app.register(authStub);
+
+  return app;
+}
+
+// ─── Shared mock factory helpers ──────────────────────────────────────────────
+
+/**
+ * Returns an AuthUser fixture for a platform ADMIN operator (no clientId).
+ * This caller gets `scope.type === 'all'` in resolveClientScope.
+ */
+export function makeAdminUser(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    personId: 'person-admin-1',
+    operatorId: 'op-admin-1',
+    email: 'admin@test.com',
+    role: 'ADMIN' as AuthUser['role'],
+    clientId: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Returns an AuthUser fixture for a client-scoped STANDARD operator.
+ * This caller gets `scope.type === 'single'`.
+ */
+export function makeScopedUser(clientId: string, overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    personId: 'person-scoped-1',
+    operatorId: 'op-scoped-1',
+    email: 'scoped@test.com',
+    role: 'STANDARD' as AuthUser['role'],
+    clientId,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a simple mock function that returns the provided value.
+ * This is a vi.fn()-compatible stand-in for use before vi is imported.
+ */
+export function mockFn<T>(returnValue: T): () => Promise<T> {
+  return async () => returnValue;
+}

--- a/services/copilot-api/vitest.config.ts
+++ b/services/copilot-api/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],
+  },
+});

--- a/services/copilot-api/vitest.integration.config.ts
+++ b/services/copilot-api/vitest.integration.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.integration.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    testTimeout: 30000,
+    pool: 'forks',
+    maxConcurrency: 1,
+    maxWorkers: 1,
+    minWorkers: 1,
+  },
+});

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -924,7 +924,7 @@ async function deepAnalysis(
 
       for (const rawTerm of searchTerms) {
         if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
-        const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+        const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
         try {
           const searchResult = await callMcpToolViaSdk(
             deps.mcpRepoUrl, '/mcp', 'search_code',
@@ -2053,7 +2053,7 @@ async function executeRoutePipeline(
             const relevantFiles = new Set<string>();
             for (const rawTerm of searchTerms) {
               if (!rawTerm || rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().length === 0) continue;
-              const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+              const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
               try {
                 const searchResult = await callMcpToolViaSdk(
                   mcpRepoUrl, '/mcp', 'search_code',
@@ -2631,7 +2631,7 @@ async function executeRoutePipeline(
                   // Search by terms (skip non-string entries from untyped JSON config)
                   for (const rawTerm of rs.searchTerms ?? []) {
                     if (typeof rawTerm !== 'string') continue;
-                    const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').slice(0, 200);
+                    const sanitized = rawTerm.replace(/[\x00-\x1f\x7f]/g, '').trim().slice(0, 200);
                     if (!sanitized) continue;
                     try {
                       const searchResult = await callMcpToolViaSdk(

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -2024,18 +2024,18 @@ async function executeRoutePipeline(
             // Drop terms that are guaranteed noise for this client: the client's
             // own name, short code, any operator-configured ignore terms, and
             // anything shorter than 4 characters.
-            const clientNameLower = ticket.client.name.toLowerCase();
-            const clientShortCodeLower = ticket.client.shortCode.toLowerCase();
+            const clientNameLower = ticket.client.name.trim().toLowerCase();
+            const clientShortCodeLower = ticket.client.shortCode.trim().toLowerCase();
             const ignoreSet = new Set<string>(
-              (ticket.client.searchIgnoreTerms ?? []).map((t) => t.toLowerCase()),
+              (ticket.client.searchIgnoreTerms ?? []).map((t) => t.trim().toLowerCase()),
             );
             const preFilterCount = searchTerms.length;
             searchTerms = searchTerms.filter((t) => {
-              const lower = t.toLowerCase();
-              if (lower.length < 4) return false;
-              if (lower === clientNameLower) return false;
-              if (lower === clientShortCodeLower) return false;
-              if (ignoreSet.has(lower)) return false;
+              const normalized = t.trim().toLowerCase();
+              if (normalized.length < 4) return false;
+              if (normalized === clientNameLower) return false;
+              if (normalized === clientShortCodeLower) return false;
+              if (ignoreSet.has(normalized)) return false;
               return true;
             });
             if (searchTerms.length === 0) {


### PR DESCRIPTION
## v0.2.11 release

3 PRs since v0.2.10. Theme: **review-followup hygiene + tier 2 test infrastructure**. Small surface area on the runtime side; large additive testbed on the dev side.

## Highlights

### Tier 2 test infrastructure (#446)

Adds ~7500 lines of unit + integration tests across `copilot-api`, `mcp-servers/database`, `mcp-servers/platform`, `mcp-servers/repo`, plus shared `packages/test-utils/src/fixtures.ts` and per-package `vitest.config.ts` / `vitest.integration.config.ts`. New test files include:

- `mcp-database`: pool-manager, audit-logger, query-validator, systems-loader (integration), tools index
- `mcp-platform`: caller-registry, knowledge-doc, read-tool-result-artifact, safe-person-select (integration)
- `mcp-repo`: github-clone-url, list-files, prepare-repo (integration), read-file, search-code
- `copilot-api`: client-memory, clients, integrations, people, tickets routes, tool-request-dedupe (integration), shared `app-builder` test helper

Test-only landing — no runtime changes. Followup commit (`2816bab`) addresses 3 valid Copilot review nits (unused `beforeEach` import, misleading symlink-test header, inaccurate test name); 3 other Copilot comments were verified false positives — `@bronco/test-utils` IS used in this PR's integration tests.

### `Client.searchIgnoreTerms` input hygiene (#463)

Followup to v0.2.10's `searchIgnoreTerms` blocklist (#460). Addresses Copilot review:

- `services/copilot-api/src/routes/clients.ts`: new `normalizeSearchIgnoreTerms()` validates as `string[]`, rejects bad input with 400, then trims + lowercases + dedups. POST always persists a normalized array; PATCH normalizes when present, leaves absent.
- Control panel `config-tab.component.ts`: dirty-check now compares normalized arrays via `JSON.stringify`, so whitespace/casing variants no longer toggle Save inconsistently.
- `services/ticket-analyzer/src/analyzer.ts`: pre-gather filter applies `trim().toLowerCase()` to all comparison sides (`client.name`, `client.shortCode`, `searchIgnoreTerms` entries, and `searchTerms` entries), with the `< 4` length check now post-trim.

### `search_code` query trim consistency (#466)

Closes a follow-up Copilot review on #463: the pre-gather filter trimmed the term for comparison but the actual `search_code` call still ran with the un-trimmed value, producing false-negative "no match" results when terms had whitespace. Adds `.trim()` to the `sanitized` chain at all three analyzer call sites (initial-gather, pre-gather, CUSTOM_AI_QUERY) so the value passed to `search_code` matches what the pre-filter saw.

## Migration

None this release.

## Pre-deploy requirements

None. No new env vars, no schema changes, no docker-compose changes, no Dockerfile changes.

## Release sweep

| PR | Threads | Action |
|---|---|---|
| #463 | 1 unresolved at sweep time | Fixed in #466 (which is also part of this release); thread replied + resolved |
| #446 | 6 from Copilot | 3 fixed in `2816bab` (in this release); 3 verified false positives; all replied + resolved |

Earlier sweep on v0.2.10 PRs (#456, #457, #458, #460, #461, #462) found 10 unresolved threads on #461 and #462 — those represent code-quality follow-ups that don't block shipping. Triaged into:

- **#464** — `refactor(artifacts)`: use `findUnique` + extract scope-guard helper across artifact endpoints (6 threads from #462)
- **#465** — `fix(search_code)`: detect timeouts, surface tool failures, decide on `executeCommand` allowlist (4 threads from #461)

All 16 threads on shipped PRs are now resolved.

## Test plan (post-deploy)

- [ ] Hugo health: all 16 services healthy
- [ ] `/api/health` reports `version: v0.2.11`
- [ ] Send a malformed `searchIgnoreTerms` body to `POST /api/clients` (e.g., `{"searchIgnoreTerms": "not-an-array"}`) → 400, no Prisma 500
- [ ] Open a client with `searchIgnoreTerms` populated → Save button stays disabled until normalized list actually changes
- [ ] Trigger an analysis where EXTRACT_FACTS terms include leading/trailing whitespace → confirm `search_code` invocations use the trimmed value (no false-negative "no match")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
