### PR TITLE
release: orchestrated-v2 regression-fix bundle + #48 Item 7 + #465

### DIFF
--- a/docs/superpowers/plans/2026-04-28-orchestrated-v2-budget-bounds.md
+++ b/docs/superpowers/plans/2026-04-28-orchestrated-v2-budget-bounds.md
@@ -1,0 +1,1997 @@
+# Orchestrated-v2 Budget Bounds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cap worst-case orchestrated-v2 ticket-analyzer cost at ~$5 (300k tokens) by adding 5 layered guardrails (sub-task prompt revision, mid-loop budget feedback, per-artifact re-read detector, strategist batch-failure guard, ticket-level total-token cap with continuation summary), all backed by a runtime-configurable AppSetting.
+
+**Architecture:** Extract pure threshold-evaluator functions (testable in isolation), then wire them into the existing `runSubTaskLoop` and `runOrchestratedV2` loops. New `orchestrated-v2-budget-config` AppSetting loaded once at the start of each analysis run via the existing settings-resolver pattern; surfaced in the control panel's existing Analysis tab.
+
+**Tech Stack:** TypeScript / Node.js / Prisma / Zod / Fastify (backend), Angular signals + Material (frontend), Vitest (tests).
+
+**Spec:** `docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md` (commits f569582, 530e889, 96cb48f)
+
+**Branch strategy:** Single feature branch `fix/470-v2-budget-bounds` off `staging`. Each task below produces an atomic commit. Open PR against `staging` once Task 13 lands.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/shared-types/src/analysis.ts` | `OrchestratedV2BudgetConfigSchema` Zod schema + type | Modify (file exists; append schema) |
+| `packages/shared-types/src/index.ts` | Re-export new schema/type | Modify (one-line export) |
+| `services/ticket-analyzer/src/analysis/budget-thresholds.ts` | Pure threshold-evaluator functions (sub-task budget, artifact re-read, batch-failure guard, ticket budget) | **Create** |
+| `services/ticket-analyzer/src/analysis/budget-thresholds.test.ts` | Unit tests for budget-thresholds.ts | **Create** |
+| `services/ticket-analyzer/src/analysis/shared.ts` | `resolveOrchestratedV2BudgetConfig` resolver + `AnalysisDeps` extension | Modify |
+| `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` | Wire all 5 layers into the loops; revise sub-task prompt (A); thread budget config through `runOrchestratedV2` and `runSubTaskLoop` | Modify |
+| `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts` | Integration-level tests for the new wiring | Modify |
+| `services/copilot-api/src/routes/settings.ts` | New GET / PUT endpoints for `orchestrated-v2-budget-config` | Modify |
+| `services/copilot-api/src/services/settings-keys.ts` | Add `SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG` constant (or wherever existing keys live) | Modify (locate during Task 3) |
+| `services/control-panel/src/app/features/settings/settings.service.ts` | `getOrchestratedV2BudgetConfig` / `saveOrchestratedV2BudgetConfig` service methods | Modify |
+| `services/control-panel/src/app/features/settings/settings.component.ts` | New "Orchestrated v2 Budget Limits" card in the Analysis tab | Modify |
+
+**Out of scope (deferred to follow-ups):**
+- MCP tool pair (`get/set_orchestrated_v2_budget_config`) — issue #475
+- Per-`TicketCategory` budget overrides — issue #476
+
+---
+
+## Task 1: Define `OrchestratedV2BudgetConfigSchema` in shared-types
+
+**Files:**
+- Modify: `packages/shared-types/src/analysis.ts`
+- Modify: `packages/shared-types/src/index.ts` (re-export)
+- Test: schema validation runs at import time + via direct invocation in budget-thresholds tests in Task 4
+
+The Zod schema mirrors the spec verbatim. Refinement enforces `softNudgeRatio < hardStopRatio` for each tier.
+
+- [ ] **Step 1.1: Locate `analysis.ts` in shared-types and review existing exports**
+
+Run: `cat packages/shared-types/src/analysis.ts | head -40`
+
+Confirm the file exists and inspect what's already exported (so we know the import-style and type-export conventions used).
+
+- [ ] **Step 1.2: Add the schema to `analysis.ts`**
+
+Append at the end of `packages/shared-types/src/analysis.ts`:
+
+```typescript
+import { z } from 'zod';
+
+/**
+ * Runtime-configurable budget limits for orchestrated-v2 analysis.
+ * Stored as the value of the `orchestrated-v2-budget-config` AppSetting.
+ * See docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
+ *
+ * Defaults match the hard-coded constants in orchestrated-v2.ts as of pre-#470 fix.
+ */
+export const OrchestratedV2BudgetConfigSchema = z
+  .object({
+    subTask: z.object({
+      iterationCap: z.number().int().min(1).max(50).default(8),
+      tokenBudget: z.number().int().min(5_000).max(500_000).default(50_000),
+      callBudget: z.number().int().min(1).max(100).default(20),
+      softNudgeRatio: z.number().min(0.1).max(0.99).default(0.6),
+      hardStopRatio: z.number().min(0.1).max(0.99).default(0.85),
+    }).default({}),
+    ticket: z.object({
+      totalTokenBudget: z.number().int().min(50_000).max(5_000_000).default(300_000),
+      softNudgeRatio: z.number().min(0.1).max(0.99).default(0.75),
+      hardStopRatio: z.number().min(0.1).max(0.99).default(0.95),
+    }).default({}),
+    strategistGuard: z.object({
+      softNudgeBatchExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+      hardStopCumulativeExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+      hardStopConsecutiveBatchesRatio: z.number().min(0.1).max(0.99).default(0.8),
+    }).default({}),
+    subTaskReReadDetector: z.object({
+      warnAfterReadCount: z.number().int().min(2).max(20).default(2),
+    }).default({}),
+  })
+  .default({})
+  .refine(
+    (cfg) => cfg.subTask.softNudgeRatio < cfg.subTask.hardStopRatio,
+    { message: 'subTask.softNudgeRatio must be less than subTask.hardStopRatio' },
+  )
+  .refine(
+    (cfg) => cfg.ticket.softNudgeRatio < cfg.ticket.hardStopRatio,
+    { message: 'ticket.softNudgeRatio must be less than ticket.hardStopRatio' },
+  );
+
+export type OrchestratedV2BudgetConfig = z.output<typeof OrchestratedV2BudgetConfigSchema>;
+```
+
+- [ ] **Step 1.3: Re-export from package index**
+
+Open `packages/shared-types/src/index.ts`. After the existing analysis re-exports, add:
+
+```typescript
+export { OrchestratedV2BudgetConfigSchema } from './analysis.js';
+export type { OrchestratedV2BudgetConfig } from './analysis.js';
+```
+
+(If `analysis.ts` is already wholesale re-exported via `export * from './analysis.js'`, both lines are redundant — verify and skip.)
+
+- [ ] **Step 1.4: Build shared-types**
+
+Run: `pnpm --filter @bronco/shared-types build`
+Expected: clean build, no type errors. Confirms the schema's `z.output<...>` chain resolves and `.refine()` returns a usable type.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add packages/shared-types/src/analysis.ts packages/shared-types/src/index.ts
+git commit -m "feat(shared-types): add OrchestratedV2BudgetConfig schema (#470)
+
+Zod schema for the orchestrated-v2-budget-config AppSetting. Defaults
+match the hard-coded constants in orchestrated-v2.ts as of pre-fix.
+Refinements enforce softNudgeRatio < hardStopRatio.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Pure threshold-evaluator functions
+
+**Files:**
+- Create: `services/ticket-analyzer/src/analysis/budget-thresholds.ts`
+- Create: `services/ticket-analyzer/src/analysis/budget-thresholds.test.ts`
+
+Extract the four budget-evaluation decisions into pure functions so we can unit-test them in isolation. Each returns one of: `'OK' | 'SOFT_NUDGE' | 'HARD_STOP'`.
+
+- [ ] **Step 2.1: Write the failing test file**
+
+Create `services/ticket-analyzer/src/analysis/budget-thresholds.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
+import {
+  evaluateSubTaskBudget,
+  evaluateTicketBudget,
+  detectArtifactReread,
+  evaluateBatchFailureGuard,
+  type BatchFailureGuardState,
+  type SubTaskBudgetUsage,
+} from './budget-thresholds.js';
+
+const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+describe('evaluateSubTaskBudget', () => {
+  const usage: SubTaskBudgetUsage = { tokensUsed: 0, iterationsUsed: 0, toolCallsUsed: 0 };
+
+  it('returns OK below soft threshold on all axes', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 25_000 }, config.subTask)).toBe('OK');
+  });
+
+  it('returns SOFT_NUDGE at 60% tokens', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 30_000 }, config.subTask)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 85% tokens', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 42_500 }, config.subTask)).toBe('HARD_STOP');
+  });
+
+  it('returns SOFT_NUDGE at 60% iterations even when tokens low', () => {
+    expect(evaluateSubTaskBudget({ ...usage, iterationsUsed: 5 }, config.subTask)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 85% calls even when tokens and iterations low', () => {
+    expect(evaluateSubTaskBudget({ ...usage, toolCallsUsed: 17 }, config.subTask)).toBe('HARD_STOP');
+  });
+
+  it('hardest of three axes wins (HARD beats SOFT)', () => {
+    expect(evaluateSubTaskBudget({ tokensUsed: 30_000, iterationsUsed: 0, toolCallsUsed: 17 }, config.subTask)).toBe('HARD_STOP');
+  });
+});
+
+describe('evaluateTicketBudget', () => {
+  it('returns OK below 75%', () => {
+    expect(evaluateTicketBudget(150_000, config.ticket)).toBe('OK');
+  });
+
+  it('returns SOFT_NUDGE at 75%', () => {
+    expect(evaluateTicketBudget(225_000, config.ticket)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 95%', () => {
+    expect(evaluateTicketBudget(285_000, config.ticket)).toBe('HARD_STOP');
+  });
+});
+
+describe('detectArtifactReread', () => {
+  const fakeId = '11111111-1111-1111-1111-111111111111';
+
+  it('returns false on first read of an artifact', () => {
+    const counts = new Map<string, number>();
+    expect(detectArtifactReread(counts, fakeId, 2)).toBe(false);
+    expect(counts.get(fakeId)).toBe(1);
+  });
+
+  it('returns false on second read (still under threshold of 2 — fires AT threshold)', () => {
+    const counts = new Map<string, number>([[fakeId, 1]]);
+    expect(detectArtifactReread(counts, fakeId, 2)).toBe(true);
+    expect(counts.get(fakeId)).toBe(2);
+  });
+
+  it('returns true on third read with threshold 3', () => {
+    const counts = new Map<string, number>([[fakeId, 2]]);
+    expect(detectArtifactReread(counts, fakeId, 3)).toBe(true);
+  });
+
+  it('separately tracks distinct artifactIds', () => {
+    const otherId = '22222222-2222-2222-2222-222222222222';
+    const counts = new Map<string, number>([[fakeId, 5]]);
+    expect(detectArtifactReread(counts, otherId, 2)).toBe(false);
+  });
+});
+
+describe('evaluateBatchFailureGuard', () => {
+  const fresh = (): BatchFailureGuardState => ({
+    cumulativeExhausted: 0,
+    cumulativeTotal: 0,
+    consecutiveBadBatches: 0,
+  });
+
+  const exhausted = { stopReason: 'BUDGET_EXHAUSTED' as const, updatedKdSections: [] };
+  const finalized = { stopReason: 'FINALIZED' as const, updatedKdSections: ['evidence.foo'] };
+  const exhaustedWithKd = { stopReason: 'BUDGET_EXHAUSTED' as const, updatedKdSections: ['evidence.foo'] };
+
+  it('OK on first batch even if all exhausted (gives strategist a free first try)', () => {
+    const state = fresh();
+    state.cumulativeTotal = 0; // first-batch flag derived from cumulativeTotal == 0
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted], config.strategistGuard, true)).toBe('OK');
+  });
+
+  it('SOFT_NUDGE on second batch when ≥50% exhausted with empty updatedKdSections', () => {
+    const state = fresh();
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 2;
+    expect(evaluateBatchFailureGuard(state, [exhausted, finalized, exhausted], config.strategistGuard, false)).toBe('SOFT_NUDGE');
+  });
+
+  it('OK when ≥50% exhausted but updatedKdSections non-empty (sub-tasks did some work)', () => {
+    const state = fresh();
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 2;
+    expect(evaluateBatchFailureGuard(state, [exhaustedWithKd, exhaustedWithKd, finalized], config.strategistGuard, false)).toBe('OK');
+  });
+
+  it('HARD_STOP when cumulative exhausted ratio crosses 50%', () => {
+    const state = fresh();
+    state.cumulativeTotal = 8;
+    state.cumulativeExhausted = 4;
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted], config.strategistGuard, false)).toBe('HARD_STOP');
+  });
+
+  it('HARD_STOP after 2 consecutive bad batches (≥80% each)', () => {
+    const state = fresh();
+    state.consecutiveBadBatches = 1;
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 4;
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted, exhausted, exhausted, finalized], config.strategistGuard, false)).toBe('HARD_STOP');
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test to verify it fails (module-not-found is the expected failure)**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test src/analysis/budget-thresholds.test.ts`
+Expected: FAIL — module `./budget-thresholds.js` cannot be resolved.
+
+- [ ] **Step 2.3: Write the implementation**
+
+Create `services/ticket-analyzer/src/analysis/budget-thresholds.ts`:
+
+```typescript
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+
+export type ThresholdVerdict = 'OK' | 'SOFT_NUDGE' | 'HARD_STOP';
+
+export interface SubTaskBudgetUsage {
+  tokensUsed: number;
+  iterationsUsed: number;
+  toolCallsUsed: number;
+}
+
+/**
+ * Evaluate sub-task budget consumption across three axes (tokens, iterations,
+ * tool calls). Returns the WORST (most-restrictive) verdict — if tokens are at
+ * 60% but tool calls are at 85%, returns HARD_STOP.
+ */
+export function evaluateSubTaskBudget(
+  usage: SubTaskBudgetUsage,
+  config: OrchestratedV2BudgetConfig['subTask'],
+): ThresholdVerdict {
+  const tokenRatio = usage.tokensUsed / config.tokenBudget;
+  const iterRatio = usage.iterationsUsed / config.iterationCap;
+  const callRatio = usage.toolCallsUsed / config.callBudget;
+  const worst = Math.max(tokenRatio, iterRatio, callRatio);
+
+  if (worst >= config.hardStopRatio) return 'HARD_STOP';
+  if (worst >= config.softNudgeRatio) return 'SOFT_NUDGE';
+  return 'OK';
+}
+
+/**
+ * Evaluate ticket-level total token consumption against the configured budget.
+ */
+export function evaluateTicketBudget(
+  totalTokensConsumed: number,
+  config: OrchestratedV2BudgetConfig['ticket'],
+): ThresholdVerdict {
+  const ratio = totalTokensConsumed / config.totalTokenBudget;
+  if (ratio >= config.hardStopRatio) return 'HARD_STOP';
+  if (ratio >= config.softNudgeRatio) return 'SOFT_NUDGE';
+  return 'OK';
+}
+
+/**
+ * Track repeated reads of the same artifact within a sub-task. Mutates `counts`
+ * in place — caller owns the map for the duration of one sub-task. Fires (returns
+ * true) the FIRST time the count reaches the warn threshold, so the caller can
+ * append a single nudge to the next tool_result.
+ *
+ * After firing once for a given artifact, will continue to fire on every
+ * subsequent read of the same artifact in this sub-task — caller decides
+ * whether to repeat the nudge or suppress.
+ */
+export function detectArtifactReread(
+  counts: Map<string, number>,
+  artifactId: string,
+  warnAfterReadCount: number,
+): boolean {
+  const next = (counts.get(artifactId) ?? 0) + 1;
+  counts.set(artifactId, next);
+  return next >= warnAfterReadCount;
+}
+
+export interface BatchFailureGuardState {
+  cumulativeExhausted: number;
+  cumulativeTotal: number;
+  consecutiveBadBatches: number;
+}
+
+export interface BatchResultSummary {
+  stopReason: string;
+  updatedKdSections: string[];
+}
+
+/**
+ * Evaluate a freshly-completed dispatch_subtasks batch against the cumulative
+ * guard state and the per-batch failure ratio. Mutates `state` in place to
+ * accumulate metrics for the next call.
+ *
+ * `isFirstBatch` is true on the first dispatch in the run (cumulativeTotal == 0
+ * before this batch) — gives the strategist a free first try without firing
+ * the guard, since first-batch failures may reflect bad initial sub-task design
+ * rather than a death spiral.
+ */
+export function evaluateBatchFailureGuard(
+  state: BatchFailureGuardState,
+  batchResults: BatchResultSummary[],
+  config: OrchestratedV2BudgetConfig['strategistGuard'],
+  isFirstBatch: boolean,
+): ThresholdVerdict {
+  const batchSize = batchResults.length;
+  if (batchSize === 0) return 'OK';
+
+  const batchExhausted = batchResults.filter(r => r.stopReason === 'BUDGET_EXHAUSTED').length;
+  const batchExhaustedWithoutKd = batchResults.filter(
+    r => r.stopReason === 'BUDGET_EXHAUSTED' && r.updatedKdSections.length === 0,
+  ).length;
+  const batchExhaustedRatio = batchExhausted / batchSize;
+  const batchExhaustedWithoutKdRatio = batchExhaustedWithoutKd / batchSize;
+
+  // Update cumulative metrics
+  state.cumulativeExhausted += batchExhausted;
+  state.cumulativeTotal += batchSize;
+
+  // Track consecutive-bad-batches for HARD_STOP rule 2
+  if (batchExhaustedRatio >= config.hardStopConsecutiveBatchesRatio) {
+    state.consecutiveBadBatches += 1;
+  } else {
+    state.consecutiveBadBatches = 0;
+  }
+
+  // Free first batch
+  if (isFirstBatch) return 'OK';
+
+  // HARD_STOP rule 1: cumulative exhausted ratio crosses threshold
+  if (state.cumulativeTotal > 0
+    && state.cumulativeExhausted / state.cumulativeTotal >= config.hardStopCumulativeExhaustedRatio) {
+    return 'HARD_STOP';
+  }
+
+  // HARD_STOP rule 2: N consecutive bad batches (≥80% exhausted each)
+  // N is implicit — fires once consecutiveBadBatches >= 2
+  if (state.consecutiveBadBatches >= 2) {
+    return 'HARD_STOP';
+  }
+
+  // SOFT_NUDGE: this batch was bad (≥50% exhausted with empty updatedKdSections)
+  if (batchExhaustedWithoutKdRatio >= config.softNudgeBatchExhaustedRatio) {
+    return 'SOFT_NUDGE';
+  }
+
+  return 'OK';
+}
+```
+
+- [ ] **Step 2.4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test src/analysis/budget-thresholds.test.ts`
+Expected: PASS — all tests in the four `describe` blocks.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/budget-thresholds.ts services/ticket-analyzer/src/analysis/budget-thresholds.test.ts
+git commit -m "feat(analyzer): pure budget threshold evaluators (#470)
+
+Extract 5-layer guardrail decisions into pure functions:
+- evaluateSubTaskBudget (tokens / iterations / calls — worst-axis wins)
+- evaluateTicketBudget (total tokens vs ticket cap)
+- detectArtifactReread (per-artifact read counter)
+- evaluateBatchFailureGuard (cumulative + consecutive-bad-batch metrics)
+
+Each returns 'OK' | 'SOFT_NUDGE' | 'HARD_STOP'. Caller owns side
+effects (tool_result injection, tool-list restriction). Tested in
+isolation; wiring into the orchestrator follows in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Resolver `resolveOrchestratedV2BudgetConfig` in shared.ts
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/shared.ts`
+- Test: covered by integration tests in Task 8 (no isolated test for the trivial Prisma-fetch + parse pattern; matches existing peers like `resolveAnalysisVersion`)
+
+- [ ] **Step 3.1: Locate the existing peer resolvers**
+
+Run: `grep -n "resolveAnalysisVersion\|resolveMaxParallelTasks" services/ticket-analyzer/src/analysis/shared.ts`
+Expected: line numbers around 1195–1223 (per the prior recon).
+
+- [ ] **Step 3.2: Add the new resolver after `resolveMaxParallelTasks`**
+
+Open `services/ticket-analyzer/src/analysis/shared.ts`. Find `resolveMaxParallelTasks` (~line 1223). After the closing brace of that function, add:
+
+```typescript
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
+
+const ORCHESTRATED_V2_BUDGET_CONFIG_KEY = 'orchestrated-v2-budget-config';
+
+/**
+ * Load the orchestrated-v2 runtime budget config from the AppSetting table.
+ * Missing or malformed → returns parsed defaults. Called once at the top of
+ * runOrchestratedV2 and threaded through to runSubTaskLoop. Does NOT cache —
+ * each analysis run picks up fresh values.
+ */
+export async function resolveOrchestratedV2BudgetConfig(
+  db: { appSetting: { findUnique: (args: { where: { key: string } }) => Promise<{ value: unknown } | null> } },
+): Promise<OrchestratedV2BudgetConfig> {
+  const row = await db.appSetting.findUnique({ where: { key: ORCHESTRATED_V2_BUDGET_CONFIG_KEY } });
+  const parsed = OrchestratedV2BudgetConfigSchema.safeParse(row?.value ?? {});
+  if (!parsed.success) {
+    return OrchestratedV2BudgetConfigSchema.parse({});
+  }
+  return parsed.data;
+}
+```
+
+If the imports `OrchestratedV2BudgetConfig` / `OrchestratedV2BudgetConfigSchema` already exist near the top of the file from a prior task, merge — don't duplicate.
+
+- [ ] **Step 3.3: Build the analyzer to confirm no type errors**
+
+Run: `pnpm --filter @bronco/ticket-analyzer build`
+Expected: clean build.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/shared.ts
+git commit -m "feat(analyzer): resolveOrchestratedV2BudgetConfig (#470)
+
+Loads orchestrated-v2-budget-config AppSetting at analysis-run time.
+Missing or malformed values fall through to schema defaults. No cache
+— each run fetches fresh, matching the peer resolveAnalysisVersion
+pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: REST endpoints — GET / PUT `/api/settings/orchestrated-v2-budget-config`
+
+**Files:**
+- Modify: `services/copilot-api/src/routes/settings.ts`
+- Test: existing integration test pattern in `services/copilot-api/src/routes/settings.test.ts` if it exists; otherwise verify manually via dev server
+
+- [ ] **Step 4.1: Locate the existing analysis-strategy-version endpoint pair as the template**
+
+Run: `grep -n "SETTINGS_KEY_ANALYSIS_STRATEGY_VERSION\|analysis-strategy-version" services/copilot-api/src/routes/settings.ts | head -10`
+Expected: matches at lines ~1160 and ~1168 (per prior recon).
+
+- [ ] **Step 4.2: Locate where the SETTINGS_KEY constants are declared**
+
+Run: `grep -rn "SETTINGS_KEY_ANALYSIS_STRATEGY_VERSION" services/copilot-api/src/`
+Expected: a single declaration site (likely top of `settings.ts` or in a `settings-keys.ts` module). Add the new constant in the same place.
+
+- [ ] **Step 4.3: Add the SETTINGS_KEY constant**
+
+In the file you found in Step 4.2, alongside `SETTINGS_KEY_ANALYSIS_STRATEGY_VERSION`, add:
+
+```typescript
+export const SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG = 'orchestrated-v2-budget-config';
+```
+
+- [ ] **Step 4.4: Add the GET / PUT endpoint pair to settings.ts**
+
+Open `services/copilot-api/src/routes/settings.ts`. Find the `analysis-strategy-version` PUT handler closing brace (~line 1200). Immediately after, add:
+
+```typescript
+  // ---------------------------------------------------------------------------
+  // Orchestrated v2 Budget Config (#470)
+  // ---------------------------------------------------------------------------
+
+  fastify.get('/api/settings/orchestrated-v2-budget-config', async () => {
+    const row = await fastify.db.appSetting.findUnique({
+      where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+    });
+    if (!row) return OrchestratedV2BudgetConfigSchema.parse({});
+    const parsed = OrchestratedV2BudgetConfigSchema.safeParse(row.value);
+    if (!parsed.success) {
+      logger.warn(
+        { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG, errors: parsed.error.issues },
+        'Stored orchestrated-v2 budget config is malformed — resetting to defaults',
+      );
+      const defaults = OrchestratedV2BudgetConfigSchema.parse({});
+      await fastify.db.appSetting.update({
+        where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+        data: { value: defaults as unknown as object },
+      });
+      return defaults;
+    }
+    return parsed.data;
+  });
+
+  fastify.put<{ Body: Record<string, unknown> }>(
+    '/api/settings/orchestrated-v2-budget-config',
+    { preHandler: requireRole(OperatorRole.ADMIN) },
+    async (request) => {
+      const parsed = OrchestratedV2BudgetConfigSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+        return fastify.httpErrors.badRequest(`Invalid orchestrated-v2 budget config: ${msg}`);
+      }
+      const config = parsed.data;
+      const row = await fastify.db.appSetting.upsert({
+        where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+        update: { value: config as unknown as object },
+        create: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG, value: config as unknown as object },
+      });
+      return row.value as typeof config;
+    },
+  );
+```
+
+Add `OrchestratedV2BudgetConfigSchema` to the imports at the top of the file:
+
+```typescript
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
+```
+
+- [ ] **Step 4.5: Build copilot-api**
+
+Run: `pnpm --filter @bronco/copilot-api build`
+Expected: clean.
+
+- [ ] **Step 4.6: Smoke-test via curl**
+
+Start dev server: `pnpm dev:api` (in a separate terminal, leave running until end of task).
+
+```bash
+curl -s http://localhost:3000/api/settings/orchestrated-v2-budget-config | jq .
+```
+Expected: returns the JSON config with all default values.
+
+```bash
+curl -s -X PUT http://localhost:3000/api/settings/orchestrated-v2-budget-config \
+  -H 'Content-Type: application/json' \
+  -H "Cookie: $(get_admin_session_cookie)" \
+  -d '{"ticket":{"totalTokenBudget":250000}}' | jq .
+```
+(Operator must be admin; obtain cookie however local dev does it.)
+Expected: returns the merged config with `ticket.totalTokenBudget=250000` and other fields at defaults.
+
+```bash
+curl -s http://localhost:3000/api/settings/orchestrated-v2-budget-config | jq .ticket.totalTokenBudget
+```
+Expected: `250000` (persisted).
+
+Reset to defaults:
+```bash
+curl -s -X PUT http://localhost:3000/api/settings/orchestrated-v2-budget-config \
+  -H 'Content-Type: application/json' \
+  -H "Cookie: $(get_admin_session_cookie)" \
+  -d '{}'
+```
+Expected: returns the all-defaults config.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add services/copilot-api/src/routes/settings.ts services/copilot-api/src/routes/settings-keys.ts
+git commit -m "feat(api): GET/PUT orchestrated-v2-budget-config endpoints (#470)
+
+Per-feature settings endpoint pair following the analysis-strategy-version
+template. PUT is ADMIN-only; Zod-validated; malformed stored values are
+auto-reset to defaults on GET with a WARN log.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(If `settings-keys.ts` didn't exist and the constant lives in `settings.ts`, just stage `settings.ts`.)
+
+---
+
+## Task 5: Sub-task system prompt revision (Layer A)
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts:523-530`
+
+Replace the misleading "call finalize_subtask as the LAST action" instruction with budget-aware guidance. The new prompt is static (no config inputs) — A is the cheapest layer.
+
+- [ ] **Step 5.1: Update `subTaskInstructions`**
+
+Open `services/ticket-analyzer/src/analysis/orchestrated-v2.ts`. Locate `subTaskInstructions` (lines ~523-530). Replace the entire array literal with:
+
+```typescript
+  const subTaskInstructions = [
+    'You are a focused investigator. Execute your sub-task intent thoroughly using the available tools.',
+    'Record each finding by calling kd_* tools (platform__kd_add_subsection, platform__kd_update_section).',
+    'Do NOT dump raw tool output into your response — the knowledge doc is the source of truth.',
+    '',
+    'BUDGET DISCIPLINE — read carefully:',
+    '- You have a hard budget (tokens, iterations, tool calls). The runner will warn you when you cross 60%.',
+    '- When using `platform__read_tool_result_artifact`, prefer `grep` mode to find specific patterns over paging through chunks. If the truncated preview shown in the prior tool_result is enough to support a finding, work from that — do NOT re-read the same artifact.',
+    '- Re-reading the same artifact more than once will trigger a warning. Heed it.',
+    '- Partial findings with what you have are MORE useful than burning the entire budget chasing more.',
+    'When you have enough to justify a finding, call `finalize_subtask` with a concise summary (100-300 words)',
+    'and the list of KD section keys you updated. Earlier finalize is better than budget-exhausted.',
+  ].join(' ');
+```
+
+- [ ] **Step 5.2: Locate the existing snapshot test for the prompt (if any)**
+
+Run: `grep -n "subTaskInstructions\|focused investigator" services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`
+
+If a snapshot exists, update it. If none, skip — the prompt is exercised by integration tests in Task 8.
+
+- [ ] **Step 5.3: Build the analyzer**
+
+Run: `pnpm --filter @bronco/ticket-analyzer build`
+Expected: clean.
+
+- [ ] **Step 5.4: Run all analyzer tests**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test`
+Expected: PASS. If a snapshot fails because of the prompt change, regenerate the snapshot (`pnpm test -u`).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+git commit -m "feat(analyzer): budget-aware sub-task system prompt (#470 layer A)
+
+Replaces 'call finalize_subtask as the LAST action — do not call before
+gathered all data' (which actively encouraged budget exhaustion) with
+explicit budget discipline:
+  - explains the threshold-warning mechanism
+  - tells the agent to grep instead of paging artifacts
+  - declares partial findings preferable to budget burn
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Wire re-read detector into `runSubTaskLoop` (Layer C)
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` (`runSubTaskLoop`)
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`
+
+Maintain a per-sub-task `Map<artifactId, count>`. After each `read_tool_result_artifact` call, evaluate via `detectArtifactReread`. When it fires, append a guidance line to that tool's `tool_result.content`.
+
+- [ ] **Step 6.1: Add an integration test stub for the wiring**
+
+Open `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`. Add a new `describe` block (after existing ones):
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+// imports for runSubTaskLoop test fixtures — match the patterns already in this file
+
+describe('runSubTaskLoop — re-read detector (Layer C)', () => {
+  it('appends a re-read warning to the second tool_result for the same artifactId', async () => {
+    // Arrange: build a stubbed AnalysisDeps where ai.generateWithTools returns
+    //   iter1: tool_use read_tool_result_artifact (artifactId=A)
+    //   iter2: tool_use read_tool_result_artifact (artifactId=A)  // re-read
+    //   iter3: tool_use finalize_subtask
+    // Act: invoke runSubTaskLoop with this stub
+    // Assert: the messages array passed into the iter3 generateWithTools call
+    //         contains a tool_result whose content includes the substring
+    //         "You've read artifact" (case-insensitive) — emitted on the second read.
+
+    // Detailed setup follows the existing test pattern in this file. If no
+    // existing pattern matches, build a minimal stub that satisfies the
+    // imports of runSubTaskLoop and its types. The stub does NOT need to
+    // execute real MCP tools — replace `executeAgenticToolCall` via vi.mock
+    // to return a synthetic, non-error result.
+
+    expect(true).toBe(false); // placeholder — replace with real assertion in Step 6.4
+  });
+});
+```
+
+- [ ] **Step 6.2: Run the test to verify it fails**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test src/analysis/orchestrated-v2.test.ts -t "re-read detector"`
+Expected: FAIL — placeholder `expect(true).toBe(false)`.
+
+- [ ] **Step 6.3: Wire the detector into `runSubTaskLoop`**
+
+Open `services/ticket-analyzer/src/analysis/orchestrated-v2.ts`. Locate the top of `runSubTaskLoop` (line 148+). Add imports near the top of the file:
+
+```typescript
+import { detectArtifactReread, evaluateSubTaskBudget } from './budget-thresholds.js';
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+```
+
+Update the `runSubTaskLoop` signature to accept the budget config:
+
+```typescript
+async function runSubTaskLoop(
+  deps: AnalysisDeps,
+  ticketId: string,
+  clientId: string,
+  category: string,
+  skipClientMemory: boolean,
+  subTaskId: string,
+  intent: string,
+  contextKdSections: string[],
+  tools: AIToolDefinition[],
+  mcpIntegrations: Map<string, McpIntegrationInfo>,
+  repoIdByPrefix: Map<string, string>,
+  subTaskSystemPrompt: string,
+  model: string,
+  budgetConfig: OrchestratedV2BudgetConfig,                                   // NEW
+  orchestration?: { id: string; iteration: number; parentLogId?: string },
+  toolResultMaxTokens?: number,
+  defaultMaxTokens?: number,
+): Promise<SubTaskRunResult> {
+```
+
+Inside `runSubTaskLoop`, after the existing `failureTracker` declaration (around line 172), add:
+
+```typescript
+  const artifactReadCounts = new Map<string, number>();
+```
+
+Within the per-tool-call block (around lines 344-406, the `for (const toolUse of toolUseBlocks)` loop), AFTER `toolResults.push(...)` is called and BEFORE the next iteration of the inner for-loop, add the re-read check. The cleanest path is to compute the warning BEFORE pushing the tool_result, so we can include the warning in the content. Restructure the block slightly:
+
+Locate the existing block (~lines 360-378):
+```typescript
+      const fullResult = result.result;
+      const fullSizeChars = fullResult.length;
+      const threshold = toolResultMaxTokens ?? 4000;
+      const artifactId = deps.artifactStoragePath && !result.isError ? randomUUID() : undefined;
+      const truncated = !result.isError && !!artifactId && shouldTruncate(fullResult, threshold);
+      const contentForModel = truncated && artifactId
+        ? buildTruncatedPreview(fullResult, artifactId)
+        : fullResult;
+
+      toolCallLog.push({
+        tool: toolUse.name,
+        system: (toolUse.input as Record<string, unknown>)?.system_name as string | undefined,
+        input: toolUse.input,
+        output: fullResult.slice(0, 500),
+        durationMs: elapsed,
+      });
+
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: contentForModel,
+        ...(result.isError ? { is_error: true } : {}),
+      });
+```
+
+Replace the `toolResults.push(...)` block with:
+
+```typescript
+      // Layer C: detect re-reads of the same artifact and append a guidance nudge
+      let contentWithMaybeNudge: string = contentForModel;
+      if (toolUse.name === 'platform__read_tool_result_artifact') {
+        const inputArtifactId = (toolUse.input as Record<string, unknown>)?.artifactId;
+        if (typeof inputArtifactId === 'string' && inputArtifactId.length > 0) {
+          const fired = detectArtifactReread(
+            artifactReadCounts,
+            inputArtifactId,
+            budgetConfig.subTaskReReadDetector.warnAfterReadCount,
+          );
+          if (fired) {
+            const count = artifactReadCounts.get(inputArtifactId) ?? 0;
+            contentWithMaybeNudge = [
+              contentForModel,
+              '',
+              `⚠️ You have read artifact ${inputArtifactId} ${count} times in this sub-task. Use \`grep\` mode to find specific patterns, or proceed with the data you have and call \`finalize_subtask\`.`,
+            ].join('\n');
+          }
+        }
+      }
+
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: contentWithMaybeNudge,
+        ...(result.isError ? { is_error: true } : {}),
+      });
+```
+
+- [ ] **Step 6.4: Implement the test from Step 6.1**
+
+Replace the placeholder `expect(true).toBe(false)` with the real assertion. Example pattern (adapt to whatever fixture style is already used in the file):
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import type { AIToolUseBlock } from '@bronco/shared-types';
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
+// import the actual runSubTaskLoop or its public re-export — adjust as needed
+// (runSubTaskLoop is currently NOT exported from orchestrated-v2.ts; if so, export it
+// for testability or add a thin wrapper. The minimal change: export it.)
+
+describe('runSubTaskLoop — re-read detector (Layer C)', () => {
+  it('appends a re-read warning to the second tool_result for the same artifactId', async () => {
+    const sameArtifactId = '11111111-1111-1111-1111-111111111111';
+
+    const generateWithToolsCalls: Array<{ messages: unknown[] }> = [];
+    const ai = {
+      generateWithTools: vi.fn(async ({ messages }: { messages: unknown[] }) => {
+        generateWithToolsCalls.push({ messages: structuredClone(messages) });
+        const callIndex = generateWithToolsCalls.length;
+        if (callIndex === 1) {
+          return {
+            stopReason: 'tool_use',
+            usage: { inputTokens: 100, outputTokens: 50 },
+            contentBlocks: [
+              {
+                type: 'tool_use',
+                id: 'tu-1',
+                name: 'platform__read_tool_result_artifact',
+                input: { artifactId: sameArtifactId, ticketId: 'tk', offset: 0, limit: 4000 },
+              } satisfies AIToolUseBlock,
+            ],
+          };
+        }
+        if (callIndex === 2) {
+          return {
+            stopReason: 'tool_use',
+            usage: { inputTokens: 100, outputTokens: 50 },
+            contentBlocks: [
+              {
+                type: 'tool_use',
+                id: 'tu-2',
+                name: 'platform__read_tool_result_artifact',
+                input: { artifactId: sameArtifactId, ticketId: 'tk', offset: 4000, limit: 4000 },
+              } satisfies AIToolUseBlock,
+            ],
+          };
+        }
+        // Third call: finalize
+        return {
+          stopReason: 'tool_use',
+          usage: { inputTokens: 100, outputTokens: 50 },
+          contentBlocks: [
+            {
+              type: 'tool_use',
+              id: 'tu-3',
+              name: 'finalize_subtask',
+              input: { summary: 'done', updatedKdSections: [] },
+            } satisfies AIToolUseBlock,
+          ],
+        };
+      }),
+    };
+
+    // Mock the executeAgenticToolCall side-effect to return synthetic content
+    vi.mock('./shared.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./shared.js')>();
+      return {
+        ...actual,
+        executeAgenticToolCall: vi.fn(async () => ({
+          result: 'fake artifact content',
+          isError: false,
+        })),
+      };
+    });
+
+    const deps = {
+      ai,
+      db: { /* minimal stub — runSubTaskLoop calls loadKnowledgeDoc only when contextKdSections nonempty */ },
+      appLog: { info: vi.fn(), warn: vi.fn() },
+      artifactStoragePath: undefined, // skip artifact-write path
+    };
+
+    const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+    // Call runSubTaskLoop — adjust import path / export visibility as needed
+    const { runSubTaskLoop } = await import('./orchestrated-v2.js');
+
+    await runSubTaskLoop(
+      deps as never,
+      'tk',
+      'cl',
+      'GENERAL',
+      false,
+      'st-1',
+      'test intent',
+      [],
+      [], // tools
+      new Map(),
+      new Map(),
+      'test system prompt',
+      'haiku',
+      config,
+    );
+
+    // The 3rd generateWithTools call's messages array should contain the
+    // tool_result for tu-2 with the warning embedded.
+    const thirdCallMessages = generateWithToolsCalls[2].messages as Array<{ role: string; content: unknown }>;
+    const lastUserMsg = [...thirdCallMessages].reverse().find(m => m.role === 'user');
+    const lastUserContent = JSON.stringify(lastUserMsg?.content ?? '');
+    expect(lastUserContent).toMatch(/you have read artifact/i);
+    expect(lastUserContent).toMatch(/2 times/i);
+  });
+});
+```
+
+If `runSubTaskLoop` is not currently exported, add `export` to its declaration in `orchestrated-v2.ts`.
+
+- [ ] **Step 6.5: Run the test to verify it passes**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test src/analysis/orchestrated-v2.test.ts -t "re-read detector"`
+Expected: PASS.
+
+Run the full test suite to confirm no regressions:
+`pnpm --filter @bronco/ticket-analyzer test`
+Expected: PASS.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+git commit -m "feat(analyzer): per-artifact re-read detector in sub-task loop (#470 layer C)
+
+Counts read_tool_result_artifact calls per artifactId within a
+sub-task. When count crosses the configured threshold (default 2),
+appends a warning to the next tool_result instructing the agent to
+use grep mode or finalize.
+
+Threads OrchestratedV2BudgetConfig through runSubTaskLoop signature
+in preparation for layers B (token thresholds) and the wire-up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Sub-task budget soft-nudge + hard-stop in `runSubTaskLoop` (Layer B)
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` (`runSubTaskLoop`)
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`
+
+At the top of each iteration in `runSubTaskLoop`, evaluate `evaluateSubTaskBudget`. On `SOFT_NUDGE` (first crossing only), inject a synthetic `tool_result` warning into `messages` BEFORE the `generateWithTools` call. On `HARD_STOP`, restrict the `tools` parameter to `[FINALIZE_SUBTASK_TOOL]` only.
+
+- [ ] **Step 7.1: Add the integration tests for B**
+
+Add to `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`:
+
+```typescript
+describe('runSubTaskLoop — budget thresholds (Layer B)', () => {
+  it('injects a soft-nudge tool_result on the iteration that crosses 60%', async () => {
+    // Stub generateWithTools to consume tokens such that after iter1 we're at 65% of 50k = 32.5k
+    // Assert: iter2's messages contains a system-style tool_result with "60%" or "Budget" warning
+    expect(true).toBe(false); // placeholder
+  });
+
+  it('restricts tool list to [finalize_subtask] only when crossing 85%', async () => {
+    // Stub generateWithTools usage to push past 85% by iter2
+    // Assert: iter3's `tools` parameter has length 1 and name finalize_subtask
+    expect(true).toBe(false); // placeholder
+  });
+});
+```
+
+- [ ] **Step 7.2: Run the new tests to verify they fail**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test src/analysis/orchestrated-v2.test.ts -t "budget thresholds"`
+Expected: FAIL.
+
+- [ ] **Step 7.3: Implement Layer B in `runSubTaskLoop`**
+
+Open `orchestrated-v2.ts`. In `runSubTaskLoop`, locate the top of the iteration loop (`for (let iteration = 0; ...)` ~line 221). Add state-tracking flags BEFORE the loop:
+
+```typescript
+  let softNudgeFired = false;
+  let hardStopActive = false;
+  // toolsWithFinalize already exists earlier in the function
+  const finalizeOnlyTools: AIToolDefinition[] = [FINALIZE_SUBTASK_TOOL];
+```
+
+REPLACE the existing budget hard-cap block at the top of the iteration loop (the existing `if (tokensSoFar >= SUB_TASK_TOKEN_BUDGET) break;` and `if (totalToolCalls >= SUB_TASK_CALL_BUDGET) break;`) with the new evaluator-based logic:
+
+```typescript
+    lastIterationRun = iteration + 1;
+    const tokensSoFar = totalInputTokens + totalOutputTokens;
+
+    const verdict = evaluateSubTaskBudget(
+      { tokensUsed: tokensSoFar, iterationsUsed: iteration, toolCallsUsed: totalToolCalls },
+      budgetConfig.subTask,
+    );
+
+    if (verdict === 'SOFT_NUDGE' && !softNudgeFired) {
+      softNudgeFired = true;
+      const tokenPct = Math.round((tokensSoFar / budgetConfig.subTask.tokenBudget) * 100);
+      const callPct = Math.round((totalToolCalls / budgetConfig.subTask.callBudget) * 100);
+      const iterPct = Math.round((iteration / budgetConfig.subTask.iterationCap) * 100);
+      // Inject a synthetic user-role text message (NOT a tool_result, since no
+      // tool_use is pending). Models treat user messages as conversation turns;
+      // this won't break the well-formed message thread.
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ Budget warning: tokens ${tokenPct}%, tool calls ${callPct}%, iterations ${iterPct}%. You are crossing 60% of one or more budgets. Consider finalizing soon — call \`finalize_subtask\` with what you have if your findings already support a useful summary. Further tool calls will be cut off at 85%.`,
+          },
+        ],
+      });
+      appLog.info(
+        `Sub-task ${subTaskId} soft-nudge fired at iteration ${iteration + 1} (tokens=${tokenPct}%, calls=${callPct}%, iter=${iterPct}%)`,
+        { ticketId, subTaskId, iteration: iteration + 1 },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    if (verdict === 'HARD_STOP') {
+      hardStopActive = true;
+      appLog.info(
+        `Sub-task ${subTaskId} hard-stop active at iteration ${iteration + 1} — restricting tools to [finalize_subtask]`,
+        { ticketId, subTaskId, iteration: iteration + 1, tokensSoFar, totalToolCalls },
+        ticketId,
+        'ticket',
+      );
+      // If the model has already had one chance with restricted tools and STILL
+      // didn't finalize, break out — we don't want to spend any more iterations.
+      // Detection: if the previous message turn was already a finalize-only
+      // generateWithTools call, the agent is genuinely stuck.
+      // For simplicity and because the agent can almost always finalize when the
+      // tool list is just finalize_subtask, we allow ONE pass before breaking.
+      if (iteration > 0 && hardStopActive) {
+        // Already in hard-stop from prior iteration — give one more chance, then exit
+        // (this branch only triggers if the loop reached here in two consecutive iterations
+        // with hardStopActive=true, which means the agent didn't call finalize_subtask
+        // even when offered no other tool. Bail out via existing budget-exhaustion path.)
+      }
+    }
+```
+
+Then UPDATE the `generateWithTools` call inside the loop to use the conditional tool list:
+
+```typescript
+      response = await ai.generateWithTools({
+        // ...existing fields...
+        tools: hardStopActive ? finalizeOnlyTools : toolsWithFinalize,
+        // ...rest unchanged
+      });
+```
+
+(Find the existing `tools: toolsWithFinalize,` line — around line 266 — and swap.)
+
+NOTE: The existing budget-exhaustion path at the end of the function (`partialSummary = fallbackFromToolResults(...)` ~ line 461) remains unchanged — it's the safety net for the case where even `finalizeOnlyTools` fails to produce a `finalize_subtask` call.
+
+- [ ] **Step 7.4: Implement the tests from Step 7.1**
+
+Replace the placeholder tests with real assertions following the same `vi.mock('./shared.js')` + `generateWithTools` stub pattern from Task 6. Each test injects token usage in the `usage` field of the stubbed response so the budget evaluator crosses the threshold.
+
+Soft-nudge test:
+```typescript
+it('injects a soft-nudge user message on the iteration that crosses 60%', async () => {
+  // Stub: iter1 returns usage = { inputTokens: 32_000, outputTokens: 1_000 }  → 33k of 50k = 66%
+  // After iter1, before iter2's call, evaluator returns SOFT_NUDGE.
+  // Assert: iter2's `messages` contains a user message with text ".*60%.*" or "Budget warning"
+
+  const calls: Array<{ messages: unknown[]; tools: { name: string }[] }> = [];
+  const ai = {
+    generateWithTools: vi.fn(async ({ messages, tools }) => {
+      calls.push({ messages: structuredClone(messages), tools });
+      const idx = calls.length;
+      if (idx === 1) {
+        return {
+          stopReason: 'tool_use',
+          usage: { inputTokens: 32_000, outputTokens: 1_000 },
+          contentBlocks: [{ type: 'tool_use', id: 't1', name: 'finalize_subtask', input: { summary: 's', updatedKdSections: [] } }],
+        };
+      }
+      // unreachable in this test (finalize already called)
+      throw new Error('unexpected iter ' + idx);
+    }),
+  };
+  // ... shared stub pattern as in Task 6 ...
+  await runSubTaskLoop(deps as never, 'tk', 'cl', 'GENERAL', false, 'st', 'intent', [], [], new Map(), new Map(), 'sp', 'haiku', config);
+
+  // Soft nudge fires AT THE TOP of iter2 (which never runs because iter1 finalized)
+  // — to test the soft-nudge injection more directly, structure the stub so iter1
+  // does NOT finalize but instead consumes 33k tokens via a non-decision tool, then
+  // iter2 finalizes. The test should assert the iter2 messages contain the warning.
+  // (Adapt accordingly.)
+});
+```
+
+Hard-stop test follows the same pattern but with `iter1` consuming 43k tokens and asserting `calls[1].tools.length === 1 && calls[1].tools[0].name === 'finalize_subtask'`.
+
+- [ ] **Step 7.5: Run all the analyzer tests**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test`
+Expected: all PASS, including the new B tests.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+git commit -m "feat(analyzer): sub-task budget soft-nudge + hard-stop (#470 layer B)
+
+At the top of each iteration in runSubTaskLoop:
+- evaluate against the configured soft/hard ratios across tokens,
+  iterations, and tool calls (worst-axis wins)
+- on SOFT_NUDGE first crossing: inject a budget-warning user message
+  into the conversation
+- on HARD_STOP: restrict the next generateWithTools call's tool list
+  to [finalize_subtask] only — the only remaining option is to wrap up
+
+Existing budget-exhaustion safety net at end of the loop is unchanged
+and serves as the final backstop.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Strategist batch-failure guard (Layer D)
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` (`runOrchestratedV2`)
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`
+
+In `runOrchestratedV2`, after each dispatch_subtasks batch resolves and `allSubTaskResults` is populated, evaluate `evaluateBatchFailureGuard`. SOFT_NUDGE injects a tool_result warning before the next strategist iteration; HARD_STOP restricts `finalStrategistTools` to `[COMPLETE_ANALYSIS_TOOL, kd_read_toc, kd_read_section]` for the rest of the run.
+
+- [ ] **Step 8.1: Add the integration test**
+
+```typescript
+describe('runOrchestratedV2 — batch-failure guard (Layer D)', () => {
+  it('hard-stops when 80% of two consecutive batches were BUDGET_EXHAUSTED', async () => {
+    // Stub: 2 strategist iterations dispatch 5 sub-tasks each; each sub-task stub returns
+    //   { stopReason: 'BUDGET_EXHAUSTED', updatedKdSections: [] }
+    // Assert: third strategist generateWithTools call's `tools` parameter does NOT contain
+    //         dispatch_subtasks — only complete_analysis, kd_read_toc, kd_read_section
+    expect(true).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 8.2: Run to verify failure**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test -t "batch-failure guard"` — expect FAIL.
+
+- [ ] **Step 8.3: Wire the guard into `runOrchestratedV2`**
+
+Open `orchestrated-v2.ts`. Locate `runOrchestratedV2` (~line 842). Near the existing `stallState` declaration (~line 977), add the new guard state:
+
+```typescript
+import { evaluateBatchFailureGuard, type BatchFailureGuardState } from './budget-thresholds.js';
+
+const batchFailureState: BatchFailureGuardState = {
+  cumulativeExhausted: 0,
+  cumulativeTotal: 0,
+  consecutiveBadBatches: 0,
+};
+let strategistHardStopActive = false;
+
+// Pre-build the restricted strategist tool list (computed once)
+const restrictedStrategistTools: AIToolDefinition[] = finalStrategistTools.filter(
+  t => t.name === 'complete_analysis' || t.name === 'platform__kd_read_toc' || t.name === 'platform__kd_read_section',
+);
+```
+
+Inside the strategist's inner tool-loop (~line 1018), where the `tools: finalStrategistTools` parameter is set on `generateWithTools`, swap to:
+
+```typescript
+        tools: strategistHardStopActive ? restrictedStrategistTools : finalStrategistTools,
+```
+
+After the batch executes and `allSubTaskResults` is populated (after line 1353), BEFORE the `if (dispatchCallId)` block that pushes results back to the strategist, add:
+
+```typescript
+      // Layer D: evaluate batch-failure guard
+      const isFirstBatch = batchFailureState.cumulativeTotal === 0;
+      const guardVerdict = evaluateBatchFailureGuard(
+        batchFailureState,
+        allSubTaskResults.map(r => ({ stopReason: r.stopReason, updatedKdSections: r.updatedKdSections })),
+        budgetConfig.strategistGuard,
+        isFirstBatch,
+      );
+
+      if (guardVerdict === 'HARD_STOP') {
+        strategistHardStopActive = true;
+        appLog.warn(
+          `Strategist hard-stop activated at iteration ${i + 1} — cumulative ${batchFailureState.cumulativeExhausted}/${batchFailureState.cumulativeTotal} sub-tasks BUDGET_EXHAUSTED, consecutiveBadBatches=${batchFailureState.consecutiveBadBatches}`,
+          { ticketId, iteration: i + 1, cumulative: batchFailureState },
+          ticketId,
+          'ticket',
+        );
+      }
+```
+
+In the `if (dispatchCallId)` block where the tool_result content is built (lines 1359-1378), modify the `JSON.stringify(resultPayload, null, 2)` content to optionally prepend a guard message:
+
+```typescript
+      if (dispatchCallId) {
+        const resultPayload = allSubTaskResults.map(r => ({
+          sub_task_id: r.subTaskId,
+          intent: r.intent,
+          summary: r.summary,
+          updatedKdSections: r.updatedKdSections,
+          stopReason: r.stopReason,
+          iterationsUsed: r.iterationsUsed,
+          tokensUsed: r.tokensUsed,
+        }));
+
+        let guardWarning = '';
+        if (guardVerdict === 'SOFT_NUDGE') {
+          guardWarning = `⚠️ ${batchFailureState.cumulativeExhausted}/${batchFailureState.cumulativeTotal} sub-tasks BUDGET_EXHAUSTED so far. Many of those produced no usable findings (empty updatedKdSections). Before dispatching another batch, read the knowledge doc with kd_read_toc to see what's been written, and consider whether complete_analysis is the right next call.\n\n`;
+        } else if (guardVerdict === 'HARD_STOP') {
+          guardWarning = `⚠️ Cost guard hard-stop: too many sub-tasks BUDGET_EXHAUSTED. Further dispatch is blocked. You may now ONLY call complete_analysis (or kd_read_toc / kd_read_section to inspect findings before doing so). Wrap up the analysis with what's available.\n\n`;
+        }
+
+        const content = guardWarning + JSON.stringify(resultPayload, null, 2);
+
+        strategistMessages.push({
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: dispatchCallId,
+              content,
+            } satisfies AIToolResultBlock,
+          ],
+        });
+      } else {
+        // ...existing fallback path unchanged...
+      }
+```
+
+- [ ] **Step 8.4: Implement the test**
+
+Build the stub generator that returns 5 BUDGET_EXHAUSTED results per dispatch and runs for 2 iterations of dispatch + 1 iteration where the strategist tool list should be restricted. Assert via `expect(calls[N].tools).not.toContainEqual(expect.objectContaining({ name: 'dispatch_subtasks' }))`.
+
+- [ ] **Step 8.5: Run analyzer tests**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test` — all PASS.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+git commit -m "feat(analyzer): strategist batch-failure guard (#470 layer D)
+
+Tracks per-batch and cumulative BUDGET_EXHAUSTED ratios across the
+orchestrated-v2 strategist loop. Trips on:
+- SOFT_NUDGE: ≥50% of current batch BUDGET_EXHAUSTED with empty
+  updatedKdSections (and not first batch). Injects a warning into the
+  next strategist tool_result.
+- HARD_STOP: cumulative ≥50% BUDGET_EXHAUSTED, OR 2 consecutive batches
+  each ≥80% BUDGET_EXHAUSTED. Restricts strategist tool list to
+  [complete_analysis, kd_read_toc, kd_read_section] for remainder of run.
+
+Sibling guard alongside the existing updateStallState — does NOT replace.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Ticket-level total-token budget + continuation summary (Layer E + E.1)
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` (`runOrchestratedV2`)
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts`
+
+`orchTotalInputTokens + orchTotalOutputTokens` are already tracked in `runOrchestratedV2`. Add `evaluateTicketBudget` check at the top of each strategist iteration. SOFT_NUDGE injects warning into next strategist message. HARD_STOP restricts strategist tools (same restricted list as D) AND injects the E.1 continuation-summary directive into the message stream.
+
+- [ ] **Step 9.1: Add the integration test**
+
+```typescript
+describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
+  it('hard-stops at 95% of totalTokenBudget and injects the continuation-notes directive', async () => {
+    // Set config.ticket.totalTokenBudget to 1000 for fast threshold crossing.
+    // Stub strategist generateWithTools to consume 950 tokens on iter 1.
+    // Assert: iter 2's messages contains a tool_result with substring "## Continuation Notes"
+    //         AND the tools parameter is the restricted set.
+    expect(true).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 9.2: Run to verify failure**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test -t "ticket budget"` — expect FAIL.
+
+- [ ] **Step 9.3: Implement Layers E + E.1**
+
+In `runOrchestratedV2`, near the strategist hard-stop state from Task 8:
+
+```typescript
+import { evaluateTicketBudget } from './budget-thresholds.js';
+
+let ticketSoftNudgeFired = false;
+let ticketHardStopActive = false;
+```
+
+The `restrictedStrategistTools` from Task 8 is reused.
+
+At the top of the OUTER strategist loop (`for (let i = 0; i < orchMaxIterations; i++)` ~line 1005), BEFORE the inner tool loop starts, add:
+
+```typescript
+    // Layer E: ticket-level total-token budget evaluation
+    const totalTokensSoFar = orchTotalInputTokens + orchTotalOutputTokens;
+    const ticketVerdict = evaluateTicketBudget(totalTokensSoFar, budgetConfig.ticket);
+
+    if (ticketVerdict === 'SOFT_NUDGE' && !ticketSoftNudgeFired) {
+      ticketSoftNudgeFired = true;
+      const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
+      // The strategist's last message was a tool_result for dispatch_subtasks
+      // (or initial user prompt). Inject a follow-up user-text message warning.
+      strategistMessages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ Ticket budget at ${pct}% (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens). You are approaching the cost cap. Consider whether enough findings are in the knowledge doc to call complete_analysis. Further dispatch will be blocked at 95%.`,
+          },
+        ],
+      });
+      appLog.info(
+        `Ticket soft-nudge at iteration ${i + 1} (${pct}% of budget consumed)`,
+        { ticketId, iteration: i + 1, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    if (ticketVerdict === 'HARD_STOP' && !ticketHardStopActive) {
+      ticketHardStopActive = true;
+      const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
+      appLog.warn(
+        `Ticket hard-stop activated at iteration ${i + 1} (${pct}% of budget consumed)`,
+        { ticketId, iteration: i + 1, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
+        ticketId,
+        'ticket',
+      );
+
+      // E.1: Inject the continuation-summary directive
+      strategistMessages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: [
+              `⚠️ Ticket budget hard-cap reached (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens, ${pct}%). You can no longer dispatch sub-tasks.`,
+              `Read the knowledge doc with \`kd_read_toc\` / \`kd_read_section\` and call \`complete_analysis\` next.`,
+              ``,
+              `**Required:** include a \`## Continuation Notes\` section in your \`finalAnalysis\` with the following structure (use exactly these subheadings):`,
+              ``,
+              `\`\`\``,
+              `## Continuation Notes`,
+              ``,
+              `### What we established`,
+              `- <bullet list of confirmed findings, each with KD section reference>`,
+              ``,
+              `### Hypotheses still open`,
+              `- <bullet list of hypotheses introduced but not verified>`,
+              ``,
+              `### Investigation threads not completed`,
+              `- <bullet list of sub-task intents that hit BUDGET_EXHAUSTED with no usable summary>`,
+              ``,
+              `### Suggested next batch`,
+              `- <2–3 sub-task intents that would be most valuable to retry on continuation, with which artifacts/sections to load as context>`,
+              `\`\`\``,
+              ``,
+              `Going slightly over the budget cap to write this summary is permitted and expected.`,
+            ].join('\n'),
+          },
+        ],
+      });
+    }
+```
+
+The `tools` parameter on the strategist's `generateWithTools` call in the inner loop becomes:
+
+```typescript
+        tools: (strategistHardStopActive || ticketHardStopActive) ? restrictedStrategistTools : finalStrategistTools,
+```
+
+(Replace the prior single-condition swap from Task 8.)
+
+- [ ] **Step 9.4: Implement the test**
+
+Build the stub: small `totalTokenBudget` (e.g., 1000), stub strategist to return `usage: { inputTokens: 950, outputTokens: 0 }` on iter 1, then `complete_analysis` on iter 2. Assert:
+- iter 2's `messages` includes a user text message containing `## Continuation Notes`
+- iter 2's `tools` is the restricted set (length 3, includes `complete_analysis` but NOT `dispatch_subtasks`)
+
+- [ ] **Step 9.5: Run analyzer tests**
+
+Run: `pnpm --filter @bronco/ticket-analyzer test` — all PASS.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+git commit -m "feat(analyzer): ticket-level budget cap + continuation summary (#470 layer E + E.1)
+
+At the top of each strategist iteration in runOrchestratedV2:
+- evaluate accumulated input+output tokens vs config.ticket.totalTokenBudget
+- on SOFT_NUDGE (default 75%): inject a budget-warning user message into
+  the strategist's next turn (fires once per run)
+- on HARD_STOP (default 95%): inject the E.1 continuation-notes directive
+  AND restrict the strategist's tool list to [complete_analysis,
+  kd_read_toc, kd_read_section]
+
+The continuation directive instructs the strategist to write a
+structured 'Continuation Notes' section in finalAnalysis covering: what
+was established, open hypotheses, incomplete threads, and suggested
+next-batch sub-task intents. This bounds the cost overshoot to one
+strategist call (~8k tokens) and provides resumable structured state
+for a future #48 Item 7 manual re-analysis flow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Wire `OrchestratedV2BudgetConfig` through the public entry point
+
+**Files:**
+- Modify: `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` (`runOrchestratedV2`)
+
+Up to this point, `runSubTaskLoop` accepts a `budgetConfig` parameter (added in Task 6) and `runOrchestratedV2` references `budgetConfig` (added in Tasks 8 + 9). Now thread the config from the resolver into `runOrchestratedV2` and remove the hard-coded `SUB_TASK_*` constants.
+
+- [ ] **Step 10.1: Load the budget config in `runOrchestratedV2`**
+
+Open `orchestrated-v2.ts`. Near the top of `runOrchestratedV2` (~line 856, after `defaultMaxTokens` and `toolResultMaxTokens` are loaded), add:
+
+```typescript
+  const budgetConfig = await resolveOrchestratedV2BudgetConfig(db);
+  appLog.info(
+    `Orchestrated v2 run starting with budget config: ticket=${budgetConfig.ticket.totalTokenBudget}, subTask.tokens=${budgetConfig.subTask.tokenBudget}`,
+    { ticketId, budgetConfig },
+    ticketId,
+    'ticket',
+  );
+```
+
+Add the import at the top of the file:
+
+```typescript
+import { resolveOrchestratedV2BudgetConfig } from './shared.js';
+```
+
+(Or merge into the existing `from './shared.js'` import.)
+
+- [ ] **Step 10.2: Replace the hard-coded constants in `runSubTaskLoop`**
+
+Find the existing constants at the top of `orchestrated-v2.ts` (~lines 92-97):
+
+```typescript
+const SUB_TASK_ITERATION_CAP = 8;
+const SUB_TASK_TOKEN_BUDGET = 50_000;
+const SUB_TASK_CALL_BUDGET = 20;
+```
+
+Replace with:
+
+```typescript
+/**
+ * Hard-coded fallback values for the orchestrated-v2 sub-task budget. These are
+ * the schema defaults from `OrchestratedV2BudgetConfigSchema` — kept here for
+ * reference and as the values used when the new config plumbing is bypassed
+ * (e.g. older callers of `runSubTaskLoop` not yet migrated).
+ *
+ * Live runtime values come from `resolveOrchestratedV2BudgetConfig(db)` and
+ * are passed through `runOrchestratedV2` → `runSubTaskLoop` via `budgetConfig`.
+ */
+const DEFAULT_SUB_TASK_BUDGET = {
+  iterationCap: 8,
+  tokenBudget: 50_000,
+  callBudget: 20,
+} as const;
+```
+
+In `runSubTaskLoop`, replace remaining direct references to `SUB_TASK_ITERATION_CAP` / `SUB_TASK_TOKEN_BUDGET` / `SUB_TASK_CALL_BUDGET` with `budgetConfig.subTask.iterationCap` / `.tokenBudget` / `.callBudget`. Also replace the budget-line text in the user prompt (~line 196):
+
+```typescript
+  const budgetLine = `## Budget\nMax ${budgetConfig.subTask.iterationCap} iterations, max ${budgetConfig.subTask.tokenBudget.toLocaleString()} tokens total, max ${budgetConfig.subTask.callBudget} tool calls. Call \`finalize_subtask\` once you are done — do not wait until budget is exhausted.`;
+```
+
+The for-loop bound:
+
+```typescript
+  for (let iteration = 0; iteration < budgetConfig.subTask.iterationCap; iteration++) {
+```
+
+- [ ] **Step 10.3: Update `executeOrchestratedSubTaskV2` to forward `budgetConfig`**
+
+Find the call to `runSubTaskLoop` inside `executeOrchestratedSubTaskV2` (~line 596). Add `budgetConfig` to the argument list — it'll need to be passed in via `executeOrchestratedSubTaskV2`'s signature:
+
+```typescript
+async function executeOrchestratedSubTaskV2(
+  // ...existing params...
+  budgetConfig: OrchestratedV2BudgetConfig,                                  // NEW
+  modelMap?: Record<string, string>,
+  toolResultMaxTokens?: number,
+): Promise<SubTaskRunResult> {
+```
+
+And forward to both `runSubTaskLoop` calls inside the function (the first call ~line 596, and the retry call ~line 631). Plus update the call sites in `runOrchestratedV2` (the parallel-batch dispatch around lines 1247 and 1298) to pass `budgetConfig`.
+
+- [ ] **Step 10.4: Build and run all tests**
+
+Run: `pnpm --filter @bronco/ticket-analyzer build`
+Expected: clean.
+
+Run: `pnpm --filter @bronco/ticket-analyzer test`
+Expected: all PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+git commit -m "feat(analyzer): wire OrchestratedV2BudgetConfig through runOrchestratedV2 (#470)
+
+Loads orchestrated-v2-budget-config AppSetting at the top of each run
+via resolveOrchestratedV2BudgetConfig, threads it through to
+runSubTaskLoop and the strategist evaluators. Hard-coded SUB_TASK_*
+constants replaced with DEFAULT_SUB_TASK_BUDGET for reference; live
+values now come from the runtime config.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Control panel — `SettingsService` methods
+
+**Files:**
+- Modify: `services/control-panel/src/app/features/settings/settings.service.ts`
+
+Add a service method pair following the existing `getAnalysisStrategyVersion` / `saveAnalysisStrategyVersion` template (per prior recon at `settings.service.ts:302-307`).
+
+- [ ] **Step 11.1: Read the existing service method as the template**
+
+Run: `sed -n '290,320p' services/control-panel/src/app/features/settings/settings.service.ts`
+Expected: shows the existing analysis-strategy-version method pair.
+
+- [ ] **Step 11.2: Add the new methods**
+
+Append after the analysis-strategy-version pair:
+
+```typescript
+  // ---------------------------------------------------------------------------
+  // Orchestrated v2 Budget Config (#470)
+  // ---------------------------------------------------------------------------
+
+  getOrchestratedV2BudgetConfig(): Observable<OrchestratedV2BudgetConfig> {
+    return this.api.get<OrchestratedV2BudgetConfig>('/settings/orchestrated-v2-budget-config');
+  }
+
+  saveOrchestratedV2BudgetConfig(config: OrchestratedV2BudgetConfig): Observable<OrchestratedV2BudgetConfig> {
+    return this.api.put<OrchestratedV2BudgetConfig>('/settings/orchestrated-v2-budget-config', config);
+  }
+```
+
+Add the import at the top of the file:
+
+```typescript
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+```
+
+- [ ] **Step 11.3: Build the control panel**
+
+Run: `pnpm --filter @bronco/control-panel build`
+Expected: clean.
+
+- [ ] **Step 11.4: Commit**
+
+```bash
+git add services/control-panel/src/app/features/settings/settings.service.ts
+git commit -m "feat(control-panel): SettingsService methods for orchestrated-v2 budget (#470)
+
+Mirrors the analysis-strategy-version service-method pattern.
+Consumed by the budget-card component in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Control panel — settings card component
+
+**Files:**
+- Modify: `services/control-panel/src/app/features/settings/settings.component.ts`
+
+Add a new "Orchestrated v2 Budget Limits" card to the existing Analysis tab. Each numeric field bound to a signal with min/max validation.
+
+- [ ] **Step 12.1: Read the existing Analysis tab structure**
+
+Run: `sed -n '340,430p' services/control-panel/src/app/features/settings/settings.component.ts`
+Expected: shows the Analysis tab declaration and the existing analysis-strategy-version card around lines 408-422.
+
+- [ ] **Step 12.2: Add the budget-config card to the template**
+
+Within the Analysis tab section, after the analysis-strategy-version card, add a new `<mat-card>` (or whatever the existing pattern uses):
+
+```html
+<mat-card class="settings-card">
+  <mat-card-header>
+    <mat-card-title>Orchestrated v2 Budget Limits</mat-card-title>
+    <mat-card-subtitle>
+      Caps cost per ticket-analysis run. Lower values reduce worst-case cost; too low may cut healthy analyses short.
+    </mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <h4>Sub-task limits (per investigation)</h4>
+    <mat-form-field>
+      <mat-label>Iteration cap</mat-label>
+      <input matInput type="number" min="1" max="50"
+             [value]="budgetConfig().subTask.iterationCap"
+             (change)="updateSubTaskField('iterationCap', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Token budget</mat-label>
+      <input matInput type="number" min="5000" max="500000" step="1000"
+             [value]="budgetConfig().subTask.tokenBudget"
+             (change)="updateSubTaskField('tokenBudget', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Tool call budget</mat-label>
+      <input matInput type="number" min="1" max="100"
+             [value]="budgetConfig().subTask.callBudget"
+             (change)="updateSubTaskField('callBudget', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Soft-nudge ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().subTask.softNudgeRatio"
+             (change)="updateSubTaskField('softNudgeRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Hard-stop ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().subTask.hardStopRatio"
+             (change)="updateSubTaskField('hardStopRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+
+    <h4>Ticket-level cap (whole analysis)</h4>
+    <mat-form-field>
+      <mat-label>Total token budget</mat-label>
+      <input matInput type="number" min="50000" max="5000000" step="10000"
+             [value]="budgetConfig().ticket.totalTokenBudget"
+             (change)="updateTicketField('totalTokenBudget', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Soft-nudge ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().ticket.softNudgeRatio"
+             (change)="updateTicketField('softNudgeRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Hard-stop ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().ticket.hardStopRatio"
+             (change)="updateTicketField('hardStopRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+
+    <h4>Strategist guard</h4>
+    <mat-form-field>
+      <mat-label>Soft-nudge batch exhausted ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().strategistGuard.softNudgeBatchExhaustedRatio"
+             (change)="updateGuardField('softNudgeBatchExhaustedRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Hard-stop cumulative ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().strategistGuard.hardStopCumulativeExhaustedRatio"
+             (change)="updateGuardField('hardStopCumulativeExhaustedRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Hard-stop consecutive batches ratio</mat-label>
+      <input matInput type="number" min="0.1" max="0.99" step="0.05"
+             [value]="budgetConfig().strategistGuard.hardStopConsecutiveBatchesRatio"
+             (change)="updateGuardField('hardStopConsecutiveBatchesRatio', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+
+    <h4>Re-read detector</h4>
+    <mat-form-field>
+      <mat-label>Warn after read count</mat-label>
+      <input matInput type="number" min="2" max="20"
+             [value]="budgetConfig().subTaskReReadDetector.warnAfterReadCount"
+             (change)="updateReReadField('warnAfterReadCount', $any($event.target).valueAsNumber)">
+    </mat-form-field>
+  </mat-card-content>
+  <mat-card-actions>
+    <button mat-raised-button color="primary" (click)="saveBudgetConfig()" [disabled]="!budgetConfigDirty()">
+      Save
+    </button>
+    <button mat-button (click)="reloadBudgetConfig()" [disabled]="!budgetConfigDirty()">
+      Reset
+    </button>
+  </mat-card-actions>
+</mat-card>
+```
+
+- [ ] **Step 12.3: Add the component-class state and methods**
+
+Inside the `SettingsComponent` class, near the existing `analysisStrategyVersion` signal:
+
+```typescript
+  budgetConfig = signal<OrchestratedV2BudgetConfig>(this.defaultBudgetConfig());
+  private budgetConfigInitial = signal<OrchestratedV2BudgetConfig>(this.defaultBudgetConfig());
+  budgetConfigDirty = computed(() =>
+    JSON.stringify(this.budgetConfig()) !== JSON.stringify(this.budgetConfigInitial()),
+  );
+
+  private defaultBudgetConfig(): OrchestratedV2BudgetConfig {
+    return {
+      subTask: { iterationCap: 8, tokenBudget: 50_000, callBudget: 20, softNudgeRatio: 0.6, hardStopRatio: 0.85 },
+      ticket: { totalTokenBudget: 300_000, softNudgeRatio: 0.75, hardStopRatio: 0.95 },
+      strategistGuard: { softNudgeBatchExhaustedRatio: 0.5, hardStopCumulativeExhaustedRatio: 0.5, hardStopConsecutiveBatchesRatio: 0.8 },
+      subTaskReReadDetector: { warnAfterReadCount: 2 },
+    };
+  }
+
+  reloadBudgetConfig(): void {
+    this.settingsSvc.getOrchestratedV2BudgetConfig().subscribe({
+      next: (cfg) => {
+        this.budgetConfig.set(cfg);
+        this.budgetConfigInitial.set(cfg);
+      },
+      error: (err) => {
+        this.snackBar.open('Failed to load budget config: ' + err.message, 'OK', { duration: 5000 });
+      },
+    });
+  }
+
+  saveBudgetConfig(): void {
+    this.settingsSvc.saveOrchestratedV2BudgetConfig(this.budgetConfig()).subscribe({
+      next: (cfg) => {
+        this.budgetConfig.set(cfg);
+        this.budgetConfigInitial.set(cfg);
+        this.snackBar.open('Budget config saved', 'OK', { duration: 3000 });
+      },
+      error: (err) => {
+        this.snackBar.open('Failed to save: ' + err.message, 'OK', { duration: 5000 });
+      },
+    });
+  }
+
+  updateSubTaskField(field: keyof OrchestratedV2BudgetConfig['subTask'], value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, subTask: { ...c.subTask, [field]: value } }));
+  }
+
+  updateTicketField(field: keyof OrchestratedV2BudgetConfig['ticket'], value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, ticket: { ...c.ticket, [field]: value } }));
+  }
+
+  updateGuardField(field: keyof OrchestratedV2BudgetConfig['strategistGuard'], value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, strategistGuard: { ...c.strategistGuard, [field]: value } }));
+  }
+
+  updateReReadField(field: keyof OrchestratedV2BudgetConfig['subTaskReReadDetector'], value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, subTaskReReadDetector: { ...c.subTaskReReadDetector, [field]: value } }));
+  }
+```
+
+Imports (top of component file):
+
+```typescript
+import { computed, signal } from '@angular/core';
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+```
+
+In `ngOnInit` (or wherever existing settings are loaded), add:
+
+```typescript
+    this.reloadBudgetConfig();
+```
+
+- [ ] **Step 12.4: Build and dev-test**
+
+Run: `pnpm --filter @bronco/control-panel build`
+Expected: clean.
+
+Start dev server: `pnpm dev:panel`
+Open browser to the Settings page → Analysis tab. Verify the new card renders, fields populate from the API, and Save / Reset behave correctly. Also verify min/max enforcement on inputs.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add services/control-panel/src/app/features/settings/settings.component.ts
+git commit -m "feat(control-panel): orchestrated-v2 budget config card (#470)
+
+Adds 'Orchestrated v2 Budget Limits' card to the existing Settings →
+Analysis tab. Sections: sub-task limits, ticket-level cap, strategist
+guard, re-read detector. Each numeric field signal-bound; Save sends
+the merged config to PUT /api/settings/orchestrated-v2-budget-config.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Final integration smoke + open PR
+
+**Files:**
+- No code changes — verification only
+
+- [ ] **Step 13.1: Replay-test against ticket #49**
+
+(Manual; requires hitting the dev server with a real ticket.)
+
+In a dev environment, set the budget config to a tight cap to confirm hard-stop fires cleanly:
+
+```bash
+curl -X PUT http://localhost:3000/api/settings/orchestrated-v2-budget-config \
+  -H 'Content-Type: application/json' \
+  -H "Cookie: $(get_admin_session_cookie)" \
+  -d '{"ticket":{"totalTokenBudget":50000}}'
+```
+
+Trigger an analysis on a copy/replay of ticket `cf1b96e8`. Watch the analyzer logs for:
+- "Sub-task soft-nudge fired"
+- "Sub-task hard-stop active" (if any sub-task crosses 85%)
+- "Strategist hard-stop activated" OR "Ticket hard-stop activated"
+- The final composed analysis ending with `## Continuation Notes` when hard-stop fires
+
+Restore default config:
+
+```bash
+curl -X PUT http://localhost:3000/api/settings/orchestrated-v2-budget-config \
+  -H 'Content-Type: application/json' \
+  -H "Cookie: $(get_admin_session_cookie)" \
+  -d '{}'
+```
+
+- [ ] **Step 13.2: Run all suites once more**
+
+Run: `pnpm typecheck` (whole monorepo)
+Expected: clean.
+
+Run: `pnpm test` (whole monorepo) — or scoped to the touched packages if monorepo-wide is too slow:
+`pnpm --filter @bronco/shared-types --filter @bronco/ticket-analyzer --filter @bronco/copilot-api --filter @bronco/control-panel test`
+Expected: all PASS.
+
+- [ ] **Step 13.3: Push branch and open PR**
+
+```bash
+git push -u origin fix/470-v2-budget-bounds
+```
+
+Open PR against `staging`:
+
+```bash
+gh pr create --base staging --head fix/470-v2-budget-bounds \
+  --title "fix: bound orchestrated-v2 analysis cost (#470)" \
+  --body-file .tmp/pr-470-body.md
+```
+
+PR body file (`.tmp/pr-470-body.md`):
+
+```markdown
+## Summary
+
+Caps worst-case orchestrated-v2 ticket-analyzer cost at the configured ticket budget (default 300k tokens ≈ $5). Fixes #470.
+
+Adds 5 layered guardrails:
+- **A** — budget-aware sub-task system prompt
+- **B** — sub-task budget soft-nudge (60%) + hard-stop (85%)
+- **C** — per-artifact re-read detector
+- **D** — strategist batch-failure guard (cumulative + consecutive metrics)
+- **E** — ticket-level total-token cap with continuation-summary directive on hard-stop
+
+All thresholds runtime-configurable via the new `orchestrated-v2-budget-config` AppSetting, surfaced in Settings → Analysis tab.
+
+Spec: `docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md`
+
+Deferred follow-ups: #475 (MCP tool pair), #476 (per-category overrides).
+
+## Test plan
+
+- [x] Unit tests for budget-thresholds.ts (5 evaluator functions × multiple scenarios)
+- [x] Integration tests for runSubTaskLoop (re-read detector, soft-nudge, hard-stop)
+- [x] Integration tests for runOrchestratedV2 (batch-failure guard, ticket budget, continuation-summary directive)
+- [x] Manual replay of ticket #49 with tightened cap — confirms clean hard-stop with continuation summary
+- [x] Manual control-panel verification — card renders, save persists, reload reflects DB state
+- [x] `pnpm typecheck` clean across monorepo
+```
+
+Resolves #470.
+```
+
+- [ ] **Step 13.4: Wait for Copilot review**
+
+Per `feedback_pr_review_handling.md` (memory), Copilot auto-reviews PRs targeting `staging`. Once Copilot posts comments, address each per the PR Review Comment Handling section in CLAUDE.md (push fix → reply to comment → resolve thread).
+
+- [ ] **Step 13.5: Merge once review passes**
+
+Standard squash-merge to `staging`. Issue #470 auto-closes via `Resolves #470` in PR body.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer A (sub-task prompt revision) → Task 5 ✓
+- Layer B (sub-task soft-nudge + hard-stop) → Task 7 ✓
+- Layer C (re-read detector) → Task 6 ✓
+- Layer D (strategist batch-failure guard) → Task 8 ✓
+- Layer E + E.1 (ticket budget + continuation summary) → Task 9 ✓
+- AppSetting schema → Task 1 ✓
+- Resolver → Task 3 ✓
+- REST endpoints → Task 4 ✓
+- Control panel UI → Tasks 11 + 12 ✓
+- Acceptance criteria 1 (replay ticket #49) → Task 13.1 ✓
+- Acceptance criteria 2 (healthy tickets unchanged) → Implicit; covered by existing tests passing in Task 5+ ✓
+- Acceptance criteria 3 (operator can change config via UI) → Task 12 ✓
+- Acceptance criteria 4 (unit-test coverage for all 5 layers) → Tasks 2, 6, 7, 8, 9 ✓
+- Acceptance criteria 5 (v1 paths unchanged) → No code changes to v1 files; verified in Task 13.2 ✓
+
+**No placeholders:** All tasks include concrete code blocks. The two test placeholders in Steps 6.1/7.1/8.1/9.1 are explicitly marked and replaced in their corresponding implementation steps (6.4/7.4/8.4/9.4).
+
+**Type consistency:**
+- `OrchestratedV2BudgetConfig` used consistently across Tasks 1, 2, 3, 4, 6, 7, 9, 10, 11, 12.
+- `ThresholdVerdict`, `SubTaskBudgetUsage`, `BatchFailureGuardState`, `BatchResultSummary` defined in Task 2 and used in 6, 7, 8, 9, 10.
+- `evaluateSubTaskBudget` / `evaluateTicketBudget` / `detectArtifactReread` / `evaluateBatchFailureGuard` — all four function names referenced consistently.
+- `budgetConfig` parameter name on `runSubTaskLoop` and `executeOrchestratedSubTaskV2` consistent.
+- `restrictedStrategistTools` used identically in Tasks 8 and 9.
+- `softNudgeFired` / `hardStopActive` (sub-task) vs `ticketSoftNudgeFired` / `ticketHardStopActive` (ticket) — distinct names per scope, consistent within scope.
+
+**Memory pre-flights respected:**
+- `feedback_commit_each_fix.md` — each task is a separate commit ✓
+- `feedback_commit_messages.md` — write to repo `.tmp/` and commit via `-F`, never inline heredoc ✓ (PR body uses `.tmp/pr-470-body.md`)
+- `feedback_worktree_branch_naming.md` — branch is `fix/470-v2-budget-bounds`, prefix `fix/` ✓
+- `feedback_subagent_test_updates.md` — every code change ships with a sibling `.test.ts` update in the same commit ✓
+- `feedback_test_files_in_src_tsconfig.md` — new `budget-thresholds.test.ts` is in `src/`; if there's a tsconfig exclude pattern, verify it covers the new file (Step 2.4 build) ✓
+- `feedback_shell_commands.md` — all command examples use `git -C` style or absolute paths; no `cd` chaining ✓

--- a/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
+++ b/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
@@ -1,0 +1,231 @@
+# Bound orchestrated-v2 analysis cost (#470 + budget config)
+
+**Status:** Design — pending review
+**Date:** 2026-04-28
+**Tickets:** #470 (read-loop budget burn), implicit cost-bound for #471 / #472 follow-ups
+
+## Problem
+
+The orchestrated-v2 ticket analyzer can burn $15–40 of Opus tokens per ticket without producing usable findings. Live evidence from ticket #49 (`cf1b96e8`) on 2026-04-27:
+
+- ~60% of dispatched sub-tasks hit `BUDGET_EXHAUSTED` without calling `finalize_subtask`. The reliable failure mode is sub-tasks that loop on `read_tool_result_artifact`, paging through cached artifacts in 4k-char chunks until they hit the 50k-token / 8-iteration / 20-call budget.
+- The strategist's fallback when a sub-task burns out is the **first tool call's first 500 chars** (`fallbackFromToolResults` in `orchestrated-v2.ts:108-112`). For a paging loop, that's the head of the first artifact read — useless to the strategist.
+- The strategist sees this empty-summary signal and dispatches MORE sub-tasks on the same investigation thread. The existing stall guard (lines 790-828) only fires on (1) zero dispatch + zero KD writes, (2) three identical dispatch hashes, or (3) zero KD writes after 3 iterations — none of which catch the read-loop death-spiral.
+- **The per-sub-task token cap (50k) is effectively inert at the ticket level.** When a sub-task returns BUDGET_EXHAUSTED with a partial summary, the strategist's natural response is to dispatch a replacement sub-task. There is no ticket-level total budget.
+
+For comparison, `flat-v1` analyzes the same class of ticket for ~$1–2.
+
+## Goal
+
+Bound the worst-case cost of a single orchestrated-v2 ticket analysis to a hard ceiling (default $5, configurable), without regressing the analysis quality of healthy tickets.
+
+## Non-goals
+
+- Reanalyzing v1 budget — v1 lacks this architecture.
+- Detecting strategist-level `read_tool_result_artifact` loops directly. (E catches the cost; not addressing the loop pathology itself in this spec.)
+- Per-ticket-category budget tuning. Single global config for now.
+- Replay tooling / cost regression test harness — separate concern.
+
+## Solution: layered guardrails (A + B + C + D + E)
+
+Five independent layers compose into a defense-in-depth fix. Each addresses a distinct contribution to the cost burn, and the combination bounds total cost even when individual layers are bypassed.
+
+### A. Sub-task system prompt revision
+
+**File:** `services/ticket-analyzer/src/analysis/orchestrated-v2.ts:523-530` (`subTaskInstructions`)
+
+The current prompt actively encourages running to budget exhaustion: *"Call `finalize_subtask` as the LAST action — do not call it before you have gathered all the data you need."* Replace with budget-aware guidance:
+
+- Explicit budget mention with units.
+- `read_tool_result_artifact` guidance: prefer `grep` mode for surgical search; if the truncated preview supports a finding, work from that.
+- Permission to finalize on partial findings: "Partial findings with what you have are more useful than burning the budget chasing more."
+
+### B. Mid-loop budget feedback (hybrid: soft nudge → hard-stop)
+
+**Function:** `runSubTaskLoop` in `orchestrated-v2.ts:148+`
+
+At the top of each iteration after computing `tokensSoFar` / `totalToolCalls`:
+
+- **Soft-nudge** (default 60% of any budget — tokens, iterations, or calls — whichever fires first): inject a synthetic `tool_result` block into the next strategist turn warning of approaching ceiling. Fires once per threshold crossing (tracked with a flag).
+- **Hard-stop** (default 85% of any budget): on the next `generateWithTools` call, set `tools` parameter to ONLY `[FINALIZE_SUBTASK_TOOL]`. The agent's only option is to wrap up.
+
+Hard-stop is enforced by tool-list filtering, not message injection — more reliable than relying on agent compliance with a warning.
+
+### C. Per-artifact re-read detector
+
+In the sub-task loop, maintain a counter map keyed on `(toolName, artifactId)` for `read_tool_result_artifact` calls. When the same artifact is read >= the warn threshold (default 2):
+
+- Append a guidance line to the next iteration's `tool_result`: *"⚠️ You've read artifact X N times. Use `grep` mode for specific patterns, or finalize with what you have."*
+
+Targets the specific failure mode (sequential paging through one artifact). Does not block the call; gives the agent one course-correction signal.
+
+### D. Strategist batch-failure guard
+
+**Location:** strategist loop in `executeOrchestratedV2`, after each `dispatch_subtasks` resolves. Sibling to the existing `updateStallState` guard at `orchestrated-v2.ts:790-828` — does NOT replace or merge into it. The existing guard catches strategist-level repetition and zero-progress; D adds an orthogonal trigger keyed on cumulative sub-task budget exhaustion.
+
+Compute per-batch metrics:
+- `budgetExhaustedCount` / `totalCount`
+- `kdWritesInBatch` (sum of `updatedKdSections.length` across results)
+
+Maintain cumulative tracking across batches:
+- `cumulativeExhausted` / `cumulativeTotal`
+- `consecutiveBadBatches` (count of consecutive batches with ≥80% BUDGET_EXHAUSTED)
+
+Trip conditions:
+- **Soft-nudge** (default): current batch ≥50% BUDGET_EXHAUSTED with empty `updatedKdSections`, AND batch is not the first → inject a tool_result on the next strategist turn.
+- **Hard-stop** (default): cumulative ≥50% BUDGET_EXHAUSTED OR `consecutiveBadBatches >= 2` → restrict strategist tool list to `[COMPLETE_ANALYSIS_TOOL, kd_read_toc, kd_read_section]`. No more dispatches possible.
+
+Closes the failure mode where the strategist treats partial summaries as "interim progress, dispatch more."
+
+### E. Ticket-level total token budget
+
+**Location:** `executeOrchestratedV2` entry point (orchestrated-v2.ts).
+
+Track `totalTokensConsumed` = strategist usage (input + output) + sum of every sub-task's `inputTokens + outputTokens` returned in `SubTaskRunResult`.
+
+After each strategist iteration, before the next strategist `generateWithTools` call:
+
+- **Soft-nudge** at 75% of `TICKET_TOTAL_TOKEN_BUDGET`: inject `tool_result` warning on next strategist turn.
+- **Hard-stop** at 95%: strategist tool list reduced to `[COMPLETE_ANALYSIS_TOOL, kd_read_toc, kd_read_section]`.
+
+Default value: `300_000` tokens (≈$5 hard ceiling at Opus rate). The user explicitly chose 300k; v1 handles the same workload for ~$1–2, so 300k leaves ~3× headroom for v2's strategist overhead.
+
+Side benefit: bounds runaway *strategist* cost from any source (including its own `read_tool_result_artifact` access, which is currently unguarded).
+
+## Configuration via DB AppSetting
+
+All numeric thresholds load from a single `AppSetting` at analysis-run time and surface in the control panel for tuning without redeploy.
+
+### AppSetting key
+
+`orchestrated-v2-budget-config` (JSON value).
+
+### Schema (Zod, in `packages/shared-types/src/analysis.ts`)
+
+```ts
+export const OrchestratedV2BudgetConfigSchema = z.object({
+  subTask: z.object({
+    iterationCap: z.number().int().min(1).max(50).default(8),
+    tokenBudget: z.number().int().min(5_000).max(500_000).default(50_000),
+    callBudget: z.number().int().min(1).max(100).default(20),
+    softNudgeRatio: z.number().min(0.1).max(0.99).default(0.6),
+    hardStopRatio: z.number().min(0.1).max(0.99).default(0.85),
+  }),
+  ticket: z.object({
+    totalTokenBudget: z.number().int().min(50_000).max(5_000_000).default(300_000),
+    softNudgeRatio: z.number().min(0.1).max(0.99).default(0.75),
+    hardStopRatio: z.number().min(0.1).max(0.99).default(0.95),
+  }),
+  strategistGuard: z.object({
+    softNudgeBatchExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+    hardStopCumulativeExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+    hardStopConsecutiveBatchesRatio: z.number().min(0.1).max(0.99).default(0.8),
+  }),
+  subTaskReReadDetector: z.object({
+    warnAfterReadCount: z.number().int().min(2).max(20).default(2),
+  }),
+});
+
+export type OrchestratedV2BudgetConfig = z.output<typeof OrchestratedV2BudgetConfigSchema>;
+```
+
+Refinement: `softNudgeRatio < hardStopRatio` enforced by `.refine(...)`.
+
+### Resolver
+
+New helper in `services/ticket-analyzer/src/analysis/shared.ts` following the existing `resolveAnalysisVersion` / `resolveMaxParallelTasks` pattern (no cache, fresh fetch per analysis run):
+
+```ts
+export async function resolveOrchestratedV2BudgetConfig(db: DbClient): Promise<OrchestratedV2BudgetConfig> {
+  const row = await db.appSetting.findUnique({ where: { key: 'orchestrated-v2-budget-config' } });
+  const parsed = OrchestratedV2BudgetConfigSchema.safeParse(row?.value ?? {});
+  return parsed.success ? parsed.data : OrchestratedV2BudgetConfigSchema.parse({});
+}
+```
+
+Loaded once at the top of `executeOrchestratedV2`; passed down to `runSubTaskLoop` and the strategist guard. Does not change mid-run.
+
+### REST API
+
+New per-feature endpoint pair in `services/copilot-api/src/routes/settings.ts`, matching the existing `analysis-strategy-version` pattern (lines 1168–1199):
+
+- `GET /api/settings/orchestrated-v2-budget-config` — returns current value or defaults
+- `PUT /api/settings/orchestrated-v2-budget-config` — ADMIN-only; Zod-validated body; upserts AppSetting
+
+### Control panel UI
+
+New card in the existing **Analysis tab** of `services/control-panel/src/app/features/settings/settings.component.ts` (the same tab that holds the v1/v2 strategy selector at lines 408–422).
+
+- Card title: **"Orchestrated v2 Budget Limits"**
+- Sections: Sub-task budgets, Ticket budget, Strategist guard, Re-read detector
+- Each numeric field bound to a `signal<number>` with min/max validation matching Zod schema
+- Save button → `settingsSvc.saveOrchestratedV2BudgetConfig(value)` (new service method, mirrors `saveAnalysisStrategyVersion` at `settings.service.ts:302-307`)
+- Footer help text: "Lower values reduce worst-case cost; too low may cut healthy analyses short. See docs."
+
+## MCP Platform Server sync
+
+CLAUDE.md mandates that every API operation should be accessible via both REST and MCP. The new endpoint pair therefore needs a corresponding MCP tool in `mcp-servers/platform/src/tools/`:
+
+- `get_orchestrated_v2_budget_config` (read-only, allowed for analyzer / admin callers)
+- `set_orchestrated_v2_budget_config` (admin-only — gated by caller registry)
+
+## Testing strategy
+
+### Unit tests
+File: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts` (extend existing — file confirmed present)
+
+- A: snapshot the new system prompt string (regression guard)
+- B (soft-nudge): stub `runSubTaskLoop` deps; simulate sub-task at 60% token usage; assert tool_result warning injected
+- B (hard-stop): simulate sub-task at 85% token usage; assert tools parameter on next call is `[FINALIZE_SUBTASK_TOOL]` only
+- C: simulate 2 reads of the same artifactId; assert nudge appended to subsequent tool_result
+- D (soft-nudge): mock dispatch_subtasks result with 50% BUDGET_EXHAUSTED + empty updatedKdSections; assert tool_result injected on next strategist turn
+- D (hard-stop): mock cumulative metrics crossing 50% threshold; assert strategist tool list reduced to finalization tools
+- E: mock budget config with `totalTokenBudget: 100_000`; track usage from a stub strategist + sub-tasks crossing 75% / 95%; assert the corresponding nudge / hard-stop behaviors
+- Config resolver: missing AppSetting → all defaults; malformed JSON → all defaults; partial JSON → defaults merge with provided values
+
+### Integration smoke
+Manual replay of one historical ticket via dev with low cap (e.g. `totalTokenBudget: 50_000`) to verify the run terminates cleanly via E without crashing.
+
+### Unchanged
+v1 paths (flat-v1, orchestrated-v1) — no test changes.
+
+## Edge cases
+
+- **Existing in-flight tickets at deploy time:** budget loaded at analysis start; in-flight runs continue with whatever defaults they captured. No mid-run config reload.
+- **AppSetting missing or malformed:** Zod safeParse fall-through to defaults. Logged at WARN level once per analyzer process startup if malformed.
+- **User sets unreasonable value:** Zod min/max guards prevent obviously-broken values (e.g. `tokenBudget: 0`). Soft refinement `softNudgeRatio < hardStopRatio` enforced.
+- **Strategist already at hard-stop and `complete_analysis` itself fails:** existing `composeFinalAnalysis` + `fallbackFillRequiredSections` flow handles. No new behavior needed.
+- **Sub-task hard-stopped via B but happens to call finalize_subtask in the same turn:** tool list filter ensures the only available tool IS finalize_subtask, so this is the expected outcome.
+- **Race between B's hard-stop and D's hard-stop:** they operate at different layers (sub-task vs. strategist). Both can be active simultaneously; no interaction.
+
+## Files modified
+
+### Backend
+- `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` — main logic for A, B, C, D, E + config plumbing
+- `services/ticket-analyzer/src/analysis/shared.ts` — `resolveOrchestratedV2BudgetConfig` helper, `AnalysisDeps` extension
+- `services/copilot-api/src/routes/settings.ts` — new GET/PUT endpoint pair
+- `packages/shared-types/src/analysis.ts` — `OrchestratedV2BudgetConfigSchema` + type
+- `mcp-servers/platform/src/tools/` — new MCP tool pair (REST/MCP parity)
+
+### Frontend
+- `services/control-panel/src/app/features/settings/settings.component.ts` — new card in Analysis tab
+- `services/control-panel/src/app/features/settings/settings.service.ts` — new service method pair
+
+### Tests
+- `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts` — unit tests for A–E
+
+## Out of scope (future work / separate issues)
+
+- Strategist `read_tool_result_artifact` loop detection (#470 successor — addressing the loop itself, not just its cost)
+- Per-ticket-category budget tuning (e.g. DATABASE_PERF gets larger budget than BUG_FIX)
+- Replay harness / cost regression test in CI
+- Issue #471 (sub-task tool allowlist inconsistency) — independent root cause; separate fix
+- Issue #472 (worktree concurrency) — independent root cause; separate fix
+
+## Acceptance criteria
+
+1. With default config, replaying ticket #49 (`cf1b96e8`) terminates within 300k tokens (~$5) and produces a non-empty executive summary, even if degraded vs a perfect run.
+2. Healthy tickets that previously analyzed in <100k tokens continue to complete without hitting any soft-nudge.
+3. Operator can change `totalTokenBudget` via the control panel and the next analysis picks up the new value.
+4. All five layers (A–E) have unit-test coverage for their trigger conditions.
+5. v1 paths and other v2 features (sub-task tool allowlist, KD writes, fallback compose) unchanged — verified by existing tests passing.

--- a/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
+++ b/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
@@ -251,7 +251,7 @@ v1 paths (flat-v1, orchestrated-v1) — no test changes.
 ## Out of scope (future work / separate issues)
 
 - Strategist `read_tool_result_artifact` loop detection (#470 successor — addressing the loop itself, not just its cost)
-- Per-ticket-category budget tuning (e.g. DATABASE_PERF gets larger budget than BUG_FIX)
+- Per-ticket-category budget tuning — deferred to #476 (e.g. DATABASE_PERF gets larger budget than BUG_FIX). Trigger: measure first, extend the schema once real-world data shows a category-cost gradient.
 - Replay harness / cost regression test in CI
 - MCP tool pair for budget config — deferred to #475 (admin-scoped, slack-integration use case)
 - Re-analysis flow that consumes `## Continuation Notes` — deferred to #48 Item 7

--- a/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
+++ b/docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
@@ -86,11 +86,43 @@ Track `totalTokensConsumed` = strategist usage (input + output) + sum of every s
 After each strategist iteration, before the next strategist `generateWithTools` call:
 
 - **Soft-nudge** at 75% of `TICKET_TOTAL_TOKEN_BUDGET`: inject `tool_result` warning on next strategist turn.
-- **Hard-stop** at 95%: strategist tool list reduced to `[COMPLETE_ANALYSIS_TOOL, kd_read_toc, kd_read_section]`.
+- **Hard-stop** at 95%: strategist tool list reduced to `[COMPLETE_ANALYSIS_TOOL, kd_read_toc, kd_read_section]`. The `tool_result` injected with this restriction includes a **continuation-summary directive** (see below).
 
 Default value: `300_000` tokens (≈$5 hard ceiling at Opus rate). The user explicitly chose 300k; v1 handles the same workload for ~$1–2, so 300k leaves ~3× headroom for v2's strategist overhead.
 
 Side benefit: bounds runaway *strategist* cost from any source (including its own `read_tool_result_artifact` access, which is currently unguarded).
+
+#### E.1. Continuation summary on hard-stop
+
+When E's hard-stop fires, the user wants the run to close out with a **structured "where I left off" summary** so a manual re-analysis can pick up the thread. The strategist's forced `complete_analysis` call must include this even if it pushes the run slightly over budget — bounded overshoot of one strategist call (~8k output tokens) is the explicit trade-off.
+
+The injected `tool_result` accompanying the hard-stop tool-list restriction reads (verbatim):
+
+> ⚠️ Ticket budget hard-cap reached (X / Y tokens, Z%). You can no longer dispatch sub-tasks. Read the knowledge doc with `kd_read_toc` / `kd_read_section` and call `complete_analysis` next.
+>
+> **Required:** include a `## Continuation Notes` section in your `finalAnalysis` with the following structure (use exactly these subheadings):
+>
+> ```
+> ## Continuation Notes
+>
+> ### What we established
+> - <bullet list of confirmed findings, each with KD section reference>
+>
+> ### Hypotheses still open
+> - <bullet list of hypotheses introduced but not verified>
+>
+> ### Investigation threads not completed
+> - <bullet list of sub-task intents that hit BUDGET_EXHAUSTED with no usable summary>
+>
+> ### Suggested next batch
+> - <2–3 sub-task intents that would be most valuable to retry on continuation, with which artifacts/sections to load as context>
+> ```
+>
+> Going slightly over the budget cap to write this summary is permitted and expected.
+
+The `composeFinalAnalysis` function does NOT need changes — the strategist's `finalAnalysis` text flows through untouched, and the executive-summary section in the AI_ANALYSIS event will surface the continuation notes. The Knowledge Doc itself is unchanged by this; the notes live only in the executive summary.
+
+Composes with the future #48 Item 7 (re-analysis steering with prior executive summary) — the `## Continuation Notes` section IS the steering input for that follow-up.
 
 ## Configuration via DB AppSetting
 
@@ -162,12 +194,13 @@ New card in the existing **Analysis tab** of `services/control-panel/src/app/fea
 - Save button → `settingsSvc.saveOrchestratedV2BudgetConfig(value)` (new service method, mirrors `saveAnalysisStrategyVersion` at `settings.service.ts:302-307`)
 - Footer help text: "Lower values reduce worst-case cost; too low may cut healthy analyses short. See docs."
 
-## MCP Platform Server sync
+## MCP Platform Server sync — DEFERRED
 
-CLAUDE.md mandates that every API operation should be accessible via both REST and MCP. The new endpoint pair therefore needs a corresponding MCP tool in `mcp-servers/platform/src/tools/`:
+CLAUDE.md mandates REST/MCP parity for new API operations. The MCP tool pair is **deferred to issue #475** because of a self-modification risk: if `set_orchestrated_v2_budget_config` were exposed to the analyzer's caller allowlist, the analysis agent could in principle re-configure its own cost limits — an unacceptable foot-gun for a runaway-cost guardrail.
 
-- `get_orchestrated_v2_budget_config` (read-only, allowed for analyzer / admin callers)
-- `set_orchestrated_v2_budget_config` (admin-only — gated by caller registry)
+The follow-up issue (#475) covers building the tool pair with strict caller scoping (analyzer can READ but not WRITE) and a slack-integration use case for admin runtime tuning.
+
+For this PR: REST endpoints only. The control panel uses REST. The analyzer reads its budget directly via Prisma (no MCP needed).
 
 ## Testing strategy
 
@@ -181,6 +214,7 @@ File: `services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts` (extend ex
 - D (soft-nudge): mock dispatch_subtasks result with 50% BUDGET_EXHAUSTED + empty updatedKdSections; assert tool_result injected on next strategist turn
 - D (hard-stop): mock cumulative metrics crossing 50% threshold; assert strategist tool list reduced to finalization tools
 - E: mock budget config with `totalTokenBudget: 100_000`; track usage from a stub strategist + sub-tasks crossing 75% / 95%; assert the corresponding nudge / hard-stop behaviors
+- E.1: assert hard-stop tool_result content includes the `## Continuation Notes` directive with all four required subheadings
 - Config resolver: missing AppSetting → all defaults; malformed JSON → all defaults; partial JSON → defaults merge with provided values
 
 ### Integration smoke
@@ -201,11 +235,11 @@ v1 paths (flat-v1, orchestrated-v1) — no test changes.
 ## Files modified
 
 ### Backend
-- `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` — main logic for A, B, C, D, E + config plumbing
+- `services/ticket-analyzer/src/analysis/orchestrated-v2.ts` — main logic for A, B, C, D, E + config plumbing + E.1 continuation-summary directive
 - `services/ticket-analyzer/src/analysis/shared.ts` — `resolveOrchestratedV2BudgetConfig` helper, `AnalysisDeps` extension
 - `services/copilot-api/src/routes/settings.ts` — new GET/PUT endpoint pair
 - `packages/shared-types/src/analysis.ts` — `OrchestratedV2BudgetConfigSchema` + type
-- `mcp-servers/platform/src/tools/` — new MCP tool pair (REST/MCP parity)
+- (MCP tool pair deferred — see #475)
 
 ### Frontend
 - `services/control-panel/src/app/features/settings/settings.component.ts` — new card in Analysis tab
@@ -219,13 +253,15 @@ v1 paths (flat-v1, orchestrated-v1) — no test changes.
 - Strategist `read_tool_result_artifact` loop detection (#470 successor — addressing the loop itself, not just its cost)
 - Per-ticket-category budget tuning (e.g. DATABASE_PERF gets larger budget than BUG_FIX)
 - Replay harness / cost regression test in CI
+- MCP tool pair for budget config — deferred to #475 (admin-scoped, slack-integration use case)
+- Re-analysis flow that consumes `## Continuation Notes` — deferred to #48 Item 7
 - Issue #471 (sub-task tool allowlist inconsistency) — independent root cause; separate fix
 - Issue #472 (worktree concurrency) — independent root cause; separate fix
 
 ## Acceptance criteria
 
-1. With default config, replaying ticket #49 (`cf1b96e8`) terminates within 300k tokens (~$5) and produces a non-empty executive summary, even if degraded vs a perfect run.
+1. With default config, replaying ticket #49 (`cf1b96e8`) terminates within 300k tokens (~$5) plus the bounded continuation-summary overshoot (≤8k strategist output tokens) and produces a non-empty executive summary that includes the `## Continuation Notes` section when E hard-stop fires.
 2. Healthy tickets that previously analyzed in <100k tokens continue to complete without hitting any soft-nudge.
 3. Operator can change `totalTokenBudget` via the control panel and the next analysis picks up the new value.
-4. All five layers (A–E) have unit-test coverage for their trigger conditions.
+4. All five layers (A–E) have unit-test coverage for their trigger conditions; E.1's continuation-summary directive is asserted by an additional test.
 5. v1 paths and other v2 features (sub-task tool allowlist, KD writes, fallback compose) unchanged — verified by existing tests passing.

--- a/mcp-servers/repo/src/repo-manager.test.ts
+++ b/mcp-servers/repo/src/repo-manager.test.ts
@@ -50,7 +50,8 @@ describe('RepoManager — concurrent worktree creation coalescing (#472)', () =>
       mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc'),
     );
 
-    // Yield to the microtask queue so the in-flight cache settles.
+    // Yield to the next event-loop turn so the in-flight cache settles
+    // (setImmediate schedules a macrotask, run after pending microtasks).
     await new Promise((r) => setImmediate(r));
 
     expect(createCount).toBe(1);
@@ -88,7 +89,7 @@ describe('RepoManager — concurrent worktree creation coalescing (#472)', () =>
     expect(createCount).toBe(3);
   });
 
-  it('clears the in-flight slot on resolution so a subsequent failed-then-retry can run', async () => {
+  it('clears the in-flight slot on settlement so a subsequent failed-then-retry can run', async () => {
     let attempt = 0;
 
     class TestRepoManager extends RepoManager {
@@ -113,6 +114,70 @@ describe('RepoManager — concurrent worktree creation coalescing (#472)', () =>
     const path = await mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc');
     expect(path).toBe(FAKE_PATH('gather-ticket-abc', 'repo-1'));
     expect(attempt).toBe(2);
+  });
+
+  it('cleanupSession waits for in-flight creates for the same sessionId before removing', async () => {
+    // Regression for the #482 review: cleanupSession used to fire `rm -rf`
+    // on the session directory while a create was mid-flight, racing against
+    // the create's git operations. The fix snapshots in-flight promises for
+    // the matching sessionId and awaits them before proceeding.
+    const order: string[] = [];
+    let resolveCreate: ((path: string) => void) | null = null;
+
+    class TestRepoManager extends RepoManager {
+      override async createWorktree(repoId: string, sessionId: string): Promise<string> {
+        order.push(`create-start:${sessionId}:${repoId}`);
+        return new Promise<string>((resolve) => {
+          resolveCreate = (path) => {
+            order.push(`create-resolve:${sessionId}:${repoId}`);
+            resolve(path);
+          };
+        });
+      }
+      // Stub removeWorktree + the rm of the session directory so cleanup
+      // doesn't try to access the real filesystem; just trace the order.
+      protected override async removeWorktree(): Promise<void> {
+        order.push('remove-worktree');
+      }
+      protected override async pathExists(): Promise<boolean> {
+        return false; // session dir does not exist; cleanup skips the rm
+      }
+    }
+
+    const mgr = new TestRepoManager(fakeDb, baseConfig);
+
+    // Kick off a create for gather-ticket-abc:repo-1
+    const createPromise = mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc');
+
+    // Yield so the in-flight slot is populated before cleanup checks it
+    await new Promise((r) => setImmediate(r));
+    expect(order).toEqual(['create-start:gather-ticket-abc:repo-1']);
+
+    // Start cleanup BEFORE the create resolves — it must NOT proceed until
+    // the create settles.
+    const cleanupPromise = mgr.cleanupSession('gather-ticket-abc');
+
+    // Give cleanup a chance to advance — but it should be parked awaiting
+    // the in-flight create promise.
+    await new Promise((r) => setImmediate(r));
+    expect(order).toEqual(['create-start:gather-ticket-abc:repo-1']);
+
+    // Now resolve the create. Cleanup should now proceed.
+    resolveCreate!(FAKE_PATH('gather-ticket-abc', 'repo-1'));
+
+    await Promise.all([createPromise, cleanupPromise]);
+
+    // Resolution happened before any cleanup work — proves we awaited
+    // the in-flight before removing.
+    const resolveIdx = order.indexOf('create-resolve:gather-ticket-abc:repo-1');
+    const removeIdx = order.indexOf('remove-worktree');
+    // remove-worktree may not appear because the worktree map was empty
+    // at cleanup time (the test stub never adds entries), so we just
+    // assert resolve fired and order is monotonic.
+    expect(resolveIdx).toBeGreaterThanOrEqual(0);
+    if (removeIdx !== -1) {
+      expect(removeIdx).toBeGreaterThan(resolveIdx);
+    }
   });
 
   // clone() coalescing: uses the identical in-flight-promise pattern as

--- a/mcp-servers/repo/src/repo-manager.test.ts
+++ b/mcp-servers/repo/src/repo-manager.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for repo-manager's promise-coalescing behavior (#472).
+ *
+ * Concurrent orchestrated-v2 sub-tasks share a `gather-{ticketId}` sessionId.
+ * Without coalescing, 5 parallel callers all see `worktrees.get(key) ===
+ * undefined` and all call `createWorktree`, racing on `git worktree add` to
+ * the same path. The fix coalesces in-flight creates so concurrent callers
+ * await a single shared promise.
+ *
+ * These tests use a subclass that overrides `createWorktree` to count
+ * invocations and pause resolution — no real git, fs, or network.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { PrismaClient } from '@bronco/db';
+import { RepoManager } from './repo-manager.js';
+import type { Config } from './config.js';
+
+const FAKE_PATH = (sessionId: string, repoId: string) =>
+  `/tmp/test-workspace/worktrees/${sessionId}/${repoId}`;
+
+const baseConfig = {
+  REPO_WORKSPACE_PATH: '/tmp/test-workspace',
+  ENCRYPTION_KEY: 'test-key',
+  WORKTREE_TTL_MINUTES: 60,
+} as unknown as Config;
+
+const fakeDb = {} as PrismaClient;
+
+describe('RepoManager — concurrent worktree creation coalescing (#472)', () => {
+  it('coalesces parallel getOrCreateWorktree calls for the same (repoId, sessionId)', async () => {
+    let createCount = 0;
+    let resolveCreate: ((path: string) => void) | null = null;
+
+    class TestRepoManager extends RepoManager {
+      // Override the inner create to pause resolution and count invocations.
+      // Concurrent callers should all join the in-flight promise; only one
+      // override-call should fire.
+      override async createWorktree(repoId: string, sessionId: string): Promise<string> {
+        createCount++;
+        return new Promise<string>((resolve) => {
+          resolveCreate = resolve;
+        });
+      }
+    }
+
+    const mgr = new TestRepoManager(fakeDb, baseConfig);
+
+    const promises = Array.from({ length: 5 }, () =>
+      mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc'),
+    );
+
+    // Yield to the microtask queue so the in-flight cache settles.
+    await new Promise((r) => setImmediate(r));
+
+    expect(createCount).toBe(1);
+    expect(resolveCreate).not.toBeNull();
+
+    // Resolve the single in-flight create — all 5 promises should resolve.
+    resolveCreate!(FAKE_PATH('gather-ticket-abc', 'repo-1'));
+
+    const results = await Promise.all(promises);
+    expect(results).toHaveLength(5);
+    for (const result of results) {
+      expect(result).toBe(FAKE_PATH('gather-ticket-abc', 'repo-1'));
+    }
+  });
+
+  it('does NOT coalesce calls for different (repoId, sessionId) keys', async () => {
+    let createCount = 0;
+
+    class TestRepoManager extends RepoManager {
+      override async createWorktree(repoId: string, sessionId: string): Promise<string> {
+        createCount++;
+        return FAKE_PATH(sessionId, repoId);
+      }
+    }
+
+    const mgr = new TestRepoManager(fakeDb, baseConfig);
+
+    // Three different keys should each trigger their own create.
+    await Promise.all([
+      mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc'),
+      mgr.getOrCreateWorktree('repo-2', 'gather-ticket-abc'),
+      mgr.getOrCreateWorktree('repo-1', 'gather-ticket-def'),
+    ]);
+
+    expect(createCount).toBe(3);
+  });
+
+  it('clears the in-flight slot on resolution so a subsequent failed-then-retry can run', async () => {
+    let attempt = 0;
+
+    class TestRepoManager extends RepoManager {
+      override async createWorktree(repoId: string, sessionId: string): Promise<string> {
+        attempt++;
+        if (attempt === 1) {
+          throw new Error('simulated first-attempt git failure');
+        }
+        return FAKE_PATH(sessionId, repoId);
+      }
+    }
+
+    const mgr = new TestRepoManager(fakeDb, baseConfig);
+
+    // First call: should reject with the simulated failure.
+    await expect(
+      mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc'),
+    ).rejects.toThrow('simulated first-attempt');
+
+    // Second call: in-flight slot was cleared by the .finally() handler so
+    // we get a fresh attempt rather than the stuck-rejected previous promise.
+    const path = await mgr.getOrCreateWorktree('repo-1', 'gather-ticket-abc');
+    expect(path).toBe(FAKE_PATH('gather-ticket-abc', 'repo-1'));
+    expect(attempt).toBe(2);
+  });
+
+  // clone() coalescing: uses the identical in-flight-promise pattern as
+  // getOrCreateWorktree (see the implementation). Asserting it via
+  // promise-reference identity at the public surface doesn't work because
+  // async-fn return values are wrapped in a fresh Promise — the underlying
+  // cloneImpl still runs once, but the wrapper around it differs per call.
+  // Coverage of the same coalescing pattern is provided by the three
+  // getOrCreateWorktree tests above; an integration-level proof for clone
+  // would require mocking the entire git toolchain, which is out of scope
+  // for unit tests.
+});

--- a/mcp-servers/repo/src/repo-manager.ts
+++ b/mcp-servers/repo/src/repo-manager.ts
@@ -21,6 +21,18 @@ export class RepoManager {
   private worktrees = new Map<string, WorktreeEntry>();
   private cleanupTimer: ReturnType<typeof setInterval> | undefined;
 
+  // Promise-coalescing caches (#472). Concurrent callers for the same key
+  // share the in-flight promise so we never run `git clone` / `git fetch` /
+  // `git worktree add` against the same path simultaneously — a single bare
+  // repo or worktree path can only support one mutating git op at a time
+  // (lock files in .git/), and parallel orchestrated-v2 sub-tasks all share
+  // the same `gather-{ticketId}` sessionId.
+  //
+  // Entries are removed in `.finally()` regardless of resolution, so a
+  // failed first attempt won't permanently poison the slot.
+  private cloneInFlight = new Map<string, Promise<string>>();
+  private worktreeInFlight = new Map<string, Promise<string>>();
+
   constructor(
     private readonly db: PrismaClient,
     private readonly config: Config,
@@ -46,6 +58,19 @@ export class RepoManager {
   }
 
   async clone(repoId: string): Promise<string> {
+    // Coalesce concurrent calls for the same repo — both `git clone --bare`
+    // and `git fetch --all` lock the bare repo, so two parallel callers will
+    // race on the lock file. See #472.
+    const inflight = this.cloneInFlight.get(repoId);
+    if (inflight) return inflight;
+    const promise = this.cloneImpl(repoId).finally(() => {
+      this.cloneInFlight.delete(repoId);
+    });
+    this.cloneInFlight.set(repoId, promise);
+    return promise;
+  }
+
+  private async cloneImpl(repoId: string): Promise<string> {
     const repo = await this.db.codeRepo.findUnique({ where: { id: repoId } });
     if (!repo) throw new Error(`CodeRepo not found: ${repoId}`);
     if (!repo.isActive) throw new Error(`CodeRepo is inactive: ${repoId}`);
@@ -138,7 +163,18 @@ export class RepoManager {
       return existing.path;
     }
 
-    return this.createWorktree(repoId, sessionId);
+    // Coalesce concurrent creates for the same key. Without this, parallel
+    // orchestrated-v2 sub-tasks sharing a `gather-{ticketId}` sessionId all
+    // see the missing-worktree state, all call createWorktree, and all race
+    // on `git worktree add` to the same path — leaving 4 of 5 sub-tasks
+    // failing with non-retryable errors. See #472.
+    const inflight = this.worktreeInFlight.get(key);
+    if (inflight) return inflight;
+    const promise = this.createWorktree(repoId, sessionId).finally(() => {
+      this.worktreeInFlight.delete(key);
+    });
+    this.worktreeInFlight.set(key, promise);
+    return promise;
   }
 
   async cleanupSession(sessionId: string): Promise<void> {

--- a/mcp-servers/repo/src/repo-manager.ts
+++ b/mcp-servers/repo/src/repo-manager.ts
@@ -25,8 +25,10 @@ export class RepoManager {
   // share the in-flight promise so we never run `git clone` / `git fetch` /
   // `git worktree add` against the same path simultaneously — a single bare
   // repo or worktree path can only support one mutating git op at a time
-  // (lock files in .git/), and parallel orchestrated-v2 sub-tasks all share
-  // the same `gather-{ticketId}` sessionId.
+  // (bare repos hold their lock files directly under the repo directory,
+  // e.g. `index.lock`; worktrees hold them under their own `.git/`), and
+  // parallel orchestrated-v2 sub-tasks all share the same `gather-{ticketId}`
+  // sessionId.
   //
   // Entries are removed in `.finally()` regardless of resolution, so a
   // failed first attempt won't permanently poison the slot.
@@ -117,7 +119,11 @@ export class RepoManager {
     return barePath;
   }
 
-  async createWorktree(repoId: string, sessionId: string): Promise<string> {
+  // protected so the only public path through createWorktree is via
+  // getOrCreateWorktree (which coalesces concurrent calls). The protected
+  // visibility still allows the test subclass in repo-manager.test.ts to
+  // override this method for instrumentation. See #472.
+  protected async createWorktree(repoId: string, sessionId: string): Promise<string> {
     const repo = await this.db.codeRepo.findUnique({ where: { id: repoId } });
     if (!repo) throw new Error(`CodeRepo not found: ${repoId}`);
 
@@ -178,6 +184,27 @@ export class RepoManager {
   }
 
   async cleanupSession(sessionId: string): Promise<void> {
+    // Wait for any in-flight worktree creates for THIS sessionId to settle
+    // before we delete the session directory. Without this, a `cleanupSession`
+    // call landing during a parallel create would race the create's git ops
+    // against our `rm -rf` and produce confusing failures (#472 review).
+    //
+    // We snapshot the pending promises into an array — iterating
+    // `worktreeInFlight` directly while creates settle could trip a "Map was
+    // modified during iteration" guard if a `.finally()` fires mid-iteration.
+    // Settled creates rather than rejected ones are fine (we're about to
+    // delete anyway) so we swallow rejections via `.catch(() => undefined)`.
+    const sessionPrefix = `${sessionId}:`;
+    const pendingForSession: Array<Promise<unknown>> = [];
+    for (const [key, promise] of this.worktreeInFlight) {
+      if (key.startsWith(sessionPrefix)) {
+        pendingForSession.push(promise.catch(() => undefined));
+      }
+    }
+    if (pendingForSession.length > 0) {
+      await Promise.all(pendingForSession);
+    }
+
     const toRemove: string[] = [];
     for (const [key, entry] of this.worktrees) {
       if (entry.sessionId === sessionId) {

--- a/mcp-servers/repo/src/tools/search-code.test.ts
+++ b/mcp-servers/repo/src/tools/search-code.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { validateCommand } from '../command-validator.js';
+import { classifyExecError } from './search-code.js';
 
 // ---------------------------------------------------------------------------
 // Helpers mirrored from search-code.ts (private, so we test via validateCommand)
@@ -139,5 +140,72 @@ describe('search-code: flags', () => {
   it('adds -e before the query', () => {
     const cmd = buildSearchCommand('myFunc', ['.ts']);
     expect(cmd).toContain('-e ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyExecError — distinguish timeout / signal / rg-error / no-matches
+// (#465: previously all rejections fell into `code ?? 1` which masked timeouts
+// and kills as silent "no matches" results)
+// ---------------------------------------------------------------------------
+
+describe('classifyExecError', () => {
+  it('classifies rg exit 1 as no-matches (the expected non-error path)', () => {
+    const err = { code: 1, stdout: '', stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('no-matches');
+    expect(c.exitCode).toBe(1);
+  });
+
+  it('classifies rg exit 2 as rg-error (e.g. invalid regex)', () => {
+    const err = { code: 2, stdout: '', stderr: 'rg: regex parse error: unclosed group' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('rg-error');
+    expect(c.exitCode).toBe(2);
+    expect(c.stderr).toContain('regex parse error');
+  });
+
+  it('classifies SIGTERM (timeout-fired kill) as timeout', () => {
+    // Node's execAsync sets `killed: true` and `signal: 'SIGTERM'` when the
+    // `timeout` option fires. Code is undefined in that path.
+    const err = { killed: true, signal: 'SIGTERM', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('timeout');
+    expect(c.signal).toBe('SIGTERM');
+  });
+
+  it('classifies SIGKILL (OOM / external kill) as killed (not timeout)', () => {
+    const err = { killed: true, signal: 'SIGKILL', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('killed');
+    expect(c.signal).toBe('SIGKILL');
+  });
+
+  it('classifies signal-only (no killed flag, no code) as killed', () => {
+    // Some Node versions or wrappers may carry the signal without `killed`.
+    const err = { signal: 'SIGINT', code: undefined, stderr: '' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('killed');
+    expect(c.signal).toBe('SIGINT');
+  });
+
+  it('classifies a rejection with neither code nor signal as unknown', () => {
+    const err = { stderr: 'unexpected' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('unknown');
+    expect(c.stderr).toBe('unexpected');
+  });
+
+  it('handles a non-object rejection without throwing', () => {
+    const c = classifyExecError('boom');
+    expect(c.kind).toBe('unknown');
+    expect(c.stderr).toBeUndefined();
+  });
+
+  it('preserves stderr on rg-error so the operator-facing message is informative', () => {
+    const err = { code: 2, stderr: 'rg: io error: too many open files' };
+    const c = classifyExecError(err);
+    expect(c.kind).toBe('rg-error');
+    expect(c.stderr).toBe('rg: io error: too many open files');
   });
 });

--- a/mcp-servers/repo/src/tools/search-code.ts
+++ b/mcp-servers/repo/src/tools/search-code.ts
@@ -25,6 +25,64 @@ function describeRepo(repo: { name: string; description: string | null }): strin
   return repo.description ? repo.description : 'Code repository';
 }
 
+/**
+ * Classify an `execAsync` rejection so the caller can distinguish
+ * "ripgrep ran and found nothing" (exit 1) from real failures
+ * (timeout / signal / system error / rg internal error). Without this, all
+ * non-zero exits previously bucketed as `code ?? 1`, masking timeouts and
+ * kills as silent "no matches" results (#465).
+ *
+ * Exported for unit testing.
+ */
+export interface ExecErrorClassification {
+  /**
+   *  - 'no-matches': rg exited 1 (no matches found, treat as empty result).
+   *  - 'rg-error':   rg exited 2+ (e.g. invalid regex, IO error).
+   *  - 'timeout':    process killed by execAsync's `timeout` option.
+   *  - 'killed':     process killed by some other signal (OOM, SIGKILL, etc).
+   *  - 'unknown':    rejection didn't carry a recognizable shape (rare).
+   */
+  kind: 'no-matches' | 'rg-error' | 'timeout' | 'killed' | 'unknown';
+  exitCode?: number;
+  signal?: string;
+  stderr?: string;
+}
+
+export function classifyExecError(err: unknown): ExecErrorClassification {
+  const e = err as {
+    code?: number | string;
+    signal?: NodeJS.Signals | string | null;
+    killed?: boolean;
+    stderr?: string;
+  };
+
+  const stderr = typeof e?.stderr === 'string' ? e.stderr : undefined;
+  const codeNum = typeof e?.code === 'number' ? e.code : undefined;
+  const signal = e?.signal ?? undefined;
+  const killed = e?.killed === true;
+
+  // execAsync sets `killed: true` and `signal: 'SIGTERM'` when the `timeout`
+  // option fires. Treat any killed-by-signal rejection as a real error rather
+  // than a "no matches" result. Distinguish timeout from other signals so the
+  // operator-facing error message is actionable.
+  if (killed || (signal && signal !== null)) {
+    const sigName = typeof signal === 'string' ? signal : undefined;
+    if (sigName === 'SIGTERM') {
+      return { kind: 'timeout', signal: sigName, stderr };
+    }
+    return { kind: 'killed', signal: sigName, stderr };
+  }
+
+  if (codeNum === 1) {
+    return { kind: 'no-matches', exitCode: 1, stderr };
+  }
+  if (codeNum !== undefined) {
+    return { kind: 'rg-error', exitCode: codeNum, stderr };
+  }
+
+  return { kind: 'unknown', stderr };
+}
+
 export function registerSearchCodeTool(
   server: McpServer,
   deps: { db: PrismaClient; repoManager: RepoManager },
@@ -103,6 +161,16 @@ export function registerSearchCodeTool(
         '.',
       ].join(' ');
 
+      // Direct exec rationale (#465 Item 3): we deliberately bypass the
+      // command-validator/executeCommand path here. That path is built for
+      // arbitrary operator commands via `repo_exec` (find/grep/cat/etc.) and
+      // would require us to add `rg` to its base allowlist. Here, every shell
+      // token is constructed under our control: flags are constants, globs go
+      // through a strict `^[A-Za-z0-9._*?\[\]/-]+$` regex, the user query is
+      // single-quoted via `shellQuote` and isolated by `--`. We also impose
+      // an explicit timeout + maxBuffer below. The defense-in-depth concern
+      // raised on PR #461 is real but the threat model here is different —
+      // search_code is internal, not a generic shell.
       try {
         const worktreePath = await repoManager.getOrCreateWorktree(repoId, sid);
 
@@ -111,16 +179,38 @@ export function registerSearchCodeTool(
           const result = await execAsync(command, { cwd: worktreePath, timeout: 30_000, maxBuffer: 1024 * 1024 });
           stdout = result.stdout;
         } catch (err: unknown) {
-          const execErr = err as { stdout?: string; stderr?: string; code?: number };
-          const exitCode = execErr.code ?? 1;
-          stdout = execErr.stdout ?? '';
-          // rg exits 1 when no matches found — not an error for us.
-          if (exitCode !== 1) {
-            const stderr = execErr.stderr || '(no stderr)';
-            return {
-              content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code error on ${repo.name}: exit=${exitCode}\n${stderr}` }],
-              isError: true,
-            };
+          const classification = classifyExecError(err);
+          // rg's stdout up to the failure point can still contain partial
+          // matches — keep it for the no-matches case.
+          const partial = (err as { stdout?: string }).stdout ?? '';
+          stdout = partial;
+
+          const stderr = classification.stderr || '(no stderr)';
+          switch (classification.kind) {
+            case 'no-matches':
+              // Expected — rg exits 1 when nothing matches. Fall through
+              // to the empty-stdout output path below.
+              break;
+            case 'timeout':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code timed out on ${repo.name} after 30s. The query may be too broad — try a more specific term, narrow the file extensions, or break the search into multiple calls.\n${stderr}` }],
+                isError: true,
+              };
+            case 'killed':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code was killed (signal=${classification.signal ?? 'unknown'}) on ${repo.name}. This usually indicates the host is under memory pressure or the worktree was cleaned up mid-search.\n${stderr}` }],
+                isError: true,
+              };
+            case 'rg-error':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code error on ${repo.name}: rg exit=${classification.exitCode}\n${stderr}` }],
+                isError: true,
+              };
+            case 'unknown':
+              return {
+                content: [{ type: 'text' as const, text: `[${describeRepo(repo)}] search_code failed on ${repo.name} with no exit code and no signal — likely a child-process spawn or system error.\n${stderr}` }],
+                isError: true,
+              };
           }
         }
 

--- a/packages/ai-provider/src/factory.ts
+++ b/packages/ai-provider/src/factory.ts
@@ -9,6 +9,7 @@ import type { ProviderConfigRow } from './provider-config-resolver.js';
 import { PromptResolver } from './prompt-resolver.js';
 import type { PromptOverrideRow } from './prompt-resolver.js';
 import type { AiUsageEntry, AiArchiveEntry, AiCostLookup } from './types.js';
+import { stripNulBytes } from './scrub.js';
 
 const log = createLogger('ai-router');
 
@@ -255,13 +256,22 @@ export function createAIRouter(
 
   const usageWriter = async (entry: AiUsageEntry): Promise<string | undefined> => {
     if (!dbReady) return undefined;
-    // Prisma JSON fields need undefined (not null) for "no value" — strip null conversationMetadata
+    // Prisma JSON fields need undefined (not null) for "no value" — strip null conversationMetadata.
+    // Also scrub NUL bytes from the three free-text columns (#473): Postgres TEXT rejects 0x00,
+    // and inbound conversation content can carry stray NULs from UTF-16 LE source-file reads or
+    // binary artifact content. Without this scrub the entire audit-log row is dropped on insert.
     const { conversationMetadata, logId, ...rest } = entry;
+    const scrubbedRest = {
+      ...rest,
+      promptText: stripNulBytes(rest.promptText),
+      systemPrompt: stripNulBytes(rest.systemPrompt),
+      responseText: stripNulBytes(rest.responseText),
+    };
     const data = {
       ...(logId ? { id: logId } : {}),
       ...(conversationMetadata != null
-        ? { ...rest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
-        : rest),
+        ? { ...scrubbedRest, conversationMetadata: conversationMetadata as unknown as Record<string, unknown> }
+        : scrubbedRest),
     };
     const row = await db.aiUsageLog.create({ data: data as Record<string, unknown> });
     return row.id;
@@ -269,9 +279,15 @@ export function createAIRouter(
 
   const archiveWriter = async (entry: AiArchiveEntry): Promise<void> => {
     if (!dbReady) return;
-    // Cast conversationMessages to satisfy Prisma's JSON type
+    // Cast conversationMessages to satisfy Prisma's JSON type. Scrub NUL bytes from the
+    // three free-text columns for the same reason as usageWriter (see #473).
     const { conversationMessages, ...rest } = entry;
-    const data: Record<string, unknown> = { ...rest };
+    const data: Record<string, unknown> = {
+      ...rest,
+      fullPrompt: stripNulBytes(rest.fullPrompt),
+      fullResponse: stripNulBytes(rest.fullResponse),
+      systemPrompt: stripNulBytes(rest.systemPrompt),
+    };
     if (conversationMessages != null) {
       data.conversationMessages = conversationMessages;
     }

--- a/packages/ai-provider/src/scrub.test.ts
+++ b/packages/ai-provider/src/scrub.test.ts
@@ -6,7 +6,7 @@ describe('stripNulBytes', () => {
     expect(stripNulBytes('hello world')).toBe('hello world');
   });
 
-  it('returns the same reference (no allocation) when no NUL bytes are present', () => {
+  it('returns the same string when no NUL bytes are present', () => {
     const input = 'hello world';
     expect(stripNulBytes(input)).toBe(input);
   });

--- a/packages/ai-provider/src/scrub.test.ts
+++ b/packages/ai-provider/src/scrub.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { stripNulBytes } from './scrub.js';
+
+describe('stripNulBytes', () => {
+  it('returns unchanged when no NUL bytes are present', () => {
+    expect(stripNulBytes('hello world')).toBe('hello world');
+  });
+
+  it('returns the same reference (no allocation) when no NUL bytes are present', () => {
+    const input = 'hello world';
+    expect(stripNulBytes(input)).toBe(input);
+  });
+
+  it('strips a single NUL byte', () => {
+    expect(stripNulBytes('hello\x00world')).toBe('helloworld');
+  });
+
+  it('strips multiple NUL bytes', () => {
+    expect(stripNulBytes('\x00a\x00b\x00c\x00')).toBe('abc');
+  });
+
+  it('returns null pass-through', () => {
+    expect(stripNulBytes(null)).toBeNull();
+  });
+
+  it('returns undefined pass-through', () => {
+    expect(stripNulBytes(undefined)).toBeUndefined();
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(stripNulBytes('')).toBe('');
+  });
+
+  it('preserves Unicode characters that are not NUL', () => {
+    expect(stripNulBytes('café\x00résumé')).toBe('caférésumé');
+  });
+
+  it('handles all-NUL input', () => {
+    expect(stripNulBytes('\x00\x00\x00')).toBe('');
+  });
+
+  it('handles a NUL embedded in a long realistic string (UTF-16 LE artifact)', () => {
+    // Simulate the failure mode: a 1-char-per-2-bytes UTF-16 LE source string
+    // surviving a naive UTF-8 read — every other byte is 0x00.
+    const input = 's\x00e\x00l\x00e\x00c\x00t\x00 \x00*\x00';
+    expect(stripNulBytes(input)).toBe('select *');
+  });
+});

--- a/packages/ai-provider/src/scrub.ts
+++ b/packages/ai-provider/src/scrub.ts
@@ -23,8 +23,17 @@
 const NUL = String.fromCharCode(0);
 const NUL_PATTERN = new RegExp(NUL, 'g');
 
-export function stripNulBytes<T extends string | null | undefined>(value: T): T {
+// Overloads keep the return type sound: a `string` input returns a `string`,
+// and `null` / `undefined` pass through with their exact types preserved.
+// The previous generic `T extends string | null | undefined` + `as T` cast
+// would mis-declare the result for branded / literal-string inputs, since the
+// stripped value is no longer assignable to the branded input type.
+export function stripNulBytes(value: string): string;
+export function stripNulBytes(value: null): null;
+export function stripNulBytes(value: undefined): undefined;
+export function stripNulBytes(value: string | null | undefined): string | null | undefined;
+export function stripNulBytes(value: string | null | undefined): string | null | undefined {
   if (value == null) return value;
   if (!value.includes(NUL)) return value;
-  return value.replace(NUL_PATTERN, '') as T;
+  return value.replace(NUL_PATTERN, '');
 }

--- a/packages/ai-provider/src/scrub.ts
+++ b/packages/ai-provider/src/scrub.ts
@@ -1,0 +1,30 @@
+/**
+ * Strips NUL bytes (0x00) from a string. Postgres TEXT columns reject any
+ * value containing NUL with error 22021 ("invalid byte sequence for encoding
+ * 'UTF8': 0x00"). This scrubber sits at every persistence chokepoint where
+ * agent-supplied content (tool results, system prompts, response text) is
+ * about to land in the audit log or prompt archive — see issue #473.
+ *
+ * The scrub is defense-in-depth: if upstream content is ever NUL-clean, this
+ * is a no-op (cheap path skips the regex). When NULs do appear, they are
+ * removed silently — the alternative is the entire row being dropped on
+ * insert, which corrupts cost tracking and the analysis trace UI.
+ *
+ * Pass-through for `null` / `undefined` so call sites can wrap nullable fields
+ * without nullish-checks scattered through the writer.
+ *
+ * Likely upstream sources of NUL bytes (not addressed by this scrub — file
+ * follow-up issues if found):
+ *   - `read_file` against UTF-16 LE encoded source files (Windows-default
+ *     SQL files have interspersed 0x00 bytes that survive a naive UTF-8 read).
+ *   - Binary content read via `read_tool_result_artifact` and serialized into
+ *     the conversation message stream.
+ */
+const NUL = String.fromCharCode(0);
+const NUL_PATTERN = new RegExp(NUL, 'g');
+
+export function stripNulBytes<T extends string | null | undefined>(value: T): T {
+  if (value == null) return value;
+  if (!value.includes(NUL)) return value;
+  return value.replace(NUL_PATTERN, '') as T;
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -15,6 +15,9 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "zod": "^3.23.0"
+  },
   "devDependencies": {
     "typescript": "^5.5.0"
   }

--- a/packages/shared-types/src/analysis.ts
+++ b/packages/shared-types/src/analysis.ts
@@ -38,6 +38,10 @@ export const OrchestratedV2BudgetConfigSchema = z
   .refine(
     (cfg) => cfg.ticket.softNudgeRatio < cfg.ticket.hardStopRatio,
     { message: 'ticket.softNudgeRatio must be less than ticket.hardStopRatio' },
+  )
+  .refine(
+    (cfg) => cfg.strategistGuard.softNudgeBatchExhaustedRatio <= cfg.strategistGuard.hardStopCumulativeExhaustedRatio,
+    { message: 'strategistGuard.softNudgeBatchExhaustedRatio must be less than or equal to strategistGuard.hardStopCumulativeExhaustedRatio (otherwise the soft nudge would never fire before the hard stop)' },
   );
 
 export type OrchestratedV2BudgetConfig = z.output<typeof OrchestratedV2BudgetConfigSchema>;

--- a/packages/shared-types/src/analysis.ts
+++ b/packages/shared-types/src/analysis.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Runtime-configurable budget limits for orchestrated-v2 analysis.
+ * Stored as the value of the `orchestrated-v2-budget-config` AppSetting.
+ * See docs/superpowers/specs/2026-04-28-orchestrated-v2-budget-bounds-design.md
+ *
+ * Defaults match the hard-coded constants in orchestrated-v2.ts as of pre-#470 fix.
+ */
+export const OrchestratedV2BudgetConfigSchema = z
+  .object({
+    subTask: z.object({
+      iterationCap: z.number().int().min(1).max(50).default(8),
+      tokenBudget: z.number().int().min(5_000).max(500_000).default(50_000),
+      callBudget: z.number().int().min(1).max(100).default(20),
+      softNudgeRatio: z.number().min(0.1).max(0.99).default(0.6),
+      hardStopRatio: z.number().min(0.1).max(0.99).default(0.85),
+    }).default({}),
+    ticket: z.object({
+      totalTokenBudget: z.number().int().min(50_000).max(5_000_000).default(300_000),
+      softNudgeRatio: z.number().min(0.1).max(0.99).default(0.75),
+      hardStopRatio: z.number().min(0.1).max(0.99).default(0.95),
+    }).default({}),
+    strategistGuard: z.object({
+      softNudgeBatchExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+      hardStopCumulativeExhaustedRatio: z.number().min(0.1).max(0.99).default(0.5),
+      hardStopConsecutiveBatchesRatio: z.number().min(0.1).max(0.99).default(0.8),
+    }).default({}),
+    subTaskReReadDetector: z.object({
+      warnAfterReadCount: z.number().int().min(2).max(20).default(2),
+    }).default({}),
+  })
+  .default({})
+  .refine(
+    (cfg) => cfg.subTask.softNudgeRatio < cfg.subTask.hardStopRatio,
+    { message: 'subTask.softNudgeRatio must be less than subTask.hardStopRatio' },
+  )
+  .refine(
+    (cfg) => cfg.ticket.softNudgeRatio < cfg.ticket.hardStopRatio,
+    { message: 'ticket.softNudgeRatio must be less than ticket.hardStopRatio' },
+  );
+
+export type OrchestratedV2BudgetConfig = z.output<typeof OrchestratedV2BudgetConfigSchema>;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -30,4 +30,5 @@ export * from './action-safety.js';
 export * from './self-client.js';
 export * from './person.js';
 export * from './access-type.js';
+export * from './analysis.js';
 export * from './auth.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,10 @@ importers:
         version: 5.9.3
 
   packages/shared-types:
+    dependencies:
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.5.0

--- a/services/control-panel/src/app/core/services/settings.service.ts
+++ b/services/control-panel/src/app/core/services/settings.service.ts
@@ -152,6 +152,30 @@ export interface AnalysisStrategyVersionConfig {
   version: 'v1' | 'v2';
 }
 
+/** Mirrors OrchestratedV2BudgetConfig from @bronco/shared-types (#470). */
+export interface OrchestratedV2BudgetConfig {
+  subTask: {
+    iterationCap: number;
+    tokenBudget: number;
+    callBudget: number;
+    softNudgeRatio: number;
+    hardStopRatio: number;
+  };
+  ticket: {
+    totalTokenBudget: number;
+    softNudgeRatio: number;
+    hardStopRatio: number;
+  };
+  strategistGuard: {
+    softNudgeBatchExhaustedRatio: number;
+    hardStopCumulativeExhaustedRatio: number;
+    hardStopConsecutiveBatchesRatio: number;
+  };
+  subTaskReReadDetector: {
+    warnAfterReadCount: number;
+  };
+}
+
 export interface SelfAnalysisConfig {
   postAnalysisTrigger: boolean;
   ticketCloseTrigger: boolean;
@@ -312,5 +336,17 @@ export class SettingsService {
   }
   saveSelfAnalysis(config: Partial<SelfAnalysisConfig>): Observable<SelfAnalysisConfig> {
     return this.api.patch<SelfAnalysisConfig>('/settings/self-analysis', config);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orchestrated v2 Budget Config (#470)
+  // ---------------------------------------------------------------------------
+
+  getOrchestratedV2BudgetConfig(): Observable<OrchestratedV2BudgetConfig> {
+    return this.api.get<OrchestratedV2BudgetConfig>('/settings/orchestrated-v2-budget-config');
+  }
+
+  saveOrchestratedV2BudgetConfig(config: OrchestratedV2BudgetConfig): Observable<OrchestratedV2BudgetConfig> {
+    return this.api.put<OrchestratedV2BudgetConfig>('/settings/orchestrated-v2-budget-config', config);
   }
 }

--- a/services/control-panel/src/app/features/settings/settings.component.ts
+++ b/services/control-panel/src/app/features/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, OnDestroy } from '@angular/core';
 import { Subject, Subscription, debounceTime, switchMap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -18,6 +18,7 @@ import {
   SlackSystemConfig,
   PromptRetentionConfig,
   ToolRequestRateLimitConfig,
+  OrchestratedV2BudgetConfig,
 } from '../../core/services/settings.service.js';
 import { ExternalServiceDialogComponent } from './external-service-dialog.component.js';
 import { StatusConfigDialogComponent } from './status-config-dialog.component.js';
@@ -426,6 +427,101 @@ function getTabIndexFromSlug(tab: string | null | undefined): number {
             </app-card>
 
             <app-card>
+              <h2 class="section-title">Orchestrated v2 Budget Limits</h2>
+              <p class="hint">
+                Numeric guardrails for the orchestrated-v2 analysis engine. Sub-task limits apply per
+                dispatched task; ticket limits cap the whole run. Ratios are fractions of the
+                respective budget (0.1&ndash;0.99). Changes take effect on the next analysis run.
+              </p>
+              @if (budgetConfigLoading()) {
+                <div class="loading-wrapper"><span class="loading-text">Loading...</span></div>
+              } @else {
+                <h3 class="subsection-title">Sub-task limits</h3>
+                <div class="form-grid">
+                  <app-form-field label="Iteration cap" hint="Max tool-call iterations per sub-task (1–50)">
+                    <input class="text-input" type="number" min="1" max="50"
+                      [value]="budgetConfig().subTask.iterationCap"
+                      (input)="updateSubTaskField('iterationCap', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Token budget" hint="Max tokens per sub-task (5000–500000)">
+                    <input class="text-input" type="number" min="5000" max="500000" step="1000"
+                      [value]="budgetConfig().subTask.tokenBudget"
+                      (input)="updateSubTaskField('tokenBudget', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Tool call budget" hint="Max tool calls per sub-task (1–100)">
+                    <input class="text-input" type="number" min="1" max="100"
+                      [value]="budgetConfig().subTask.callBudget"
+                      (input)="updateSubTaskField('callBudget', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Soft-nudge ratio" hint="Fraction of token budget at which a soft nudge fires (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().subTask.softNudgeRatio"
+                      (input)="updateSubTaskField('softNudgeRatio', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Hard-stop ratio" hint="Fraction of token budget at which the sub-task is force-stopped (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().subTask.hardStopRatio"
+                      (input)="updateSubTaskField('hardStopRatio', +$any($event.target).value)">
+                  </app-form-field>
+                </div>
+
+                <h3 class="subsection-title">Ticket-level cap</h3>
+                <div class="form-grid">
+                  <app-form-field label="Total token budget" hint="Max tokens across the entire orchestrated run (50000–5000000)">
+                    <input class="text-input" type="number" min="50000" max="5000000" step="10000"
+                      [value]="budgetConfig().ticket.totalTokenBudget"
+                      (input)="updateTicketField('totalTokenBudget', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Soft-nudge ratio" hint="Fraction of ticket token budget for a soft nudge (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().ticket.softNudgeRatio"
+                      (input)="updateTicketField('softNudgeRatio', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Hard-stop ratio" hint="Fraction of ticket token budget at which the run is force-stopped (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().ticket.hardStopRatio"
+                      (input)="updateTicketField('hardStopRatio', +$any($event.target).value)">
+                  </app-form-field>
+                </div>
+
+                <h3 class="subsection-title">Strategist guard</h3>
+                <div class="form-grid">
+                  <app-form-field label="Soft-nudge batch exhausted ratio" hint="Fraction of batches exhausted before a soft nudge fires (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().strategistGuard.softNudgeBatchExhaustedRatio"
+                      (input)="updateGuardField('softNudgeBatchExhaustedRatio', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Hard-stop cumulative ratio" hint="Cumulative exhausted-batch fraction for a hard stop (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().strategistGuard.hardStopCumulativeExhaustedRatio"
+                      (input)="updateGuardField('hardStopCumulativeExhaustedRatio', +$any($event.target).value)">
+                  </app-form-field>
+                  <app-form-field label="Hard-stop consecutive batches ratio" hint="Consecutive fully-exhausted batches fraction for a hard stop (0.1–0.99)">
+                    <input class="text-input" type="number" min="0.1" max="0.99" step="0.05"
+                      [value]="budgetConfig().strategistGuard.hardStopConsecutiveBatchesRatio"
+                      (input)="updateGuardField('hardStopConsecutiveBatchesRatio', +$any($event.target).value)">
+                  </app-form-field>
+                </div>
+
+                <h3 class="subsection-title">Re-read detector</h3>
+                <div class="form-grid">
+                  <app-form-field label="Warn after read count" hint="Number of times a sub-task re-reads the same section before a warning is logged (2–20)">
+                    <input class="text-input" type="number" min="2" max="20"
+                      [value]="budgetConfig().subTaskReReadDetector.warnAfterReadCount"
+                      (input)="updateReReadField(+$any($event.target).value)">
+                  </app-form-field>
+                </div>
+
+                <div class="card-actions">
+                  <app-bronco-button variant="primary" (click)="saveBudgetConfig()" [disabled]="!budgetConfigDirty() || budgetConfigSaving()">
+                    @if (budgetConfigSaving()) { Saving... } @else { Save }
+                  </app-bronco-button>
+                  <app-bronco-button variant="secondary" (click)="reloadBudgetConfig()" [disabled]="!budgetConfigDirty()">Reset</app-bronco-button>
+                </div>
+              }
+            </app-card>
+
+            <app-card>
               <h2 class="section-title">Self Analysis</h2>
               <p class="hint">
                 Configure triggers for Bronco to analyze its own operations and suggest improvements.
@@ -676,6 +772,12 @@ function getTabIndexFromSlug(tab: string | null | undefined): number {
       font-weight: 600;
       color: var(--text-primary);
     }
+    .subsection-title {
+      margin: 16px 0 8px;
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-secondary);
+    }
     .hint {
       color: var(--text-tertiary);
       margin-bottom: 16px;
@@ -866,6 +968,21 @@ export class SettingsComponent implements OnInit, OnDestroy {
     { value: 'v1', label: 'v1 (legacy \u2014 full context per call + raw-append knowledge doc)' },
   ];
 
+  // Orchestrated v2 Budget Config
+  private readonly budgetConfigDefaults: OrchestratedV2BudgetConfig = {
+    subTask: { iterationCap: 8, tokenBudget: 50_000, callBudget: 20, softNudgeRatio: 0.6, hardStopRatio: 0.85 },
+    ticket: { totalTokenBudget: 300_000, softNudgeRatio: 0.75, hardStopRatio: 0.95 },
+    strategistGuard: { softNudgeBatchExhaustedRatio: 0.5, hardStopCumulativeExhaustedRatio: 0.5, hardStopConsecutiveBatchesRatio: 0.8 },
+    subTaskReReadDetector: { warnAfterReadCount: 2 },
+  };
+  budgetConfig = signal<OrchestratedV2BudgetConfig>({ ...this.budgetConfigDefaults });
+  private budgetConfigInitial = signal<OrchestratedV2BudgetConfig>({ ...this.budgetConfigDefaults });
+  budgetConfigDirty = computed(() =>
+    JSON.stringify(this.budgetConfig()) !== JSON.stringify(this.budgetConfigInitial()),
+  );
+  budgetConfigLoading = signal(true);
+  budgetConfigSaving = signal(false);
+
   // Self Analysis tab
   selfAnalysisLoading = signal(true);
   selfAnalysisPostAnalysis = signal(false);
@@ -900,6 +1017,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.loadActionSafety();
     this.loadAnalysisStrategy();
     this.loadAnalysisStrategyVersion();
+    this.reloadBudgetConfig();
     this.loadSelfAnalysis();
     this.loadSystemConfigs();
 
@@ -1188,6 +1306,59 @@ export class SettingsComponent implements OnInit, OnDestroy {
         this.toast.error('Failed to save analysis strategy version');
       },
     });
+  }
+
+  // ─── Orchestrated v2 Budget Config ───
+
+  reloadBudgetConfig(): void {
+    this.budgetConfigLoading.set(true);
+    this.settingsSvc.getOrchestratedV2BudgetConfig().subscribe({
+      next: (cfg) => {
+        this.budgetConfig.set(cfg);
+        this.budgetConfigInitial.set(cfg);
+        this.budgetConfigLoading.set(false);
+      },
+      error: () => {
+        this.budgetConfigLoading.set(false);
+        this.toast.error('Failed to load orchestrated v2 budget config');
+      },
+    });
+  }
+
+  saveBudgetConfig(): void {
+    this.budgetConfigSaving.set(true);
+    this.settingsSvc.saveOrchestratedV2BudgetConfig(this.budgetConfig()).subscribe({
+      next: (cfg) => {
+        this.budgetConfig.set(cfg);
+        this.budgetConfigInitial.set(cfg);
+        this.budgetConfigSaving.set(false);
+        this.toast.success('Budget config saved');
+      },
+      error: () => {
+        this.budgetConfigSaving.set(false);
+        this.toast.error('Failed to save budget config');
+      },
+    });
+  }
+
+  updateSubTaskField<K extends keyof OrchestratedV2BudgetConfig['subTask']>(field: K, value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, subTask: { ...c.subTask, [field]: value } }));
+  }
+
+  updateTicketField<K extends keyof OrchestratedV2BudgetConfig['ticket']>(field: K, value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, ticket: { ...c.ticket, [field]: value } }));
+  }
+
+  updateGuardField<K extends keyof OrchestratedV2BudgetConfig['strategistGuard']>(field: K, value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, strategistGuard: { ...c.strategistGuard, [field]: value } }));
+  }
+
+  updateReReadField(value: number): void {
+    if (Number.isNaN(value)) return;
+    this.budgetConfig.update(c => ({ ...c, subTaskReReadDetector: { warnAfterReadCount: value } }));
   }
 
   // ─── Self Analysis ───

--- a/services/copilot-api/src/routes/settings.ts
+++ b/services/copilot-api/src/routes/settings.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { TicketStatus, TicketCategory, DEFAULT_OPERATIONAL_ALERT_CONFIG, DEFAULT_ACTION_SAFETY_CONFIG, OperatorRole } from '@bronco/shared-types';
+import { TicketStatus, TicketCategory, DEFAULT_OPERATIONAL_ALERT_CONFIG, DEFAULT_ACTION_SAFETY_CONFIG, OperatorRole, OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
 import type { OperationalAlertConfig, ActionSafetyConfig, ActionSafetyLevel } from '@bronco/shared-types';
 import { Mailer, createLogger, decrypt, encrypt, loadSmtpFromDb, looksEncrypted } from '@bronco/shared-utils';
 import { z } from 'zod';
@@ -44,6 +44,7 @@ const SETTINGS_KEY_PROMPT_RETENTION = 'system-config-prompt-retention';
 const SETTINGS_KEY_ACTION_SAFETY = 'system-config-action-safety';
 const SETTINGS_KEY_ANALYSIS_STRATEGY = 'system-config-analysis-strategy';
 const SETTINGS_KEY_ANALYSIS_STRATEGY_VERSION = 'analysis-strategy-version';
+const SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG = 'orchestrated-v2-budget-config';
 const SETTINGS_KEY_SELF_ANALYSIS = 'self_analysis_config';
 const SETTINGS_KEY_TOOL_REQUEST_RATE_LIMIT = 'tool-request-rate-limit-per-run';
 
@@ -1196,6 +1197,50 @@ export async function settingsRoutes(fastify: FastifyInstance, opts: SettingsRou
         create: { key: SETTINGS_KEY_ANALYSIS_STRATEGY_VERSION, value: config as unknown as object },
       });
       return row.value as AnalysisStrategyVersionConfig;
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Orchestrated v2 Budget Config (#470)
+  // ---------------------------------------------------------------------------
+
+  fastify.get('/api/settings/orchestrated-v2-budget-config', async () => {
+    const row = await fastify.db.appSetting.findUnique({
+      where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+    });
+    if (!row) return OrchestratedV2BudgetConfigSchema.parse({});
+    const parsed = OrchestratedV2BudgetConfigSchema.safeParse(row.value);
+    if (!parsed.success) {
+      logger.warn(
+        { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG, errors: parsed.error.issues },
+        'Stored orchestrated-v2 budget config is malformed — resetting to defaults',
+      );
+      const defaults = OrchestratedV2BudgetConfigSchema.parse({});
+      await fastify.db.appSetting.update({
+        where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+        data: { value: defaults as unknown as object },
+      });
+      return defaults;
+    }
+    return parsed.data;
+  });
+
+  fastify.put<{ Body: Record<string, unknown> }>(
+    '/api/settings/orchestrated-v2-budget-config',
+    { preHandler: requireRole(OperatorRole.ADMIN) },
+    async (request) => {
+      const parsed = OrchestratedV2BudgetConfigSchema.safeParse(request.body);
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+        return fastify.httpErrors.badRequest(`Invalid orchestrated-v2 budget config: ${msg}`);
+      }
+      const config = parsed.data;
+      const row = await fastify.db.appSetting.upsert({
+        where: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG },
+        update: { value: config as unknown as object },
+        create: { key: SETTINGS_KEY_ORCHESTRATED_V2_BUDGET_CONFIG, value: config as unknown as object },
+      });
+      return row.value as typeof config;
     },
   );
 

--- a/services/ticket-analyzer/src/analysis/budget-thresholds.test.ts
+++ b/services/ticket-analyzer/src/analysis/budget-thresholds.test.ts
@@ -44,6 +44,10 @@ describe('evaluateTicketBudget', () => {
     expect(evaluateTicketBudget(150_000, config.ticket)).toBe('OK');
   });
 
+  it('returns OK just below 75% (boundary inclusivity check)', () => {
+    expect(evaluateTicketBudget(224_999, config.ticket)).toBe('OK');
+  });
+
   it('returns SOFT_NUDGE at 75%', () => {
     expect(evaluateTicketBudget(225_000, config.ticket)).toBe('SOFT_NUDGE');
   });

--- a/services/ticket-analyzer/src/analysis/budget-thresholds.test.ts
+++ b/services/ticket-analyzer/src/analysis/budget-thresholds.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
+import {
+  evaluateSubTaskBudget,
+  evaluateTicketBudget,
+  detectArtifactReread,
+  evaluateBatchFailureGuard,
+  type BatchFailureGuardState,
+  type SubTaskBudgetUsage,
+} from './budget-thresholds.js';
+
+const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+describe('evaluateSubTaskBudget', () => {
+  const usage: SubTaskBudgetUsage = { tokensUsed: 0, iterationsUsed: 0, toolCallsUsed: 0 };
+
+  it('returns OK below soft threshold on all axes', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 25_000 }, config.subTask)).toBe('OK');
+  });
+
+  it('returns SOFT_NUDGE at 60% tokens', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 30_000 }, config.subTask)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 85% tokens', () => {
+    expect(evaluateSubTaskBudget({ ...usage, tokensUsed: 42_500 }, config.subTask)).toBe('HARD_STOP');
+  });
+
+  it('returns SOFT_NUDGE at 60% iterations even when tokens low', () => {
+    expect(evaluateSubTaskBudget({ ...usage, iterationsUsed: 5 }, config.subTask)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 85% calls even when tokens and iterations low', () => {
+    expect(evaluateSubTaskBudget({ ...usage, toolCallsUsed: 17 }, config.subTask)).toBe('HARD_STOP');
+  });
+
+  it('hardest of three axes wins (HARD beats SOFT)', () => {
+    expect(evaluateSubTaskBudget({ tokensUsed: 30_000, iterationsUsed: 0, toolCallsUsed: 17 }, config.subTask)).toBe('HARD_STOP');
+  });
+});
+
+describe('evaluateTicketBudget', () => {
+  it('returns OK below 75%', () => {
+    expect(evaluateTicketBudget(150_000, config.ticket)).toBe('OK');
+  });
+
+  it('returns SOFT_NUDGE at 75%', () => {
+    expect(evaluateTicketBudget(225_000, config.ticket)).toBe('SOFT_NUDGE');
+  });
+
+  it('returns HARD_STOP at 95%', () => {
+    expect(evaluateTicketBudget(285_000, config.ticket)).toBe('HARD_STOP');
+  });
+});
+
+describe('detectArtifactReread', () => {
+  const fakeId = '11111111-1111-1111-1111-111111111111';
+
+  it('returns false on first read of an artifact', () => {
+    const counts = new Map<string, number>();
+    expect(detectArtifactReread(counts, fakeId, 2)).toBe(false);
+    expect(counts.get(fakeId)).toBe(1);
+  });
+
+  it('returns true on second read when threshold is 2 (fires AT threshold)', () => {
+    const counts = new Map<string, number>([[fakeId, 1]]);
+    expect(detectArtifactReread(counts, fakeId, 2)).toBe(true);
+    expect(counts.get(fakeId)).toBe(2);
+  });
+
+  it('returns true on third read with threshold 3', () => {
+    const counts = new Map<string, number>([[fakeId, 2]]);
+    expect(detectArtifactReread(counts, fakeId, 3)).toBe(true);
+  });
+
+  it('separately tracks distinct artifactIds', () => {
+    const otherId = '22222222-2222-2222-2222-222222222222';
+    const counts = new Map<string, number>([[fakeId, 5]]);
+    expect(detectArtifactReread(counts, otherId, 2)).toBe(false);
+  });
+});
+
+describe('evaluateBatchFailureGuard', () => {
+  const fresh = (): BatchFailureGuardState => ({
+    cumulativeExhausted: 0,
+    cumulativeTotal: 0,
+    consecutiveBadBatches: 0,
+  });
+
+  const exhausted = { stopReason: 'BUDGET_EXHAUSTED' as const, updatedKdSections: [] };
+  const finalized = { stopReason: 'FINALIZED' as const, updatedKdSections: ['evidence.foo'] };
+  const exhaustedWithKd = { stopReason: 'BUDGET_EXHAUSTED' as const, updatedKdSections: ['evidence.foo'] };
+
+  it('OK on first batch even if all exhausted (gives strategist a free first try)', () => {
+    const state = fresh();
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted], config.strategistGuard, true)).toBe('OK');
+  });
+
+  it('SOFT_NUDGE on second batch when ≥50% exhausted with empty updatedKdSections', () => {
+    const state = fresh();
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 2;
+    expect(evaluateBatchFailureGuard(state, [exhausted, finalized, exhausted], config.strategistGuard, false)).toBe('SOFT_NUDGE');
+  });
+
+  it('OK when ≥50% exhausted but updatedKdSections non-empty (sub-tasks did some work)', () => {
+    const state = fresh();
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 2;
+    expect(evaluateBatchFailureGuard(state, [exhaustedWithKd, exhaustedWithKd, finalized], config.strategistGuard, false)).toBe('OK');
+  });
+
+  it('HARD_STOP when cumulative exhausted ratio crosses 50%', () => {
+    const state = fresh();
+    state.cumulativeTotal = 8;
+    state.cumulativeExhausted = 4;
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted], config.strategistGuard, false)).toBe('HARD_STOP');
+  });
+
+  it('HARD_STOP after 2 consecutive bad batches (≥80% each)', () => {
+    const state = fresh();
+    state.consecutiveBadBatches = 1;
+    state.cumulativeTotal = 5;
+    state.cumulativeExhausted = 4;
+    expect(evaluateBatchFailureGuard(state, [exhausted, exhausted, exhausted, exhausted, finalized], config.strategistGuard, false)).toBe('HARD_STOP');
+  });
+});

--- a/services/ticket-analyzer/src/analysis/budget-thresholds.ts
+++ b/services/ticket-analyzer/src/analysis/budget-thresholds.ts
@@ -1,0 +1,132 @@
+import type { OrchestratedV2BudgetConfig } from '@bronco/shared-types';
+
+export type ThresholdVerdict = 'OK' | 'SOFT_NUDGE' | 'HARD_STOP';
+
+export interface SubTaskBudgetUsage {
+  tokensUsed: number;
+  iterationsUsed: number;
+  toolCallsUsed: number;
+}
+
+/**
+ * Evaluate sub-task budget consumption across three axes (tokens, iterations,
+ * tool calls). Returns the WORST (most-restrictive) verdict — if tokens are at
+ * 60% but tool calls are at 85%, returns HARD_STOP.
+ */
+export function evaluateSubTaskBudget(
+  usage: SubTaskBudgetUsage,
+  config: OrchestratedV2BudgetConfig['subTask'],
+): ThresholdVerdict {
+  const tokenRatio = usage.tokensUsed / config.tokenBudget;
+  const iterRatio = usage.iterationsUsed / config.iterationCap;
+  const callRatio = usage.toolCallsUsed / config.callBudget;
+  const worst = Math.max(tokenRatio, iterRatio, callRatio);
+
+  if (worst >= config.hardStopRatio) return 'HARD_STOP';
+  if (worst >= config.softNudgeRatio) return 'SOFT_NUDGE';
+  return 'OK';
+}
+
+/**
+ * Evaluate ticket-level total token consumption against the configured budget.
+ */
+export function evaluateTicketBudget(
+  totalTokensConsumed: number,
+  config: OrchestratedV2BudgetConfig['ticket'],
+): ThresholdVerdict {
+  const ratio = totalTokensConsumed / config.totalTokenBudget;
+  if (ratio >= config.hardStopRatio) return 'HARD_STOP';
+  if (ratio >= config.softNudgeRatio) return 'SOFT_NUDGE';
+  return 'OK';
+}
+
+/**
+ * Track repeated reads of the same artifact within a sub-task. Mutates `counts`
+ * in place — caller owns the map for the duration of one sub-task. Fires (returns
+ * true) the FIRST time the count reaches the warn threshold, so the caller can
+ * append a single nudge to the next tool_result.
+ *
+ * After firing once for a given artifact, will continue to fire on every
+ * subsequent read of the same artifact in this sub-task — caller decides
+ * whether to repeat the nudge or suppress.
+ */
+export function detectArtifactReread(
+  counts: Map<string, number>,
+  artifactId: string,
+  warnAfterReadCount: number,
+): boolean {
+  const next = (counts.get(artifactId) ?? 0) + 1;
+  counts.set(artifactId, next);
+  return next >= warnAfterReadCount;
+}
+
+export interface BatchFailureGuardState {
+  cumulativeExhausted: number;
+  cumulativeTotal: number;
+  consecutiveBadBatches: number;
+}
+
+export interface BatchResultSummary {
+  stopReason: string;
+  updatedKdSections: string[];
+}
+
+/**
+ * Evaluate a freshly-completed dispatch_subtasks batch against the cumulative
+ * guard state and the per-batch failure ratio. Mutates `state` in place to
+ * accumulate metrics for the next call.
+ *
+ * `isFirstBatch` is true on the first dispatch in the run (cumulativeTotal == 0
+ * before this batch) — gives the strategist a free first try without firing
+ * the guard, since first-batch failures may reflect bad initial sub-task design
+ * rather than a death spiral.
+ */
+export function evaluateBatchFailureGuard(
+  state: BatchFailureGuardState,
+  batchResults: BatchResultSummary[],
+  config: OrchestratedV2BudgetConfig['strategistGuard'],
+  isFirstBatch: boolean,
+): ThresholdVerdict {
+  const batchSize = batchResults.length;
+  if (batchSize === 0) return 'OK';
+
+  const batchExhausted = batchResults.filter(r => r.stopReason === 'BUDGET_EXHAUSTED').length;
+  const batchExhaustedWithoutKd = batchResults.filter(
+    r => r.stopReason === 'BUDGET_EXHAUSTED' && r.updatedKdSections.length === 0,
+  ).length;
+  const batchExhaustedRatio = batchExhausted / batchSize;
+  const batchExhaustedWithoutKdRatio = batchExhaustedWithoutKd / batchSize;
+
+  // Update cumulative metrics
+  state.cumulativeExhausted += batchExhausted;
+  state.cumulativeTotal += batchSize;
+
+  // Track consecutive-bad-batches for HARD_STOP rule 2
+  if (batchExhaustedRatio >= config.hardStopConsecutiveBatchesRatio) {
+    state.consecutiveBadBatches += 1;
+  } else {
+    state.consecutiveBadBatches = 0;
+  }
+
+  // Free first batch
+  if (isFirstBatch) return 'OK';
+
+  // HARD_STOP rule 1: cumulative exhausted ratio crosses threshold (strictly over)
+  if (state.cumulativeTotal > 0
+    && state.cumulativeExhausted / state.cumulativeTotal > config.hardStopCumulativeExhaustedRatio) {
+    return 'HARD_STOP';
+  }
+
+  // HARD_STOP rule 2: N consecutive bad batches (≥80% exhausted each)
+  // N is implicit — fires once consecutiveBadBatches >= 2
+  if (state.consecutiveBadBatches >= 2) {
+    return 'HARD_STOP';
+  }
+
+  // SOFT_NUDGE: this batch was bad (≥50% exhausted with empty updatedKdSections)
+  if (batchExhaustedWithoutKdRatio >= config.softNudgeBatchExhaustedRatio) {
+    return 'SOFT_NUDGE';
+  }
+
+  return 'OK';
+}

--- a/services/ticket-analyzer/src/analysis/budget-thresholds.ts
+++ b/services/ticket-analyzer/src/analysis/budget-thresholds.ts
@@ -111,7 +111,12 @@ export function evaluateBatchFailureGuard(
   // Free first batch
   if (isFirstBatch) return 'OK';
 
-  // HARD_STOP rule 1: cumulative exhausted ratio crosses threshold (strictly over)
+  // HARD_STOP rule 1: cumulative exhausted ratio crosses threshold.
+  // Strictly `>` (not `>=`): when softNudgeBatchExhaustedRatio and
+  // hardStopCumulativeExhaustedRatio are equal (e.g. both 0.5 by default),
+  // the boundary value belongs to SOFT_NUDGE so the nudge always fires at
+  // least once before the hard stop. Reverting this to `>=` will silently
+  // break the SOFT_NUDGE-at-50% test in budget-thresholds.test.ts.
   if (state.cumulativeTotal > 0
     && state.cumulativeExhausted / state.cumulativeTotal > config.hardStopCumulativeExhaustedRatio) {
     return 'HARD_STOP';

--- a/services/ticket-analyzer/src/analysis/flat-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.test.ts
@@ -763,6 +763,98 @@ describe('runFlatV2', () => {
       const userMsg = capturedMessages.find(m => m.role === 'user');
       expect(userMsg?.content).toContain('Can you check table fragmentation?');
     });
+
+    it('surfaces priorExecutiveSummary as a dedicated section ahead of the conversation history (#48 Item 7)', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      const reanalysisCtx = {
+        conversationHistory: '### [2026-04-20 09:00] Reply (chad@example.com)\n\nFollow-up.',
+        triggerReplyText: 'Continue from where you left off.',
+        priorExecutiveSummary: [
+          '## Executive Summary',
+          '',
+          'Identified deadlock between Orders and OrderLines transactions.',
+          '',
+          '## Continuation Notes',
+          '',
+          'Budget cap fired before validating fix on staging. Next run should rerun the trace test.',
+        ].join('\n'),
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).toContain('## Prior Executive Summary');
+      expect(capturedSystemPrompt).toContain('Identified deadlock between Orders and OrderLines transactions.');
+      expect(capturedSystemPrompt).toContain('## Continuation Notes');
+      expect(capturedSystemPrompt).toContain('rerun the trace test');
+
+      // Ordering: Prior Executive Summary comes before Conversation History so
+      // the strategist sees the prior findings as primary steering input.
+      const priorIdx = capturedSystemPrompt.indexOf('## Prior Executive Summary');
+      const histIdx = capturedSystemPrompt.indexOf('## Conversation History');
+      expect(priorIdx).toBeGreaterThan(-1);
+      expect(histIdx).toBeGreaterThan(-1);
+      expect(priorIdx).toBeLessThan(histIdx);
+    });
+
+    it('omits the Prior Executive Summary section when reanalysisCtx has no priorExecutiveSummary', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      const reanalysisCtx = {
+        conversationHistory: '## History',
+        triggerReplyText: 'Continue.',
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).not.toContain('## Prior Executive Summary');
+    });
+
+    it('truncates a prior executive summary that exceeds the cap, keeping the tail (Continuation Notes)', async () => {
+      const db = makeMockDb();
+      let capturedSystemPrompt = '';
+      const generateWithTools = vi.fn().mockImplementation(async (req: { systemPrompt: string }) => {
+        capturedSystemPrompt = req.systemPrompt;
+        return makeFinalTextResponse('re-analysis done');
+      });
+      const deps = makeDeps(db, generateWithTools);
+
+      // Build a > 8000-char summary with the Continuation Notes at the end.
+      const filler = 'X'.repeat(9000);
+      const tail = '## Continuation Notes\n\nResume sub-task 3 (index review) — sub-tasks 1 and 2 already wrote findings.';
+      const reanalysisCtx = {
+        conversationHistory: '## History',
+        triggerReplyText: 'Continue.',
+        priorExecutiveSummary: `${filler}\n\n${tail}`,
+      };
+
+      await runFlatV2(deps, makePipelineCtx(), makeStep(), makeToolCtx(), {
+        maxIterations: 1,
+        reanalysisCtx,
+      });
+
+      expect(capturedSystemPrompt).toContain('Prior executive summary truncated');
+      expect(capturedSystemPrompt).toContain('## Continuation Notes');
+      expect(capturedSystemPrompt).toContain('Resume sub-task 3');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/services/ticket-analyzer/src/analysis/flat-v2.ts
+++ b/services/ticket-analyzer/src/analysis/flat-v2.ts
@@ -17,6 +17,7 @@ import {
   saveMcpToolArtifact,
   shouldTruncate,
   SUFFICIENCY_EVAL_INSTRUCTIONS,
+  truncatePriorExecutiveSummary,
   type AgenticToolContext,
   type AnalysisDeps,
   type AnalysisPipelineContext,
@@ -83,6 +84,18 @@ export async function runFlatV2(
     );
     const reanalAttBlock = buildAttachmentsBlock(attachments);
     if (reanalAttBlock) systemParts.push(reanalAttBlock);
+    // #48 Item 7: surface the prior run's composed analysis as a primary
+    // steering input, ahead of the chronological conversation history. If the
+    // prior run hit the ticket-budget cap, this includes the agent's
+    // `## Continuation Notes` section telling us where to pick up.
+    if (reanalysisCtx.priorExecutiveSummary) {
+      systemParts.push(
+        '',
+        '## Prior Executive Summary',
+        '',
+        truncatePriorExecutiveSummary(reanalysisCtx.priorExecutiveSummary),
+      );
+    }
     systemParts.push(
       '',
       '## Conversation History',

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1339,6 +1339,90 @@ describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
     expect(iter2.tools.map(t => t.name)).not.toContain('dispatch_subtasks');
     expect(iter2.tools.map(t => t.name)).toContain('complete_analysis');
   });
+
+  it('aborts dispatch and injects directive when batch worst-case would overflow ticket cap (#477 review)', async () => {
+    // Pre-batch overshoot guard. Top-of-iteration is below HARD_STOP, but the
+    // batch's worst-case cost would push past the cap.
+    //
+    // Configure a tight ticket budget where iter 1 stays under HARD_STOP at
+    // top-of-iter, but the dispatched batch (5 sub-tasks × 50_000 token
+    // budget = 250_000 worst-case) would overflow.
+    //
+    // ticket.totalTokenBudget = 300_000 (default), iter 1 strategist returns
+    // 200_000 inputTokens (~67%, below soft-nudge of 75%). Then iter 1's
+    // dispatch is 5 sub-tasks; pre-batch worst-case = 5 × 50_000 = 250_000;
+    // 200_000 + 250_000 = 450_000 > 300_000 → wouldOverflow = true.
+    //
+    // Expected: iter 1's batch is aborted; directive is injected; the
+    // dispatch_subtasks call gets a synthetic abort tool_result; iter 2's
+    // strategist tool list is restricted.
+
+    const calls: Array<{ role: 'strategist' | 'subtask'; messages: unknown[]; tools: { name: string }[] }> = [];
+
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: unknown[]; tools: Array<{ name: string }> }) => {
+      const isStrategist = tools.some(t => t.name === 'dispatch_subtasks' || t.name === 'complete_analysis');
+      const role = isStrategist ? 'strategist' : 'subtask';
+      calls.push({ role, messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+
+      if (isStrategist) {
+        const strategistCallNum = calls.filter(c => c.role === 'strategist').length;
+        if (strategistCallNum === 1) {
+          // Iter 1: dispatch 5 sub-tasks, consume 200_000 tokens (below top-of-iter HARD_STOP at 285k).
+          // Worst-case batch cost: 5 × 50_000 = 250_000. Total worst-case: 450_000 > 300_000.
+          return {
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 200_000, outputTokens: 0 },
+            contentBlocks: [{
+              type: 'tool_use' as const, id: 'd1', name: 'dispatch_subtasks',
+              input: {
+                subtasks: [
+                  { id: 'st-1', intent: 'a', tools: [], model: 'haiku' },
+                  { id: 'st-2', intent: 'b', tools: [], model: 'haiku' },
+                  { id: 'st-3', intent: 'c', tools: [], model: 'haiku' },
+                  { id: 'st-4', intent: 'd', tools: [], model: 'haiku' },
+                  { id: 'st-5', intent: 'e', tools: [], model: 'haiku' },
+                ],
+              },
+            } satisfies AIToolUseBlock],
+          };
+        }
+        // Iter 2: complete_analysis (after batch was aborted)
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 0, outputTokens: 0 },
+          contentBlocks: [{
+            type: 'tool_use' as const, id: 'c1', name: 'complete_analysis',
+            input: { finalAnalysis: 'completed under pre-batch hard-stop' },
+          } satisfies AIToolUseBlock],
+        };
+      }
+      // Sub-task path should NEVER be hit if pre-batch guard works.
+      throw new Error('Sub-task generateWithTools called — pre-batch guard failed to abort');
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // Verify the sub-task path was never invoked (pre-batch guard aborted before execution)
+    const subtaskCalls = calls.filter(c => c.role === 'subtask');
+    expect(subtaskCalls).toHaveLength(0);
+
+    // Iter 2 strategist must have seen the directive AND have a restricted tool list
+    const strategistCalls = calls.filter(c => c.role === 'strategist');
+    expect(strategistCalls.length).toBeGreaterThanOrEqual(2);
+    const iter2 = strategistCalls[1];
+    const iter2MessagesStr = JSON.stringify(iter2.messages);
+    expect(iter2MessagesStr).toMatch(/## Continuation Notes/);
+    expect(iter2MessagesStr).toMatch(/Dispatch aborted/);
+    expect(iter2.tools.map(t => t.name)).not.toContain('dispatch_subtasks');
+    expect(iter2.tools.map(t => t.name)).toContain('complete_analysis');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -19,6 +19,8 @@ import type { PrismaClient } from '@bronco/db';
 import type { AIRouter } from '@bronco/ai-provider';
 import type { AppLogger } from '@bronco/shared-utils';
 import { initEmptyKnowledgeDoc } from '@bronco/shared-utils';
+import type { AIToolUseBlock } from '@bronco/shared-types';
+import { OrchestratedV2BudgetConfigSchema } from '@bronco/shared-types';
 
 // ---------------------------------------------------------------------------
 // Module-level mocks — must precede SUT import
@@ -44,6 +46,21 @@ vi.mock('@bronco/shared-utils', async (importOriginal) => {
   };
 });
 
+// Stub executeAgenticToolCall in shared.js so tests run without live MCP servers.
+// importOriginal preserves all other exports (constants, types, helpers) used by
+// orchestrated-v2.ts so existing tests are unaffected.
+vi.mock('./shared.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./shared.js')>();
+  return {
+    ...actual,
+    executeAgenticToolCall: vi.fn(async (toolUse: AIToolUseBlock) => ({
+      toolUseId: toolUse.id,
+      result: 'fake tool result content',
+      isError: false,
+    })),
+  };
+});
+
 // Stub v2-knowledge-doc helpers so they don't touch the DB.
 vi.mock('./v2-knowledge-doc.js', () => ({
   composeFinalAnalysis: vi.fn().mockReturnValue('composed analysis'),
@@ -61,7 +78,7 @@ import {
 } from './v2-knowledge-doc.js';
 
 // Import the SUT (after mocks are in place)
-import { runOrchestratedV2 } from './orchestrated-v2.js';
+import { runOrchestratedV2, runSubTaskLoop } from './orchestrated-v2.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -890,6 +907,106 @@ describe('stall guard: writeStallMarker is called with ⚠️ marker text', () =
     expect(ticketId).toBe('ticket-stall-check');
     expect(iteration).toBe(3); // stalls on 3rd identical iteration
     expect(reason).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSubTaskLoop — re-read detector (Layer C)
+// ---------------------------------------------------------------------------
+
+describe('runSubTaskLoop — re-read detector (Layer C)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('appends a re-read warning to the second tool_result for the same artifactId', async () => {
+    // Three iterations:
+    //   iter1: tool_use platform__read_tool_result_artifact (artifactId=A) → first read, no warning
+    //   iter2: tool_use platform__read_tool_result_artifact (artifactId=A) → second read (count=2), warning fires
+    //   iter3: tool_use finalize_subtask → loop exits
+    //
+    // We capture every messages array passed to generateWithTools.
+    // After iter2's tool_result is appended, iter3's call receives messages
+    // that include the nudge text in the tool_result for tu-2.
+
+    const sameArtifactId = '11111111-1111-1111-1111-111111111111';
+    const capturedMessages: Array<Array<{ role: string; content: unknown }>> = [];
+
+    const generateWithToolsMock = vi.fn(async ({ messages }: { messages: Array<{ role: string; content: unknown }> }) => {
+      capturedMessages.push(structuredClone(messages) as Array<{ role: string; content: unknown }>);
+      const idx = capturedMessages.length;
+
+      if (idx === 1) {
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+          contentBlocks: [{
+            type: 'tool_use' as const,
+            id: 'tu-1',
+            name: 'platform__read_tool_result_artifact',
+            input: { artifactId: sameArtifactId, ticketId: 'tk', offset: 0, limit: 4000 },
+          } satisfies AIToolUseBlock],
+        };
+      }
+      if (idx === 2) {
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+          contentBlocks: [{
+            type: 'tool_use' as const,
+            id: 'tu-2',
+            name: 'platform__read_tool_result_artifact',
+            input: { artifactId: sameArtifactId, ticketId: 'tk', offset: 4000, limit: 4000 },
+          } satisfies AIToolUseBlock],
+        };
+      }
+      // idx === 3: finalize_subtask → loop exits
+      return {
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 100, outputTokens: 50 },
+        contentBlocks: [{
+          type: 'tool_use' as const,
+          id: 'tu-3',
+          name: 'finalize_subtask',
+          input: { summary: 'done', updatedKdSections: [] },
+        } satisfies AIToolUseBlock],
+      };
+    });
+
+    const ai = { generateWithTools: generateWithToolsMock, generate: vi.fn() } as unknown as AIRouter;
+    const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+    await runSubTaskLoop(
+      {
+        ai,
+        db: undefined as never,
+        appLog: makeAppLog(),
+        artifactStoragePath: undefined,
+      } as never,
+      'tk',          // ticketId
+      'cl',          // clientId
+      'GENERAL',     // category
+      false,         // skipClientMemory
+      'st-1',        // subTaskId
+      'test intent', // intent
+      [],            // contextKdSections (empty → no DB load)
+      [],            // tools
+      new Map(),     // mcpIntegrations
+      new Map(),     // repoIdByPrefix
+      'test system prompt', // subTaskSystemPrompt
+      'haiku',       // model
+      config,        // budgetConfig
+    );
+
+    // Should have been called exactly 3 times
+    expect(capturedMessages.length).toBeGreaterThanOrEqual(3);
+
+    // The third call's messages should include the re-read warning in a tool_result
+    const thirdCallMessages = capturedMessages[2];
+    const lastUser = [...thirdCallMessages].reverse().find(m => m.role === 'user');
+    const lastContent = JSON.stringify(lastUser?.content ?? '');
+    expect(lastContent).toMatch(/you have read artifact/i);
+    expect(lastContent).toMatch(/2 times/i);
   });
 });
 

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1426,6 +1426,138 @@ describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #471 regression: kd-only tool requests must not trigger "tool resolution failed"
+// ---------------------------------------------------------------------------
+
+describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('does NOT error when the strategist requests only kd_* tools', async () => {
+    // Live failure (cf1b96e8 watch, 2026-04-27): st-6-document-all was dispatched with
+    // tools=['kd_update_section', 'kd_add_subsection']. The legacy `nonKdInitial`
+    // check fired the "Tool resolution failed" early-return because no NON-kd tools
+    // were resolved — even though the requested kd_* tools DID match via substring.
+    //
+    // Post-fix: resolution.resolved (or resolution.fuzzy) being non-empty is the
+    // correct signal that the request matched something. A sub-task whose only job
+    // is to write findings to the knowledge doc should run cleanly.
+
+    // Snapshot messages at call time — orchestrator mutates the array reference
+    // between calls, so we deep-clone each call's messages to inspect the
+    // mid-run state later.
+    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
+    const responses = [
+      // strategist iter 1: dispatch one sub-task requesting only kd_* tools
+      {
+        contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+          subtasks: [{
+            id: 'st-document',
+            intent: 'Record findings to the KD',
+            tools: ['kd_update_section', 'kd_add_subsection'],
+            model: 'sonnet',
+          }],
+        }, 'tu_dispatch')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 100, outputTokens: 80 },
+      },
+      // sub-task: finalize with a successful summary
+      {
+        contentBlocks: [makeToolUseBlock('finalize_subtask', {
+          summary: 'Documented evidence in evidence.foo',
+          updatedKdSections: ['evidence.foo'],
+        }, 'tu_finalize')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 50, outputTokens: 40 },
+      },
+      // strategist iter 2: complete_analysis after sub-task succeeded
+      {
+        contentBlocks: [makeToolUseBlock('complete_analysis', {
+          finalAnalysis: 'Findings recorded.',
+        }, 'tu_complete')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 120, outputTokens: 60 },
+      },
+    ];
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+      return responses[callSnapshots.length - 1];
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // 3 calls total: strategist dispatch + sub-task finalize + strategist complete.
+    // Pre-fix would have produced only 2 calls (sub-task short-circuited before
+    // its own generateWithTools).
+    expect(callSnapshots).toHaveLength(3);
+
+    // The strategist's iter-2 call (call 3, index 2) must include the sub-task's
+    // SUCCESS summary as the dispatch tool_result — not the "Tool resolution
+    // failed" error string.
+    const iter2Messages = callSnapshots[2].messages;
+    const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
+    expect(lastUserContent).toMatch(/Documented evidence/);
+    expect(lastUserContent).toMatch(/FINALIZED/);
+    expect(lastUserContent).not.toMatch(/Tool resolution failed/);
+  });
+
+  it('still errors when every requested tool is genuinely unknown', async () => {
+    // Negative case: if the strategist names tools that don't exist at all, the
+    // sub-task should still short-circuit with the resolution-failed error so the
+    // strategist gets a clear signal.
+    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
+    const responses = [
+      {
+        contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+          subtasks: [{
+            id: 'st-bogus',
+            intent: 'Use nonexistent tools',
+            tools: ['this_tool_does_not_exist', 'neither_does_this_one'],
+            model: 'sonnet',
+          }],
+        }, 'tu_dispatch')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 100, outputTokens: 80 },
+      },
+      {
+        contentBlocks: [makeToolUseBlock('complete_analysis', {
+          finalAnalysis: 'Cannot proceed.',
+        }, 'tu_complete')],
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 120, outputTokens: 60 },
+      },
+    ];
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+      return responses[callSnapshots.length - 1];
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // 2 calls only — sub-task short-circuited before its own generateWithTools.
+    expect(callSnapshots).toHaveLength(2);
+
+    const iter2Messages = callSnapshots[1].messages;
+    const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
+    expect(lastUserContent).toMatch(/Tool resolution failed/);
+  });
+});
+// ---------------------------------------------------------------------------
 // v1 orchestrated re-analysis redirect (dispatcher in analyzer.ts)
 // ---------------------------------------------------------------------------
 

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1011,6 +1011,112 @@ describe('runSubTaskLoop — re-read detector (Layer C)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSubTaskLoop — budget thresholds (Layer B)
+// ---------------------------------------------------------------------------
+
+describe('runSubTaskLoop — budget thresholds (Layer B)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('injects a soft-nudge text message on the iteration that crosses 60%', async () => {
+    // Default config: tokenBudget=50_000, softNudgeRatio=0.6 → soft threshold at 30_000 tokens.
+    // iter1 returns 31_000 input tokens (pushes total past 30k, below 42.5k hard-stop).
+    // iter2 calls finalize_subtask → loop exits.
+    // We assert that the messages array passed to iter2 includes a 'Budget warning' user message.
+    const calls: Array<{ messages: unknown[]; tools: { name: string }[] }> = [];
+    const ai = {
+      generateWithTools: vi.fn(async ({ messages, tools }: { messages: unknown[]; tools: { name: string }[] }) => {
+        calls.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+        const idx = calls.length;
+        if (idx === 1) {
+          return {
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 31_000, outputTokens: 100 },
+            contentBlocks: [{
+              type: 'tool_use' as const, id: 't1', name: 'platform__kd_read_toc',
+              input: { ticketId: 'tk' },
+            } satisfies AIToolUseBlock],
+          };
+        }
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+          contentBlocks: [{
+            type: 'tool_use' as const, id: 't2', name: 'finalize_subtask',
+            input: { summary: 'done', updatedKdSections: [] },
+          } satisfies AIToolUseBlock],
+        };
+      }),
+    };
+
+    const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+    const { runSubTaskLoop } = await import('./orchestrated-v2.js');
+    await runSubTaskLoop(
+      { ai, db: undefined as never, appLog: { info: vi.fn(), warn: vi.fn() }, artifactStoragePath: undefined } as never,
+      'tk', 'cl', 'GENERAL', false, 'st-1', 'test intent',
+      [], [],
+      new Map(), new Map(),
+      'sp', 'haiku',
+      config,
+    );
+
+    // Soft-nudge fires AT TOP of iter2 — the messages passed to calls[1] must include it
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    const iter2Messages = calls[1].messages as Array<{ role: string; content: unknown }>;
+    const stringified = JSON.stringify(iter2Messages);
+    expect(stringified).toMatch(/Budget warning/i);
+  });
+
+  it('restricts tool list to [finalize_subtask] only when crossing 85%', async () => {
+    // Default config: tokenBudget=50_000, hardStopRatio=0.85 → hard threshold at 42_500 tokens.
+    // iter1 returns 43_000 input tokens (pushes total past 42.5k → HARD_STOP on iter2 top).
+    // iter2 call should have tools restricted to [finalize_subtask] only.
+    const calls: Array<{ messages: unknown[]; tools: { name: string }[] }> = [];
+    const ai = {
+      generateWithTools: vi.fn(async ({ messages, tools }: { messages: unknown[]; tools: { name: string }[] }) => {
+        calls.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+        const idx = calls.length;
+        if (idx === 1) {
+          return {
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 43_000, outputTokens: 100 },
+            contentBlocks: [{
+              type: 'tool_use' as const, id: 't1', name: 'platform__kd_read_toc',
+              input: { ticketId: 'tk' },
+            } satisfies AIToolUseBlock],
+          };
+        }
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 100, outputTokens: 50 },
+          contentBlocks: [{
+            type: 'tool_use' as const, id: 't2', name: 'finalize_subtask',
+            input: { summary: 'done', updatedKdSections: [] },
+          } satisfies AIToolUseBlock],
+        };
+      }),
+    };
+
+    const config = OrchestratedV2BudgetConfigSchema.parse({});
+
+    const { runSubTaskLoop } = await import('./orchestrated-v2.js');
+    await runSubTaskLoop(
+      { ai, db: undefined as never, appLog: { info: vi.fn(), warn: vi.fn() }, artifactStoragePath: undefined } as never,
+      'tk', 'cl', 'GENERAL', false, 'st-1', 'test intent',
+      [], [],
+      new Map(), new Map(),
+      'sp', 'haiku',
+      config,
+    );
+
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls[1].tools.map(t => t.name)).toEqual(['finalize_subtask']);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // v2-knowledge-doc: writeStallMarker body content is verified in
 // v2-knowledge-doc.test.ts (see the "writeStallMarker" describe block there).
 // That test file does NOT mock v2-knowledge-doc, so the real function runs.

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1429,6 +1429,29 @@ describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
 // #471 regression: kd-only tool requests must not trigger "tool resolution failed"
 // ---------------------------------------------------------------------------
 
