### PR TITLE
fix: exclude co-located test files from tsc build (mcp-repo + mcp-db + mcp-platform + copilot-api)

### DIFF
--- a/mcp-servers/database/tsconfig.json
+++ b/mcp-servers/database/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/mcp-servers/platform/tsconfig.json
+++ b/mcp-servers/platform/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/mcp-servers/repo/tsconfig.json
+++ b/mcp-servers/repo/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/services/copilot-api/tsconfig.json
+++ b/services/copilot-api/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes the v0.2.11 deploy failure. The Tier 2 test PR (#446) landed `*.test.ts` and `*.integration.test.ts` files under `src/` of `mcp-repo`, `mcp-database`, `mcp-platform`, and `copilot-api`, but didn't add the matching `exclude` patterns to those packages' tsconfigs. The host-side CI (`pnpm typecheck` and `pnpm build`) passed because devDeps are installed there. The Docker production-stage build fails because `tsc` compiles the test files, those test files import the devDep `@bronco/test-utils`, and devDeps aren't installed in production stages — TS2307 cannot find module.

This is the **exact same failure mode** as #448 (v0.2.8 hotfix on `shared-utils`, `ai-provider`, `ticket-analyzer`). The Tier 2 PR repeated the pattern in 4 new packages and missed the tsconfig step.

## What lands

| File | Change |
|---|---|
| `mcp-servers/repo/tsconfig.json` | Adds `"exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]` |
| `mcp-servers/database/tsconfig.json` | Same |
| `mcp-servers/platform/tsconfig.json` | Same |
| `services/copilot-api/tsconfig.json` | Same |

Vitest discovers tests via its own globs and is unaffected; test runs continue to work.

## Verification

- `pnpm --filter @bronco/mcp-repo --filter @bronco/mcp-database --filter @bronco/mcp-platform --filter @bronco/copilot-api typecheck` — clean

## Production state

- v0.2.10 is currently live on Hugo, healthy, all 16 services up
- v0.2.11 was tagged but the deploy step was SKIPPED (Docker build matrix cancelled all builds when `mcp-repo` failed) — production was not touched
- After this fix lands and is promoted, a new tag will trigger deploy

## Follow-up

Per `feedback_test_files_in_src_tsconfig.md`, the long-term fix is to add this exclude pattern to `tsconfig.base.json` so it propagates automatically to every extending tsconfig. That requires verifying TS extends-inheritance behavior for the non-overriding `exclude` field and is out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
