### PR TITLE
fix: allow kd-only sub-task tool requests (#471)

### DIFF
--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1426,6 +1426,138 @@ describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #471 regression: kd-only tool requests must not trigger "tool resolution failed"
+// ---------------------------------------------------------------------------
+
+describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('does NOT error when the strategist requests only kd_* tools', async () => {
+    // Live failure (cf1b96e8 watch, 2026-04-27): st-6-document-all was dispatched with
+    // tools=['kd_update_section', 'kd_add_subsection']. The legacy `nonKdInitial`
+    // check fired the "Tool resolution failed" early-return because no NON-kd tools
+    // were resolved — even though the requested kd_* tools DID match via substring.
+    //
+    // Post-fix: resolution.resolved (or resolution.fuzzy) being non-empty is the
+    // correct signal that the request matched something. A sub-task whose only job
+    // is to write findings to the knowledge doc should run cleanly.
+
+    // Snapshot messages at call time — orchestrator mutates the array reference
+    // between calls, so we deep-clone each call's messages to inspect the
+    // mid-run state later.
+    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
+    const responses = [
+      // strategist iter 1: dispatch one sub-task requesting only kd_* tools
+      {
+        contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+          subtasks: [{
+            id: 'st-document',
+            intent: 'Record findings to the KD',
+            tools: ['kd_update_section', 'kd_add_subsection'],
+            model: 'sonnet',
+          }],
+        }, 'tu_dispatch')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 100, outputTokens: 80 },
+      },
+      // sub-task: finalize with a successful summary
+      {
+        contentBlocks: [makeToolUseBlock('finalize_subtask', {
+          summary: 'Documented evidence in evidence.foo',
+          updatedKdSections: ['evidence.foo'],
+        }, 'tu_finalize')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 50, outputTokens: 40 },
+      },
+      // strategist iter 2: complete_analysis after sub-task succeeded
+      {
+        contentBlocks: [makeToolUseBlock('complete_analysis', {
+          finalAnalysis: 'Findings recorded.',
+        }, 'tu_complete')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 120, outputTokens: 60 },
+      },
+    ];
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+      return responses[callSnapshots.length - 1];
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // 3 calls total: strategist dispatch + sub-task finalize + strategist complete.
+    // Pre-fix would have produced only 2 calls (sub-task short-circuited before
+    // its own generateWithTools).
+    expect(callSnapshots).toHaveLength(3);
+
+    // The strategist's iter-2 call (call 3, index 2) must include the sub-task's
+    // SUCCESS summary as the dispatch tool_result — not the "Tool resolution
+    // failed" error string.
+    const iter2Messages = callSnapshots[2].messages;
+    const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
+    expect(lastUserContent).toMatch(/Documented evidence/);
+    expect(lastUserContent).toMatch(/FINALIZED/);
+    expect(lastUserContent).not.toMatch(/Tool resolution failed/);
+  });
+
+  it('still errors when every requested tool is genuinely unknown', async () => {
+    // Negative case: if the strategist names tools that don't exist at all, the
+    // sub-task should still short-circuit with the resolution-failed error so the
+    // strategist gets a clear signal.
+    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
+    const responses = [
+      {
+        contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+          subtasks: [{
+            id: 'st-bogus',
+            intent: 'Use nonexistent tools',
+            tools: ['this_tool_does_not_exist', 'neither_does_this_one'],
+            model: 'sonnet',
+          }],
+        }, 'tu_dispatch')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 100, outputTokens: 80 },
+      },
+      {
+        contentBlocks: [makeToolUseBlock('complete_analysis', {
+          finalAnalysis: 'Cannot proceed.',
+        }, 'tu_complete')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 120, outputTokens: 60 },
+      },
+    ];
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+      return responses[callSnapshots.length - 1];
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // 2 calls only — sub-task short-circuited before its own generateWithTools.
+    expect(callSnapshots).toHaveLength(2);
+
+    const iter2Messages = callSnapshots[1].messages;
+    const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
+    expect(lastUserContent).toMatch(/Tool resolution failed/);
+  });
+});
+// ---------------------------------------------------------------------------
 // v1 orchestrated re-analysis redirect (dispatcher in analyzer.ts)
 // ---------------------------------------------------------------------------
 

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1429,6 +1429,29 @@ describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
 // #471 regression: kd-only tool requests must not trigger "tool resolution failed"
 // ---------------------------------------------------------------------------
 