+// Helper for scripted-response generateWithTools mocks. Snapshots the messages
+// array at call time (orchestrator mutates the reference between calls) and
+// throws a clear error if the SUT makes more calls than there are scripted
+// responses — much easier to diagnose than the silent `undefined` return that
+// vi.fn() would otherwise produce.
+type CallSnapshot = { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> };
+
+function makeScriptedAi(responses: ReadonlyArray<{ contentBlocks: unknown[]; stopReason: 'tool_use'; usage: { inputTokens: number; outputTokens: number } }>): { ai: AIRouter; snapshots: CallSnapshot[] } {
+  const snapshots: CallSnapshot[] = [];
+  const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
+    snapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+    const response = responses[snapshots.length - 1];
+    if (response === undefined) {
+      throw new Error(
+        `Scripted-AI mock exhausted: SUT made call #${snapshots.length} but only ${responses.length} response(s) were scripted. Add another entry to the responses array or fix the SUT.`,
+      );
+    }
+    return response;
+  });
+  const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+  return { ai, snapshots };
+}
+
 describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)', () => {
   beforeEach(() => {
     resetKdMocks();
@@ -1444,11 +1467,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // correct signal that the request matched something. A sub-task whose only job
     // is to write findings to the knowledge doc should run cleanly.
 
-    // Snapshot messages at call time — orchestrator mutates the array reference
-    // between calls, so we deep-clone each call's messages to inspect the
-    // mid-run state later.
-    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
-    const responses = [
+    const { ai, snapshots } = makeScriptedAi([
       // strategist iter 1: dispatch one sub-task requesting only kd_* tools
       {
         contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
@@ -1459,7 +1478,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
             model: 'sonnet',
           }],
         }, 'tu_dispatch')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 100, outputTokens: 80 },
       },
       // sub-task: finalize with a successful summary
