### PR TITLE
feat(analyzer): surface prior executive summary as re-analysis steering input (#48 Item 7)

### DIFF
--- a/services/ticket-analyzer/src/analysis/flat-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.test.ts
@@ -763,6 +763,98 @@ describe('runFlatV2', () => {
       const userMsg = capturedMessages.find(m => m.role === 'user');
       expect(userMsg?.content).toContain('Can you check table fragmentation?');
     });
+
+    it('surfaces priorExecutiveSummary as a dedicated section ahead of the conversation history (#48 Item 7)', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      const reanalysisCtx = {
+        conversationHistory: '### [2026-04-20 09:00] Reply (chad@example.com)\n\nFollow-up.',
+        triggerReplyText: 'Continue from where you left off.',
+        priorExecutiveSummary: [
+          '## Executive Summary',
+          '',
+          'Identified deadlock between Orders and OrderLines transactions.',
+          '',
+          '## Continuation Notes',
+          '',
+          'Budget cap fired before validating fix on staging. Next run should rerun the trace test.',
+        ].join('\n'),
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).toContain('## Prior Executive Summary');
+      expect(capturedSystemPrompt).toContain('Identified deadlock between Orders and OrderLines transactions.');
+      expect(capturedSystemPrompt).toContain('## Continuation Notes');
+      expect(capturedSystemPrompt).toContain('rerun the trace test');
+
+      // Ordering: Prior Executive Summary comes before Conversation History so
+      // the strategist sees the prior findings as primary steering input.
+      const priorIdx = capturedSystemPrompt.indexOf('## Prior Executive Summary');
+      const histIdx = capturedSystemPrompt.indexOf('## Conversation History');
+      expect(priorIdx).toBeGreaterThan(-1);
+      expect(histIdx).toBeGreaterThan(-1);
+      expect(priorIdx).toBeLessThan(histIdx);
+    });
+
+    it('omits the Prior Executive Summary section when reanalysisCtx has no priorExecutiveSummary', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      const reanalysisCtx = {
+        conversationHistory: '## History',
+        triggerReplyText: 'Continue.',
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).not.toContain('## Prior Executive Summary');
+    });
+
+    it('truncates a prior executive summary that exceeds the cap, keeping the tail (Continuation Notes)', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      // Build a > 8000-char summary with the Continuation Notes at the end.
+      const filler = 'X'.repeat(9000);
+      const tail = '## Continuation Notes\n\nResume sub-task 3 (index review) — sub-tasks 1 and 2 already wrote findings.';
+      const reanalysisCtx = {
+        conversationHistory: '## History',
+        triggerReplyText: 'Continue.',
+        priorExecutiveSummary: `${filler}\n\n${tail}`,
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).toContain('Prior executive summary truncated');
+      expect(capturedSystemPrompt).toContain('## Continuation Notes');
+      expect(capturedSystemPrompt).toContain('Resume sub-task 3');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/services/ticket-analyzer/src/analysis/flat-v2.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.ts
@@ -17,6 +17,7 @@ import {
   saveMcpToolArtifact,
   shouldTruncate,
   SUFFICIENCY_EVAL_INSTRUCTIONS,
+  truncatePriorExecutiveSummary,
   type AgenticToolContext,
   type AnalysisDeps,
   type AnalysisPipelineContext,
@@ -83,6 +84,18 @@ export async function runFlatV2(
     );
     const reanalAttBlock = buildAttachmentsBlock(attachments);
     if (reanalAttBlock) systemParts.push(reanalAttBlock);
+    // #48 Item 7: surface the prior run's composed analysis as a primary
+    // steering input, ahead of the chronological conversation history. If the
+    // prior run hit the ticket-budget cap, this includes the agent's
+    // `## Continuation Notes` section telling us where to pick up.
+    if (reanalysisCtx.priorExecutiveSummary) {
+      systemParts.push(
+        '',
+        '## Prior Executive Summary',
+        '',
+        truncatePriorExecutiveSummary(reanalysisCtx.priorExecutiveSummary),
+      );
+    }
     systemParts.push(
       '',
       '## Conversation History',

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1581,3 +1581,128 @@ describe('v1 orchestrated re-analysis redirect', () => {
   // analyzer.integration.test.ts.
   it.todo('redirect covered in analyzer.integration.test.ts (deferred)');
 });
+
+// ---------------------------------------------------------------------------
+// runOrchestratedV2 — re-analysis surfaces priorExecutiveSummary (#48 Item 7)
+// ---------------------------------------------------------------------------
+
+describe('runOrchestratedV2 — re-analysis surfaces priorExecutiveSummary (#48 Item 7)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  /**
+   * Re-analysis-aware mock DB. Adds `artifact.findMany` (consumed by
+   * `buildArtifactCatalog` during the re-analysis prompt build) on top of the
+   * standard mock surface.
+   */
+  function makeReanalysisDb(): PrismaClient {
+    const base = makeMockDb() as unknown as Record<string, unknown>;
+    base.artifact = { findMany: vi.fn().mockResolvedValue([]) };
+    return base as unknown as PrismaClient;
+  }
+
+  /** Captures the very first strategist user message (initial re-analysis prompt). */
+  function captureFirstUserMessage(generateWithTools: ReturnType<typeof vi.fn>): { read: () => string } {
+    let captured = '';
+    let firstSeen = false;
+    generateWithTools.mockImplementation(async (req: { messages: Array<{ role: string; content: unknown }> }) => {
+      if (!firstSeen) {
+        const userMsg = req.messages.find((m) => m.role === 'user');
+        captured = typeof userMsg?.content === 'string' ? userMsg.content : '';
+        firstSeen = true;
+      }
+      // Return complete_analysis immediately so the run terminates fast
+      return {
+        contentBlocks: [makeToolUseBlock('complete_analysis', { finalAnalysis: 'done' }, 'tu_complete')],
+        stopReason: 'tool_use',
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    });
+    return { read: () => captured };
+  }
+
+  it('injects ## Prior Executive Summary section between Operator Reply and Prior Knowledge Document', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const reanalysisCtx = {
+      conversationHistory: '### [2026-04-20] Reply\n\nfollow-up',
+      triggerReplyText: 'Continue from where you left off.',
+      priorExecutiveSummary: [
+        '## Executive Summary',
+        '',
+        'Identified deadlock between Orders and OrderLines.',
+        '',
+        '## Continuation Notes',
+        '',
+        'Sub-task 3 (index review) did not complete. Resume there.',
+      ].join('\n'),
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '## Problem Statement\n\nx',
+      reanalysisCtx,
+    });
+
+    const text = captured.read();
+    expect(text).toContain('## Prior Executive Summary');
+    expect(text).toContain('Identified deadlock between Orders and OrderLines.');
+    expect(text).toContain('## Continuation Notes');
+    expect(text).toContain('Sub-task 3 (index review) did not complete. Resume there.');
+
+    // Ordering: Operator Reply → Prior Executive Summary → Prior Knowledge Document
+    const opReplyIdx = text.indexOf('## Operator Reply');
+    const priorIdx = text.indexOf('## Prior Executive Summary');
+    const kdIdx = text.indexOf('## Prior Knowledge Document');
+    expect(opReplyIdx).toBeGreaterThan(-1);
+    expect(priorIdx).toBeGreaterThan(opReplyIdx);
+    expect(kdIdx).toBeGreaterThan(priorIdx);
+  });
+
+  it('omits the Prior Executive Summary section when reanalysisCtx has no priorExecutiveSummary', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const reanalysisCtx = {
+      conversationHistory: '### [2026-04-20] Reply\n\nfollow-up',
+      triggerReplyText: 'Continue.',
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '',
+      reanalysisCtx,
+    });
+
+    expect(captured.read()).not.toContain('## Prior Executive Summary');
+  });
+
+  it('truncates priorExecutiveSummary that exceeds the cap, keeping the tail (Continuation Notes)', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const filler = 'X'.repeat(9000);
+    const tail = '## Continuation Notes\n\nResume sub-task 3 (index review).';
+    const reanalysisCtx = {
+      conversationHistory: '## History',
+      triggerReplyText: 'Continue.',
+      priorExecutiveSummary: `${filler}\n\n${tail}`,
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '',
+      reanalysisCtx,
+    });
+
+    const text = captured.read();
+    expect(text).toContain('Prior executive summary truncated');
+    expect(text).toContain('## Continuation Notes');
+    expect(text).toContain('Resume sub-task 3');
+  });
+});

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -34,6 +34,7 @@ import {
   resolveTaskTools,
   saveMcpToolArtifact,
   shouldTruncate,
+  truncatePriorExecutiveSummary,
   type AgenticToolContext,
   type AnalysisDeps,
   type AnalysisPipelineContext,
@@ -1045,10 +1046,22 @@ export async function runOrchestratedV2(
         '',
         '## Operator Reply',
         reanalysisCtx.triggerReplyText || '(no reply text available — see conversation history)',
+      ];
+      // #48 Item 7: surface the prior run's composed analysis as a primary
+      // steering input. If the prior run hit the ticket-budget cap, it includes
+      // a `## Continuation Notes` section telling us where to pick up.
+      if (reanalysisCtx.priorExecutiveSummary) {
+        sections.push(
+          '',
+          '## Prior Executive Summary',
+          truncatePriorExecutiveSummary(reanalysisCtx.priorExecutiveSummary),
+        );
+      }
+      sections.push(
         '',
         '## Prior Knowledge Document',
         priorRunsContext || existingKnowledgeDoc || '(no prior knowledge document)',
-      ];
+      );
       if (artifactCatalog) {
         sections.push('', '## Prior Artifacts', artifactCatalog);
       }