+// Helper for scripted-response generateWithTools mocks. Snapshots the messages
+// array at call time (orchestrator mutates the reference between calls) and
+// throws a clear error if the SUT makes more calls than there are scripted
+// responses — much easier to diagnose than the silent `undefined` return that
+// vi.fn() would otherwise produce.
+type CallSnapshot = { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> };
+
+function makeScriptedAi(responses: ReadonlyArray<{ contentBlocks: unknown[]; stopReason: 'tool_use'; usage: { inputTokens: number; outputTokens: number } }>): { ai: AIRouter; snapshots: CallSnapshot[] } {
+  const snapshots: CallSnapshot[] = [];
+  const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+    snapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+    const response = responses[snapshots.length - 1];
+    if (response === undefined) {
+      throw new Error(
+        `Scripted-AI mock exhausted: SUT made call #${snapshots.length} but only ${responses.length} response(s) were scripted. Add another entry to the responses array or fix the SUT.`,
+      );
+    }
+    return response;
+  });
+  const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+  return { ai, snapshots };
+}
+
 describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)', () => {
   beforeEach(() => {
     resetKdMocks();
@@ -1444,11 +1467,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // correct signal that the request matched something. A sub-task whose only job
     // is to write findings to the knowledge doc should run cleanly.
 
-    // Snapshot messages at call time — orchestrator mutates the array reference
-    // between calls, so we deep-clone each call's messages to inspect the
-    // mid-run state later.
-    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
-    const responses = [
+    const { ai, snapshots } = makeScriptedAi([
       // strategist iter 1: dispatch one sub-task requesting only kd_* tools
       {
         contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
@@ -1459,7 +1478,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
             model: 'sonnet',
           }],
         }, 'tu_dispatch')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 100, outputTokens: 80 },
       },
       // sub-task: finalize with a successful summary
@@ -1468,7 +1487,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
           summary: 'Documented evidence in evidence.foo',
           updatedKdSections: ['evidence.foo'],
         }, 'tu_finalize')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 50, outputTokens: 40 },
       },
       // strategist iter 2: complete_analysis after sub-task succeeded
@@ -1476,16 +1495,11 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
         contentBlocks: [makeToolUseBlock('complete_analysis', {
           finalAnalysis: 'Findings recorded.',
         }, 'tu_complete')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 120, outputTokens: 60 },
       },
-    ];
-    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
-      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
-      return responses[callSnapshots.length - 1];
-    });
+    ]);
 
-    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
     await runOrchestratedV2(
       makeDeps(ai),
       makeCtx(),
@@ -1497,12 +1511,12 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // 3 calls total: strategist dispatch + sub-task finalize + strategist complete.
     // Pre-fix would have produced only 2 calls (sub-task short-circuited before
     // its own generateWithTools).
-    expect(callSnapshots).toHaveLength(3);
+    expect(snapshots).toHaveLength(3);
 
     // The strategist's iter-2 call (call 3, index 2) must include the sub-task's
     // SUCCESS summary as the dispatch tool_result — not the "Tool resolution
     // failed" error string.
-    const iter2Messages = callSnapshots[2].messages;
+    const iter2Messages = snapshots[2].messages;
     const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
     expect(lastUserContent).toMatch(/Documented evidence/);
     expect(lastUserContent).toMatch(/FINALIZED/);
@@ -1513,8 +1527,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // Negative case: if the strategist names tools that don't exist at all, the
     // sub-task should still short-circuit with the resolution-failed error so the
     // strategist gets a clear signal.
-    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
-    const responses = [
+    const { ai, snapshots } = makeScriptedAi([
       {
         contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
           subtasks: [{
@@ -1524,23 +1537,18 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
             model: 'sonnet',
           }],
         }, 'tu_dispatch')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 100, outputTokens: 80 },
       },
       {
         contentBlocks: [makeToolUseBlock('complete_analysis', {
           finalAnalysis: 'Cannot proceed.',
         }, 'tu_complete')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 120, outputTokens: 60 },
       },
-    ];
-    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
-      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
-      return responses[callSnapshots.length - 1];
-    });
+    ]);
 