@@ -1468,7 +1487,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
           summary: 'Documented evidence in evidence.foo',
           updatedKdSections: ['evidence.foo'],
         }, 'tu_finalize')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 50, outputTokens: 40 },
       },
       // strategist iter 2: complete_analysis after sub-task succeeded
@@ -1476,16 +1495,11 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
         contentBlocks: [makeToolUseBlock('complete_analysis', {
           finalAnalysis: 'Findings recorded.',
         }, 'tu_complete')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 120, outputTokens: 60 },
       },
-    ];
-    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
-      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
-      return responses[callSnapshots.length - 1];
-    });
+    ]);
 
-    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
     await runOrchestratedV2(
       makeDeps(ai),
       makeCtx(),
@@ -1497,12 +1511,12 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // 3 calls total: strategist dispatch + sub-task finalize + strategist complete.
     // Pre-fix would have produced only 2 calls (sub-task short-circuited before
     // its own generateWithTools).
-    expect(callSnapshots).toHaveLength(3);
+    expect(snapshots).toHaveLength(3);
 
     // The strategist's iter-2 call (call 3, index 2) must include the sub-task's
     // SUCCESS summary as the dispatch tool_result — not the "Tool resolution
     // failed" error string.
-    const iter2Messages = callSnapshots[2].messages;
+    const iter2Messages = snapshots[2].messages;
     const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
     expect(lastUserContent).toMatch(/Documented evidence/);
     expect(lastUserContent).toMatch(/FINALIZED/);
@@ -1513,8 +1527,7 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     // Negative case: if the strategist names tools that don't exist at all, the
     // sub-task should still short-circuit with the resolution-failed error so the
     // strategist gets a clear signal.
-    const callSnapshots: Array<{ messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }> = [];
-    const responses = [
+    const { ai, snapshots } = makeScriptedAi([
       {
         contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
           subtasks: [{
@@ -1524,23 +1537,18 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
             model: 'sonnet',
           }],
         }, 'tu_dispatch')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 100, outputTokens: 80 },
       },
       {
         contentBlocks: [makeToolUseBlock('complete_analysis', {
           finalAnalysis: 'Cannot proceed.',
         }, 'tu_complete')],
-        stopReason: 'tool_use' as const,
+        stopReason: 'tool_use',
         usage: { inputTokens: 120, outputTokens: 60 },
       },
-    ];
-    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: Array<{ role: string; content: unknown }>; tools: Array<{ name: string }> }) => {
-      callSnapshots.push({ messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
-      return responses[callSnapshots.length - 1];
-    });
+    ]);
 
