### PR TITLE
fix(analysis-trace): collapse inner-loop strategist siblings + promote child response (#48 Item 3)

### DIFF
--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-expand.dialog.ts
@@ -3,7 +3,7 @@ import { CommonModule, DecimalPipe, JsonPipe } from '@angular/common';
 import { DialogComponent, BroncoButtonComponent, IconComponent } from '../../../shared/components/index.js';
 import { TicketService } from '../../../core/services/ticket.service.js';
 import type { TraceNode, TraceToolPill } from './analysis-trace.types.js';
-import { firstUserMessageText, parsedMcpToolError, responseText } from './analysis-trace.merge.js';
+import { effectivePrimaryResponse, firstUserMessageText, parsedMcpToolError } from './analysis-trace.merge.js';
 
 export interface ExpandPayload {
   kind: 'node' | 'pill';
@@ -241,7 +241,11 @@ export class AnalysisTraceExpandDialogComponent {
   }
 
   respText(n: TraceNode): string {
-    return responseText(n.entry);
+    // Mirrors the renderer (analysis-trace-node.component.ts:respLine) so the
+    // expanded dialog surfaces a `primaryResponseOverride` promoted by Pass 2
+    // when the row's own `responseText` is empty. Falls back to the entry's
+    // raw response when no override is set. (#48 Item 3 — Copilot review)
+    return effectivePrimaryResponse(n);
   }
 
   errorAsText(n: TraceNode): string {

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-node.component.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace-node.component.ts
@@ -2,7 +2,7 @@ import { Component, effect, input, output, signal } from '@angular/core';
 import { CommonModule, DatePipe, DecimalPipe } from '@angular/common';
 import { BroncoButtonComponent, IconComponent } from '../../../shared/components/index.js';
 import { AnalysisTraceToolPillComponent } from './analysis-trace-tool-pill.component.js';
-import { firstUserMessageText, responseText } from './analysis-trace.merge.js';
+import { firstUserMessageText, effectivePrimaryResponse } from './analysis-trace.merge.js';
 import type { TraceFilters, TraceNode, TraceToolPill } from './analysis-trace.types.js';
 
 /** Event emitted when the user clicks a card or tool pill. */
@@ -210,7 +210,7 @@ export class AnalysisTraceNodeComponent {
   }
 
   respLine(n: TraceNode): string | null {
-    const r = responseText(n.entry);
+    const r = effectivePrimaryResponse(n);
     if (!r.trim()) return null;
     return this.firstLine(r);
   }

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.spec.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.spec.ts
@@ -5,6 +5,7 @@ import {
   buildInitialTree,
   collapseToolCalls,
   condenseDeepNodes,
+  effectivePrimaryResponse,
   mergeSamePrompts,
   runMergePipeline,
   samePromptPrefix,
@@ -120,6 +121,37 @@ describe('buildInitialTree — parent-child + orchestration fallback', () => {
     expect(tree[0].children.length).toBe(1);
     expect(tree[0].children[0].entry.id).toBe(subTask.id);
   });
+
+  // Regression: #48 Item 3.
+  //
+  // The orchestrated-v2 strategist runs an inner generateWithTools loop and
+  // writes one ai_usage_logs row per call. None of the inner-loop rows after
+  // the first set parentLogId, so they would otherwise become dangling root
+  // siblings. The orchestrationId fallback must chain them under the first
+  // strategist row of the same orchestrationId so Pass 2 can collapse them.
+  it('attaches subsequent non-sub-task strategist rows of same orchestrationId under the first', () => {
+    idSeq = 0;
+    const orchId = 'orch-inner-loop';
+    const strat1 = aiEntry({
+      prompt: 'investigate the ticket',
+      response: 'reasoning + dispatch',
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+    const strat2 = aiEntry({
+      prompt: 'investigate the ticket',
+      response: '', // Empty response — pure tool_use turn.
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+    const strat3 = aiEntry({
+      prompt: 'investigate the ticket',
+      response: 'final reasoning',
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+    const tree = buildInitialTree([strat1, strat2, strat3]);
+    expect(tree.length).toBe(1);
+    expect(tree[0].entry.id).toBe(strat1.id);
+    expect(tree[0].children.map(c => c.entry.id)).toEqual([strat2.id, strat3.id]);
+  });
 });
 
 describe('Pass 2 — same-prompt merge', () => {
@@ -159,6 +191,100 @@ describe('Pass 2 — same-prompt merge', () => {
     const merged = mergeSamePrompts(tree);
     expect(merged[0].children.length).toBe(1);
     expect(merged[0].continuations.length).toBe(0);
+  });
+
+  // Regression: #48 Item 3 — Analysis Trace prompt-without-response render glitch.
+  //
+  // In agentic tool loops every iteration's stored `promptText` is the same
+  // initial user message (router.ts `extractLastUserMessage` skips
+  // tool_result-only user messages). Iteration 1 commonly emits a `tool_use`
+  // stopReason with NO text content, so its `responseText` is empty. Iteration
+  // 2 then emits the actual analysis text. Pre-fix Pass 2 absorbed iter 2's
+  // response into `continuations[]`, leaving the merged card with an empty
+  // primary response — the renderer showed Prompt with no `→` line.
+  describe('Pass 2 regression — promotes child response when parent primary is empty', () => {
+    it('promotes child response into primaryResponseOverride when parent has empty response', () => {
+      idSeq = 0;
+      const iter1 = aiEntry({ prompt: 'investigate the ticket', response: '' });
+      const iter2 = aiEntry({ prompt: 'investigate the ticket', response: 'I found the deadlock', parentId: iter1.id });
+
+      const tree = buildInitialTree([iter1, iter2]);
+      const merged = mergeSamePrompts(tree);
+
+      expect(merged.length).toBe(1);
+      const node = merged[0];
+      expect(node.entry.id).toBe(iter1.id);
+      // The child's response is promoted, not relegated to a continuation chip.
+      expect(node.primaryResponseOverride).toBe('I found the deadlock');
+      expect(node.continuations).toEqual([]);
+      // effectivePrimaryResponse() returns the override so the renderer shows a `→` line.
+      expect(effectivePrimaryResponse(node)).toBe('I found the deadlock');
+    });
+
+    it('keeps parent primary AND queues child as continuation when both non-empty', () => {
+      idSeq = 0;
+      const iter1 = aiEntry({ prompt: 'investigate', response: 'reasoning + tool call' });
+      const iter2 = aiEntry({ prompt: 'investigate', response: 'final answer', parentId: iter1.id });
+
+      const tree = buildInitialTree([iter1, iter2]);
+      const merged = mergeSamePrompts(tree);
+
+      expect(merged.length).toBe(1);
+      const node = merged[0];
+      expect(node.primaryResponseOverride).toBeUndefined();
+      expect(node.continuations).toEqual(['final answer']);
+      expect(effectivePrimaryResponse(node)).toBe('reasoning + tool call');
+    });
+
+    it('promotes the first non-empty entry when stack of three has empty parent', () => {
+      idSeq = 0;
+      const iter1 = aiEntry({ prompt: 'investigate', response: '' });
+      const iter2 = aiEntry({ prompt: 'investigate', response: '', parentId: iter1.id });
+      const iter3 = aiEntry({ prompt: 'investigate', response: 'final answer', parentId: iter2.id });
+
+      const tree = buildInitialTree([iter1, iter2, iter3]);
+      const merged = mergeSamePrompts(tree);
+
+      expect(merged.length).toBe(1);
+      const node = merged[0];
+      expect(node.primaryResponseOverride).toBe('final answer');
+      expect(node.continuations).toEqual([]);
+      expect(effectivePrimaryResponse(node)).toBe('final answer');
+    });
+
+    it('promotes the first continuation bubbled up from a deeper merge', () => {
+      idSeq = 0;
+      // Parent empty; child empty but grandchild has the answer.
+      // Post-order merge collapses grandchild→child (continuations=['answer']),
+      // then child→parent: parent should promote that bubbled continuation.
+      const parent = aiEntry({ prompt: 'investigate', response: '' });
+      const child = aiEntry({ prompt: 'investigate', response: '', parentId: parent.id });
+      const grand = aiEntry({ prompt: 'investigate', response: 'answer', parentId: child.id });
+
+      const tree = buildInitialTree([parent, child, grand]);
+      const merged = mergeSamePrompts(tree);
+
+      expect(merged.length).toBe(1);
+      const node = merged[0];
+      expect(node.primaryResponseOverride).toBe('answer');
+      expect(node.continuations).toEqual([]);
+    });
+  });
+
+  describe('effectivePrimaryResponse', () => {
+    it('falls back to entry.responseText when no override is set', () => {
+      idSeq = 0;
+      const entry = aiEntry({ prompt: 'q', response: 'a' });
+      const tree = buildInitialTree([entry]);
+      expect(effectivePrimaryResponse(tree[0])).toBe('a');
+    });
+
+    it('returns empty string when neither override nor entry response is set', () => {
+      idSeq = 0;
+      const entry = aiEntry({ prompt: 'q', response: '' });
+      const tree = buildInitialTree([entry]);
+      expect(effectivePrimaryResponse(tree[0])).toBe('');
+    });
   });
 });
 
@@ -275,5 +401,43 @@ describe('runMergePipeline — end-to-end', () => {
     expect(roots[0].continuations).toEqual([]);
     expect(roots[0].toolPills).toEqual([]);
     expect(roots[0].children.length).toBe(2);
+  });
+
+  // Fixture mirroring the production data shape that produced #48 Item 3:
+  // one outer orchestration iteration where the strategist's inner-loop
+  // writes three ai_usage_logs rows with the same prompt prefix; the middle
+  // row has an empty response (`tool_use` stopReason, no text). End-to-end,
+  // the merged tree must be a single card with a non-empty `→` line.
+  it('regression #48 Item 3: orchestrated-v2 inner-loop with empty middle row renders one card with a non-empty primary response', () => {
+    idSeq = 0;
+    const orchId = 'orch-9204c365';
+    const sharedPrompt =
+      'Investigate this ticket. Here is the full context:\n\n## Ticket\nSubject: Evolution DB Deadlock';
+    const strat1 = aiEntry({
+      prompt: sharedPrompt,
+      response: 'The subtasks keep exhausting budgets. The kd_update_section call failed earlier.',
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+    const strat2 = aiEntry({
+      prompt: sharedPrompt,
+      response: '', // ← the empty middle that used to render dangling
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+    const strat3 = aiEntry({
+      prompt: sharedPrompt,
+      response: 'Now let me directly dispatch focused subtasks for the code analysis.',
+      conversationMetadata: { orchestrationId: orchId, orchestrationIteration: 5, isSubTask: false },
+    });
+
+    const { roots } = runMergePipeline([strat1, strat2, strat3]);
+    expect(roots.length).toBe(1);
+    const card = roots[0];
+    // First strategist absorbs the inner-loop sibling rows.
+    expect(card.entry.id).toBe(strat1.id);
+    expect(card.children.length).toBe(0);
+    // strat1's primary stays as the surface response; strat3's text becomes a
+    // continuation (strat2's empty body is dropped — nothing to surface).
+    expect(card.continuations).toEqual([strat3.responseText]);
+    expect(card.primaryResponseOverride).toBeUndefined();
   });
 });

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.merge.ts
@@ -59,6 +59,22 @@ export function responseText(entry: UnifiedLogEntry): string {
 }
 
 /**
+ * Effective primary response for a merged node.
+ *
+ * Pass 2 may set `primaryResponseOverride` when the absorbing parent's own
+ * `entry.responseText` is empty (e.g. a `tool_use`-stopReason iteration whose
+ * assistant turn was 100% tool_use blocks). In that case the override holds
+ * the first non-empty merged response so the renderer can show a `→` line
+ * instead of a dangling prompt.
+ */
+export function effectivePrimaryResponse(node: TraceNode): string {
+  if (typeof node.primaryResponseOverride === 'string' && node.primaryResponseOverride.length > 0) {
+    return node.primaryResponseOverride;
+  }
+  return responseText(node.entry);
+}
+
+/**
  * Pass 1 — Tree build.
  *
  * Attach each entry under its `parentLogId`. Entries lacking `parentLogId`
@@ -92,8 +108,17 @@ export function buildInitialTree(entries: UnifiedLogEntry[]): TraceNode[] {
     }
   }
 
-  // Fallback: orchestration-based nesting for AI sub-tasks that lack parentLogId.
-  // Find the non-sub-task strategist with the same orchestrationId; attach under it.
+  // Fallback: orchestration-based nesting for AI rows that lack parentLogId.
+  //
+  // Strategist anchor: the FIRST non-sub-task row seen per orchestrationId is
+  // the anchor. Sub-tasks for that orchId attach under it. Subsequent
+  // non-sub-task strategist rows for the same orchId — these are inner-loop
+  // strategist calls (orchestrated-v2's strategist tool loop emits one
+  // ai_usage_logs row per generateWithTools call but does not chain them via
+  // parentLogId) — also attach under the anchor so Pass 2's same-prompt
+  // merge can collapse them into one card. Without this, an inner-loop call
+  // whose response is empty (pure tool_use turn) renders as a dangling
+  // sibling root with no `→` line. (#48 Item 3)
   const strategistByOrchId = new Map<string, TraceNode>();
   for (const entry of entries) {
     if (entry.type !== 'ai') continue;
@@ -112,7 +137,6 @@ export function buildInitialTree(entries: UnifiedLogEntry[]): TraceNode[] {
     if (attached.has(entry.id)) continue;
     if (entry.type !== 'ai') continue;
     const meta = getMeta(entry);
-    if (!isSubTask(meta)) continue;
     const orchId = getOrchestrationId(meta);
     if (!orchId) continue;
     const strategist = strategistByOrchId.get(orchId);
@@ -173,9 +197,35 @@ function mergeOne(node: TraceNode): void {
       // Absorb child into node: response becomes a continuation, grandchildren
       // re-parent under node. toolPills and prior continuations on the child
       // also bubble up so merged nodes don't lose their collapsed tool pills.
-      const childResponse = responseText(child.entry);
-      if (childResponse.trim().length > 0) node.continuations.push(childResponse);
-      if (child.continuations.length > 0) node.continuations.push(...child.continuations);
+      //
+      // Special-case: when the parent's own primary response is empty (a
+      // `tool_use`-stopReason iteration emitted only tool_use blocks), the
+      // first non-empty source from this absorption — the child's response or
+      // its own continuations — is promoted to the parent's primary instead
+      // of vanishing into `continuations[]` (which only renders as a "+N"
+      // chip). Without this promotion the merged card would show a prompt
+      // with no `→` response line — the regression #48 Item 3 surfaced.
+      // The child may itself be a merged node from an earlier inner pass —
+      // either with its primary stored on `entry.responseText` OR promoted to
+      // `primaryResponseOverride` (e.g. when child's own children supplied the
+      // first non-empty response). Pull both, in order, so a deeply nested
+      // promotion still bubbles up to the surface card.
+      const childPrimary = effectivePrimaryResponse(child);
+      const incoming: string[] = [];
+      if (childPrimary.trim().length > 0) incoming.push(childPrimary);
+      if (child.continuations.length > 0) incoming.push(...child.continuations);
+
+      const parentPrimaryEmpty = effectivePrimaryResponse(node).trim().length === 0;
+      let promoted = false;
+      for (const text of incoming) {
+        if (!promoted && parentPrimaryEmpty && text.trim().length > 0) {
+          node.primaryResponseOverride = text;
+          promoted = true;
+          continue;
+        }
+        node.continuations.push(text);
+      }
+
       if (child.toolPills.length > 0) node.toolPills.push(...child.toolPills);
       node.children.splice(i, 1, ...child.children);
       // Do not advance i: re-examine the spliced-in children against this parent.

--- a/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.types.ts
+++ b/services/control-panel/src/app/features/tickets/analysis-trace/analysis-trace.types.ts
@@ -41,6 +41,17 @@ export interface TraceNode {
    * `children`. UI can expand inline.
    */
   condensed?: TraceNode[];
+  /**
+   * Override for the rendered "primary" assistant response.
+   *
+   * When the absorbing parent's own `entry.responseText` is empty (e.g. a
+   * `tool_use`-stopReason iteration that emitted only tool_use content
+   * blocks), Pass 2 promotes the first non-empty merged response from the
+   * absorbed children into this field instead of leaving it buried in
+   * `continuations[]`. Renderers should prefer this over `responseText(entry)`
+   * when present, so a merged card never shows a prompt with no `→` response.
+   */
+  primaryResponseOverride?: string;
 }
 
 /** Options for the merge pipeline. */


### PR DESCRIPTION
## Summary

Fixes #48 Item 3 — the Analysis Trace tab renders some `ai_usage_logs` rows as a "dangling" prompt panel with no `→` response line (visually broken card).

Two related fixes in `services/control-panel/src/app/features/tickets/analysis-trace/`:

- **`buildInitialTree`** — extend the orchestrationId fallback so subsequent non-sub-task strategist rows of the same `orchestrationId` chain under the first strategist of that orchestrationId. Orchestrated-v2's strategist runs an inner `generateWithTools` loop that emits one row per call without setting `parentLogId`, so without this every inner-loop call after the first became a dangling root sibling.
- **`mergeSamePrompts`** — when the absorbing parent's effective primary response is empty (a `tool_use`-stopReason iteration whose assistant turn was 100% tool_use blocks) and an absorbed child has a non-empty response, promote that response to a new `primaryResponseOverride` field on the merged `TraceNode` instead of relegating it to a `+N continuations` chip. The renderer's `respLine()` now reads `effectivePrimaryResponse(node)` so a merged card always shows a `→` line when any source row had a response.

Repro case: ticket `b39bf699-f86d-45ea-87d4-501078ab5edd` (#48 Evolution DB Deadlock) — orchestrated-v2 iteration 5 had three strategist rows with the same prompt prefix; the middle one had `responseText=''` and rendered with no completion shown. Verified the data shape directly against the snapshot DB during the fix.

## Test plan

- [x] `pnpm exec vitest run analysis-trace.merge.spec.ts` — 23/23 pass, including 6 new regression tests covering Pass 2 promotion (parent-empty/child-non-empty, recursive bubble-up, three-deep stacks) and one end-to-end pipeline test mirroring the b39bf699 data shape
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` clean
- [ ] Visual smoke on local-stack against b39bf699: open Analysis Trace tab, confirm iter-5 strategist card now shows `→ The subtasks keep exhausting budgets...` instead of dangling prompt (deferred — re-do once permissions are sorted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
