### PR TITLE
fix: scrub NUL bytes before persisting AI usage / archive (#473)

### DIFF
--- a/packages/ai-provider/src/factory.ts
+++ b/packages/ai-provider/src/factory.ts
@@ -9,6 +9,7 @@ import type { ProviderConfigRow } from './provider-config-resolver.js';
 import { PromptResolver } from './prompt-resolver.js';
 import type { PromptOverrideRow } from './prompt-resolver.js';
 import type { AiUsageEntry, AiArchiveEntry, AiCostLookup } from './types.js';
+import { stripNulBytes } from './scrub.js';
 
 const log = createLogger('ai-router');
 
@@ -255,13 +256,22 @@ export function createAIRouter(
 
   const usageWriter = async (entry: AiUsageEntry): Promise<string | undefined> => {
     if (!dbReady) return undefined;
-    // Prisma JSON fields need undefined (not null) for "no value" — strip null conversationMetadata
+    // Prisma JSON fields need undefined (not null) for "no value" — strip null conversationMetadata.
+    // Also scrub NUL bytes from the three free-text columns (#473): Postgres TEXT rejects 0x00,
+    // and inbound conversation content can carry stray NULs from UTF-16 LE source-file reads or
+    // binary artifact content. Without this scrub the entire audit-log row is dropped on insert.
     const { conversationMetadata, logId, ...rest } = entry;
+    const scrubbedRest = {
+      ...rest,
+      promptText: stripNulBytes(rest.promptText),
+      systemPrompt: stripNulBytes(rest.systemPrompt),
+      responseText: stripNulBytes(rest.responseText),
+    };
     const data = {
       ...(logId ? { id: logId } : {}),
       ...(conversationMetadata != null
-        ? { ...rest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
-        : rest),
+        ? { ...scrubbedRest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
+        : scrubbedRest),
     };
     const row = await db.aiUsageLog.create({ data: data as Record<string, unknown> });
     return row.id;
@@ -269,9 +279,15 @@ export function createAIRouter(
 
   const archiveWriter = async (entry: AiArchiveEntry): Promise<void> => {
     if (!dbReady) return;
-    // Cast conversationMessages to satisfy Prisma's JSON type
+    // Cast conversationMessages to satisfy Prisma's JSON type. Scrub NUL bytes from the
+    // three free-text columns for the same reason as usageWriter (see #473).
     const { conversationMessages, ...rest } = entry;
-    const data: Record<string, unknown> = { ...rest };
+    const data: Record<string, unknown> = {
+      ...rest,
+      fullPrompt: stripNulBytes(rest.fullPrompt),
+      fullResponse: stripNulBytes(rest.fullResponse),
+      systemPrompt: stripNulBytes(rest.systemPrompt),
+    };
     if (conversationMessages != null) {
       data.conversationMessages = conversationMessages;
     }

--- a/packages/ai-provider/src/scrub.test.ts
+++ b/packages/ai-provider/src/scrub.test.ts
@@ -6,7 +6,7 @@ describe('stripNulBytes', () => {
     expect(stripNulBytes('hello world')).toBe('hello world');
   });
 
-  it('returns the same reference (no allocation) when no NUL bytes are present', () => {
+  it('returns the same string when no NUL bytes are present', () => {
     const input = 'hello world';
     expect(stripNulBytes(input)).toBe(input);
   });

--- a/packages/ai-provider/src/scrub.test.ts
+++ b/packages/ai-provider/src/scrub.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { stripNulBytes } from './scrub.js';
+
+describe('stripNulBytes', () => {
+  it('returns unchanged when no NUL bytes are present', () => {
+    expect(stripNulBytes('hello world')).toBe('hello world');
+  });
+
+  it('returns the same reference (no allocation) when no NUL bytes are present', () => {
+    const input = 'hello world';
+    expect(stripNulBytes(input)).toBe(input);
+  });
+
+  it('strips a single NUL byte', () => {
+    expect(stripNulBytes('hello\x00world')).toBe('helloworld');
+  });
+
+  it('strips multiple NUL bytes', () => {
+    expect(stripNulBytes('\x00a\x00b\x00c\x00')).toBe('abc');
+  });
+
+  it('returns null pass-through', () => {
+    expect(stripNulBytes(null)).toBeNull();
+  });
+
+  it('returns undefined pass-through', () => {
+    expect(stripNulBytes(undefined)).toBeUndefined();
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(stripNulBytes('')).toBe('');
+  });
+
+  it('preserves Unicode characters that are not NUL', () => {
+    expect(stripNulBytes('café\x00résumé')).toBe('caférésumé');
+  });
+
+  it('handles all-NUL input', () => {
+    expect(stripNulBytes('\x00\x00\x00')).toBe('');
+  });
+
+  it('handles a NUL embedded in a long realistic string (UTF-16 LE artifact)', () => {
+    // Simulate the failure mode: a 1-char-per-2-bytes UTF-16 LE source string
+    // surviving a naive UTF-8 read — every other byte is 0x00.
+    const input = 's\x00e\x00l\x00e\x00c\x00t\x00 \x00*\x00';
+    expect(stripNulBytes(input)).toBe('select *');
+  });
+});

--- a/packages/ai-provider/src/scrub.ts
+++ b/packages/ai-provider/src/scrub.ts
@@ -23,8 +23,17 @@
 const NUL = String.fromCharCode(0);
 const NUL_PATTERN = new RegExp(NUL, 'g');
 
-export function stripNulBytes<T extends string | null | undefined>(value: T): T {
+// Overloads keep the return type sound: a `string` input returns a `string`,
+// and `null` / `undefined` pass through with their exact types preserved.
+// The previous generic `T extends string | null | undefined` + `as T` cast
+// would mis-declare the result for branded / literal-string inputs, since the
+// stripped value is no longer assignable to the branded input type.
+export function stripNulBytes(value: string): string;
+export function stripNulBytes(value: null): null;
+export function stripNulBytes(value: undefined): undefined;
+export function stripNulBytes(value: string | null | undefined): string | null | undefined;
+export function stripNulBytes(value: string | null | undefined): string | null | undefined {
   if (value == null) return value;
   if (!value.includes(NUL)) return value;
-  return value.replace(NUL_PATTERN, '') as T;
+  return value.replace(NUL_PATTERN, '');
 }

--- a/packages/ai-provider/src/scrub.ts
+++ b/packages/ai-provider/src/scrub.ts
@@ -1,0 +1,30 @@
+/**
+ * Strips NUL bytes (0x00) from a string. Postgres TEXT columns reject any
+ * value containing NUL with error 22021 ("invalid byte sequence for encoding
+ * 'UTF8': 0x00"). This scrubber sits at every persistence chokepoint where
+ * agent-supplied content (tool results, system prompts, response text) is
+ * about to land in the audit log or prompt archive — see issue #473.
+ *
+ * The scrub is defense-in-depth: if upstream content is ever NUL-clean, this
+ * is a no-op (cheap path skips the regex). When NULs do appear, they are
+ * removed silently — the alternative is the entire row being dropped on
+ * insert, which corrupts cost tracking and the analysis trace UI.
+ *
+ * Pass-through for `null` / `undefined` so call sites can wrap nullable fields
+ * without nullish-checks scattered through the writer.
+ *
+ * Likely upstream sources of NUL bytes (not addressed by this scrub — file
+ * follow-up issues if found):
+ *   - `read_file` against UTF-16 LE encoded source files (Windows-default
+ *     SQL files have interspersed 0x00 bytes that survive a naive UTF-8 read).
+ *   - Binary content read via `read_tool_result_artifact` and serialized into
+ *     the conversation message stream.
+ */
+const NUL = String.fromCharCode(0);
+const NUL_PATTERN = new RegExp(NUL, 'g');
+
+export function stripNulBytes<T extends string | null | undefined>(value: T): T {
+  if (value == null) return value;
+  if (!value.includes(NUL)) return value;
+  return value.replace(NUL_PATTERN, '') as T;
+}


### PR DESCRIPTION
## Summary

Postgres TEXT columns reject any value containing `0x00` with error 22021. Inbound conversation content (tool results, system prompts, response text) carried stray NUL bytes — likely from `read_file` against UTF-16 LE source files — silently dropping ~90% of `ai_usage_logs` rows during the 2026-04-27 watch of orchestrated-v2 ticket analyses. Resolves #473.

This is the cheap defensive scrub. Upstream investigation (find the actual NUL source and fix at its read site) deferred to a follow-up if the scrub catches anything in production logs.

## What changed

- New `packages/ai-provider/src/scrub.ts` — pure `stripNulBytes` helper. Cheap-path skips the regex when content is clean; pass-through for `null` / `undefined`.
- `packages/ai-provider/src/factory.ts` — applies the scrub at the two persistence chokepoints:
  - `usageWriter` — `promptText`, `systemPrompt`, `responseText`
  - `archiveWriter` — `fullPrompt`, `fullResponse`, `systemPrompt`

## Why a scrub instead of upstream-only fix

Even if we patch every upstream source today, future MCP tools / `read_file` modes / artifact reads will keep producing the same failure. The persistence boundary is the right place for a hard guarantee — Postgres can never accept a NUL, so the writers can never let one through.

## Impact

Once deployed:
- Cost tracking on `ai_usage_logs` becomes accurate again (was 90% dropped during the regression watch)
- Analysis Trace UI gets a complete view of every Opus DEEP_ANALYSIS call
- The Item 6 follow-up (re-measure Opus spend post-deploy) is unblocked

## Test plan

- [x] 10 unit tests on `stripNulBytes` covering: clean strings, single NUL, multiple NULs, all-NUL, null/undefined pass-through, Unicode preservation, simulated UTF-16 LE artifact
- [x] All existing ai-provider tests pass (88 total, 0 regressions)
- [x] Build clean (`pnpm --filter @bronco/ai-provider build`)
- [ ] Manual production verification — once deployed, watch `bronco-ticket-analyzer` logs for absence of `invalid byte sequence for encoding "UTF8"` errors during the next orchestrated-v2 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