--- a/services/ticket-analyzer/src/analysis/shared.test.ts
+++ b/services/ticket-analyzer/src/analysis/shared.test.ts
@@ -40,6 +40,8 @@ import {
   resolveTaskTools,
   sanitizeFilenameSegment,
   executeAgenticToolCall,
+  truncatePriorExecutiveSummary,
+  PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP,
   type McpIntegrationInfo,
 } from './shared.js';
 import { callMcpToolViaSdk } from '@bronco/shared-utils';
@@ -871,3 +873,44 @@ describe('executeAgenticToolCall', () => {
     expect(tracker.get(sortedKey)).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// truncatePriorExecutiveSummary (#48 Item 7)
+// ---------------------------------------------------------------------------
+
+describe('truncatePriorExecutiveSummary', () => {
+  it('returns the input unchanged when length <= cap', () => {
+    const input = 'short summary';
+    expect(truncatePriorExecutiveSummary(input)).toBe(input);
+  });
+
+  it('returns the input unchanged at exactly the cap boundary', () => {
+    const input = 'a'.repeat(PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP);
+    expect(truncatePriorExecutiveSummary(input)).toBe(input);
+  });
+
+  it('truncates from the front when length > cap, preserving the tail', () => {
+    const head = 'HEAD_MARKER_AT_START';
+    const filler = 'x'.repeat(PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP);
+    const tail = '## Continuation Notes\n\nResume here.';
+    const input = `${head}\n${filler}\n${tail}`;
+    const out = truncatePriorExecutiveSummary(input);
+
+    // Tail (Continuation Notes) is preserved
+    expect(out).toContain('## Continuation Notes');
+    expect(out).toContain('Resume here.');
+    // Head fell off the front
+    expect(out).not.toContain('HEAD_MARKER_AT_START');
+    // Truncation marker present
+    expect(out).toContain(`Prior executive summary truncated to last ${PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP} chars`);
+  });
+
+  it('respects a custom charCap argument', () => {
+    const input = 'a'.repeat(100);
+    const out = truncatePriorExecutiveSummary(input, 50);
+    expect(out).toContain('truncated to last 50 chars');
+    // Output is the marker + ellipsis + last 50 chars; bounded.
+    expect(out.length).toBeLessThan(input.length + 200);
+  });
+});
+

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -1340,11 +1340,40 @@ export interface ReanalysisContext {
   /** The ticket event ID that triggered this re-analysis (for metadata tracking). */
   triggerEventId?: string;
   /**
+   * Full content of the most recent AI_ANALYSIS event for this ticket — the
+   * composed final analysis sent to the operator (Executive Summary +
+   * Problem/Root Cause/Recommended Fix/Risks pulled from the KD). Surfaced
+   * as a dedicated section in the v2 strategies' prompts so the strategist
+   * sees prior findings — and any `## Continuation Notes` section written by
+   * a prior budget-capped run — as primary steering input rather than buried
+   * in the conversation history (#48 Item 7).
+   *
+   * Strategies cap this at their own prompt budget; producer should pass the
+   * full content, no pre-truncation.
+   */
+  priorExecutiveSummary?: string;
+  /**
    * Continuation mode for orchestrated re-analysis. When undefined, defaults
    * to 'continue'. Producer (#312 Chat tab) classifies operator-reply intent
    * and sets this; pre-#312 callers leave it unset.
    */
   mode?: ReanalysisMode;
+}
+
+/** Per-run cap for the `## Prior Executive Summary` section in v2 strategy prompts. */
+export const PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP = 8000;
+
+/**
+ * Truncate the prior executive summary for inclusion in a re-analysis prompt.
+ * Keeps the tail (where `## Continuation Notes` lives if E.1 fired) and
+ * prefixes a marker so the strategist knows the summary was clipped.
+ */
+export function truncatePriorExecutiveSummary(
+  summary: string,
+  charCap: number = PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP,
+): string {
+  if (summary.length <= charCap) return summary;
+  return `[Prior executive summary truncated to last ${charCap} chars — full version in the AI Analysis event]\n\n…${summary.slice(-charCap)}`;
 }
 
 export interface StrategyStep {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3545,10 +3545,26 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
           }
           triggerReplyText = latestReply.content ?? '';
         }
+        // Pull the most-recent AI_ANALYSIS event content (full, no truncation
+        // here — the strategy modules cap it for their prompt budget). This is
+        // the composed final analysis we sent to the operator last time, and
+        // includes any `## Continuation Notes` section written when the prior
+        // run hit the ticket-level budget cap. v2 strategies surface it as a
+        // dedicated `## Prior Executive Summary` section so the strategist
+        // builds on the prior findings rather than re-doing the work (#48
+        // Item 7). We scan the unsliced `allHistory` so a long-running ticket
+        // with > 20 events still surfaces the most recent AI_ANALYSIS even if
+        // it falls outside the lightweight conversation-history window.
+        const priorAiAnalysisEvent = [...allHistory]
+          .reverse()
+          .find((e) => e.eventType === 'AI_ANALYSIS');
+        const priorExecutiveSummary = priorAiAnalysisEvent?.content?.trim() || undefined;
+
         const reanalysisContext: ReanalysisContext = {
           conversationHistory: formatConversationHistory(conversationHistory),
           triggerReplyText,
           triggerEventId,
+          ...(priorExecutiveSummary && { priorExecutiveSummary }),
           // Threaded from the Chat tab endpoint (#312). flat + orchestrated
           // strategies already consume `reanalysisCtx.mode` to branch their
           // system prompt between continue / refine / fresh_start.


### PR DESCRIPTION
## Summary

When a reply triggers re-analysis, the v2 strategies (orchestrated-v2 + flat-v2) now see the most-recent `AI_ANALYSIS` event content as a dedicated `## Prior Executive Summary` section in their initial prompt — ahead of the conversation history. Composes with the E.1 continuation-notes layer from #477 / #470: if the prior run hit the ticket-budget cap, the agent's `## Continuation Notes` section is preserved through truncation, telling the next strategist exactly where to pick up.

**Why:** Previously the prior executive summary was only present buried inside the chronological conversation history, truncated to 3000 chars per event, with no signal that it was the primary steering input. The strategist would often re-do work the prior run had already completed.

**Source:** Internal review of analysis ticket #48 (Evolution DB Deadlock, `b39bf699-f86d-45ea-87d4-501078ab5edd`), Item 7 from the regression sweep documented in `.tmp/SESSION-STATE-2026-04-28.md`.

## Changes

- `analysis/shared.ts` — adds `priorExecutiveSummary?: string` to `ReanalysisContext`; new `truncatePriorExecutiveSummary` helper (default 8000-char tail-keep, with truncation marker).
- `analyzer.ts` re-analysis path — pulls the most-recent `AI_ANALYSIS` event from the **unsliced** event history (so it surfaces even when the most recent AI_ANALYSIS is older than the 20-event conversation-history window) and threads it through `ReanalysisContext`.
- `orchestrated-v2.ts` — injects `## Prior Executive Summary` between `## Operator Reply` and `## Prior Knowledge Document` in the strategist's initial user message.
- `flat-v2.ts` — injects `## Prior Executive Summary` ahead of `## Conversation History` in the re-analysis system prompt.

v1 strategies are intentionally not modified. Per `CLAUDE.md`, v1 is historical fidelity and must not be retrofit with v2 features.

## Tests

| File | Cases |
|---|---|
| `shared.test.ts` | `truncatePriorExecutiveSummary`: short pass-through, boundary at exact cap, head-truncate while preserving tail (Continuation Notes), custom cap |
| `flat-v2.test.ts` | section is injected, section is omitted when no priorExecutiveSummary, ordering vs. Conversation History, truncation tail-preservation |
| `orchestrated-v2.test.ts` | section is injected, section is omitted when absent, truncation tail-preservation, ordering Operator Reply → Prior Executive Summary → Prior Knowledge Document |

`pnpm --filter @bronco/ticket-analyzer test`: 260 passed (3 new flat-v2 cases, 3 new orchestrated-v2 cases, 4 new shared cases).
`pnpm build` + `pnpm typecheck`: green.

## Test plan

- [ ] CI passes
- [ ] Copilot review
- [ ] Post-deploy: trigger a re-analysis on a ticket that has a prior `AI_ANALYSIS` event. Confirm the strategist's first request body in the analysis trace contains a `## Prior Executive Summary` section with the prior composed analysis.
- [ ] Post-deploy + #470 verification (task #16): replay ticket #49 with a tightened budget cap, let it hit E.1, then send a reply. Verify the next run sees the `## Continuation Notes` from the capped run as primary steering input and resumes the unfinished sub-task instead of restarting.