-    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
     await runOrchestratedV2(
       makeDeps(ai),
       makeCtx(),
@@ -1550,9 +1558,9 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     );
 
     // 2 calls only — sub-task short-circuited before its own generateWithTools.
-    expect(callSnapshots).toHaveLength(2);
+    expect(snapshots).toHaveLength(2);
 
-    const iter2Messages = callSnapshots[1].messages;
+    const iter2Messages = snapshots[1].messages;
     const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
     expect(lastUserContent).toMatch(/Tool resolution failed/);
   });

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -642,9 +642,17 @@ async function executeOrchestratedSubTaskV2(
     initialToolNames.add(artifactTool.name);
   }
 
-  // If tools were requested but none matched at all (kd_* tools excluded), return early with guidance
-  const nonKdInitial = initialTools.filter(t => !t.name.startsWith('platform__kd_') && t.name !== 'platform__read_tool_result_artifact');
-  if (task.tools.length > 0 && nonKdInitial.length === 0) {
+  // If every requested tool failed to match anything (no exact, no base-name,
+  // no substring, no fuzzy candidate above the score threshold), return early
+  // with guidance — the strategist named tools that don't exist.
+  //
+  // Subtle bug fixed in #471: the prior check tested whether `initialTools` had
+  // any non-kd tools, which incorrectly fired for sub-tasks that legitimately
+  // requested ONLY kd_* tools (e.g. a "document findings" sub-task). Those
+  // requests are genuine matches via `resolveTaskTools` and should NOT error.
+  // Use the resolver's own `resolved` + `fuzzy` outputs as the source of truth.
+  const noResolutionAtAll = resolution.resolved.length === 0 && resolution.fuzzy.size === 0;
+  if (task.tools.length > 0 && noResolutionAtAll) {
     const MAX_TOOLS_IN_ERROR = 10;
     const toolNames = agenticTools.map(t => t.name);
     const availableList = toolNames.length > MAX_TOOLS_IN_ERROR


### PR DESCRIPTION
## Summary

Sub-task tool resolution incorrectly fired "Tool resolution failed" for any sub-task that requested ONLY kd_* tools (e.g. a "document findings" sub-task whose entire job is to write to the knowledge doc). Resolves #471.

Live evidence (cf1b96e8 watch, 2026-04-27): `st-6-document-all` was dispatched with `tools=['kd_update_section', 'kd_add_subsection']`. Both names resolved cleanly via substring match against `platform__kd_*` in `resolveTaskTools`, but the post-resolution check filtered out kd_* tools and concluded "no real matches found" — failing the sub-task before it could even run.

## What changed

`services/ticket-analyzer/src/analysis/orchestrated-v2.ts:574-575` — replaced the proxy check on `nonKdInitial.length === 0` with the more direct `resolution.resolved.length === 0 && resolution.fuzzy.size === 0`. This trusts the resolver's own outputs: a non-empty `resolved` (confident match) or `fuzzy` (best-effort match) means the request found something, regardless of whether it happens to be a kd_* tool.

Two regression tests added to `orchestrated-v2.test.ts`:
- **Positive:** kd-only request resolves cleanly — sub-task runs, finalizes, success summary lands in the strategist's tool_result, no error
- **Negative:** genuinely-unknown tools still trigger "Tool resolution failed" — preserves the original guard's intent for the real failure case

Note on test design: orchestrator mutates the strategist's `messages` array between calls, so post-run inspection of `mock.calls[N][0].messages` would see the FINAL state. Tests use `structuredClone` inside the mock to snapshot messages at call time.

## Test plan

- [x] Two new regression tests pass
- [x] Full ticket-analyzer suite — 225 pass, 2 todo, 0 regressions
- [x] Build clean
- [ ] Production verification once deployed: trigger an analysis where the strategist dispatches a sub-task with `tools: ['kd_update_section', 'kd_add_subsection']` and confirm the sub-task runs successfully (does not short-circuit with the resolution-failed error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
