### PR TITLE
merge: staging → master (tsconfig test-exclude hotfix to unblock v0.2.11 deploy)

### DIFF
--- a/mcp-servers/database/tsconfig.json
+++ b/mcp-servers/database/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/mcp-servers/platform/tsconfig.json
+++ b/mcp-servers/platform/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/mcp-servers/repo/tsconfig.json
+++ b/mcp-servers/repo/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }

--- a/services/copilot-api/tsconfig.json
+++ b/services/copilot-api/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]
 }


### PR DESCRIPTION
## Hotfix promotion — tsconfig test-file exclude

v0.2.11 tagged successfully but the deploy step was **skipped** because the Docker production-stage build for `mcp-repo` failed: the Tier 2 test PR (#446) added `*.test.ts` and `*.integration.test.ts` files under `src/` of 4 packages without adding the matching `exclude` patterns to those packages' tsconfigs. Same failure mode and fix as #448 (v0.2.8 hotfix).

This PR brings the fix from staging → master so a new tag triggers deploy.

## Highlights

- `mcp-servers/repo/tsconfig.json`, `mcp-servers/database/tsconfig.json`, `mcp-servers/platform/tsconfig.json`, `services/copilot-api/tsconfig.json`: add `"exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts"]`

That's it. No code changes, no schema changes, no env changes.

## Production state

- v0.2.10 is currently live and healthy
- v0.2.11 was tagged but never deployed (Docker build failed); production was not touched
- Merging this PR triggers a new tag (v0.2.12 likely) which will deploy v0.2.11's content + this fix

## Test plan

- [ ] All Docker builds succeed
- [ ] Deploy to Hugo completes
- [ ] `/api/health` reports `version: v0.2.12` (or whatever the new tag is)
- [ ] All 16 containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
