### PR TITLE
fix(search_code): detect timeouts, surface tool failures, document direct-exec rationale (#465)

### DIFF
--- a/mcp-servers/repo/src/tools/search-code.test.ts
+++ b/mcp-servers/repo/src/tools/search-code.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { validateCommand } from '../command-validator.js';
+import { classifyExecError } from './search-code.js';
 
 // ---------------------------------------------------------------------------
 // Helpers mirrored from search-code.ts (private, so we test via validateCommand)
@@ -139,5 +140,72 @@ describe('search-code: flags', () => {
   it('adds -e before the query', () => {
     const cmd = buildSearchCommand('myFunc', ['.ts']);
     expect(cmd).toContain('-e ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyExecError — distinguish timeout / signal / rg-error / no-matches
+// (#465: previously all rejections fell into `code ?? 1` which masked timeouts
+// and kills as silent "no matches" results)
+// ---------------------------------------------------------------------------
+
+describe('classifyExecError', () => {
+  it('classifies rg exit 1 as no-matches (the expected non-error path)', () => {
+    const err = { code: 1, stdout: '', stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('no-matches');
+    expect(c.exitCode).toBe(1);
+  });
+
+  it('classifies rg exit 2 as rg-error (e.g. invalid regex)', () => {
+    const err = { code: 2, stdout: '', stderr: 'rg: regex parse error: unclosed group' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('rg-error');
+    expect(c.exitCode).toBe(2);
+    expect(c.stderr).toContain('regex parse error');
+  });
+
+  it('classifies SIGTERM (timeout-fired kill) as timeout', () => {
+    // Node's execAsync sets `killed: true` and `signal: 'SIGTERM'` when the
+    // `timeout` option fires. Code is undefined in that path.
+    const err = { killed: true, signal: 'SIGTERM', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('timeout');
+    expect(c.signal).toBe('SIGTERM');
+  });
+
+  it('classifies SIGKILL (OOM / external kill) as killed (not timeout)', () => {
+    const err = { killed: true, signal: 'SIGKILL', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('killed');
+    expect(c.signal).toBe('SIGKILL');
+  });
+
+  it('classifies signal-only (no killed flag, no code) as killed', () => {
+    // Some Node versions or wrappers may carry the signal without `killed`.
+    const err = { signal: 'SIGINT', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('killed');
+    expect(c.signal).toBe('SIGINT');
+  });
+
+  it('classifies a rejection with neither code nor signal as unknown', () => {
+    const err = { stderr: 'unexpected' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('unknown');
+    expect(c.stderr).toBe('unexpected');
+  });
+
+  it('handles a non-object rejection without throwing', () => {
+    const c = classifyExecError('boom');
+    expect(c.kind).toBe('unknown');
+    expect(c.stderr).toBeUndefined();
+  });
+
+  it('preserves stderr on rg-error so the operator-facing message is informative', () => {
+    const err = { code: 2, stderr: 'rg: io error: too many open files' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('rg-error');
+    expect(c.stderr).toBe('rg: io error: too many open files');
   });
 });

--- a/mcp-servers/repo/src/tools/search-code.ts
+++ b/mcp-servers/repo/src/tools/search-code.ts
@@ -25,6 +25,64 @@ function describeRepo(repo: { name: string; description: string | null }): strin
   return repo.description ? repo.description : 'Code repository';
 }
 
+/**
+ * Classify an `execAsync` rejection so the caller can distinguish
+ * "ripgrep ran and found nothing" (exit 1) from real failures
+ * (timeout / signal / system error / rg internal error). Without this, all
+ * non-zero exits previously bucketed as `code ?? 1`, masking timeouts and
+ * kills as silent "no matches" results (#465).
+ *
+ * Exported for unit testing.
+ */
+export interface ExecErrorClassification {
+  /**
+   *  - 'no-matches': rg exited 1 (no matches found, treat as empty result).
+   *  - 'rg-error':   rg exited 2+ (e.g. invalid regex, IO error).
+   *  - 'timeout':    process killed by execAsync's `timeout` option.
+   *  - 'killed':     process killed by some other signal (OOM, SIGKILL, etc).
+   *  - 'unknown':    rejection didn't carry a recognizable shape (rare).
+   */
+  kind: 'no-matches' | 'rg-error' | 'timeout' | 'killed' | 'unknown';
+  exitCode?: number;
+  signal?: string;
+  stderr?: string;
+}
+
+export function classifyExecError(err: unknown): ExecErrorClassification {
+  const e = err as {
+    code?: number | string;
+    signal?: NodeJS.Signals | string | null;
+    killed?: boolean;
+    stderr?: string;
+  };
+
+  const stderr = typeof e?.stderr === 'string' ? e.stderr : undefined;
+  const codeNum = typeof e?.code === 'number' ? e.code : undefined;
+  const signal = e?.signal ?? undefined;
+  const killed = e?.killed === true;
+
+  // execAsync sets `killed: true` and `signal: 'SIGTERM'` when the `timeout`
+  // option fires. Treat any killed-by-signal rejection as a real error rather
+  // than a "no matches" result. Distinguish timeout from other signals so the
+  // operator-facing error message is actionable.
+  if (killed || (signal && signal !== null)) {
+    const sigName = typeof signal === 'string' ? signal : undefined;
+    if (sigName === 'SIGTERM') {
+      return { kind: 'timeout', signal: sigName, stderr };
+    }
+    return { kind: 'killed', signal: sigName, stderr };
+  }
+
+  if (codeNum === 1) {
+    return { kind: 'no-matches', exitCode: 1, stderr };
+  }
+  if (codeNum !== undefined) {
+    return { kind: 'rg-error', exitCode: codeNum, stderr };
+  }
+
+  return { kind: 'unknown', stderr };
+}
+
 export function registerSearchCodeTool(
   server: McpServer,
   deps: { db: PrismaClient; repoManager: RepoManager },
@@ -103,6 +161,16 @@ export function registerSearchCodeTool(
         '.',
       ].join(' ');
 
+      // Direct exec rationale (#465 Item 3): we deliberately bypass the
+      // command-validator/executeCommand path here. That path is built for
+      // arbitrary operator commands via `repo_exec` (find/grep/cat/etc.) and
+      // would require us to add `rg` to its base allowlist. Here, every shell
+      // token is constructed under our control: flags are constants, globs go
+      // through a strict `^[A-Za-z0-9._*?\[\]/-]+$` regex, the user query is
+      // single-quoted via `shellQuote` and isolated by `--`. We also impose
+      // an explicit timeout + maxBuffer below. The defense-in-depth concern
+      // raised on PR #461 is real but the threat model here is different —
+      // search_code is internal, not a generic shell.
       try {
         const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
 
@@ -111,16 +179,38 @@ export function registerSearchCodeTool(
           const result = await execAsync(command, { cwd: worktreePath, timeout: 30_000, maxBuffer: 1024 * 1024 });
           stdout = result.stdout;
         } catch (err: unknown) {
-          const execErr = err as { stdout?: string; stderr?: string; code?: number };
-          const exitCode = execErr.code ?? 1;
-          stdout = execErr.stdout ?? '';
-          // rg exits 1 when no matches found — not an error for us.
-          if (exitCode !== 1) {
-            const stderr = execErr.stderr || '(no stderr)';
-            return {
-              content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code error on ${repo.name}: exit=${exitCode}\n${stderr}` }],
-              isError: true,
-            };
+          const classification = classifyExecError(err);
+          // rg's stdout up to the failure point can still contain partial
+          // matches — keep it for the no-matches case.
+          const partial = (err as { stdout?: string }).stdout ?? '';
+          stdout = partial;
+
+          const stderr = classification.stderr || '(no stderr)';
+          switch (classification.kind) {
+            case 'no-matches':
+              // Expected — rg exits 1 when nothing matches. Fall through
+              // to the empty-stdout output path below.
+              break;
+            case 'timeout':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code timed out on ${repo.name} after 30s. The query may be too broad — try a more specific term, narrow the file extensions, or break the search into multiple calls.\n${stderr}` }],
+                isError: true,
+              };
+            case 'killed':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code was killed (signal=${classification.signal ?? 'unknown'}) on ${repo.name}. This usually indicates the host is under memory pressure or the worktree was cleaned up mid-search.\n${stderr}` }],
+                isError: true,
+              };
+            case 'rg-error':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code error on ${repo.name}: rg exit=${classification.exitCode}\n${stderr}` }],
+                isError: true,
+              };
+            case 'unknown':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code failed on ${repo.name} with no exit code and no signal — likely a child-process spawn or system error.\n${stderr}` }],
+                isError: true,
+              };
           }
         }
 

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -941,8 +941,17 @@ async function deepAnalysis(
               }
             }
           }
-        } catch {
-          // search found nothing — that's fine
+        } catch (err) {
+          // `callMcpToolViaSdk` throws when the MCP result has `isError: true`
+          // — that includes real failures (timeout, auth, tool-internal errors),
+          // not only the genuine "no matches" case. Log at warn so an empty
+          // repo context is debuggable in production rather than silent (#465).
+          appLog.warn(
+            `Pre-gather search_code failed on ${repo.name} for term "${sanitized.slice(0, 80)}"`,
+            { ticketId, repo: repo.name, term: sanitized, err: err instanceof Error ? err.message : String(err) },
+            ticketId,
+            'ticket',
+          );
         }
       }
 
@@ -2649,7 +2658,18 @@ async function executeRoutePipeline(
                           }
                         }
                       }
-                    } catch { /* search found nothing */ }
+                    } catch (err) {
+                      // See note on pre-gather above: failures here include
+                      // real errors (timeout, auth, tool-internal), not only
+                      // genuine empty-result cases. Surface at warn so missing
+                      // CUSTOM_AI_QUERY context is debuggable in prod (#465).
+                      appLog.warn(
+                        `CUSTOM_AI_QUERY search_code failed on ${repo.name} for term "${sanitized.slice(0, 80)}"`,
+                        { ticketId, repo: repo.name, term: sanitized, err: err instanceof Error ? err.message : String(err) },
+                        ticketId,
+                        'ticket',
+                      );
+                    }
                   }
 
                   // Add explicit file paths, rejecting paths that could expose


### PR DESCRIPTION
## Summary

Fixes the three observability gaps surfaced by Copilot's review of PR #461 (the ripgrep switch).

### 1. Timeout / kill misclassification

`mcp-servers/repo/src/tools/search-code.ts` — extracted `classifyExecError` to distinguish the five rejection shapes that `execAsync` can produce:

| Kind | Trigger | Caller-facing behavior |
|---|---|---|
| `no-matches` | rg exit 1 | Empty result (expected) |
| `rg-error` | rg exit 2+ | Surface stderr to caller |
| `timeout` | `killed=true` + `signal=SIGTERM` (timeout option fired) | "search_code timed out after 30s — narrow the query" |
| `killed` | other signals (SIGKILL, SIGINT) | "killed (signal=…) — host under memory pressure" |
| `unknown` | rejection with no code/signal | "spawn or system error" |

Previously every rejection bucketed as `code ?? 1`, treating timeouts and external kills as silent "no matches" results.

### 2. Swallowed failures in analyzer.ts

`services/ticket-analyzer/src/analyzer.ts` — both `} catch { /* search found nothing */ }` blocks (pre-gather around line 944, CUSTOM_AI_QUERY around line 2652) replaced with `appLog.warn` calls including repo, term, and error message. `callMcpToolViaSdk` throws when the MCP result has `isError: true`, so what looked like "search found nothing" was actually masking real timeouts, auth failures, and tool-internal errors with no log signal.

### 3. Direct-exec rationale (Item 3)

Documented in `search-code.ts` why we deliberately bypass the `command-validator/executeCommand` path. That validator is built for arbitrary operator commands via `repo_exec` (find/grep/cat/etc.) and would require adding `rg` to its base allowlist. In `search_code`, every shell token is constructed under our control: constant flags, regex-validated globs (`^[A-Za-z0-9._*?\[\]/-]+$`), `shellQuote`'d query isolated by `--`, plus our own timeout + maxBuffer. Different threat model — internal-tool exception accepted.

## Tests

`mcp-servers/repo/src/tools/search-code.test.ts` adds 8 unit cases for `classifyExecError` covering all five kinds, stderr preservation, signal-only rejections, and non-object rejections.

- `pnpm --filter @bronco/mcp-repo test`: 78 passed
- `pnpm --filter @bronco/ticket-analyzer test`: 250 passed
- `pnpm build` + `pnpm typecheck`: green

## Origin

#465 — release sweep of v0.2.10 (2026-04-26).

## Test plan

- [ ] CI passes
- [ ] Copilot review
- [ ] Post-deploy: tail `bronco-ticket-analyzer-1` logs during a re-analysis run; confirm any `search_code` failures now surface as `Pre-gather search_code failed on …` warn lines instead of silent gaps in repo context.
- [ ] Post-deploy: verify a deliberately broad search (e.g. against a large repo) hits the 30s timeout and returns the new "timed out after 30s — narrow the query" error string instead of an empty `[found 0 matches]`.