-    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
     await runOrchestratedV2(
       makeDeps(ai),
       makeCtx(),
@@ -1550,9 +1558,9 @@ describe('sub-task allowlist resolution: kd-only requests resolve cleanly (#471)
     );
 
     // 2 calls only — sub-task short-circuited before its own generateWithTools.
-    expect(callSnapshots).toHaveLength(2);
+    expect(snapshots).toHaveLength(2);
 
-    const iter2Messages = callSnapshots[1].messages;
+    const iter2Messages = snapshots[1].messages;
     const lastUserContent = JSON.stringify([...iter2Messages].reverse().find(m => m.role === 'user')?.content ?? '');
     expect(lastUserContent).toMatch(/Tool resolution failed/);
   });

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1133,6 +1133,122 @@ describe('writeStallMarker (v2-knowledge-doc)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// runOrchestratedV2 — batch-failure guard (Layer D)
+// ---------------------------------------------------------------------------
+
+describe('runOrchestratedV2 — batch-failure guard (Layer D)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('hard-stops strategist tool list when 80% of two consecutive batches were BUDGET_EXHAUSTED', async () => {
+    // Approach B: distinguish strategist vs sub-task calls by tools parameter.
+    // Sub-tasks return a huge inputTokens value (> SUB_TASK_TOKEN_BUDGET=50_000) on
+    // their first call so the legacy token-budget check fires and the sub-task loop
+    // returns BUDGET_EXHAUSTED after exactly one generateWithTools call.
+    //
+    // Sequence:
+    //   - Strategist iter 1: dispatch_subtasks → 5 sub-tasks (all BUDGET_EXHAUSTED)
+    //   - Batch 1 guard: isFirstBatch=true → OK (free pass); cumulativeExhausted=5
+    //   - Strategist iter 2: dispatch_subtasks → 5 more sub-tasks (all BUDGET_EXHAUSTED)
+    //   - Batch 2 guard: cumulative 10/10 > 0.5 → HARD_STOP; strategistHardStopActive=true
+    //   - Strategist iter 3: should receive restrictedStrategistTools (no dispatch_subtasks)
+    //   - Strategist iter 3: calls complete_analysis → run ends
+    //
+    // The default strategistGuard config: hardStopCumulativeExhaustedRatio=0.5, so
+    // 10/10 > 0.5 triggers HARD_STOP on the cumulative rule.
+
+    const fiveSubtasks = (prefix: string) =>
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `${prefix}-st-${i + 1}`,
+        intent: `Intent ${prefix} ${i + 1}`,
+        tools: [],
+        model: 'sonnet',
+      }));
+
+    // Capture the tools list passed to each strategist call (non-finalize tools)
+    const strategistToolLists: Array<string[]> = [];
+    let strategistCallCount = 0;
+
+    const generateWithTools = vi.fn().mockImplementation(
+      ({ tools }: { tools: Array<{ name: string }> }) => {
+        const hasDispatch = tools.some(t => t.name === 'dispatch_subtasks');
+        const hasFinalize = tools.some(t => t.name === 'finalize_subtask');
+
+        if (hasFinalize) {
+          // Sub-task call — return a large token count to trigger token budget exhaustion
+          // (SUB_TASK_TOKEN_BUDGET=50_000; reporting 51_000 exceeds it)
+          return Promise.resolve({
+            contentBlocks: [makeToolUseBlock('platform__kd_read_toc', { ticketId: 'ticket-test-001' })],
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 51_000, outputTokens: 100 },
+          });
+        }
+
+        // Strategist call
+        strategistCallCount++;
+        strategistToolLists.push(tools.map(t => t.name));
+
+        if (strategistCallCount === 1) {
+          // Iter 1: dispatch 5 sub-tasks (batch 1)
+          return Promise.resolve({
+            contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+              subtasks: fiveSubtasks('b1'),
+            }, `tu_dispatch_1`)],
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 100, outputTokens: 80 },
+          });
+        }
+        if (strategistCallCount === 2) {
+          // Iter 2: dispatch 5 sub-tasks (batch 2) — still has dispatch_subtasks available
+          // because hard-stop fires AFTER this batch resolves (at end of iter 2)
+          expect(hasDispatch).toBe(true);
+          return Promise.resolve({
+            contentBlocks: [makeToolUseBlock('dispatch_subtasks', {
+              subtasks: fiveSubtasks('b2'),
+            }, `tu_dispatch_2`)],
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 100, outputTokens: 80 },
+          });
+        }
+        // Strategist call 3+: should be restricted (no dispatch_subtasks)
+        return Promise.resolve({
+          contentBlocks: [makeToolUseBlock('complete_analysis', {
+            finalAnalysis: 'Guard fired — wrapping up with available findings.',
+          }, 'tu_complete')],
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 50, outputTokens: 25 },
+        });
+      },
+    );
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 10, existingKnowledgeDoc: '' },
+    );
+
+    // Strategist must have been called at least 3 times
+    expect(strategistCallCount).toBeGreaterThanOrEqual(3);
+
+    // Strategist call 1 and 2: full tool list — includes dispatch_subtasks
+    expect(strategistToolLists[0]).toContain('dispatch_subtasks');
+    expect(strategistToolLists[1]).toContain('dispatch_subtasks');
+
+    // Strategist call 3 (after HARD_STOP): restricted — no dispatch_subtasks
+    expect(strategistToolLists[2]).not.toContain('dispatch_subtasks');
+    // Restricted list must contain exactly the three permitted tools
+    expect(strategistToolLists[2]).toContain('complete_analysis');
+    expect(strategistToolLists[2]).toContain('platform__kd_read_toc');
+    expect(strategistToolLists[2]).toContain('platform__kd_read_section');
+    expect(strategistToolLists[2]).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // v1 orchestrated re-analysis redirect (dispatcher in analyzer.ts)
 // ---------------------------------------------------------------------------
 

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1581,3 +1581,128 @@ describe('v1 orchestrated re-analysis redirect', () => {
   // analyzer.integration.test.ts.
   it.todo('redirect covered in analyzer.integration.test.ts (deferred)');
 });
+
+// ---------------------------------------------------------------------------
+// runOrchestratedV2 — re-analysis surfaces priorExecutiveSummary (#48 Item 7)
+// ---------------------------------------------------------------------------
+
+describe('runOrchestratedV2 — re-analysis surfaces priorExecutiveSummary (#48 Item 7)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  /**
+   * Re-analysis-aware mock DB. Adds `artifact.findMany` (consumed by
+   * `buildArtifactCatalog` during the re-analysis prompt build) on top of the
+   * standard mock surface.
+   */
+  function makeReanalysisDb(): PrismaClient {
+    const base = makeMockDb() as unknown as Record<string, unknown>;
+    base.artifact = { findMany: vi.fn().mockResolvedValue([]) };
+    return base as unknown as PrismaClient;
+  }
+
+  /** Captures the very first strategist user message (initial re-analysis prompt). */
+  function captureFirstUserMessage(generateWithTools: ReturnType<typeof vi.fn>): { read: () => string } {
+    let captured = '';
+    let firstSeen = false;
+    generateWithTools.mockImplementation(async (req: { messages: Array<{ role: string; content: unknown }> }) => {
+      if (!firstSeen) {
+        const userMsg = req.messages.find((m) => m.role === 'user');
+        captured = typeof userMsg?.content === 'string' ? userMsg.content : '';
+        firstSeen = true;
+      }
+      // Return complete_analysis immediately so the run terminates fast
+      return {
+        contentBlocks: [makeToolUseBlock('complete_analysis', { finalAnalysis: 'done' }, 'tu_complete')],
+        stopReason: 'tool_use',
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    });
+    return { read: () => captured };
+  }
+
+  it('injects ## Prior Executive Summary section between Operator Reply and Prior Knowledge Document', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const reanalysisCtx = {
+      conversationHistory: '### [2026-04-20] Reply\n\nfollow-up',
+      triggerReplyText: 'Continue from where you left off.',
+      priorExecutiveSummary: [
+        '## Executive Summary',
+        '',
+        'Identified deadlock between Orders and OrderLines.',
+        '',
+        '## Continuation Notes',
+        '',
+        'Sub-task 3 (index review) did not complete. Resume there.',
+      ].join('\n'),
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '## Problem Statement\n\nx',
+      reanalysisCtx,
+    });
+
+    const text = captured.read();
+    expect(text).toContain('## Prior Executive Summary');
+    expect(text).toContain('Identified deadlock between Orders and OrderLines.');
+    expect(text).toContain('## Continuation Notes');
+    expect(text).toContain('Sub-task 3 (index review) did not complete. Resume there.');
+
+    // Ordering: Operator Reply → Prior Executive Summary → Prior Knowledge Document
+    const opReplyIdx = text.indexOf('## Operator Reply');
+    const priorIdx = text.indexOf('## Prior Executive Summary');
+    const kdIdx = text.indexOf('## Prior Knowledge Document');
+    expect(opReplyIdx).toBeGreaterThan(-1);
+    expect(priorIdx).toBeGreaterThan(opReplyIdx);
+    expect(kdIdx).toBeGreaterThan(priorIdx);
+  });
+
+  it('omits the Prior Executive Summary section when reanalysisCtx has no priorExecutiveSummary', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const reanalysisCtx = {
+      conversationHistory: '### [2026-04-20] Reply\n\nfollow-up',
+      triggerReplyText: 'Continue.',
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '',
+      reanalysisCtx,
+    });
+
+    expect(captured.read()).not.toContain('## Prior Executive Summary');
+  });
+
+  it('truncates priorExecutiveSummary that exceeds the cap, keeping the tail (Continuation Notes)', async () => {
+    const generateWithTools = vi.fn();
+    const captured = captureFirstUserMessage(generateWithTools);
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+
+    const filler = 'X'.repeat(9000);
+    const tail = '## Continuation Notes\n\nResume sub-task 3 (index review).';
+    const reanalysisCtx = {
+      conversationHistory: '## History',
+      triggerReplyText: 'Continue.',
+      priorExecutiveSummary: `${filler}\n\n${tail}`,
+    };
+
+    await runOrchestratedV2(makeDeps(ai, makeReanalysisDb()), makeCtx(), makeStep(), makeToolCtx(), {
+      maxIterations: 2,
+      existingKnowledgeDoc: '',
+      reanalysisCtx,
+    });
+
+    const text = captured.read();
+    expect(text).toContain('Prior executive summary truncated');
+    expect(text).toContain('## Continuation Notes');
+    expect(text).toContain('Resume sub-task 3');
+  });
+});

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.test.ts
@@ -1249,6 +1249,99 @@ describe('runOrchestratedV2 — batch-failure guard (Layer D)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// runOrchestratedV2 — ticket budget (Layer E + E.1)
+// ---------------------------------------------------------------------------
+
+describe('runOrchestratedV2 — ticket budget (Layer E + E.1)', () => {
+  beforeEach(() => {
+    resetKdMocks();
+  });
+
+  it('hard-stops at 95% of totalTokenBudget and injects the continuation-notes directive', async () => {
+    // The default ticket.totalTokenBudget is 300_000 with hardStopRatio=0.95.
+    // Hard-stop fires when totalTokensSoFar >= 285_000 (95% of 300_000).
+    //
+    // Sequence:
+    //   - Strategist iter 1: dispatch 1 sub-task, returns 285_001 inputTokens
+    //     → orchTotalInputTokens = 285_001 after iter 1 completes
+    //   - Sub-task: finalize immediately with 0 tokens
+    //   - Strategist iter 2: top-of-loop evaluation sees 285_001 >= 285_000 → E hard-stop fires
+    //   - E.1 directive injected into strategistMessages
+    //   - Iter 2 strategist call: restricted tool list (no dispatch_subtasks)
+    //   - Iter 2 strategist: calls complete_analysis → run ends
+
+    const calls: Array<{ role: 'strategist' | 'subtask'; messages: unknown[]; tools: { name: string }[] }> = [];
+
+    const generateWithTools = vi.fn(async ({ messages, tools }: { messages: unknown[]; tools: Array<{ name: string }> }) => {
+      const isStrategist = tools.some(t => t.name === 'dispatch_subtasks' || t.name === 'complete_analysis');
+      const role = isStrategist ? 'strategist' : 'subtask';
+      calls.push({ role, messages: structuredClone(messages), tools: tools.map(t => ({ name: t.name })) });
+
+      if (isStrategist) {
+        const strategistCallNum = calls.filter(c => c.role === 'strategist').length;
+        if (strategistCallNum === 1) {
+          // Iter 1 strategist: dispatch one sub-task; report 285_001 tokens consumed
+          // (just over the 95% threshold of 300_000) so iter 2 fires the hard-stop
+          return {
+            stopReason: 'tool_use' as const,
+            usage: { inputTokens: 285_001, outputTokens: 0 },
+            contentBlocks: [{
+              type: 'tool_use' as const, id: 'd1', name: 'dispatch_subtasks',
+              input: { subtasks: [{ id: 'st-1', intent: 'check', tools: [], model: 'haiku' }] },
+            } satisfies AIToolUseBlock],
+          };
+        }
+        // Iter 2 strategist (after E hard-stop should be active): immediate complete_analysis
+        return {
+          stopReason: 'tool_use' as const,
+          usage: { inputTokens: 0, outputTokens: 0 },
+          contentBlocks: [{
+            type: 'tool_use' as const, id: 'c1', name: 'complete_analysis',
+            input: { finalAnalysis: 'completed under hard-stop' },
+          } satisfies AIToolUseBlock],
+        };
+      }
+      // Sub-task: finalize immediately, zero tokens
+      return {
+        stopReason: 'tool_use' as const,
+        usage: { inputTokens: 0, outputTokens: 0 },
+        contentBlocks: [{
+          type: 'tool_use' as const, id: 'f1', name: 'finalize_subtask',
+          input: { summary: 'minimal', updatedKdSections: [] },
+        } satisfies AIToolUseBlock],
+      };
+    });
+
+    const ai = { generateWithTools, generate: vi.fn() } as unknown as AIRouter;
+    await runOrchestratedV2(
+      makeDeps(ai),
+      makeCtx(),
+      makeStep(),
+      makeToolCtx(),
+      { maxIterations: 5, existingKnowledgeDoc: '' },
+    );
+
+    // Verify we got at least 2 strategist calls
+    const strategistCalls = calls.filter(c => c.role === 'strategist');
+    expect(strategistCalls.length).toBeGreaterThanOrEqual(2);
+
+    const iter2 = strategistCalls[1];
+    const iter2MessagesStr = JSON.stringify(iter2.messages);
+
+    // The iter-2 messages should contain the continuation-notes directive
+    expect(iter2MessagesStr).toMatch(/## Continuation Notes/);
+    expect(iter2MessagesStr).toMatch(/What we established/);
+    expect(iter2MessagesStr).toMatch(/Hypotheses still open/);
+    expect(iter2MessagesStr).toMatch(/Investigation threads not completed/);
+    expect(iter2MessagesStr).toMatch(/Suggested next batch/);
+
+    // The iter-2 strategist call's tool list must be restricted (no dispatch_subtasks)
+    expect(iter2.tools.map(t => t.name)).not.toContain('dispatch_subtasks');
+    expect(iter2.tools.map(t => t.name)).toContain('complete_analysis');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // v1 orchestrated re-analysis redirect (dispatcher in analyzer.ts)
 // ---------------------------------------------------------------------------
 

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -16,7 +16,7 @@ import type {
   AIMessage,
   OrchestratedV2BudgetConfig,
 } from '@bronco/shared-types';
-import { detectArtifactReread } from './budget-thresholds.js';
+import { detectArtifactReread, evaluateSubTaskBudget } from './budget-thresholds.js';
 import {
   buildArtifactCatalog,
   buildRepoNudgeSnippet,
@@ -222,9 +222,53 @@ export async function runSubTaskLoop(
     : { logId: subTaskLogId };
 
   let lastIterationRun = 0;
+  let softNudgeFired = false;
+  let hardStopActive = false;
+  const finalizeOnlyTools: AIToolDefinition[] = [FINALIZE_SUBTASK_TOOL];
+
   for (let iteration = 0; iteration < SUB_TASK_ITERATION_CAP; iteration++) {
     lastIterationRun = iteration + 1;
     const tokensSoFar = totalInputTokens + totalOutputTokens;
+
+    // Layer B: evaluator-based soft-nudge + hard-stop (fires ABOVE the legacy safety-net breaks)
+    const verdict = evaluateSubTaskBudget(
+      { tokensUsed: tokensSoFar, iterationsUsed: iteration, toolCallsUsed: totalToolCalls },
+      budgetConfig.subTask,
+    );
+
+    if (verdict === 'SOFT_NUDGE' && !softNudgeFired) {
+      softNudgeFired = true;
+      const tokenPct = Math.round((tokensSoFar / budgetConfig.subTask.tokenBudget) * 100);
+      const callPct = Math.round((totalToolCalls / budgetConfig.subTask.callBudget) * 100);
+      const iterPct = Math.round((iteration / budgetConfig.subTask.iterationCap) * 100);
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ Budget warning: tokens ${tokenPct}%, tool calls ${callPct}%, iterations ${iterPct}%. You are crossing 60% of one or more budgets. Consider finalizing soon — call \`finalize_subtask\` with what you have if your findings already support a useful summary. Further tool calls will be cut off at 85%.`,
+          },
+        ],
+      });
+      appLog.info(
+        `Sub-task ${subTaskId} soft-nudge fired at iteration ${iteration + 1} (tokens=${tokenPct}%, calls=${callPct}%, iter=${iterPct}%)`,
+        { ticketId, subTaskId, iteration: iteration + 1 },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    if (verdict === 'HARD_STOP') {
+      hardStopActive = true;
+      appLog.info(
+        `Sub-task ${subTaskId} hard-stop active at iteration ${iteration + 1} — restricting tools to [finalize_subtask]`,
+        { ticketId, subTaskId, iteration: iteration + 1, tokensSoFar, totalToolCalls },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    // Legacy safety-net break checks (use hardcoded constants; T10 will remove these)
     if (tokensSoFar >= SUB_TASK_TOKEN_BUDGET) {
       appLog.info(
         `Sub-task ${subTaskId} exhausted token budget (${tokensSoFar} >= ${SUB_TASK_TOKEN_BUDGET}) at iteration ${iteration + 1}`,
@@ -267,7 +311,7 @@ export async function runSubTaskLoop(
           ...orchCtx,
         },
         messages,
-        tools: toolsWithFinalize,
+        tools: hardStopActive ? finalizeOnlyTools : toolsWithFinalize,
         systemPrompt: subTaskSystemPrompt,
         providerOverride: 'CLAUDE',
         modelOverride: model,

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -252,7 +252,7 @@ export async function runSubTaskLoop(
       );
     }
 
-    if (verdict === 'HARD_STOP') {
+    if (verdict === 'HARD_STOP' && !hardStopActive) {
       hardStopActive = true;
       appLog.info(
         `Sub-task ${subTaskId} hard-stop active at iteration ${iteration + 1} — restricting tools to [finalize_subtask]`,
@@ -260,6 +260,9 @@ export async function runSubTaskLoop(
         ticketId,
         'ticket',
       );
+    } else if (verdict === 'HARD_STOP') {
+      // Sticky after first transition; no further log to keep the loop quiet
+      hardStopActive = true;
     }
 
     // Legacy safety-net break checks (backed by runtime budgetConfig values)

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -16,7 +16,7 @@ import type {
   AIMessage,
   OrchestratedV2BudgetConfig,
 } from '@bronco/shared-types';
-import { detectArtifactReread, evaluateSubTaskBudget } from './budget-thresholds.js';
+import { detectArtifactReread, evaluateSubTaskBudget, evaluateBatchFailureGuard, type BatchFailureGuardState } from './budget-thresholds.js';
 import {
   buildArtifactCatalog,
   buildRepoNudgeSnippet,
@@ -1064,6 +1064,22 @@ export async function runOrchestratedV2(
   let stallReason: string | null = null;
   let stallIteration = 0;
 
+  // Layer D: strategist batch-failure guard state
+  const batchFailureState: BatchFailureGuardState = {
+    cumulativeExhausted: 0,
+    cumulativeTotal: 0,
+    consecutiveBadBatches: 0,
+  };
+  let strategistHardStopActive = false;
+
+  // Pre-build the restricted strategist tool list (computed once for the run)
+  const restrictedStrategistTools: AIToolDefinition[] = finalStrategistTools.filter(
+    t =>
+      t.name === 'complete_analysis' ||
+      t.name === 'platform__kd_read_toc' ||
+      t.name === 'platform__kd_read_section',
+  );
+
   // ---------------------------------------------------------------------------
   // Strategist message loop
   // ---------------------------------------------------------------------------
@@ -1113,7 +1129,7 @@ export async function runOrchestratedV2(
           strategyVersion: 'v2' as const,
         },
         messages: strategistMessages,
-        tools: finalStrategistTools,
+        tools: strategistHardStopActive ? restrictedStrategistTools : finalStrategistTools,
         systemPrompt: strategistSystemPrompt,
         providerOverride: 'CLAUDE',
         modelOverride: 'claude-opus-4-6',
@@ -1434,6 +1450,25 @@ export async function runOrchestratedV2(
         }
       }
 
+      // Layer D: evaluate batch-failure guard
+      const isFirstBatch = batchFailureState.cumulativeTotal === 0;
+      const guardVerdict = evaluateBatchFailureGuard(
+        batchFailureState,
+        allSubTaskResults.map(r => ({ stopReason: r.stopReason, updatedKdSections: r.updatedKdSections })),
+        budgetConfig.strategistGuard,
+        isFirstBatch,
+      );
+
+      if (guardVerdict === 'HARD_STOP') {
+        strategistHardStopActive = true;
+        appLog.warn(
+          `Strategist hard-stop activated at iteration ${i + 1} — cumulative ${batchFailureState.cumulativeExhausted}/${batchFailureState.cumulativeTotal} sub-tasks BUDGET_EXHAUSTED, consecutiveBadBatches=${batchFailureState.consecutiveBadBatches}`,
+          { ticketId, iteration: i + 1, cumulative: { ...batchFailureState } },
+          ticketId,
+          'ticket',
+        );
+      }
+
       // Append sub-task results to strategist messages as tool_result for the dispatch_subtasks call.
       // Use the captured `dispatchCallId` from this iteration (not a history scan) to ensure
       // the tool_result is threaded onto the correct dispatch_subtasks tool_use block.
@@ -1448,13 +1483,22 @@ export async function runOrchestratedV2(
           tokensUsed: r.tokensUsed,
         }));
 
+        let guardWarning = '';
+        if (guardVerdict === 'SOFT_NUDGE') {
+          guardWarning = `⚠️ ${batchFailureState.cumulativeExhausted}/${batchFailureState.cumulativeTotal} sub-tasks BUDGET_EXHAUSTED so far. Many produced no usable findings (empty updatedKdSections). Before dispatching another batch, read the knowledge doc with kd_read_toc to see what's been written, and consider whether complete_analysis is the right next call.\n\n`;
+        } else if (guardVerdict === 'HARD_STOP') {
+          guardWarning = `⚠️ Cost guard hard-stop: too many sub-tasks BUDGET_EXHAUSTED. Further dispatch is blocked. You may now ONLY call complete_analysis (or kd_read_toc / kd_read_section to inspect findings before doing so). Wrap up the analysis with what's available.\n\n`;
+        }
+
+        const content = guardWarning + JSON.stringify(resultPayload, null, 2);
+
         strategistMessages.push({
           role: 'user',
           content: [
             {
               type: 'tool_result',
               tool_use_id: dispatchCallId,
-              content: JSON.stringify(resultPayload, null, 2),
+              content,
             } satisfies AIToolResultBlock,
           ],
         });

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -7,14 +7,16 @@ import {
   updateSection,
   withTicketLock,
 } from '@bronco/shared-utils';
-import { KnowledgeDocSectionKey, KnowledgeDocUpdateMode, TaskType } from '@bronco/shared-types';
+import { KnowledgeDocSectionKey, KnowledgeDocUpdateMode, OrchestratedV2BudgetConfigSchema, TaskType } from '@bronco/shared-types';
 import type {
   AITextBlock,
   AIToolDefinition,
   AIToolResultBlock,
   AIToolUseBlock,
   AIMessage,
+  OrchestratedV2BudgetConfig,
 } from '@bronco/shared-types';
+import { detectArtifactReread } from './budget-thresholds.js';
 import {
   buildArtifactCatalog,
   buildRepoNudgeSnippet,
@@ -145,7 +147,7 @@ function formatKdSectionFromDoc(
  * `buildAgenticTools` returned — it is NOT part of `buildAgenticTools` because
  * it is orchestrated-v2–only and must not be visible to flat-v2 / v1 agents.
  */
-async function runSubTaskLoop(
+export async function runSubTaskLoop(
   deps: AnalysisDeps,
   ticketId: string,
   clientId: string,
@@ -159,6 +161,7 @@ async function runSubTaskLoop(
   repoIdByPrefix: Map<string, string>,
   subTaskSystemPrompt: string,
   model: string,
+  budgetConfig: OrchestratedV2BudgetConfig,
   orchestration?: { id: string; iteration: number; parentLogId?: string },
   toolResultMaxTokens?: number,
   defaultMaxTokens?: number,
@@ -170,6 +173,7 @@ async function runSubTaskLoop(
   let totalOutputTokens = 0;
   let totalToolCalls = 0;
   const failureTracker = new Map<string, number>();
+  const artifactReadCounts = new Map<string, number>();
 
   // Build the tool list: requested tools + finalize_subtask (always appended)
   const toolsWithFinalize: AIToolDefinition[] = [
@@ -370,10 +374,31 @@ async function runSubTaskLoop(
         durationMs: elapsed,
       });
 
+      // Layer C: detect re-reads of the same artifact and append a guidance nudge
+      let contentWithMaybeNudge: string = contentForModel;
+      if (toolUse.name === 'platform__read_tool_result_artifact') {
+        const inputArtifactId = (toolUse.input as Record<string, unknown>)?.artifactId;
+        if (typeof inputArtifactId === 'string' && inputArtifactId.length > 0) {
+          const fired = detectArtifactReread(
+            artifactReadCounts,
+            inputArtifactId,
+            budgetConfig.subTaskReReadDetector.warnAfterReadCount,
+          );
+          if (fired) {
+            const count = artifactReadCounts.get(inputArtifactId) ?? 0;
+            contentWithMaybeNudge = [
+              contentForModel,
+              '',
+              `⚠️ You have read artifact ${inputArtifactId} ${count} times in this sub-task. Use \`grep\` mode to find specific patterns, or proceed with the data you have and call \`finalize_subtask\`.`,
+            ].join('\n');
+          }
+        }
+      }
+
       toolResults.push({
         type: 'tool_result',
         tool_use_id: toolUse.id,
-        content: contentForModel,
+        content: contentWithMaybeNudge,
         ...(result.isError ? { is_error: true } : {}),
       });
 
@@ -510,6 +535,7 @@ async function executeOrchestratedSubTaskV2(
   agenticTools: AIToolDefinition[],
   mcpIntegrations: Map<string, McpIntegrationInfo>,
   repoIdByPrefix: Map<string, string>,
+  budgetConfig: OrchestratedV2BudgetConfig,
   orchestration?: { id: string; iteration: number; parentLogId?: string },
   modelMap?: Record<string, string>,
   toolResultMaxTokens?: number,
@@ -613,6 +639,7 @@ async function executeOrchestratedSubTaskV2(
     repoIdByPrefix,
     subTaskSystemPrompt,
     model,
+    budgetConfig,
     orchestration,
     toolResultMaxTokens,
     defaultMaxTokens,
@@ -647,6 +674,7 @@ async function executeOrchestratedSubTaskV2(
         repoIdByPrefix,
         subTaskSystemPrompt,
         model,
+        budgetConfig,
         orchestration,
         toolResultMaxTokens,
         defaultMaxTokens,
@@ -860,6 +888,9 @@ export async function runOrchestratedV2(
 
   const defaultMaxTokens = await deps.loadDefaultMaxTokens?.() ?? undefined;
   const toolResultMaxTokens = await getToolResultMaxTokens(db);
+
+  // T10 will replace this with: const budgetConfig = await resolveOrchestratedV2BudgetConfig(db);
+  const budgetConfig = OrchestratedV2BudgetConfigSchema.parse({});
 
   const maxParallelTasks = await resolveMaxParallelTasks(db);
   const orchModelMap = await resolveOrchestratedModelMap(db);
@@ -1267,6 +1298,7 @@ export async function runOrchestratedV2(
               agenticTools,
               mcpIntegrations,
               repoIdByPrefix,
+              budgetConfig,
               { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId },
               orchModelMap,
               toolResultMaxTokens,
@@ -1317,6 +1349,7 @@ export async function runOrchestratedV2(
                 agenticTools,
                 mcpIntegrations,
                 repoIdByPrefix,
+                budgetConfig,
                 { id: orchestrationId, iteration: i + 1, parentLogId: strategistLogId },
                 orchModelMap,
                 toolResultMaxTokens,

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -16,7 +16,7 @@ import type {
   AIMessage,
   OrchestratedV2BudgetConfig,
 } from '@bronco/shared-types';
-import { detectArtifactReread, evaluateSubTaskBudget, evaluateBatchFailureGuard, type BatchFailureGuardState } from './budget-thresholds.js';
+import { detectArtifactReread, evaluateSubTaskBudget, evaluateBatchFailureGuard, evaluateTicketBudget, type BatchFailureGuardState } from './budget-thresholds.js';
 import {
   buildArtifactCatalog,
   buildRepoNudgeSnippet,
@@ -1072,6 +1072,10 @@ export async function runOrchestratedV2(
   };
   let strategistHardStopActive = false;
 
+  // Layer E: ticket-level total-token budget state
+  let ticketSoftNudgeFired = false;
+  let ticketHardStopActive = false;
+
   // Pre-build the restricted strategist tool list (computed once for the run)
   const restrictedStrategistTools: AIToolDefinition[] = finalStrategistTools.filter(
     t =>
@@ -1103,6 +1107,75 @@ export async function runOrchestratedV2(
     const orchestrationId = randomUUID();
     appLog.info(`Orchestrated analysis iteration ${i + 1}/${orchMaxIterations}`, { ticketId, iteration: i + 1, orchestrationId }, ticketId, 'ticket');
 
+    // Layer E: ticket-level total-token budget evaluation
+    const totalTokensSoFar = orchTotalInputTokens + orchTotalOutputTokens;
+    const ticketVerdict = evaluateTicketBudget(totalTokensSoFar, budgetConfig.ticket);
+
+    if (ticketVerdict === 'SOFT_NUDGE' && !ticketSoftNudgeFired) {
+      ticketSoftNudgeFired = true;
+      const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
+      strategistMessages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `⚠️ Ticket budget at ${pct}% (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens). You are approaching the cost cap. Consider whether enough findings are in the knowledge doc to call complete_analysis. Further dispatch will be blocked at 95%.`,
+          },
+        ],
+      });
+      appLog.info(
+        `Ticket soft-nudge at iteration ${i + 1} (${pct}% of budget consumed)`,
+        { ticketId, iteration: i + 1, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
+        ticketId,
+        'ticket',
+      );
+    }
+
+    if (ticketVerdict === 'HARD_STOP' && !ticketHardStopActive) {
+      ticketHardStopActive = true;
+      const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
+      appLog.warn(
+        `Ticket hard-stop activated at iteration ${i + 1} (${pct}% of budget consumed)`,
+        { ticketId, iteration: i + 1, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
+        ticketId,
+        'ticket',
+      );
+
+      // Layer E.1: continuation-summary directive
+      strategistMessages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: [
+              `⚠️ Ticket budget hard-cap reached (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens, ${pct}%). You can no longer dispatch sub-tasks.`,
+              `Read the knowledge doc with \`kd_read_toc\` / \`kd_read_section\` and call \`complete_analysis\` next.`,
+              ``,
+              `**Required:** include a \`## Continuation Notes\` section in your \`finalAnalysis\` with the following structure (use exactly these subheadings):`,
+              ``,
+              `\`\`\``,
+              `## Continuation Notes`,
+              ``,
+              `### What we established`,
+              `- <bullet list of confirmed findings, each with KD section reference>`,
+              ``,
+              `### Hypotheses still open`,
+              `- <bullet list of hypotheses introduced but not verified>`,
+              ``,
+              `### Investigation threads not completed`,
+              `- <bullet list of sub-task intents that hit BUDGET_EXHAUSTED with no usable summary>`,
+              ``,
+              `### Suggested next batch`,
+              `- <2-3 sub-task intents that would be most valuable to retry on continuation, with which artifacts/sections to load as context>`,
+              `\`\`\``,
+              ``,
+              `Going slightly over the budget cap to write this summary is permitted and expected.`,
+            ].join('\n'),
+          },
+        ],
+      });
+    }
+
     const strategistLogId = randomUUID();
 
     // --- Inner tool loop: call generateWithTools until strategist dispatches or completes ---
@@ -1129,7 +1202,7 @@ export async function runOrchestratedV2(
           strategyVersion: 'v2' as const,
         },
         messages: strategistMessages,
-        tools: strategistHardStopActive ? restrictedStrategistTools : finalStrategistTools,
+        tools: (strategistHardStopActive || ticketHardStopActive) ? restrictedStrategistTools : finalStrategistTools,
         systemPrompt: strategistSystemPrompt,
         providerOverride: 'CLAUDE',
         modelOverride: 'claude-opus-4-6',

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -88,21 +88,9 @@ const logger = createLogger('ticket-analyzer');
  */
 const STRATEGIST_MAX_TOKENS = 8192;
 
-// ---------------------------------------------------------------------------
-// Sub-task budget constants
-// ---------------------------------------------------------------------------
-
-/**
- * Hard-coded fallback values for the orchestrated-v2 sub-task budget. These are
- * the schema defaults from `OrchestratedV2BudgetConfigSchema` — kept here for
- * reference. Live runtime values come from `resolveOrchestratedV2BudgetConfig(db)`
- * and are passed through `runOrchestratedV2` -> `runSubTaskLoop` via `budgetConfig`.
- */
-const DEFAULT_SUB_TASK_BUDGET = {
-  iterationCap: 8,
-  tokenBudget: 50_000,
-  callBudget: 20,
-} as const;
+// Sub-task budget values now come from `OrchestratedV2BudgetConfigSchema` defaults
+// in @bronco/shared-types, loaded at runtime via `resolveOrchestratedV2BudgetConfig(db)`
+// and threaded through `runOrchestratedV2` -> `runSubTaskLoop` as `budgetConfig`.
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -34,6 +34,7 @@ import {
   resolveTaskTools,
   saveMcpToolArtifact,
   shouldTruncate,
+  truncatePriorExecutiveSummary,
   type AgenticToolContext,
   type AnalysisDeps,
   type AnalysisPipelineContext,
@@ -1045,10 +1046,22 @@ export async function runOrchestratedV2(
         '',
         '## Operator Reply',
         reanalysisCtx.triggerReplyText || '(no reply text available — see conversation history)',
+      ];
+      // #48 Item 7: surface the prior run's composed analysis as a primary
+      // steering input. If the prior run hit the ticket-budget cap, it includes
+      // a `## Continuation Notes` section telling us where to pick up.
+      if (reanalysisCtx.priorExecutiveSummary) {
+        sections.push(
+          '',
+          '## Prior Executive Summary',
+          truncatePriorExecutiveSummary(reanalysisCtx.priorExecutiveSummary),
+        );
+      }
+      sections.push(
         '',
         '## Prior Knowledge Document',
         priorRunsContext || existingKnowledgeDoc || '(no prior knowledge document)',
-      ];
+      );
       if (artifactCatalog) {
         sections.push('', '## Prior Artifacts', artifactCatalog);
       }

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -642,9 +642,17 @@ async function executeOrchestratedSubTaskV2(
     initialToolNames.add(artifactTool.name);
   }
 
-  // If tools were requested but none matched at all (kd_* tools excluded), return early with guidance
-  const nonKdInitial = initialTools.filter(t => !t.name.startsWith('platform__kd_') && t.name !== 'platform__read_tool_result_artifact');
-  if (task.tools.length > 0 && nonKdInitial.length === 0) {
+  // If every requested tool failed to match anything (no exact, no base-name,
+  // no substring, no fuzzy candidate above the score threshold), return early
+  // with guidance — the strategist named tools that don't exist.
+  //
+  // Subtle bug fixed in #471: the prior check tested whether `initialTools` had
+  // any non-kd tools, which incorrectly fired for sub-tasks that legitimately
+  // requested ONLY kd_* tools (e.g. a "document findings" sub-task). Those
+  // requests are genuine matches via `resolveTaskTools` and should NOT error.
+  // Use the resolver's own `resolved` + `fuzzy` outputs as the source of truth.
+  const noResolutionAtAll = resolution.resolved.length === 0 && resolution.fuzzy.size === 0;
+  if (task.tools.length > 0 && noResolutionAtAll) {
     const MAX_TOOLS_IN_ERROR = 10;
     const toolNames = agenticTools.map(t => t.name);
     const availableList = toolNames.length > MAX_TOOLS_IN_ERROR

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -1086,6 +1086,52 @@ export async function runOrchestratedV2(
       t.name === 'platform__kd_read_section',
   );
 
+  // E.1: continuation-summary directive injection. Used by both the top-of-iteration
+  // ticket budget check and the pre-batch overshoot guard, so each path can transition
+  // ticketHardStopActive without duplicating the directive content. Caller is
+  // responsible for the `!ticketHardStopActive` one-shot guard.
+  const injectTicketHardStopDirective = (iteration: number, totalTokensSoFar: number): void => {
+    const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
+    appLog.warn(
+      `Ticket hard-stop activated at iteration ${iteration} (${pct}% of budget consumed)`,
+      { ticketId, iteration, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
+      ticketId,
+      'ticket',
+    );
+    strategistMessages.push({
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: [
+            `⚠️ Ticket budget hard-cap reached (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens, ${pct}%). You can no longer dispatch sub-tasks.`,
+            `Read the knowledge doc with \`kd_read_toc\` / \`kd_read_section\` and call \`complete_analysis\` next.`,
+            ``,
+            `**Required:** include a \`## Continuation Notes\` section in your \`finalAnalysis\` with the following structure (use exactly these subheadings):`,
+            ``,
+            `\`\`\``,
+            `## Continuation Notes`,
+            ``,
+            `### What we established`,
+            `- <bullet list of confirmed findings, each with KD section reference>`,
+            ``,
+            `### Hypotheses still open`,
+            `- <bullet list of hypotheses introduced but not verified>`,
+            ``,
+            `### Investigation threads not completed`,
+            `- <bullet list of sub-task intents that hit BUDGET_EXHAUSTED with no usable summary>`,
+            ``,
+            `### Suggested next batch`,
+            `- <2-3 sub-task intents that would be most valuable to retry on continuation, with which artifacts/sections to load as context>`,
+            `\`\`\``,
+            ``,
+            `Going slightly over the budget cap to write this summary is permitted and expected.`,
+          ].join('\n'),
+        },
+      ],
+    });
+  };
+
   // ---------------------------------------------------------------------------
   // Strategist message loop
   // ---------------------------------------------------------------------------
@@ -1135,47 +1181,7 @@ export async function runOrchestratedV2(
 
     if (ticketVerdict === 'HARD_STOP' && !ticketHardStopActive) {
       ticketHardStopActive = true;
-      const pct = Math.round((totalTokensSoFar / budgetConfig.ticket.totalTokenBudget) * 100);
-      appLog.warn(
-        `Ticket hard-stop activated at iteration ${i + 1} (${pct}% of budget consumed)`,
-        { ticketId, iteration: i + 1, totalTokensSoFar, budget: budgetConfig.ticket.totalTokenBudget },
-        ticketId,
-        'ticket',
-      );
-
-      // Layer E.1: continuation-summary directive
-      strategistMessages.push({
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: [
-              `⚠️ Ticket budget hard-cap reached (${totalTokensSoFar} / ${budgetConfig.ticket.totalTokenBudget} tokens, ${pct}%). You can no longer dispatch sub-tasks.`,
-              `Read the knowledge doc with \`kd_read_toc\` / \`kd_read_section\` and call \`complete_analysis\` next.`,
-              ``,
-              `**Required:** include a \`## Continuation Notes\` section in your \`finalAnalysis\` with the following structure (use exactly these subheadings):`,
-              ``,
-              `\`\`\``,
-              `## Continuation Notes`,
-              ``,
-              `### What we established`,
-              `- <bullet list of confirmed findings, each with KD section reference>`,
-              ``,
-              `### Hypotheses still open`,
-              `- <bullet list of hypotheses introduced but not verified>`,
-              ``,
-              `### Investigation threads not completed`,
-              `- <bullet list of sub-task intents that hit BUDGET_EXHAUSTED with no usable summary>`,
-              ``,
-              `### Suggested next batch`,
-              `- <2-3 sub-task intents that would be most valuable to retry on continuation, with which artifacts/sections to load as context>`,
-              `\`\`\``,
-              ``,
-              `Going slightly over the budget cap to write this summary is permitted and expected.`,
-            ].join('\n'),
-          },
-        ],
-      });
+      injectTicketHardStopDirective(i + 1, totalTokensSoFar);
     }
 
     const strategistLogId = randomUUID();
@@ -1390,6 +1396,53 @@ export async function runOrchestratedV2(
         ticketId,
         'ticket',
       );
+
+      // Layer E pre-batch overshoot guard.
+      // Top-of-iteration ticketVerdict only catches budget after sub-tasks have already
+      // run. Without this, a batch dispatched at e.g. 80% can burn (subtaskCount × subTask.tokenBudget)
+      // worth of tokens before the next iteration notices — overshooting the cap by 100%+ in the
+      // worst case. Re-evaluate just before executing the batch and abort if the worst-case
+      // batch cost would push past the cap.
+      const preBatchTokens = orchTotalInputTokens + orchTotalOutputTokens;
+      const preBatchVerdict = evaluateTicketBudget(preBatchTokens, budgetConfig.ticket);
+      const worstCaseBatchTokens = plan.subtasks.length * budgetConfig.subTask.tokenBudget;
+      const wouldOverflow = preBatchTokens + worstCaseBatchTokens > budgetConfig.ticket.totalTokenBudget;
+
+      if (preBatchVerdict === 'HARD_STOP' || wouldOverflow) {
+        const reason = preBatchVerdict === 'HARD_STOP'
+          ? 'ticket budget already at hard-stop'
+          : 'worst-case batch cost would overflow ticket cap';
+        appLog.warn(
+          `Pre-batch ticket budget abort at iteration ${i + 1}: ${reason} — current=${preBatchTokens}, worst-case=${worstCaseBatchTokens}, cap=${budgetConfig.ticket.totalTokenBudget}`,
+          { ticketId, iteration: i + 1, current: preBatchTokens, worstCase: worstCaseBatchTokens, cap: budgetConfig.ticket.totalTokenBudget, reason },
+          ticketId,
+          'ticket',
+        );
+
+        if (!ticketHardStopActive) {
+          ticketHardStopActive = true;
+          injectTicketHardStopDirective(i + 1, preBatchTokens);
+        }
+
+        // Anthropic's API requires a tool_result for every tool_use. Synthesize one for the
+        // dispatch_subtasks call so the next strategist turn has a well-formed conversation,
+        // and so the strategist sees concretely what aborted the batch.
+        if (dispatchCallId) {
+          strategistMessages.push({
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: dispatchCallId,
+                content: `⚠️ Dispatch aborted: ${reason}. Current ticket cost: ${preBatchTokens} tokens; planned batch worst-case adds ${worstCaseBatchTokens}; cap is ${budgetConfig.ticket.totalTokenBudget}. You must call complete_analysis next, including the ## Continuation Notes section per the directive.`,
+              } satisfies AIToolResultBlock,
+            ],
+          });
+        }
+
+        await writeKnowledgeDocSnapshot(db, ticketId, i + 1);
+        continue;
+      }
 
       // Record iteration start in Run Log
       try {

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -524,9 +524,14 @@ async function executeOrchestratedSubTaskV2(
     'You are a focused investigator. Execute your sub-task intent thoroughly using the available tools.',
     'Record each finding by calling kd_* tools (platform__kd_add_subsection, platform__kd_update_section).',
     'Do NOT dump raw tool output into your response — the knowledge doc is the source of truth.',
-    'When you have completed your investigation, call `finalize_subtask` with a concise summary (100-300 words)',
-    'and the list of KD section keys you updated. Call `finalize_subtask` as the LAST action — do not call',
-    'it before you have gathered all the data you need.',
+    '',
+    'BUDGET DISCIPLINE — read carefully:',
+    '- You have a hard budget (tokens, iterations, tool calls). The runner will warn you when you cross 60%.',
+    '- When using `platform__read_tool_result_artifact`, prefer `grep` mode to find specific patterns over paging through chunks. If the truncated preview shown in the prior tool_result is enough to support a finding, work from that — do NOT re-read the same artifact.',
+    '- Re-reading the same artifact more than once will trigger a warning. Heed it.',
+    '- Partial findings with what you have are MORE useful than burning the entire budget chasing more.',
+    'When you have enough to justify a finding, call `finalize_subtask` with a concise summary (100-300 words)',
+    'and the list of KD section keys you updated. Earlier finalize is better than budget-exhausted.',
   ].join(' ');
 
   const priorArtifactsHint = task.priorArtifactIds && task.priorArtifactIds.length > 0

--- a/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
+++ b/services/ticket-analyzer/src/analysis/orchestrated-v2.ts
@@ -7,7 +7,7 @@ import {
   updateSection,
   withTicketLock,
 } from '@bronco/shared-utils';
-import { KnowledgeDocSectionKey, KnowledgeDocUpdateMode, OrchestratedV2BudgetConfigSchema, TaskType } from '@bronco/shared-types';
+import { KnowledgeDocSectionKey, KnowledgeDocUpdateMode, TaskType } from '@bronco/shared-types';
 import type {
   AITextBlock,
   AIToolDefinition,
@@ -30,6 +30,7 @@ import {
   ReanalysisMode,
   resolveMaxParallelTasks,
   resolveOrchestratedModelMap,
+  resolveOrchestratedV2BudgetConfig,
   resolveTaskTools,
   saveMcpToolArtifact,
   shouldTruncate,
@@ -91,12 +92,17 @@ const STRATEGIST_MAX_TOKENS = 8192;
 // Sub-task budget constants
 // ---------------------------------------------------------------------------
 
-/** Maximum model iterations per sub-task (each iteration = one generateWithTools call). */
-const SUB_TASK_ITERATION_CAP = 8;
-/** Maximum total tokens (input + output) a single sub-task may consume. */
-const SUB_TASK_TOKEN_BUDGET = 50_000;
-/** Maximum tool calls a single sub-task may make (not counting finalize_subtask). */
-const SUB_TASK_CALL_BUDGET = 20;
+/**
+ * Hard-coded fallback values for the orchestrated-v2 sub-task budget. These are
+ * the schema defaults from `OrchestratedV2BudgetConfigSchema` — kept here for
+ * reference. Live runtime values come from `resolveOrchestratedV2BudgetConfig(db)`
+ * and are passed through `runOrchestratedV2` -> `runSubTaskLoop` via `budgetConfig`.
+ */
+const DEFAULT_SUB_TASK_BUDGET = {
+  iterationCap: 8,
+  tokenBudget: 50_000,
+  callBudget: 20,
+} as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -197,7 +203,7 @@ export async function runSubTaskLoop(
       }
     }
   }
-  const budgetLine = `## Budget\nMax ${SUB_TASK_ITERATION_CAP} iterations, max ${SUB_TASK_TOKEN_BUDGET.toLocaleString()} tokens total, max ${SUB_TASK_CALL_BUDGET} tool calls. Call \`finalize_subtask\` once you are done — do not wait until budget is exhausted.`;
+  const budgetLine = `## Budget\nMax ${budgetConfig.subTask.iterationCap} iterations, max ${budgetConfig.subTask.tokenBudget.toLocaleString()} tokens total, max ${budgetConfig.subTask.callBudget} tool calls. Call \`finalize_subtask\` once you are done — do not wait until budget is exhausted.`;
   const userPrompt = [
     '## Intent',
     intent,
@@ -226,7 +232,7 @@ export async function runSubTaskLoop(
   let hardStopActive = false;
   const finalizeOnlyTools: AIToolDefinition[] = [FINALIZE_SUBTASK_TOOL];
 
-  for (let iteration = 0; iteration < SUB_TASK_ITERATION_CAP; iteration++) {
+  for (let iteration = 0; iteration < budgetConfig.subTask.iterationCap; iteration++) {
     lastIterationRun = iteration + 1;
     const tokensSoFar = totalInputTokens + totalOutputTokens;
 
@@ -268,19 +274,19 @@ export async function runSubTaskLoop(
       );
     }
 
-    // Legacy safety-net break checks (use hardcoded constants; T10 will remove these)
-    if (tokensSoFar >= SUB_TASK_TOKEN_BUDGET) {
+    // Legacy safety-net break checks (backed by runtime budgetConfig values)
+    if (tokensSoFar >= budgetConfig.subTask.tokenBudget) {
       appLog.info(
-        `Sub-task ${subTaskId} exhausted token budget (${tokensSoFar} >= ${SUB_TASK_TOKEN_BUDGET}) at iteration ${iteration + 1}`,
+        `Sub-task ${subTaskId} exhausted token budget (${tokensSoFar} >= ${budgetConfig.subTask.tokenBudget}) at iteration ${iteration + 1}`,
         { ticketId, subTaskId, tokensSoFar, iteration: iteration + 1 },
         ticketId,
         'ticket',
       );
       break;
     }
-    if (totalToolCalls >= SUB_TASK_CALL_BUDGET) {
+    if (totalToolCalls >= budgetConfig.subTask.callBudget) {
       appLog.info(
-        `Sub-task ${subTaskId} exhausted call budget (${totalToolCalls} >= ${SUB_TASK_CALL_BUDGET}) at iteration ${iteration + 1}`,
+        `Sub-task ${subTaskId} exhausted call budget (${totalToolCalls} >= ${budgetConfig.subTask.callBudget}) at iteration ${iteration + 1}`,
         { ticketId, subTaskId, totalToolCalls, iteration: iteration + 1 },
         ticketId,
         'ticket',
@@ -289,7 +295,7 @@ export async function runSubTaskLoop(
     }
 
     appLog.info(
-      `Sub-task ${subTaskId} iteration ${iteration + 1}/${SUB_TASK_ITERATION_CAP}`,
+      `Sub-task ${subTaskId} iteration ${iteration + 1}/${budgetConfig.subTask.iterationCap}`,
       { ticketId, subTaskId, iteration: iteration + 1, tokensSoFar },
       ticketId,
       'ticket',
@@ -933,8 +939,13 @@ export async function runOrchestratedV2(
   const defaultMaxTokens = await deps.loadDefaultMaxTokens?.() ?? undefined;
   const toolResultMaxTokens = await getToolResultMaxTokens(db);
 
-  // T10 will replace this with: const budgetConfig = await resolveOrchestratedV2BudgetConfig(db);
-  const budgetConfig = OrchestratedV2BudgetConfigSchema.parse({});
+  const budgetConfig = await resolveOrchestratedV2BudgetConfig(db);
+  appLog.info(
+    `Orchestrated v2 run starting with budget config: ticket.totalTokenBudget=${budgetConfig.ticket.totalTokenBudget}, subTask.tokenBudget=${budgetConfig.subTask.tokenBudget}`,
+    { ticketId, budgetConfig },
+    ticketId,
+    'ticket',
+  );
 
   const maxParallelTasks = await resolveMaxParallelTasks(db);
   const orchModelMap = await resolveOrchestratedModelMap(db);

--- a/services/ticket-analyzer/src/analysis/shared.test.ts
+++ b/services/ticket-analyzer/src/analysis/shared.test.ts
@@ -40,6 +40,8 @@ import {
   resolveTaskTools,
   sanitizeFilenameSegment,
   executeAgenticToolCall,
+  truncatePriorExecutiveSummary,
+  PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP,
   type McpIntegrationInfo,
 } from './shared.js';
 import { callMcpToolViaSdk } from '@bronco/shared-utils';
@@ -871,3 +873,44 @@ describe('executeAgenticToolCall', () => {
     expect(tracker.get(sortedKey)).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// truncatePriorExecutiveSummary (#48 Item 7)
+// ---------------------------------------------------------------------------
+
+describe('truncatePriorExecutiveSummary', () => {
+  it('returns the input unchanged when length <= cap', () => {
+    const input = 'short summary';
+    expect(truncatePriorExecutiveSummary(input)).toBe(input);
+  });
+
+  it('returns the input unchanged at exactly the cap boundary', () => {
+    const input = 'a'.repeat(PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP);
+    expect(truncatePriorExecutiveSummary(input)).toBe(input);
+  });
+
+  it('truncates from the front when length > cap, preserving the tail', () => {
+    const head = 'HEAD_MARKER_AT_START';
+    const filler = 'x'.repeat(PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP);
+    const tail = '## Continuation Notes\n\nResume here.';
+    const input = `${head}\n${filler}\n${tail}`;
+    const out = truncatePriorExecutiveSummary(input);
+
+    // Tail (Continuation Notes) is preserved
+    expect(out).toContain('## Continuation Notes');
+    expect(out).toContain('Resume here.');
+    // Head fell off the front
+    expect(out).not.toContain('HEAD_MARKER_AT_START');
+    // Truncation marker present
+    expect(out).toContain(`Prior executive summary truncated to last ${PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP} chars`);
+  });
+
+  it('respects a custom charCap argument', () => {
+    const input = 'a'.repeat(100);
+    const out = truncatePriorExecutiveSummary(input, 50);
+    expect(out).toContain('truncated to last 50 chars');
+    // Output is the marker + ellipsis + last 50 chars; bounded.
+    expect(out.length).toBeLessThan(input.length + 200);
+  });
+});
+

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -8,8 +8,9 @@ import {
   TaskType,
   SufficiencyStatus,
   SufficiencyConfidence,
+  OrchestratedV2BudgetConfigSchema,
 } from '@bronco/shared-types';
-import type { AIToolDefinition, AIToolUseBlock } from '@bronco/shared-types';
+import type { AIToolDefinition, AIToolUseBlock, OrchestratedV2BudgetConfig } from '@bronco/shared-types';
 import {
   AppLogger,
   createLogger,
@@ -1232,6 +1233,26 @@ export async function resolveMaxParallelTasks(db: PrismaClient): Promise<number>
     }
   }
   return maxParallelTasks;
+}
+
+const ORCHESTRATED_V2_BUDGET_CONFIG_KEY = 'orchestrated-v2-budget-config';
+
+/**
+ * Load the orchestrated-v2 runtime budget config from the AppSetting table.
+ * Missing or malformed → returns parsed defaults. Called once at the top of
+ * runOrchestratedV2 and threaded through to runSubTaskLoop. Does NOT cache —
+ * each analysis run picks up fresh values, mirroring the peer resolvers
+ * (resolveAnalysisVersion / resolveMaxParallelTasks) in this file.
+ */
+export async function resolveOrchestratedV2BudgetConfig(
+  db: { appSetting: { findUnique: (args: { where: { key: string } }) => Promise<{ value: unknown } | null> } },
+): Promise<OrchestratedV2BudgetConfig> {
+  const row = await db.appSetting.findUnique({ where: { key: ORCHESTRATED_V2_BUDGET_CONFIG_KEY } });
+  const parsed = OrchestratedV2BudgetConfigSchema.safeParse(row?.value ?? {});
+  if (!parsed.success) {
+    return OrchestratedV2BudgetConfigSchema.parse({});
+  }
+  return parsed.data;
 }
 
 // ---------------------------------------------------------------------------

--- a/services/ticket-analyzer/src/analysis/shared.ts
+++ b/services/ticket-analyzer/src/analysis/shared.ts
@@ -1340,11 +1340,40 @@ export interface ReanalysisContext {
   /** The ticket event ID that triggered this re-analysis (for metadata tracking). */
   triggerEventId?: string;
   /**
+   * Full content of the most recent AI_ANALYSIS event for this ticket — the
+   * composed final analysis sent to the operator (Executive Summary +
+   * Problem/Root Cause/Recommended Fix/Risks pulled from the KD). Surfaced
+   * as a dedicated section in the v2 strategies' prompts so the strategist
+   * sees prior findings — and any `## Continuation Notes` section written by
+   * a prior budget-capped run — as primary steering input rather than buried
+   * in the conversation history (#48 Item 7).
+   *
+   * Strategies cap this at their own prompt budget; producer should pass the
+   * full content, no pre-truncation.
+   */
+  priorExecutiveSummary?: string;
+  /**
    * Continuation mode for orchestrated re-analysis. When undefined, defaults
    * to 'continue'. Producer (#312 Chat tab) classifies operator-reply intent
    * and sets this; pre-#312 callers leave it unset.
    */
   mode?: ReanalysisMode;
+}
+
+/** Per-run cap for the `## Prior Executive Summary` section in v2 strategy prompts. */
+export const PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP = 8000;
+
+/**
+ * Truncate the prior executive summary for inclusion in a re-analysis prompt.
+ * Keeps the tail (where `## Continuation Notes` lives if E.1 fired) and
+ * prefixes a marker so the strategist knows the summary was clipped.
+ */
+export function truncatePriorExecutiveSummary(
+  summary: string,
+  charCap: number = PRIOR_EXECUTIVE_SUMMARY_CHAR_CAP,
+): string {
+  if (summary.length <= charCap) return summary;
+  return `[Prior executive summary truncated to last ${charCap} chars — full version in the AI Analysis event]\n\n…${summary.slice(-charCap)}`;
 }
 
 export interface StrategyStep {

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -941,8 +941,17 @@ async function deepAnalysis(
               }
             }
           }
-        } catch {
-          // search found nothing — that's fine
+        } catch (err) {
+          // `callMcpToolViaSdk` throws when the MCP result has `isError: true`
+          // — that includes real failures (timeout, auth, tool-internal errors),
+          // not only the genuine "no matches" case. Log at warn so an empty
+          // repo context is debuggable in production rather than silent (#465).
+          appLog.warn(
+            `Pre-gather search_code failed on ${repo.name} for term "${sanitized.slice(0, 80)}"`,
+            { ticketId, repo: repo.name, term: sanitized, err: err instanceof Error ? err.message : String(err) },
+            ticketId,
+            'ticket',
+          );
         }
       }
 
@@ -2649,7 +2658,18 @@ async function executeRoutePipeline(
                           }
                         }
                       }
-                    } catch { /* search found nothing */ }
+                    } catch (err) {
+                      // See note on pre-gather above: failures here include
+                      // real errors (timeout, auth, tool-internal), not only
+                      // genuine empty-result cases. Surface at warn so missing
+                      // CUSTOM_AI_QUERY context is debuggable in prod (#465).
+                      appLog.warn(
+                        `CUSTOM_AI_QUERY search_code failed on ${repo.name} for term "${sanitized.slice(0, 80)}"`,
+                        { ticketId, repo: repo.name, term: sanitized, err: err instanceof Error ? err.message : String(err) },
+                        ticketId,
+                        'ticket',
+                      );
+                    }
                   }
 
                   // Add explicit file paths, rejecting paths that could expose

--- a/services/ticket-analyzer/src/analyzer.ts
+++ b/services/ticket-analyzer/src/analyzer.ts
@@ -3545,10 +3545,26 @@ export function createAnalysisProcessor(deps: AnalyzerDeps) {
           }
           triggerReplyText = latestReply.content ?? '';
         }
+        // Pull the most-recent AI_ANALYSIS event content (full, no truncation
+        // here — the strategy modules cap it for their prompt budget). This is
+        // the composed final analysis we sent to the operator last time, and
+        // includes any `## Continuation Notes` section written when the prior
+        // run hit the ticket-level budget cap. v2 strategies surface it as a
+        // dedicated `## Prior Executive Summary` section so the strategist
+        // builds on the prior findings rather than re-doing the work (#48
+        // Item 7). We scan the unsliced `allHistory` so a long-running ticket
+        // with > 20 events still surfaces the most recent AI_ANALYSIS even if
+        // it falls outside the lightweight conversation-history window.
+        const priorAiAnalysisEvent = [...allHistory]
+          .reverse()
+          .find((e) => e.eventType === 'AI_ANALYSIS');
+        const priorExecutiveSummary = priorAiAnalysisEvent?.content?.trim() || undefined;
+
         const reanalysisContext: ReanalysisContext = {
           conversationHistory: formatConversationHistory(conversationHistory),
           triggerReplyText,
           triggerEventId,
+          ...(priorExecutiveSummary && { priorExecutiveSummary }),
           // Threaded from the Chat tab endpoint (#312). flat + orchestrated
           // strategies already consume `reanalysisCtx.mode` to branch their
           // system prompt between continue / refine / fresh_start.


### PR DESCRIPTION
## Release: orchestrated-v2 regression-fix bundle + 2 follow-ups

Promotes the v0.2.10-regression sweep from staging to master. Auto-tag → deploy-hugo (GHCR + Tailscale) fires on merge.

### What's in this release

#### Regression bundle (4 PRs, all merged 2026-04-28)

| PR | Issue | Title |
|---|---|---|
| #477 | #470 | bound orchestrated-v2 analysis cost (5-layer guardrails A–E + E.1, runtime-configurable) |
| #478 | #473 | scrub NUL bytes before persisting AI usage / archive |
| #481 | #471 | allow kd-only sub-task tool requests |
| #482 | #472 | coalesce concurrent clone + worktree creates in mcp-repo |

These four PRs together fix the four symptoms observed during the 2026-04-27 regression watch on tickets #48 (`b39bf699`) and #49 (`cf1b96e8`):

1. Read-loop budget burn — sub-task agents pageing the same `read_tool_result_artifact` until cap. Bounded by Layers A–E + E.1.
2. `aiUsageLog` NUL-byte drop — DEEP_ANALYSIS rows lost to Postgres `22021` (invalid byte sequence). Fixed by `stripNulBytes` at the persistence chokepoints.
3. Sub-task allowlist resolution inconsistency — kd-only sub-task tool requests rejected. Fixed by deriving the noResolution check from `resolution.resolved + resolution.fuzzy`.
4. Worktree concurrency — parallel orchestrated-v2 sub-tasks racing on shared `gather-{ticketId}` sessionId. Fixed by promise-coalescing in `RepoManager`.

#### Follow-ups (2 PRs, merged 2026-04-28)

| PR | Issue | Title |
|---|---|---|
| #483 | #48 Item 7 | re-analysis steering with prior executive summary |
| #484 | #465 | search_code timeout detection / tool-failure surfacing / direct-exec rationale |

### Auto-deploy

Pushes to `master` that touch `packages/`, `services/`, `mcp-servers/`, `docker-compose.yml`, or the lockfile auto-tag a semver release. This release touches all of the above, so deploy will fire.

### Post-deploy verification (next session)

- Tasks #16, #17 in the session tracker unblock once this lands.
- Watch `bronco-ticket-analyzer-1` and `bronco-copilot-api-1` for ~24h.
- Confirm `invalid byte sequence` errors disappear from logs.
- Replay ticket #49 with tightened budget cap to verify #470 hard-stop + continuation-notes flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
